### PR TITLE
Disable window position persistence on Linux Wayland

### DIFF
--- a/apps/desktop/src/main/lib/window-state/bounds-validation.test.ts
+++ b/apps/desktop/src/main/lib/window-state/bounds-validation.test.ts
@@ -302,6 +302,28 @@ describe("getInitialWindowBounds", () => {
 		});
 	});
 
+	describe("position restore disabled", () => {
+		it("should center while preserving saved size when position restore is disabled", () => {
+			const result = getInitialWindowBounds(
+				{
+					x: 100,
+					y: 200,
+					width: 800,
+					height: 600,
+					isMaximized: false,
+				},
+				{ restorePosition: false },
+			);
+
+			expect(result).toEqual({
+				width: 800,
+				height: 600,
+				center: true,
+				isMaximized: false,
+			});
+		});
+	});
+
 	describe("dimension clamping", () => {
 		it("should clamp width to work area size", () => {
 			const result = getInitialWindowBounds({

--- a/apps/desktop/src/main/lib/window-state/bounds-validation.ts
+++ b/apps/desktop/src/main/lib/window-state/bounds-validation.ts
@@ -77,6 +77,10 @@ export interface InitialWindowBounds {
 	isMaximized: boolean;
 }
 
+interface GetInitialWindowBoundsOptions {
+	restorePosition?: boolean;
+}
+
 /**
  * Computes initial window bounds from saved state, with fallbacks.
  *
@@ -86,6 +90,7 @@ export interface InitialWindowBounds {
  */
 export function getInitialWindowBounds(
 	savedState: WindowState | null,
+	options: GetInitialWindowBoundsOptions = {},
 ): InitialWindowBounds {
 	const { workAreaSize } = getScreen().getPrimaryDisplay();
 
@@ -103,6 +108,15 @@ export function getInitialWindowBounds(
 		savedState.width,
 		savedState.height,
 	);
+
+	if (options.restorePosition === false) {
+		return {
+			width,
+			height,
+			center: true,
+			isMaximized: savedState.isMaximized,
+		};
+	}
 
 	const savedBounds: Rectangle = {
 		x: savedState.x,

--- a/apps/desktop/src/main/lib/window-state/index.ts
+++ b/apps/desktop/src/main/lib/window-state/index.ts
@@ -9,3 +9,7 @@ export {
 	saveWindowState,
 	type WindowState,
 } from "./window-state";
+export {
+	isWindowPositionPersistenceEnabled,
+	setWindowStateEnvironmentForTesting,
+} from "./position-persistence";

--- a/apps/desktop/src/main/lib/window-state/position-persistence.test.ts
+++ b/apps/desktop/src/main/lib/window-state/position-persistence.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import {
+	isWindowPositionPersistenceEnabled,
+	setWindowStateEnvironmentForTesting,
+} from "./position-persistence";
+
+afterEach(() => {
+	setWindowStateEnvironmentForTesting(null);
+});
+
+describe("isWindowPositionPersistenceEnabled", () => {
+	it("should disable position persistence on Linux Wayland", () => {
+		setWindowStateEnvironmentForTesting({
+			platform: "linux",
+			env: {
+				XDG_SESSION_TYPE: "wayland",
+			},
+		});
+
+		expect(isWindowPositionPersistenceEnabled()).toBe(false);
+	});
+
+	it("should disable position persistence when WAYLAND_DISPLAY is set", () => {
+		setWindowStateEnvironmentForTesting({
+			platform: "linux",
+			env: {
+				WAYLAND_DISPLAY: "wayland-1",
+			},
+		});
+
+		expect(isWindowPositionPersistenceEnabled()).toBe(false);
+	});
+
+	it("should keep position persistence on Linux X11", () => {
+		setWindowStateEnvironmentForTesting({
+			platform: "linux",
+			env: {
+				XDG_SESSION_TYPE: "x11",
+			},
+		});
+
+		expect(isWindowPositionPersistenceEnabled()).toBe(true);
+	});
+
+	it("should keep position persistence on non-Linux platforms", () => {
+		setWindowStateEnvironmentForTesting({
+			platform: "darwin",
+			env: {
+				XDG_SESSION_TYPE: "wayland",
+			},
+		});
+
+		expect(isWindowPositionPersistenceEnabled()).toBe(true);
+	});
+});

--- a/apps/desktop/src/main/lib/window-state/position-persistence.ts
+++ b/apps/desktop/src/main/lib/window-state/position-persistence.ts
@@ -1,0 +1,29 @@
+let platformOverride: NodeJS.Platform | null = null;
+let envOverride: NodeJS.ProcessEnv | null = null;
+
+function getPlatform(): NodeJS.Platform {
+	return platformOverride ?? process.platform;
+}
+
+function getEnv(): NodeJS.ProcessEnv {
+	return envOverride ?? process.env;
+}
+
+export function setWindowStateEnvironmentForTesting(
+	override:
+		| {
+				platform?: NodeJS.Platform;
+				env?: NodeJS.ProcessEnv;
+		  }
+		| null,
+): void {
+	platformOverride = override?.platform ?? null;
+	envOverride = override?.env ?? null;
+}
+
+export function isWindowPositionPersistenceEnabled(): boolean {
+	if (getPlatform() !== "linux") return true;
+
+	const env = getEnv();
+	return env.XDG_SESSION_TYPE !== "wayland" && !env.WAYLAND_DISPLAY;
+}

--- a/apps/desktop/src/main/windows/main.ts
+++ b/apps/desktop/src/main/windows/main.ts
@@ -32,6 +32,7 @@ import {
 import { windowManager } from "../lib/window-manager";
 import {
 	getInitialWindowBounds,
+	isWindowPositionPersistenceEnabled,
 	loadWindowState,
 	saveWindowState,
 } from "../lib/window-state";
@@ -113,8 +114,11 @@ app.on("child-process-gone", (_event, details) => {
 });
 
 export async function MainWindow() {
+	const shouldPersistWindowPosition = isWindowPositionPersistenceEnabled();
 	const savedWindowState = loadWindowState();
-	const initialBounds = getInitialWindowBounds(savedWindowState);
+	const initialBounds = getInitialWindowBounds(savedWindowState, {
+		restorePosition: shouldPersistWindowPosition,
+	});
 	let persistedZoomLevel = savedWindowState?.zoomLevel;
 
 	const isDev = env.NODE_ENV === "development";
@@ -257,28 +261,36 @@ export async function MainWindow() {
 	let initialized = false;
 	let hasCompletedFirstLoad = false;
 	let saveTimeout: ReturnType<typeof setTimeout> | null = null;
+
+	const getWindowStateSnapshot = () => {
+		const isMaximized = window.isMaximized();
+		const bounds = isMaximized
+			? window.getNormalBounds()
+			: window.getBounds();
+		const zoomLevel = window.webContents.getZoomLevel();
+		return {
+			x: shouldPersistWindowPosition ? bounds.x : 0,
+			y: shouldPersistWindowPosition ? bounds.y : 0,
+			width: bounds.width,
+			height: bounds.height,
+			isMaximized,
+			zoomLevel,
+		};
+	};
+
 	const debouncedSave = () => {
 		if (!initialized || window.isDestroyed()) return;
 		if (saveTimeout) clearTimeout(saveTimeout);
 		saveTimeout = setTimeout(() => {
 			if (window.isDestroyed()) return;
-			const isMaximized = window.isMaximized();
-			const bounds = isMaximized
-				? window.getNormalBounds()
-				: window.getBounds();
-			const zoomLevel = window.webContents.getZoomLevel();
-			saveWindowState({
-				x: bounds.x,
-				y: bounds.y,
-				width: bounds.width,
-				height: bounds.height,
-				isMaximized,
-				zoomLevel,
-			});
-			persistedZoomLevel = zoomLevel;
+			const state = getWindowStateSnapshot();
+			saveWindowState(state);
+			persistedZoomLevel = state.zoomLevel;
 		}, 500);
 	};
-	window.on("move", debouncedSave);
+	if (shouldPersistWindowPosition) {
+		window.on("move", debouncedSave);
+	}
 	window.on("resize", debouncedSave);
 	window.webContents.on("zoom-changed", () => {
 		setTimeout(() => {
@@ -361,18 +373,9 @@ export async function MainWindow() {
 			isVisible: window.isVisible(),
 		});
 		// Save window state first, before any cleanup
-		const isMaximized = window.isMaximized();
-		const bounds = isMaximized ? window.getNormalBounds() : window.getBounds();
-		const zoomLevel = window.webContents.getZoomLevel();
-		saveWindowState({
-			x: bounds.x,
-			y: bounds.y,
-			width: bounds.width,
-			height: bounds.height,
-			isMaximized,
-			zoomLevel,
-		});
-		persistedZoomLevel = zoomLevel;
+		const state = getWindowStateSnapshot();
+		saveWindowState(state);
+		persistedZoomLevel = state.zoomLevel;
 
 		browserManager.unregisterAll();
 		server.close();


### PR DESCRIPTION
## Summary
- disable saved window position restore on Linux Wayland
- keep restoring size, maximized state, and zoom level
- add tests for the Wayland-specific persistence behavior

## Testing
- bun test apps/desktop/src/main/lib/window-state/bounds-validation.test.ts apps/desktop/src/main/lib/window-state/position-persistence.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Window position restoration now respects environment-specific settings and can be configured or automatically disabled based on system conditions.

* **Improvements**
  * Window zoom level persistence is maintained independently of position persistence behavior across all supported platforms.

* **Tests**
  * Added comprehensive test coverage for window state persistence across different platform and environment configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->