### PR TITLE
fix(desktop): 認証切れ時の React 無限ループを防止

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/layout.tsx
@@ -56,6 +56,7 @@ function AuthenticatedLayout() {
 	const setOriginRoute = useSettingsStore((s) => s.setOriginRoute);
 	const utils = electronTrpc.useUtils();
 	const shownWorkspaceInitWarningsRef = useRef(new Set<string>());
+	const redirectingToSignIn = useRef(false);
 	const isV2CloudEnabled =
 		useFeatureFlagEnabled(FEATURE_FLAGS.V2_CLOUD) ?? false;
 
@@ -136,8 +137,27 @@ function AuthenticatedLayout() {
 		},
 	});
 
+	// Redirect to sign-in via useEffect to avoid React infinite update loops.
+	// <Navigate> can re-trigger during concurrent renders when already at the
+	// target URL, causing router.load() → setState → re-render cycles.
+	const shouldRedirectToSignIn =
+		(!env.SKIP_ENV_VALIDATION && isPending && !hasLocalToken) ||
+		(!isSignedIn &&
+			!(hasLocalToken && !isOnline) &&
+			!(isPending || (isRefetching && !session?.user && hasLocalToken)));
+
+	useEffect(() => {
+		if (shouldRedirectToSignIn && !redirectingToSignIn.current) {
+			redirectingToSignIn.current = true;
+			void navigate({ to: "/sign-in", replace: true });
+		}
+		if (!shouldRedirectToSignIn) {
+			redirectingToSignIn.current = false;
+		}
+	}, [shouldRedirectToSignIn, navigate]);
+
 	if (isPending && !hasLocalToken && !env.SKIP_ENV_VALIDATION) {
-		return <Navigate to="/sign-in" replace />;
+		return null;
 	}
 	if (
 		(isPending || (isRefetching && !session?.user && hasLocalToken)) &&
@@ -168,7 +188,7 @@ function AuthenticatedLayout() {
 	}
 
 	if (!isSignedIn) {
-		return <Navigate to="/sign-in" replace />;
+		return null;
 	}
 
 	if (!activeOrganizationId) {


### PR DESCRIPTION
## 概要
- 認証トークン期限切れ時、`_authenticated/layout.tsx` が `<Navigate to="/sign-in">` をレンダリング
- concurrent render 中に同じ URL への navigate が複数回発火し、`router.load()` → `setState` → 再レンダリングの無限ループが発生
- 宣言的な `<Navigate>` を `useEffect` + ref ガードに置き換え、ナビゲーションを1回だけ実行するよう修正

## 根本原因分析
Sentry breadcrumbs: Electric proxy が 401 返却 → 認証状態変更 → レイアウト再レンダリング → `<Navigate to="/sign-in">` が遷移中に再度発火 → 同じ URL への navigate で `isSameUrl` 判定 → `router.load()` → 無限ループ

## 関連 Issue
Fixes ELECTRON-B (4件)

## テスト計画
- [ ] ワークスペースページで認証を期限切れにする（またはサインアウト）
- [ ] sign-in ページにフリーズなくリダイレクトされることを確認
- [ ] 通常のサインインフローが正常に動作することを確認