### PR TITLE
feat(desktop): Ports セクションのワークスペース名をワークツリー名に改善

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Works with any CLI agent. Built for local worktree-based development.
 | **ポートリストのリサイズ・フィルタ** | サイドバーの Ports セクションの高さをドラッグでリサイズ可能に（80–600px、永続化）。フィルタトグルで ports.json に定義されたポートのみ表示し、自動検出ポートを非表示にできる | [#6](https://github.com/MocA-Love/superset/pull/6) | 2026-03-28 |
 | **大規模ファイル diff 高速化** | 2000行超のファイルで CodeMirror 6 ベースの仮想化 diff ビューアに自動切替。ビューポート分のDOMのみ描画し、15000行でもスムーズ表示。既存テーマ・シンタックスハイライト再利用、未変更領域の自動折りたたみ | [#5](https://github.com/MocA-Love/superset/pull/5) | 2026-03-28 |
 | **ports.json ポートの常時表示** | ports.json に定義されたポートをプロセス検出の有無にかかわらず常にサイドバーに表示。Docker 等で検知できないポートもラベル付きで一覧に出る。検出済みポートは従来通りアクティブ表示、未検出は グレー表示で区別 | [#7](https://github.com/MocA-Love/superset/pull/7) | 2026-03-28 |
+| **Ports ワークスペース名の改善** | Ports セクションのワークスペース名をワークツリーのディレクトリ名ベースに変更。同名ワークスペースが複数ある場合でもどのワークツリーか一目で区別可能 | [#8](https://github.com/MocA-Love/superset/pull/8) | 2026-03-28 |
 
 ## Fork のビルド方法 (macOS)
 

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/PortsList/hooks/usePortsData.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/PortsList/hooks/usePortsData.ts
@@ -11,8 +11,44 @@ export interface WorkspacePortGroup {
 	ports: EnrichedPort[];
 }
 
+/**
+ * Build a display-friendly name for each workspace.
+ * Uses the worktree directory basename to distinguish workspaces
+ * that share the same user-facing name (e.g. multiple "default" worktrees).
+ */
+function buildWorkspaceDisplayNames(
+	groups: {
+		workspaces: { id: string; name: string; worktreePath: string }[];
+		sections: {
+			workspaces: { id: string; name: string; worktreePath: string }[];
+		}[];
+	}[],
+): Record<string, string> {
+	const names: Record<string, string> = {};
+
+	for (const group of groups) {
+		const allWs = [
+			...group.workspaces,
+			...group.sections.flatMap((s) => s.workspaces),
+		];
+		for (const ws of allWs) {
+			if (ws.worktreePath) {
+				const basename = ws.worktreePath.split("/").pop() || ws.name;
+				names[ws.id] =
+					basename !== ws.name ? `${basename} (${ws.name})` : ws.name;
+			} else {
+				names[ws.id] = ws.name;
+			}
+		}
+	}
+
+	return names;
+}
+
 export function usePortsData() {
-	const { data: allWorkspaces } = electronTrpc.workspaces.getAll.useQuery();
+	// getAllGrouped is already cached by the sidebar, so this is zero-cost.
+	const { data: allWorkspaceGroups } =
+		electronTrpc.workspaces.getAllGrouped.useQuery();
 
 	const utils = electronTrpc.useUtils();
 
@@ -39,15 +75,9 @@ export function usePortsData() {
 	}, [detectedPorts, showConfiguredOnly]);
 
 	const workspaceNames = useMemo(() => {
-		if (!allWorkspaces) return {};
-		return allWorkspaces.reduce(
-			(acc, ws) => {
-				acc[ws.id] = ws.name;
-				return acc;
-			},
-			{} as Record<string, string>,
-		);
-	}, [allWorkspaces]);
+		if (!allWorkspaceGroups) return {};
+		return buildWorkspaceDisplayNames(allWorkspaceGroups);
+	}, [allWorkspaceGroups]);
 
 	const workspacePortGroups = useMemo(() => {
 		const groupMap = new Map<string, EnrichedPort[]>();


### PR DESCRIPTION
## 概要

Ports セクションのワークスペース名表示を改善し、ワークツリーのディレクトリ名（basename）を使用するようにしました。

### 背景

複数のワークツリーが同じワークスペース名（例: 全て「default」）を持つ場合、Ports セクションのグループヘッダーが全て同じ名前になり、どのワークツリーのポートか区別がつかない問題がありました。

### 変更内容

- **変更ファイル**: `usePortsData.ts` のみ（1ファイル）
- `workspaces.getAll` → `workspaces.getAllGrouped` に変更（サイドバーで既にキャッシュ済みのため追加コストなし）
- `getAllGrouped` の `worktreePath` から basename を取得し表示名に使用
- 表示形式: `{ディレクトリ名} ({ワークスペース名})`（例: `ai-zyusetu-1 (default)`）
- ディレクトリ名とワークスペース名が同じ場合はワークスペース名のみ表示

### コンフリクトリスク

変更は `usePortsData.ts` の1ファイルのみ。バックエンドや型定義は変更なし。

## テスト計画

- [ ] 同名ワークスペースが複数ある場合、Ports セクションのヘッダーが区別可能なこと
- [ ] 異なるワークスペース名の場合は従来通りの表示であること
- [ ] ワークツリーパスがない（ブランチワークスペースの）場合にワークスペース名が表示されること

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workspace names in the Ports section now incorporate the worktree directory name, providing clearer distinction between multiple workspaces with the same name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->