### PR TITLE
fix(desktop): git status ワーカーに個別タイムアウトを追加

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/changes/status.ts
+++ b/apps/desktop/src/lib/trpc/routers/changes/status.ts
@@ -53,7 +53,7 @@ export const createStatusRouter = () => {
 							{
 								dedupeKey: cacheKey,
 								strategy: "coalesce",
-								timeoutMs: 45_000,
+								timeoutMs: 90_000,
 							},
 						);
 

--- a/apps/desktop/src/lib/trpc/routers/changes/utils/apply-numstat.ts
+++ b/apps/desktop/src/lib/trpc/routers/changes/utils/apply-numstat.ts
@@ -1,6 +1,9 @@
 import type { ChangedFile } from "shared/changes-types";
 import type { SimpleGit } from "simple-git";
 import { parseDiffNumstat } from "./parse-status";
+import { withTimeout } from "./with-timeout";
+
+const NUMSTAT_TIMEOUT_MS = 15_000;
 
 export async function applyNumstatToFiles(
 	git: SimpleGit,
@@ -9,20 +12,12 @@ export async function applyNumstatToFiles(
 ): Promise<void> {
 	if (files.length === 0) return;
 
-	const NUMSTAT_TIMEOUT_MS = 15_000;
 	try {
-		const numstat = await Promise.race([
+		const numstat = await withTimeout(
 			git.raw(diffArgs),
-			new Promise<never>((_, reject) =>
-				setTimeout(
-					() =>
-						reject(
-							new Error(`numstat timed out after ${NUMSTAT_TIMEOUT_MS}ms`),
-						),
-					NUMSTAT_TIMEOUT_MS,
-				),
-			),
-		]);
+			NUMSTAT_TIMEOUT_MS,
+			"diff numstat",
+		);
 		const stats = parseDiffNumstat(numstat);
 
 		for (const file of files) {

--- a/apps/desktop/src/lib/trpc/routers/changes/utils/apply-numstat.ts
+++ b/apps/desktop/src/lib/trpc/routers/changes/utils/apply-numstat.ts
@@ -9,8 +9,20 @@ export async function applyNumstatToFiles(
 ): Promise<void> {
 	if (files.length === 0) return;
 
+	const NUMSTAT_TIMEOUT_MS = 15_000;
 	try {
-		const numstat = await git.raw(diffArgs);
+		const numstat = await Promise.race([
+			git.raw(diffArgs),
+			new Promise<never>((_, reject) =>
+				setTimeout(
+					() =>
+						reject(
+							new Error(`numstat timed out after ${NUMSTAT_TIMEOUT_MS}ms`),
+						),
+					NUMSTAT_TIMEOUT_MS,
+				),
+			),
+		]);
 		const stats = parseDiffNumstat(numstat);
 
 		for (const file of files) {

--- a/apps/desktop/src/lib/trpc/routers/changes/utils/with-timeout.ts
+++ b/apps/desktop/src/lib/trpc/routers/changes/utils/with-timeout.ts
@@ -1,0 +1,25 @@
+/**
+ * Race a promise against a timeout. Clears the timer on both resolve and reject
+ * to avoid leaked timers.
+ */
+export function withTimeout<T>(
+	promise: Promise<T>,
+	ms: number,
+	label: string,
+): Promise<T> {
+	return new Promise<T>((resolve, reject) => {
+		const timer = setTimeout(() => {
+			reject(new Error(`git operation timed out after ${ms}ms: ${label}`));
+		}, ms);
+		promise.then(
+			(value) => {
+				clearTimeout(timer);
+				resolve(value);
+			},
+			(error) => {
+				clearTimeout(timer);
+				reject(error);
+			},
+		);
+	});
+}

--- a/apps/desktop/src/lib/trpc/routers/changes/workers/git-task-handlers.ts
+++ b/apps/desktop/src/lib/trpc/routers/changes/workers/git-task-handlers.ts
@@ -38,6 +38,34 @@ const MAX_LINE_COUNT_SIZE = 1 * 1024 * 1024;
 const MAX_UNTRACKED_LINE_COUNT_FILES = 200;
 const WORKER_DEBUG = process.env.SUPERSET_WORKER_DEBUG === "1";
 
+/**
+ * Per-operation timeout for individual git commands.
+ * Prevents a single slow operation from consuming the entire task budget.
+ */
+const GIT_OP_TIMEOUT_MS = 15_000;
+
+function withTimeout<T>(
+	promise: Promise<T>,
+	ms: number,
+	label: string,
+): Promise<T> {
+	return new Promise<T>((resolve, reject) => {
+		const timer = setTimeout(() => {
+			reject(new Error(`git operation timed out after ${ms}ms: ${label}`));
+		}, ms);
+		promise.then(
+			(value) => {
+				clearTimeout(timer);
+				resolve(value);
+			},
+			(error) => {
+				clearTimeout(timer);
+				reject(error);
+			},
+		);
+	});
+}
+
 function logWorkerWarning(message: string, error: unknown): void {
 	console.warn(`[changes-git-worker] ${message}`, error);
 }
@@ -127,30 +155,38 @@ async function getBranchComparison(
 	let behind = 0;
 
 	try {
-		const tracking = await git.raw([
-			"rev-list",
-			"--left-right",
-			"--count",
-			`origin/${defaultBranch}...HEAD`,
-		]);
+		const tracking = await withTimeout(
+			git.raw([
+				"rev-list",
+				"--left-right",
+				"--count",
+				`origin/${defaultBranch}...HEAD`,
+			]),
+			GIT_OP_TIMEOUT_MS,
+			"rev-list count",
+		);
 		const [behindStr, aheadStr] = tracking.trim().split(/\s+/);
 		behind = Number.parseInt(behindStr || "0", 10);
 		ahead = Number.parseInt(aheadStr || "0", 10);
 
-		const logOutput = await git.raw([
-			"log",
-			`origin/${defaultBranch}..HEAD`,
-			"--max-count=500",
-			"--format=%H|%h|%s|%an|%aI",
-		]);
+		const logOutput = await withTimeout(
+			git.raw([
+				"log",
+				`origin/${defaultBranch}..HEAD`,
+				"--max-count=500",
+				"--format=%H|%h|%s|%an|%aI",
+			]),
+			GIT_OP_TIMEOUT_MS,
+			"log commits",
+		);
 		commits = parseGitLog(logOutput);
 
 		if (ahead > 0) {
-			const nameStatus = await git.raw([
-				"diff",
-				"--name-status",
-				`origin/${defaultBranch}...HEAD`,
-			]);
+			const nameStatus = await withTimeout(
+				git.raw(["diff", "--name-status", `origin/${defaultBranch}...HEAD`]),
+				GIT_OP_TIMEOUT_MS,
+				"diff name-status",
+			);
 			againstBase = parseNameStatus(nameStatus);
 
 			await applyNumstatToFiles(git, againstBase, [
@@ -173,21 +209,20 @@ async function getTrackingBranchStatus(
 	git: SimpleGit,
 ): Promise<TrackingStatus> {
 	try {
-		const upstream = await git.raw([
-			"rev-parse",
-			"--abbrev-ref",
-			"@{upstream}",
-		]);
+		const upstream = await withTimeout(
+			git.raw(["rev-parse", "--abbrev-ref", "@{upstream}"]),
+			GIT_OP_TIMEOUT_MS,
+			"rev-parse upstream",
+		);
 		if (!upstream.trim()) {
 			return { pushCount: 0, pullCount: 0, hasUpstream: false };
 		}
 
-		const tracking = await git.raw([
-			"rev-list",
-			"--left-right",
-			"--count",
-			"@{upstream}...HEAD",
-		]);
+		const tracking = await withTimeout(
+			git.raw(["rev-list", "--left-right", "--count", "@{upstream}...HEAD"]),
+			GIT_OP_TIMEOUT_MS,
+			"rev-list tracking",
+		);
 		const [pullStr, pushStr] = tracking.trim().split(/\s+/);
 		return {
 			pushCount: Number.parseInt(pushStr || "0", 10),

--- a/apps/desktop/src/lib/trpc/routers/changes/workers/git-task-handlers.ts
+++ b/apps/desktop/src/lib/trpc/routers/changes/workers/git-task-handlers.ts
@@ -15,6 +15,7 @@ import {
 	parseGitStatus,
 	parseNameStatus,
 } from "../utils/parse-status";
+import { withTimeout } from "../utils/with-timeout";
 import type {
 	GitTaskPayloadMap,
 	GitTaskResultMap,
@@ -43,28 +44,6 @@ const WORKER_DEBUG = process.env.SUPERSET_WORKER_DEBUG === "1";
  * Prevents a single slow operation from consuming the entire task budget.
  */
 const GIT_OP_TIMEOUT_MS = 15_000;
-
-function withTimeout<T>(
-	promise: Promise<T>,
-	ms: number,
-	label: string,
-): Promise<T> {
-	return new Promise<T>((resolve, reject) => {
-		const timer = setTimeout(() => {
-			reject(new Error(`git operation timed out after ${ms}ms: ${label}`));
-		}, ms);
-		promise.then(
-			(value) => {
-				clearTimeout(timer);
-				resolve(value);
-			},
-			(error) => {
-				clearTimeout(timer);
-				reject(error);
-			},
-		);
-	});
-}
 
 function logWorkerWarning(message: string, error: unknown): void {
 	console.warn(`[changes-git-worker] ${message}`, error);


### PR DESCRIPTION
## 概要
- changes ワーカー内の個別 git コマンド (`rev-list`, `log`, `diff --numstat`) にタイムアウトがなかった
- 単一の遅いコマンド(例: 深い履歴の `rev-list`)が全体の 45 秒枠を消費してタイムアウトエラーになっていた
- `withTimeout` ヘルパーを共通ユーティリティとして切り出し、各 git 操作に 15 秒の個別タイムアウトを設定
- 全体タイムアウトを 45 秒 → 90 秒に延長
- `applyNumstatToFiles` の `Promise.race` による `clearTimeout` 漏れも修正

## 関連 Issue
Fixes ELECTRON-A (12件)

## テスト計画
- [ ] 大規模リポジトリ・深いブランチ履歴のワークスペースで git status が読み込まれることを確認
- [ ] 個別操作がタイムアウトしても部分的な結果が返ることを確認
- [ ] Sentry に "timed out after 45000ms" エラーが出なくなることを確認