### PR TITLE
feat(file-viewer): PDFファイルのプレビュー表示に対応

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/FileViewerPane.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/FileViewerPane.tsx
@@ -38,7 +38,12 @@ import {
 	retargetAbsolutePath,
 	toAbsoluteWorkspacePath,
 } from "shared/absolute-paths";
-import { isHtmlFile, isImageFile, isMarkdownFile } from "shared/file-types";
+import {
+	isHtmlFile,
+	isImageFile,
+	isMarkdownFile,
+	isPdfFile,
+} from "shared/file-types";
 import type { FileViewerMode } from "shared/tabs-types";
 import type { CodeEditorAdapter } from "../../../components";
 import { BasePaneWindow } from "../components";
@@ -621,7 +626,10 @@ export function FileViewerPane({
 		return "";
 	}, [currentDocumentContent, documentKey, rawFileData]);
 	const hasRenderedMode =
-		isMarkdownFile(filePath) || isImageFile(filePath) || isHtmlFile(filePath);
+		isMarkdownFile(filePath) ||
+		isImageFile(filePath) ||
+		isHtmlFile(filePath) ||
+		isPdfFile(filePath);
 	const hasDiff = !!diffCategory;
 	const unsavedDialogCopy = getUnsavedDialogCopy(
 		session?.pendingIntent ?? null,

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/components/FileViewerContent/FileViewerContent.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/components/FileViewerContent/FileViewerContent.tsx
@@ -580,9 +580,7 @@ export function FileViewerContent({
 	}
 
 	if (viewMode === "rendered" && isPdf) {
-		return (
-			<PdfPreviewWebview key={filePath} absolutePath={absoluteFilePath} />
-		);
+		return <PdfPreviewWebview key={filePath} absolutePath={absoluteFilePath} />;
 	}
 
 	if (viewMode === "rendered" && isImage) {

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/components/FileViewerContent/FileViewerContent.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/components/FileViewerContent/FileViewerContent.tsx
@@ -17,7 +17,12 @@ import type { Tab } from "renderer/stores/tabs/types";
 import { pathsMatch, toAbsoluteWorkspacePath } from "shared/absolute-paths";
 import type { DiffViewMode } from "shared/changes-types";
 import { detectLanguage } from "shared/detect-language";
-import { isHtmlFile, isImageFile, isSpreadsheetFile } from "shared/file-types";
+import {
+	isHtmlFile,
+	isImageFile,
+	isPdfFile,
+	isSpreadsheetFile,
+} from "shared/file-types";
 import type { FileViewerMode } from "shared/tabs-types";
 import { useScrollToFirstDiffChange } from "../../hooks/useScrollToFirstDiffChange";
 import { CodeMirrorDiffViewer } from "../CodeMirrorDiffViewer";
@@ -69,6 +74,44 @@ function HtmlPreviewWebview({ absolutePath }: { absolutePath: string }) {
 	}, [absolutePath]);
 
 	return <div ref={containerRef} className="h-full w-full bg-white" />;
+}
+
+function PdfPreviewWebview({ absolutePath }: { absolutePath: string }) {
+	const containerRef = useRef<HTMLDivElement>(null);
+
+	useEffect(() => {
+		const container = containerRef.current;
+		if (!container || !absolutePath) return;
+
+		const webview = document.createElement("webview") as Electron.WebviewTag;
+		webview.src = `file://${absolutePath}`;
+		webview.setAttribute(
+			"webpreferences",
+			"sandbox=true,nodeIntegration=false,contextIsolation=true,plugins=true",
+		);
+		webview.style.width = "100%";
+		webview.style.height = "100%";
+		webview.style.border = "none";
+
+		webview.addEventListener("will-navigate", (e) => {
+			e.preventDefault();
+		});
+
+		container.appendChild(webview);
+
+		return () => {
+			try {
+				if (webview.isConnected) {
+					webview.stop();
+				}
+				container.removeChild(webview);
+			} catch {
+				// already removed
+			}
+		};
+	}, [absolutePath]);
+
+	return <div ref={containerRef} className="h-full w-full bg-background" />;
 }
 
 interface RawFileData {
@@ -222,6 +265,7 @@ export function FileViewerContent({
 }: FileViewerContentProps) {
 	const isImage = isImageFile(filePath);
 	const isHtml = isHtmlFile(filePath);
+	const isPdf = isPdfFile(filePath);
 
 	useScrollToFirstDiffChange({
 		containerRef: diffContainerRef,
@@ -532,6 +576,12 @@ export function FileViewerContent({
 
 		return (
 			<HtmlPreviewWebview key={filePath} absolutePath={absoluteFilePath} />
+		);
+	}
+
+	if (viewMode === "rendered" && isPdf) {
+		return (
+			<PdfPreviewWebview key={filePath} absolutePath={absoluteFilePath} />
 		);
 	}
 

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/hooks/useFileContent/useFileContent.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/hooks/useFileContent/useFileContent.ts
@@ -2,7 +2,7 @@ import { useMemo } from "react";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import type { ChangeCategory } from "shared/changes-types";
 import { detectLanguage } from "shared/detect-language";
-import { getImageMimeType, isImageFile } from "shared/file-types";
+import { getImageMimeType, isImageFile, isPdfFile } from "shared/file-types";
 
 const BRANCH_QUERY_STALE_TIME_MS = 10_000;
 
@@ -55,9 +55,10 @@ export function useFileContent({
 		branchData?.worktreeBaseBranch ?? branchData?.defaultBranch ?? "main";
 
 	const isImage = isImageFile(filePath);
+	const isPdf = isPdfFile(filePath);
 
 	const rawReadEnabled =
-		!isRemote && viewMode !== "diff" && !isImage && !!filePath && !!workspaceId;
+		!isRemote && viewMode !== "diff" && !isImage && !isPdf && !!filePath && !!workspaceId;
 	const rawQuery = electronTrpc.filesystem.readFile.useQuery(
 		{
 			workspaceId: workspaceId ?? "",

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/hooks/useFileContent/useFileContent.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/hooks/useFileContent/useFileContent.ts
@@ -58,7 +58,12 @@ export function useFileContent({
 	const isPdf = isPdfFile(filePath);
 
 	const rawReadEnabled =
-		!isRemote && viewMode !== "diff" && !isImage && !isPdf && !!filePath && !!workspaceId;
+		!isRemote &&
+		viewMode !== "diff" &&
+		!isImage &&
+		!isPdf &&
+		!!filePath &&
+		!!workspaceId;
 	const rawQuery = electronTrpc.filesystem.readFile.useQuery(
 		{
 			workspaceId: workspaceId ?? "",

--- a/apps/desktop/src/shared/file-types.ts
+++ b/apps/desktop/src/shared/file-types.ts
@@ -46,6 +46,9 @@ const IMAGE_MIME_TYPE_EXTENSIONS: Record<string, string> = {
 /** HTML extensions */
 const HTML_EXTENSIONS = new Set(["html", "htm"]);
 
+/** PDF extensions */
+const PDF_EXTENSIONS = new Set(["pdf"]);
+
 /** Markdown extensions */
 const MARKDOWN_EXTENSIONS = new Set(["md", "markdown", "mdx"]);
 
@@ -126,10 +129,20 @@ export function isSpreadsheetFile(filePath: string): boolean {
 }
 
 /**
- * Checks if a file supports rendered preview (markdown, image, or HTML)
+ * Checks if a file is a PDF based on extension
+ */
+export function isPdfFile(filePath: string): boolean {
+	return PDF_EXTENSIONS.has(getExtension(filePath));
+}
+
+/**
+ * Checks if a file supports rendered preview (markdown, image, HTML, or PDF)
  */
 export function hasRenderedPreview(filePath: string): boolean {
 	return (
-		isMarkdownFile(filePath) || isImageFile(filePath) || isHtmlFile(filePath)
+		isMarkdownFile(filePath) ||
+		isImageFile(filePath) ||
+		isHtmlFile(filePath) ||
+		isPdfFile(filePath)
 	);
 }


### PR DESCRIPTION
## 概要

ファイルビューアでPDFファイルのレンダリングプレビューに対応しました。

- Chromium内蔵のPDFビューアを`<webview>`経由で利用（追加ライブラリ不要）
- PDFファイルを開くとデフォルトで`Rendered`モードで表示
- ズーム・ページ送り・テキスト検索などChromium PDFビューアの機能がそのまま利用可能

## 変更内容

- `file-types.ts`: `isPdfFile()` 関数追加、`hasRenderedPreview` にPDF追加
- `useFileContent.ts`: PDFファイルでrawテキスト読み込みをスキップ（バイナリ誤検出の回避）
- `FileViewerContent.tsx`: `PdfPreviewWebview` コンポーネント追加
- `FileViewerPane.tsx`: ツールバーのRenderedモードトグルにPDF対応追加

## テスト計画

- [ ] PDFファイルを開いてRenderedモードでプレビューが表示されること
- [ ] ページ送り・ズーム・テキスト検索が動作すること
- [ ] 大きなPDFファイルでも問題なく表示されること
- [ ] Raw/Renderedのモード切り替えが正しく動作すること