### PR TITLE
feat: Docker タブ UX 改善 & HTML ファイルプレビュー

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/docker/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/docker/index.ts
@@ -398,7 +398,11 @@ export const createDockerRouter = () => {
 			}),
 
 		startProject: publicProcedure
-			.input(composeActionInput)
+			.input(
+				composeActionInput.extend({
+					rebuild: z.boolean().optional(),
+				}),
+			)
 			.mutation(async ({ input }) => {
 				const composeFile = await resolveComposeFileForWorkspace(
 					input.workspaceId,
@@ -406,10 +410,17 @@ export const createDockerRouter = () => {
 				);
 
 				try {
-					await execDocker(
-						["compose", "-f", composeFile.absolutePath, "up", "-d"],
-						{ cwd: composeFile.directoryPath },
-					);
+					const args = [
+						"compose",
+						"-f",
+						composeFile.absolutePath,
+						"up",
+						"-d",
+					];
+					if (input.rebuild) {
+						args.push("--build", "--force-recreate");
+					}
+					await execDocker(args, { cwd: composeFile.directoryPath });
 					return { success: true };
 				} catch (error) {
 					normalizeExecError(error);
@@ -427,6 +438,27 @@ export const createDockerRouter = () => {
 				try {
 					await execDocker(
 						["compose", "-f", composeFile.absolutePath, "stop"],
+						{
+							cwd: composeFile.directoryPath,
+						},
+					);
+					return { success: true };
+				} catch (error) {
+					normalizeExecError(error);
+				}
+			}),
+
+		removeProject: publicProcedure
+			.input(composeActionInput)
+			.mutation(async ({ input }) => {
+				const composeFile = await resolveComposeFileForWorkspace(
+					input.workspaceId,
+					input.composeFilePath,
+				);
+
+				try {
+					await execDocker(
+						["compose", "-f", composeFile.absolutePath, "down"],
 						{
 							cwd: composeFile.directoryPath,
 						},

--- a/apps/desktop/src/lib/trpc/routers/docker/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/docker/index.ts
@@ -410,13 +410,7 @@ export const createDockerRouter = () => {
 				);
 
 				try {
-					const args = [
-						"compose",
-						"-f",
-						composeFile.absolutePath,
-						"up",
-						"-d",
-					];
+					const args = ["compose", "-f", composeFile.absolutePath, "up", "-d"];
 					if (input.rebuild) {
 						args.push("--build", "--force-recreate");
 					}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/FileViewerPane.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/FileViewerPane.tsx
@@ -38,7 +38,7 @@ import {
 	retargetAbsolutePath,
 	toAbsoluteWorkspacePath,
 } from "shared/absolute-paths";
-import { isImageFile, isMarkdownFile } from "shared/file-types";
+import { isHtmlFile, isImageFile, isMarkdownFile } from "shared/file-types";
 import type { FileViewerMode } from "shared/tabs-types";
 import type { CodeEditorAdapter } from "../../../components";
 import { BasePaneWindow } from "../components";
@@ -620,7 +620,8 @@ export function FileViewerPane({
 
 		return "";
 	}, [currentDocumentContent, documentKey, rawFileData]);
-	const hasRenderedMode = isMarkdownFile(filePath) || isImageFile(filePath);
+	const hasRenderedMode =
+		isMarkdownFile(filePath) || isImageFile(filePath) || isHtmlFile(filePath);
 	const hasDiff = !!diffCategory;
 	const unsavedDialogCopy = getUnsavedDialogCopy(
 		session?.pendingIntent ?? null,

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/components/FileViewerContent/FileViewerContent.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/components/FileViewerContent/FileViewerContent.tsx
@@ -17,7 +17,7 @@ import type { Tab } from "renderer/stores/tabs/types";
 import { pathsMatch, toAbsoluteWorkspacePath } from "shared/absolute-paths";
 import type { DiffViewMode } from "shared/changes-types";
 import { detectLanguage } from "shared/detect-language";
-import { isImageFile, isSpreadsheetFile } from "shared/file-types";
+import { isHtmlFile, isImageFile, isSpreadsheetFile } from "shared/file-types";
 import type { FileViewerMode } from "shared/tabs-types";
 import { useScrollToFirstDiffChange } from "../../hooks/useScrollToFirstDiffChange";
 import { CodeMirrorDiffViewer } from "../CodeMirrorDiffViewer";
@@ -32,6 +32,41 @@ import {
 	getDiffLocationFromEvent,
 	mapDiffLocationToRawPosition,
 } from "./utils/diff-location";
+
+function HtmlPreviewWebview({ absolutePath }: { absolutePath: string }) {
+	const containerRef = useRef<HTMLDivElement>(null);
+
+	useEffect(() => {
+		const container = containerRef.current;
+		if (!container || !absolutePath) return;
+
+		const webview = document.createElement("webview") as Electron.WebviewTag;
+		webview.src = `file://${absolutePath}`;
+		webview.setAttribute("webpreferences", "sandbox=true,nodeIntegration=false,contextIsolation=true");
+		webview.style.width = "100%";
+		webview.style.height = "100%";
+		webview.style.border = "none";
+
+		webview.addEventListener("will-navigate", (e) => {
+			e.preventDefault();
+		});
+
+		container.appendChild(webview);
+
+		return () => {
+			try {
+				if (webview.isConnected) {
+					webview.stop();
+				}
+				container.removeChild(webview);
+			} catch {
+				// already removed
+			}
+		};
+	}, [absolutePath]);
+
+	return <div ref={containerRef} className="h-full w-full bg-white" />;
+}
 
 interface RawFileData {
 	ok: true;
@@ -183,6 +218,7 @@ export function FileViewerContent({
 	markdownSearch,
 }: FileViewerContentProps) {
 	const isImage = isImageFile(filePath);
+	const isHtml = isHtmlFile(filePath);
 
 	useScrollToFirstDiffChange({
 		containerRef: diffContainerRef,
@@ -471,6 +507,31 @@ export function FileViewerContent({
 					</div>
 				</div>
 			</DiffViewerContextMenu>
+		);
+	}
+
+	if (viewMode === "rendered" && isHtml) {
+		if (isLoadingRaw) {
+			return (
+				<div className="flex h-full items-center justify-center text-muted-foreground">
+					Loading...
+				</div>
+			);
+		}
+
+		if (!rawFileData?.ok) {
+			return (
+				<div className="flex h-full items-center justify-center text-muted-foreground">
+					Cannot preview this file
+				</div>
+			);
+		}
+
+		return (
+			<HtmlPreviewWebview
+				key={filePath}
+				absolutePath={absoluteFilePath}
+			/>
 		);
 	}
 

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/components/FileViewerContent/FileViewerContent.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/components/FileViewerContent/FileViewerContent.tsx
@@ -42,7 +42,10 @@ function HtmlPreviewWebview({ absolutePath }: { absolutePath: string }) {
 
 		const webview = document.createElement("webview") as Electron.WebviewTag;
 		webview.src = `file://${absolutePath}`;
-		webview.setAttribute("webpreferences", "sandbox=true,nodeIntegration=false,contextIsolation=true");
+		webview.setAttribute(
+			"webpreferences",
+			"sandbox=true,nodeIntegration=false,contextIsolation=true",
+		);
 		webview.style.width = "100%";
 		webview.style.height = "100%";
 		webview.style.border = "none";
@@ -528,10 +531,7 @@ export function FileViewerContent({
 		}
 
 		return (
-			<HtmlPreviewWebview
-				key={filePath}
-				absolutePath={absoluteFilePath}
-			/>
+			<HtmlPreviewWebview key={filePath} absolutePath={absoluteFilePath} />
 		);
 	}
 

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/DockerView/DockerView.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/DockerView/DockerView.tsx
@@ -12,15 +12,22 @@ import {
 } from "@superset/ui/dialog";
 import { ScrollArea, ScrollBar } from "@superset/ui/scroll-area";
 import { toast } from "@superset/ui/sonner";
+import {
+	Tooltip,
+	TooltipContent,
+	TooltipTrigger,
+} from "@superset/ui/tooltip";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import {
 	LuBox,
 	LuBug,
 	LuChevronRight,
+	LuLoaderCircle,
 	LuPlay,
 	LuRefreshCw,
 	LuSquareTerminal,
 	LuSquareX,
+	LuTrash2,
 } from "react-icons/lu";
 import type { ElectronRouterOutputs } from "renderer/lib/electron-trpc";
 import { electronTrpc } from "renderer/lib/electron-trpc";
@@ -116,26 +123,62 @@ export function DockerView({ isActive = true }: DockerViewProps) {
 	}, [utils, workspaceId]);
 
 	const startProjectMutation = electronTrpc.docker.startProject.useMutation({
-		onSuccess: () => {
+		onMutate: (variables) => {
+			const message = variables.rebuild
+				? "コンテナをリビルド中..."
+				: "コンテナを起動中...";
+			return { toastId: toast.loading(message) };
+		},
+		onSuccess: (_data, variables, context) => {
+			const message = variables.rebuild
+				? "リビルドが完了しました"
+				: "起動しました";
+			toast.success(message, { id: context?.toastId });
 			void invalidateDockerQueries();
 		},
-		onError: (error) => {
-			toast.error("Docker compose up に失敗しました", {
+		onError: (error, variables, context) => {
+			const message = variables.rebuild
+				? "リビルドに失敗しました"
+				: "Docker compose up に失敗しました";
+			toast.error(message, {
+				id: context?.toastId,
 				description: error.message,
 			});
 		},
 	});
 
 	const stopProjectMutation = electronTrpc.docker.stopProject.useMutation({
-		onSuccess: () => {
+		onMutate: () => {
+			return { toastId: toast.loading("コンテナを停止中...") };
+		},
+		onSuccess: (_data, _variables, context) => {
+			toast.success("停止しました", { id: context?.toastId });
 			void invalidateDockerQueries();
 		},
-		onError: (error) => {
+		onError: (error, _variables, context) => {
 			toast.error("Docker compose stop に失敗しました", {
+				id: context?.toastId,
 				description: error.message,
 			});
 		},
 	});
+
+	const removeProjectMutation =
+		electronTrpc.docker.removeProject.useMutation({
+			onMutate: () => {
+				return { toastId: toast.loading("コンテナを削除中...") };
+			},
+			onSuccess: (_data, _variables, context) => {
+				toast.success("削除しました", { id: context?.toastId });
+				void invalidateDockerQueries();
+			},
+			onError: (error, _variables, context) => {
+				toast.error("Docker compose down に失敗しました", {
+					id: context?.toastId,
+					description: error.message,
+				});
+			},
+		});
 
 	const startContainerMutation = electronTrpc.docker.startContainer.useMutation(
 		{
@@ -371,37 +414,126 @@ export function DockerView({ isActive = true }: DockerViewProps) {
 														</div>
 													</button>
 												</CollapsibleTrigger>
-												<div className="flex flex-wrap items-center justify-end gap-1">
-													<Button
-														size="sm"
-														variant="outline"
-														className="h-7 px-2 whitespace-normal"
-														onClick={() =>
-															startProjectMutation.mutate({
-																composeFilePath: group.absolutePath,
-																workspaceId,
-															})
-														}
-														disabled={startProjectMutation.isPending}
-													>
-														<LuPlay className="mr-1 size-3.5" />
-														Up
-													</Button>
-													<Button
-														size="sm"
-														variant="outline"
-														className="h-7 px-2 whitespace-normal"
-														onClick={() =>
-															stopProjectMutation.mutate({
-																composeFilePath: group.absolutePath,
-																workspaceId,
-															})
-														}
-														disabled={stopProjectMutation.isPending}
-													>
-														<LuSquareX className="mr-1 size-3.5" />
-														Stop
-													</Button>
+												<div className="flex items-center gap-1">
+													{(() => {
+														const isAllRunning =
+															group.totalContainers > 0 &&
+															group.runningContainers ===
+																group.totalContainers;
+														const isAllStopped =
+															group.runningContainers === 0;
+														const isStartPending =
+															startProjectMutation.isPending;
+														const isStopPending =
+															stopProjectMutation.isPending;
+														const isRemovePending =
+															removeProjectMutation.isPending;
+														const isBusy =
+															isStartPending ||
+															isStopPending ||
+															isRemovePending;
+
+														return (
+															<>
+																<Tooltip>
+																	<TooltipTrigger asChild>
+																		<Button
+																			size="icon"
+																			variant="outline"
+																			className="size-7"
+																			onClick={() =>
+																				startProjectMutation.mutate({
+																					composeFilePath: group.absolutePath,
+																					workspaceId,
+																				})
+																			}
+																			disabled={isAllRunning || isBusy}
+																		>
+																			{isStartPending ? (
+																				<LuLoaderCircle className="size-3.5 animate-spin" />
+																			) : (
+																				<LuPlay className="size-3.5" />
+																			)}
+																		</Button>
+																	</TooltipTrigger>
+																	<TooltipContent>Up</TooltipContent>
+																</Tooltip>
+																<Tooltip>
+																	<TooltipTrigger asChild>
+																		<Button
+																			size="icon"
+																			variant="outline"
+																			className="size-7"
+																			onClick={() =>
+																				startProjectMutation.mutate({
+																					composeFilePath: group.absolutePath,
+																					workspaceId,
+																					rebuild: true,
+																				})
+																			}
+																			disabled={isBusy}
+																		>
+																			{isStartPending ? (
+																				<LuLoaderCircle className="size-3.5 animate-spin" />
+																			) : (
+																				<LuRefreshCw className="size-3.5" />
+																			)}
+																		</Button>
+																	</TooltipTrigger>
+																	<TooltipContent>Rebuild</TooltipContent>
+																</Tooltip>
+																<Tooltip>
+																	<TooltipTrigger asChild>
+																		<Button
+																			size="icon"
+																			variant="outline"
+																			className="size-7"
+																			onClick={() =>
+																				stopProjectMutation.mutate({
+																					composeFilePath: group.absolutePath,
+																					workspaceId,
+																				})
+																			}
+																			disabled={isAllStopped || isBusy}
+																		>
+																			{isStopPending ? (
+																				<LuLoaderCircle className="size-3.5 animate-spin" />
+																			) : (
+																				<LuSquareX className="size-3.5" />
+																			)}
+																		</Button>
+																	</TooltipTrigger>
+																	<TooltipContent>Stop</TooltipContent>
+																</Tooltip>
+																<Tooltip>
+																	<TooltipTrigger asChild>
+																		<Button
+																			size="icon"
+																			variant="outline"
+																			className="size-7 text-destructive"
+																			onClick={() =>
+																				removeProjectMutation.mutate({
+																					composeFilePath: group.absolutePath,
+																					workspaceId,
+																				})
+																			}
+																			disabled={
+																				(isAllStopped && group.totalContainers === 0) ||
+																				isBusy
+																			}
+																		>
+																			{isRemovePending ? (
+																				<LuLoaderCircle className="size-3.5 animate-spin" />
+																			) : (
+																				<LuTrash2 className="size-3.5" />
+																			)}
+																		</Button>
+																	</TooltipTrigger>
+																	<TooltipContent>Delete</TooltipContent>
+																</Tooltip>
+															</>
+														);
+													})()}
 												</div>
 											</div>
 										</div>

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/DockerView/DockerView.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/DockerView/DockerView.tsx
@@ -12,11 +12,7 @@ import {
 } from "@superset/ui/dialog";
 import { ScrollArea, ScrollBar } from "@superset/ui/scroll-area";
 import { toast } from "@superset/ui/sonner";
-import {
-	Tooltip,
-	TooltipContent,
-	TooltipTrigger,
-} from "@superset/ui/tooltip";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import {
 	LuBox,
@@ -163,22 +159,21 @@ export function DockerView({ isActive = true }: DockerViewProps) {
 		},
 	});
 
-	const removeProjectMutation =
-		electronTrpc.docker.removeProject.useMutation({
-			onMutate: () => {
-				return { toastId: toast.loading("コンテナを削除中...") };
-			},
-			onSuccess: (_data, _variables, context) => {
-				toast.success("削除しました", { id: context?.toastId });
-				void invalidateDockerQueries();
-			},
-			onError: (error, _variables, context) => {
-				toast.error("Docker compose down に失敗しました", {
-					id: context?.toastId,
-					description: error.message,
-				});
-			},
-		});
+	const removeProjectMutation = electronTrpc.docker.removeProject.useMutation({
+		onMutate: () => {
+			return { toastId: toast.loading("コンテナを削除中...") };
+		},
+		onSuccess: (_data, _variables, context) => {
+			toast.success("削除しました", { id: context?.toastId });
+			void invalidateDockerQueries();
+		},
+		onError: (error, _variables, context) => {
+			toast.error("Docker compose down に失敗しました", {
+				id: context?.toastId,
+				description: error.message,
+			});
+		},
+	});
 
 	const startContainerMutation = electronTrpc.docker.startContainer.useMutation(
 		{
@@ -418,14 +413,11 @@ export function DockerView({ isActive = true }: DockerViewProps) {
 													{(() => {
 														const isAllRunning =
 															group.totalContainers > 0 &&
-															group.runningContainers ===
-																group.totalContainers;
-														const isAllStopped =
-															group.runningContainers === 0;
+															group.runningContainers === group.totalContainers;
+														const isAllStopped = group.runningContainers === 0;
 														const isStartPending =
 															startProjectMutation.isPending;
-														const isStopPending =
-															stopProjectMutation.isPending;
+														const isStopPending = stopProjectMutation.isPending;
 														const isRemovePending =
 															removeProjectMutation.isPending;
 														const isBusy =
@@ -518,7 +510,8 @@ export function DockerView({ isActive = true }: DockerViewProps) {
 																				})
 																			}
 																			disabled={
-																				(isAllStopped && group.totalContainers === 0) ||
+																				(isAllStopped &&
+																					group.totalContainers === 0) ||
 																				isBusy
 																			}
 																		>

--- a/apps/desktop/src/renderer/stores/tabs/utils.ts
+++ b/apps/desktop/src/renderer/stores/tabs/utils.ts
@@ -9,11 +9,7 @@ import {
 	type FileStatus,
 	isNewFile,
 } from "shared/changes-types";
-import {
-	hasRenderedPreview,
-	isHtmlFile,
-	isImageFile,
-} from "shared/file-types";
+import { hasRenderedPreview, isHtmlFile, isImageFile } from "shared/file-types";
 import {
 	acknowledgedStatus,
 	type BrowserPaneState,

--- a/apps/desktop/src/renderer/stores/tabs/utils.ts
+++ b/apps/desktop/src/renderer/stores/tabs/utils.ts
@@ -9,7 +9,11 @@ import {
 	type FileStatus,
 	isNewFile,
 } from "shared/changes-types";
-import { hasRenderedPreview, isImageFile } from "shared/file-types";
+import {
+	hasRenderedPreview,
+	isHtmlFile,
+	isImageFile,
+} from "shared/file-types";
 import {
 	acknowledgedStatus,
 	type BrowserPaneState,
@@ -46,6 +50,8 @@ export const resolveFileViewerMode = ({
 	if (isImageFile(filePath)) return "rendered";
 	// Conflicted files show the inline conflict resolver
 	if (diffCategory === "conflicted") return "conflict";
+	// HTML files always default to raw (preview available via toggle)
+	if (isHtmlFile(filePath)) return "raw";
 	// New files have no previous version — show raw/rendered instead of an all-green diff
 	if (diffCategory && fileStatus && isNewFile(fileStatus)) {
 		if (hasRenderedPreview(filePath)) return "rendered";

--- a/apps/desktop/src/shared/file-types.ts
+++ b/apps/desktop/src/shared/file-types.ts
@@ -43,6 +43,9 @@ const IMAGE_MIME_TYPE_EXTENSIONS: Record<string, string> = {
 	"image/vnd.microsoft.icon": "ico",
 };
 
+/** HTML extensions */
+const HTML_EXTENSIONS = new Set(["html", "htm"]);
+
 /** Markdown extensions */
 const MARKDOWN_EXTENSIONS = new Set(["md", "markdown", "mdx"]);
 
@@ -109,6 +112,13 @@ export function isMarkdownFile(filePath: string): boolean {
 }
 
 /**
+ * Checks if a file is an HTML file based on extension
+ */
+export function isHtmlFile(filePath: string): boolean {
+	return HTML_EXTENSIONS.has(getExtension(filePath));
+}
+
+/**
  * Checks if a file is a spreadsheet based on extension
  */
 export function isSpreadsheetFile(filePath: string): boolean {
@@ -116,8 +126,8 @@ export function isSpreadsheetFile(filePath: string): boolean {
 }
 
 /**
- * Checks if a file supports rendered preview (markdown or image)
+ * Checks if a file supports rendered preview (markdown, image, or HTML)
  */
 export function hasRenderedPreview(filePath: string): boolean {
-	return isMarkdownFile(filePath) || isImageFile(filePath);
+	return isMarkdownFile(filePath) || isImageFile(filePath) || isHtmlFile(filePath);
 }

--- a/apps/desktop/src/shared/file-types.ts
+++ b/apps/desktop/src/shared/file-types.ts
@@ -129,5 +129,7 @@ export function isSpreadsheetFile(filePath: string): boolean {
  * Checks if a file supports rendered preview (markdown, image, or HTML)
  */
 export function hasRenderedPreview(filePath: string): boolean {
-	return isMarkdownFile(filePath) || isImageFile(filePath) || isHtmlFile(filePath);
+	return (
+		isMarkdownFile(filePath) || isImageFile(filePath) || isHtmlFile(filePath)
+	);
 }


### PR DESCRIPTION
## 概要
- **Docker タブ UX**: 右サイドバーの Docker コンテナに Rebuild/Delete ボタンとステータス連動コントロールを追加
- **HTML ファイルプレビュー**: HTML ファイルをサンドボックス化された Electron webview でプレビュー可能に。`file://` プロトコルを使用し、相対パスのリソース参照（CSS、画像、JS）も正しく解決される。デフォルトは Raw ビュー。

## テスト項目
- [ ] Docker タブ: Rebuild/Delete ボタンが表示され、コンテナのステータスに応じて動作すること
- [ ] Files サイドバーから HTML ファイルを開く → デフォルトで Raw（ソースコード）表示になること
- [ ] Rendered に切り替え → webview で HTML が正しくレンダリングされること
- [ ] 外部リソース（Google Fonts 等）が正しく読み込まれること
- [ ] 相対パスのリソース参照（例: `./style.css`）が正しく解決されること
- [ ] webview 内のナビゲーションがブロックされること（セキュリティ）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * HTMLファイルのプレビュー表示機能を追加しました
  * Dockerコンテナの再構築（Rebuild）操作を追加しました
  * Dockerコンテナの削除（Delete）操作を追加しました
  * Docker操作にツールチップ表示を追加しました
  * Docker操作実行時のローディング状態を視覚的に表示するようになりました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->