### PR TITLE
fix(desktop): webview GUEST_VIEW_MANAGER_CALL エラーを Sentry からフィルタ

### DIFF
--- a/apps/desktop/src/renderer/lib/sentry.ts
+++ b/apps/desktop/src/renderer/lib/sentry.ts
@@ -17,6 +17,15 @@ export async function initSentry(): Promise<void> {
 			dsn: env.SENTRY_DSN_DESKTOP,
 			environment: env.NODE_ENV,
 			tracesSampleRate: 0.1,
+			beforeSend(event) {
+				const message = event.exception?.values?.[0]?.value ?? "";
+				// Webview navigation errors (ERR_ABORTED, ERR_CONNECTION_REFUSED, etc.)
+				// are external-site issues, not actionable app bugs.
+				if (message.includes("GUEST_VIEW_MANAGER_CALL")) {
+					return null;
+				}
+				return event;
+			},
 		});
 
 		sentryInitialized = true;


### PR DESCRIPTION
## 概要
- 内蔵ブラウザ(webview)で外部サイト閲覧中、サイト側のリダイレクト等で `ERR_ABORTED` / `ERR_CONNECTION_REFUSED` が発生
- これが Electron 内部の `GUEST_VIEW_MANAGER_CALL` として unhandled rejection になり Sentry に送信されていた
- アプリのバグではなく外部サイト起因のため、renderer の Sentry init に `beforeSend` フィルタを追加してドロップ

## 関連 Issue
Fixes ELECTRON-M (22件), ELECTRON-W (2件)

## テスト計画
- [ ] リダイレクトが発生する外部サイトを webview で開く
- [ ] Sentry に GUEST_VIEW_MANAGER_CALL エラーが送信されないことを確認
- [ ] 他のエラーは正常に報告されることを確認