### PR TITLE
fix(desktop): フォークリポジトリ対応とブランチ切替UXの改善

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/changes/branches.ts
+++ b/apps/desktop/src/lib/trpc/routers/changes/branches.ts
@@ -16,7 +16,7 @@ import { getCurrentBranch } from "../workspaces/utils/git";
 import { getSimpleGitWithShellPath } from "../workspaces/utils/git-client";
 import { gitCreateBranch, gitSwitchBranch } from "./security/git-commands";
 import { assertRegisteredWorktree } from "./security/path-validation";
-import { clearStatusCacheForWorktree } from "./utils/status-cache";
+import { clearWorktreeStatusCaches } from "./utils/worktree-status-caches";
 
 const DEFAULT_REF_SEARCH_LIMIT = 50;
 const MAX_REF_SEARCH_LIMIT = 200;
@@ -234,7 +234,7 @@ export const createBranchesRouter = () => {
 					(await getCurrentBranch(input.worktreePath)) ?? branch;
 				persistWorktreeBranch(input.worktreePath, currentBranch);
 
-				clearStatusCacheForWorktree(input.worktreePath);
+				clearWorktreeStatusCaches(input.worktreePath);
 				return { success: true };
 			}),
 
@@ -286,7 +286,7 @@ export const createBranchesRouter = () => {
 						(await getCurrentBranch(input.worktreePath)) ?? input.branch;
 					persistWorktreeBranch(input.worktreePath, currentBranch);
 
-					clearStatusCacheForWorktree(input.worktreePath);
+					clearWorktreeStatusCaches(input.worktreePath);
 					return { success: true, branch: currentBranch };
 				},
 			),
@@ -329,7 +329,7 @@ export const createBranchesRouter = () => {
 						.run();
 				}
 
-				clearStatusCacheForWorktree(input.worktreePath);
+				clearWorktreeStatusCaches(input.worktreePath);
 				return { success: true };
 			}),
 	});

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/github/github.test.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/github/github.test.ts
@@ -168,13 +168,13 @@ describe("pull request attachment", () => {
 });
 
 describe("shouldRefreshCachedRepoContext", () => {
-	test("returns false when no cached repo context exists", () => {
+	test("returns true when no cached repo context exists", () => {
 		expect(
 			shouldRefreshCachedRepoContext({
 				originUrl: "https://github.com/superset-sh/superset",
 				cachedRepoContext: null,
 			}),
-		).toBe(false);
+		).toBe(true);
 	});
 
 	test("returns false when the cached repo still matches origin", () => {

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/github/repo-context.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/github/repo-context.ts
@@ -33,10 +33,6 @@ async function refreshRepoContext(
 			const originUrl = await getOriginUrl(worktreePath);
 			const ghUrl = normalizeGitHubUrl(data.url);
 
-			if (data.isFork) {
-				return null;
-			}
-
 			if (originUrl && ghUrl && originUrl !== ghUrl) {
 				context = {
 					repoUrl: originUrl,
@@ -47,7 +43,7 @@ async function refreshRepoContext(
 				context = {
 					repoUrl: data.url,
 					upstreamUrl: data.url,
-					isFork: false,
+					isFork: data.isFork,
 				};
 			}
 		}
@@ -92,7 +88,7 @@ export function shouldRefreshCachedRepoContext({
 	cachedRepoContext: RepoContext | null;
 }): boolean {
 	if (!cachedRepoContext) {
-		return false;
+		return true;
 	}
 
 	const normalizedOriginUrl = normalizeGitHubUrl(

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/ChangesHeader/ChangesHeader.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/ChangesHeader/ChangesHeader.tsx
@@ -697,7 +697,6 @@ function CurrentBranchSelector({
 				<CommandItem
 					onSelect={() => {
 						setMode("create");
-						setSearch("");
 						setSelectedStartPoint(null);
 					}}
 					className="gap-2 text-xs"
@@ -708,7 +707,6 @@ function CurrentBranchSelector({
 				<CommandItem
 					onSelect={() => {
 						setMode("create-from-ref");
-						setSearch("");
 						setSelectedStartPoint(null);
 					}}
 					className="gap-2 text-xs"


### PR DESCRIPTION
## 概要
- フォークリポジトリでGitタブのRepository情報が表示されない問題を修正
- ブランチ切り替え時にReviewタブ等のGitHub情報が古いまま残る問題を修正
- ブランチ作成時に入力済みの名前が引き継がれない問題を修正

## 変更内容

### 1. フォークリポジトリのコンテキスト取得修正 (`repo-context.ts`)
- `isFork: true` かつ `parent` データ無しの場合に `return null` していた箇所を削除し、フォールバックロジックで処理するように変更
- `isFork` フラグを `false` ハードコードから `data.isFork` に変更
- `shouldRefreshCachedRepoContext` でキャッシュが `null` の場合に再取得するよう修正

### 2. ブランチ切り替え時のキャッシュクリア (`branches.ts`)
- `clearStatusCacheForWorktree` → `clearWorktreeStatusCaches` に変更し、GitHubステータス・PRコメント・repoContextのバックエンドキャッシュもクリアされるように

### 3. ブランチ作成時の入力テキスト引き継ぎ (`ChangesHeader.tsx`)
- 「Create new branch」クリック時の `setSearch("")` を削除し、入力済みテキストがそのままブランチ名として引き継がれるように（VS Code同等の挙動）

## テスト計画
- [ ] フォークリポジトリを開いてGitタブのRepository情報が表示されること
- [ ] ブランチ切り替え後、Reviewタブの情報が即座に更新されること
- [ ] ブランチ検索フィールドに名前を入力→「Create new branch」で名前が引き継がれること
- [ ] 通常リポジトリ（非フォーク）で既存動作に影響がないこと

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * フォークリポジトリのコンテキスト処理を改善しました（誤った早期終了を修正）。
  * ブランチ作成モードへ切り替えた際に検索フィールドが自動でクリアされなくなりました。
  * キャッシュ刷新の挙動を強化し、キャッシュ未設定時にリポジトリ情報の再取得が確実に行われるようにしました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->