### PR TITLE
feat(desktop): add syntax highlighting for .env, CSV, TSV

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/components/CodeEditor/loadLanguageSupport.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/components/CodeEditor/loadLanguageSupport.ts
@@ -1,8 +1,10 @@
 import { StreamLanguage, type StreamParser } from "@codemirror/language";
 import type { Extension } from "@codemirror/state";
 import {
+	csvStreamLanguage,
 	graphqlStreamLanguage,
 	makefileStreamLanguage,
+	tsvStreamLanguage,
 } from "./streamLanguages";
 
 async function loadLegacyLanguage(
@@ -130,6 +132,15 @@ export async function loadLanguageSupport(
 				() => import("@codemirror/legacy-modes/mode/clike"),
 				"kotlin",
 			);
+		case "dotenv":
+			return loadLegacyLanguage(
+				() => import("@codemirror/legacy-modes/mode/properties"),
+				"properties",
+			);
+		case "csv":
+			return StreamLanguage.define(csvStreamLanguage);
+		case "tsv":
+			return StreamLanguage.define(tsvStreamLanguage);
 		default:
 			return null;
 	}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/components/CodeEditor/streamLanguages.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/components/CodeEditor/streamLanguages.ts
@@ -163,9 +163,7 @@ interface CsvState {
 	inQuote: boolean;
 }
 
-function createCsvStreamLanguage(
-	delimiter: string,
-): StreamParser<CsvState> {
+function createCsvStreamLanguage(delimiter: string): StreamParser<CsvState> {
 	return {
 		name: delimiter === "\t" ? "tsv" : "csv",
 		startState: () => ({ column: 0, inQuote: false }),

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/components/CodeEditor/streamLanguages.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/components/CodeEditor/streamLanguages.ts
@@ -141,6 +141,107 @@ export const graphqlStreamLanguage: StreamParser<GraphqlState> = {
 	},
 };
 
+// ---------------------------------------------------------------------------
+// CSV / TSV
+// ---------------------------------------------------------------------------
+
+/**
+ * Column tags cycle through existing syntax highlight token types so that each
+ * column gets a distinct color from the theme without any extra CSS.
+ */
+const COLUMN_TAGS = [
+	"string",
+	"keyword",
+	"typeName",
+	"variableName",
+	"number",
+	"className",
+] as const;
+
+interface CsvState {
+	column: number;
+	inQuote: boolean;
+}
+
+function createCsvStreamLanguage(
+	delimiter: string,
+): StreamParser<CsvState> {
+	return {
+		name: delimiter === "\t" ? "tsv" : "csv",
+		startState: () => ({ column: 0, inQuote: false }),
+		token(stream, state) {
+			// Start of line resets column
+			if (stream.sol()) {
+				state.column = 0;
+				state.inQuote = false;
+			}
+
+			const tag = COLUMN_TAGS[state.column % COLUMN_TAGS.length];
+
+			// Inside a quoted field
+			if (state.inQuote) {
+				while (!stream.eol()) {
+					if (stream.next() === '"') {
+						// Escaped quote ("") → stay in quote
+						if (stream.peek() === '"') {
+							stream.next();
+						} else {
+							state.inQuote = false;
+							// Consume trailing delimiter if present
+							if (stream.peek() === delimiter) {
+								stream.next();
+								state.column++;
+							}
+							return tag;
+						}
+					}
+				}
+				return tag;
+			}
+
+			// Opening quote at start of field
+			if (stream.peek() === '"') {
+				stream.next();
+				state.inQuote = true;
+				// Consume until closing quote or end of line
+				while (!stream.eol()) {
+					if (stream.next() === '"') {
+						if (stream.peek() === '"') {
+							stream.next();
+						} else {
+							state.inQuote = false;
+							if (stream.peek() === delimiter) {
+								stream.next();
+								state.column++;
+							}
+							return tag;
+						}
+					}
+				}
+				return tag;
+			}
+
+			// Unquoted field — consume until delimiter or eol
+			while (!stream.eol()) {
+				if (stream.peek() === delimiter) {
+					stream.next();
+					state.column++;
+					return tag;
+				}
+				stream.next();
+			}
+			return tag;
+		},
+	};
+}
+
+export const csvStreamLanguage = createCsvStreamLanguage(",");
+export const tsvStreamLanguage = createCsvStreamLanguage("\t");
+
+// ---------------------------------------------------------------------------
+// Makefile
+// ---------------------------------------------------------------------------
+
 const MAKEFILE_DIRECTIVES = new Set([
 	"-include",
 	"define",

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/components/CodeEditor/streamLanguages.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/components/CodeEditor/streamLanguages.ts
@@ -171,9 +171,8 @@ function createCsvStreamLanguage(
 		startState: () => ({ column: 0, inQuote: false }),
 		token(stream, state) {
 			// Start of line resets column
-			if (stream.sol()) {
+			if (stream.sol() && !state.inQuote) {
 				state.column = 0;
-				state.inQuote = false;
 			}
 
 			const tag = COLUMN_TAGS[state.column % COLUMN_TAGS.length];

--- a/apps/desktop/src/shared/detect-language.ts
+++ b/apps/desktop/src/shared/detect-language.ts
@@ -11,6 +11,10 @@ export function detectLanguage(filePath: string): string {
 		return "dockerfile";
 	}
 
+	if (fileName === ".env" || fileName.startsWith(".env.")) {
+		return "dotenv";
+	}
+
 	const languageMap: Record<string, string> = {
 		// JavaScript/TypeScript
 		ts: "typescript",
@@ -35,6 +39,8 @@ export function detectLanguage(filePath: string): string {
 		yml: "yaml",
 		xml: "xml",
 		toml: "toml",
+		csv: "csv",
+		tsv: "tsv",
 
 		// Markdown/Documentation
 		md: "markdown",


### PR DESCRIPTION
## Summary
- `.env` / `.env.*` ファイルのシンタックスハイライト対応（`@codemirror/legacy-modes/mode/properties`）
- CSV / TSV ファイルのシンタックスハイライト対応（カスタム StreamParser、列ごとにテーマカラーをローテーション）

## Changes
- `detect-language.ts` — `.env`, `.csv`, `.tsv` の言語検出を追加
- `loadLanguageSupport.ts` — `dotenv`, `csv`, `tsv` の CodeMirror 言語サポートを追加
- `streamLanguages.ts` — CSV/TSV 用カスタム StreamParser を追加（クォートフィールド対応）

## Test plan
- [ ] `.env` ファイルを開き、`KEY=VALUE` とコメント `#` がハイライトされることを確認
- [ ] `.env.local`, `.env.production` 等も同様にハイライトされることを確認
- [ ] `.csv` ファイルを開き、列ごとに異なる色でハイライトされることを確認
- [ ] `.tsv` ファイルを開き、タブ区切りで列ごとに色分けされることを確認
- [ ] クォートフィールド（`"hello, world"`）が正しく1つのフィールドとして扱われることを確認
- [ ] ライト/ダークテーマ両方で色が適切に表示されることを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * コードエディタでCSV・TSVファイルのサポートを追加しました。
  * .envファイルの言語検出機能を追加しました。
  * これらのファイル形式に対して構文ハイライト機能を提供します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->