### PR TITLE
feat(desktop): GitHub Actionsログのネイティブ表示

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -149,6 +149,7 @@
 		"@xterm/headless": "6.1.0-beta.195",
 		"@xterm/xterm": "6.1.0-beta.195",
 		"ai": "^6.0.0",
+		"ansi_up": "^6.0.6",
 		"better-auth": "1.4.18",
 		"better-sqlite3": "12.6.2",
 		"bindings": "^1.5.0",

--- a/apps/desktop/src/lib/trpc/routers/ui-state/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/ui-state/index.ts
@@ -106,7 +106,13 @@ const paneSchema = z.object({
 				z.object({
 					detailsUrl: z.string(),
 					name: z.string(),
-					status: z.enum(["success", "failure", "pending", "skipped", "cancelled"]),
+					status: z.enum([
+						"success",
+						"failure",
+						"pending",
+						"skipped",
+						"cancelled",
+					]),
 				}),
 			),
 			initialJobIndex: z.number().optional(),

--- a/apps/desktop/src/lib/trpc/routers/ui-state/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/ui-state/index.ts
@@ -51,6 +51,7 @@ const paneSchema = z.object({
 		"devtools",
 		"git-graph",
 		"database-explorer",
+		"action-logs",
 	]),
 	name: z.string(),
 	isNew: z.boolean().optional(),
@@ -97,6 +98,18 @@ const paneSchema = z.object({
 	databaseExplorer: z
 		.object({
 			connectionId: z.string().nullable(),
+		})
+		.optional(),
+	actionLogs: z
+		.object({
+			jobs: z.array(
+				z.object({
+					detailsUrl: z.string(),
+					name: z.string(),
+					status: z.enum(["success", "failure", "pending", "skipped", "cancelled"]),
+				}),
+			),
+			initialJobIndex: z.number().optional(),
 		})
 		.optional(),
 	workspaceRun: z

--- a/apps/desktop/src/lib/trpc/routers/workspaces/procedures/git-status.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/procedures/git-status.ts
@@ -26,6 +26,7 @@ import {
 	clearGitHubCachesForWorktree,
 	extractNwoFromUrl,
 	fetchCheckJobSteps,
+	fetchStructuredJobLogs,
 	fetchGitHubPRComments,
 	fetchGitHubPRStatus,
 	getRepoContext,
@@ -1569,6 +1570,35 @@ export const createGitStatusProcedures = () => {
 				}
 
 				return fetchCheckJobSteps(repoPath, input.detailsUrl);
+			}),
+
+		getJobLogs: publicProcedure
+			.input(
+				z.object({
+					workspaceId: z.string(),
+					detailsUrl: z.string(),
+				}),
+			)
+			.query(async ({ input }) => {
+				const workspace = getWorkspace(input.workspaceId);
+				if (!workspace) {
+					return [];
+				}
+
+				const worktree = workspace.worktreeId
+					? getWorktree(workspace.worktreeId)
+					: null;
+
+				let repoPath: string | null = worktree?.path ?? null;
+				if (!repoPath && workspace.type === "branch") {
+					const project = getProject(workspace.projectId);
+					repoPath = project?.mainRepoPath ?? null;
+				}
+				if (!repoPath) {
+					return [];
+				}
+
+				return fetchStructuredJobLogs(repoPath, input.detailsUrl);
 			}),
 	});
 };

--- a/apps/desktop/src/lib/trpc/routers/workspaces/procedures/git-status.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/procedures/git-status.ts
@@ -26,9 +26,9 @@ import {
 	clearGitHubCachesForWorktree,
 	extractNwoFromUrl,
 	fetchCheckJobSteps,
-	fetchStructuredJobLogs,
 	fetchGitHubPRComments,
 	fetchGitHubPRStatus,
+	fetchStructuredJobLogs,
 	getRepoContext,
 	type PullRequestCommentsTarget,
 } from "../utils/github";

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/github/github.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/github/github.ts
@@ -491,3 +491,104 @@ export async function fetchCheckJobSteps(
 		return [];
 	}
 }
+
+export interface StructuredJobStep {
+	name: string;
+	number: number;
+	status: "queued" | "in_progress" | "completed";
+	conclusion: string | null;
+	durationSeconds: number | null;
+	logs: string;
+}
+
+/**
+ * Fetches job step metadata and logs, returning structured per-step data.
+ */
+export async function fetchStructuredJobLogs(
+	worktreePath: string,
+	detailsUrl: string,
+): Promise<StructuredJobStep[]> {
+	const jobId = parseJobIdFromUrl(detailsUrl);
+	const nwo = parseNwoFromActionsUrl(detailsUrl);
+	if (!jobId || !nwo) {
+		return [];
+	}
+
+	try {
+		const [jobResult, logsResult] = await Promise.all([
+			execWithShellEnv(
+				"gh",
+				["api", `repos/${nwo}/actions/jobs/${jobId}`],
+				{ cwd: worktreePath },
+			),
+			execWithShellEnv(
+				"gh",
+				["api", `repos/${nwo}/actions/jobs/${jobId}/logs`],
+				{ cwd: worktreePath, maxBuffer: 10 * 1024 * 1024 },
+			),
+		]);
+
+		const raw: unknown = JSON.parse(jobResult.stdout.trim());
+		const result = GHJobResponseSchema.safeParse(raw);
+		if (!result.success || !result.data.steps) {
+			return [];
+		}
+
+		const steps = result.data.steps;
+		const rawLogs = logsResult.stdout;
+
+		// Parse raw logs into per-step sections.
+		// GitHub log format: each line starts with a timestamp like "2024-01-01T00:00:00.0000000Z "
+		// Steps are separated by ##[group] / ##[endgroup] markers, but these aren't always reliable.
+		// Instead, match by step started_at/completed_at time ranges.
+		const logLines = rawLogs.split("\n");
+		const stepLogs: Map<number, string[]> = new Map();
+
+		// Build time ranges for each step
+		const stepRanges = steps.map((step) => ({
+			number: step.number,
+			start: step.started_at ? new Date(step.started_at).getTime() : 0,
+			end: step.completed_at ? new Date(step.completed_at).getTime() : Number.POSITIVE_INFINITY,
+		}));
+
+		for (const line of logLines) {
+			const tsMatch = line.match(/^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z)\s/);
+			if (!tsMatch) continue;
+			const lineTime = new Date(tsMatch[1]).getTime();
+			const lineContent = line.slice(tsMatch[0].length);
+
+			// Find which step this line belongs to
+			for (const range of stepRanges) {
+				if (lineTime >= range.start && lineTime <= range.end + 1000) {
+					if (!stepLogs.has(range.number)) {
+						stepLogs.set(range.number, []);
+					}
+					stepLogs.get(range.number)!.push(lineContent);
+					break;
+				}
+			}
+		}
+
+		return steps.map((step) => {
+			let durationSeconds: number | null = null;
+			if (step.started_at && step.completed_at) {
+				durationSeconds = Math.round(
+					(new Date(step.completed_at).getTime() -
+						new Date(step.started_at).getTime()) /
+						1000,
+				);
+			}
+			return {
+				name: step.name,
+				number: step.number,
+				status: step.status,
+				conclusion: step.conclusion ?? null,
+				durationSeconds,
+				logs: stepLogs.get(step.number)?.join("\n") ?? "",
+			};
+		});
+	} catch (err) {
+		console.error("[fetchStructuredJobLogs] Failed:", err);
+		return [];
+	}
+}

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/github/github.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/github/github.ts
@@ -516,11 +516,9 @@ export async function fetchStructuredJobLogs(
 
 	try {
 		const [jobResult, logsResult] = await Promise.all([
-			execWithShellEnv(
-				"gh",
-				["api", `repos/${nwo}/actions/jobs/${jobId}`],
-				{ cwd: worktreePath },
-			),
+			execWithShellEnv("gh", ["api", `repos/${nwo}/actions/jobs/${jobId}`], {
+				cwd: worktreePath,
+			}),
 			execWithShellEnv(
 				"gh",
 				["api", `repos/${nwo}/actions/jobs/${jobId}/logs`],
@@ -548,11 +546,15 @@ export async function fetchStructuredJobLogs(
 		const stepRanges = steps.map((step) => ({
 			number: step.number,
 			start: step.started_at ? new Date(step.started_at).getTime() : 0,
-			end: step.completed_at ? new Date(step.completed_at).getTime() : Number.POSITIVE_INFINITY,
+			end: step.completed_at
+				? new Date(step.completed_at).getTime()
+				: Number.POSITIVE_INFINITY,
 		}));
 
 		for (const line of logLines) {
-			const tsMatch = line.match(/^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z)\s/);
+			const tsMatch = line.match(
+				/^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z)\s/,
+			);
 			if (!tsMatch) continue;
 			const lineTime = new Date(tsMatch[1]).getTime();
 			const lineContent = line.slice(tsMatch[0].length);
@@ -563,7 +565,7 @@ export async function fetchStructuredJobLogs(
 					if (!stepLogs.has(range.number)) {
 						stepLogs.set(range.number, []);
 					}
-					stepLogs.get(range.number)!.push(lineContent);
+					stepLogs.get(range.number)?.push(lineContent);
 					break;
 				}
 			}

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/github/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/github/index.ts
@@ -2,6 +2,7 @@ export type { PullRequestCommentsTarget } from "./github";
 export {
 	clearGitHubCachesForWorktree,
 	fetchCheckJobSteps,
+	fetchStructuredJobLogs,
 	fetchGitHubPRComments,
 	fetchGitHubPRStatus,
 	resolveReviewThread,

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/github/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/github/index.ts
@@ -2,9 +2,9 @@ export type { PullRequestCommentsTarget } from "./github";
 export {
 	clearGitHubCachesForWorktree,
 	fetchCheckJobSteps,
-	fetchStructuredJobLogs,
 	fetchGitHubPRComments,
 	fetchGitHubPRStatus,
+	fetchStructuredJobLogs,
 	resolveReviewThread,
 } from "./github";
 export { getPRForBranch } from "./pr-resolution";

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ActionLogsPane/ActionLogsPane.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ActionLogsPane/ActionLogsPane.tsx
@@ -1,0 +1,590 @@
+import { AnsiUp } from "ansi_up";
+import { useCallback, useRef, useState } from "react";
+import type { MosaicBranch } from "react-mosaic-component";
+import {
+	LuCheck,
+	LuChevronRight,
+	LuCircleSlash,
+	LuExternalLink,
+	LuLoaderCircle,
+	LuMinus,
+	LuRefreshCw,
+	LuSearch,
+	LuSettings,
+	LuX,
+} from "react-icons/lu";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuSeparator,
+	DropdownMenuTrigger,
+} from "@superset/ui/dropdown-menu";
+import { Button } from "@superset/ui/button";
+import { electronTrpc } from "renderer/lib/electron-trpc";
+import { useTabsStore } from "renderer/stores/tabs/store";
+import { cn } from "@superset/ui/utils";
+import { toast } from "@superset/ui/sonner";
+import type { ActionLogsJob } from "shared/tabs-types";
+import { BasePaneWindow, PaneToolbarActions } from "../components";
+
+// ── Status icon configs ──
+
+const statusIcon = {
+	success: { icon: LuCheck, className: "text-emerald-500" },
+	failure: { icon: LuX, className: "text-red-500" },
+	pending: { icon: LuLoaderCircle, className: "text-amber-500 animate-spin" },
+	skipped: { icon: LuMinus, className: "text-muted-foreground" },
+	cancelled: { icon: LuCircleSlash, className: "text-muted-foreground" },
+} as const;
+
+const stepStatusIcon = {
+	success: statusIcon.success,
+	failure: statusIcon.failure,
+	cancelled: statusIcon.cancelled,
+	skipped: statusIcon.skipped,
+	in_progress: statusIcon.pending,
+	queued: { icon: LuLoaderCircle, className: "text-muted-foreground" },
+} as const;
+
+function getStepIcon(status: string, conclusion: string | null) {
+	if (status === "completed" && conclusion) {
+		return (
+			stepStatusIcon[conclusion as keyof typeof stepStatusIcon] ??
+			stepStatusIcon.success
+		);
+	}
+	return (
+		stepStatusIcon[status as keyof typeof stepStatusIcon] ??
+		stepStatusIcon.queued
+	);
+}
+
+function formatDuration(seconds: number | null): string {
+	if (seconds === null) return "";
+	if (seconds < 60) return `${seconds}s`;
+	const m = Math.floor(seconds / 60);
+	const s = seconds % 60;
+	return s > 0 ? `${m}m ${s}s` : `${m}m`;
+}
+
+// ── ANSI rendering ──
+
+const ansiUp = new AnsiUp();
+ansiUp.use_classes = false;
+
+function renderAnsiLine(line: string): string {
+	// Strip ##[group], ##[endgroup], ##[command] etc. markers
+	const cleaned = line.replace(
+		/##\[(group|endgroup|command|error|warning|notice|debug)\]/g,
+		"",
+	);
+	return ansiUp.ansi_to_html(cleaned);
+}
+
+// ── Job steps component ──
+
+interface JobStepsProps {
+	workspaceId: string;
+	detailsUrl: string;
+	jobName: string;
+	jobStatus: string;
+	showTimestamps: boolean;
+	searchQuery: string;
+}
+
+function JobSteps({
+	workspaceId,
+	detailsUrl,
+	jobName,
+	jobStatus,
+	showTimestamps,
+	searchQuery,
+}: JobStepsProps) {
+	const [expandedSteps, setExpandedSteps] = useState<Set<number>>(new Set());
+	const rerunMutation =
+		electronTrpc.workspaces.rerunPullRequestChecks.useMutation();
+	const trpcUtils = electronTrpc.useUtils();
+
+	const { data: steps, isLoading } =
+		electronTrpc.workspaces.getJobLogs.useQuery(
+			{ workspaceId, detailsUrl },
+			{ staleTime: 30_000 },
+		);
+
+	const toggleStep = (n: number) => {
+		setExpandedSteps((prev) => {
+			const next = new Set(prev);
+			next.has(n) ? next.delete(n) : next.add(n);
+			return next;
+		});
+	};
+
+	const handleRerun = async (mode: "all" | "failed") => {
+		try {
+			const result = await rerunMutation.mutateAsync({
+				workspaceId,
+				mode,
+			});
+			toast.success(
+				`Re-running ${mode === "failed" ? "failed" : "all"} jobs (${result.rerunCount})`,
+			);
+			void trpcUtils.workspaces.getReviewStatus.invalidate();
+		} catch {
+			toast.error("Failed to re-run jobs");
+		}
+	};
+
+	if (isLoading) {
+		return (
+			<div className="flex h-full items-center justify-center gap-2 text-xs text-muted-foreground">
+				<LuLoaderCircle className="size-4 animate-spin" />
+				Loading logs...
+			</div>
+		);
+	}
+
+	if (!steps || steps.length === 0) {
+		return (
+			<div className="flex h-full items-center justify-center text-xs text-muted-foreground">
+				No logs available
+			</div>
+		);
+	}
+
+	const totalSeconds = steps.reduce(
+		(sum, s) => sum + (s.durationSeconds ?? 0),
+		0,
+	);
+	const { icon: JobIcon, className: jobIconClass } =
+		statusIcon[jobStatus as keyof typeof statusIcon] ?? statusIcon.pending;
+
+	const lowerQuery = searchQuery.toLowerCase();
+
+	return (
+		<div className="h-full overflow-auto">
+			{/* Job header */}
+			<div className="flex items-center justify-between border-b border-border px-4 py-3">
+				<div>
+					<div className="flex items-center gap-2">
+						<JobIcon
+							className={cn("size-4 shrink-0", jobIconClass)}
+						/>
+						<span className="text-sm font-medium text-primary">
+							{jobName}
+						</span>
+					</div>
+					{totalSeconds > 0 && (
+						<p className="mt-0.5 pl-6 text-xs text-muted-foreground">
+							{formatDuration(totalSeconds)}
+						</p>
+					)}
+				</div>
+				<div className="flex items-center gap-1">
+					<Button
+						type="button"
+						variant="outline"
+						size="sm"
+						className="h-6 px-2 text-[10px]"
+						disabled={rerunMutation.isPending}
+						onClick={() => void handleRerun("failed")}
+					>
+						<LuRefreshCw
+							className={cn(
+								"mr-1 size-3",
+								rerunMutation.isPending && "animate-spin",
+							)}
+						/>
+						Re-run failed
+					</Button>
+					<Button
+						type="button"
+						variant="outline"
+						size="sm"
+						className="h-6 px-2 text-[10px]"
+						disabled={rerunMutation.isPending}
+						onClick={() => void handleRerun("all")}
+					>
+						<LuRefreshCw
+							className={cn(
+								"mr-1 size-3",
+								rerunMutation.isPending && "animate-spin",
+							)}
+						/>
+						Re-run all
+					</Button>
+				</div>
+			</div>
+
+			{/* Steps */}
+			{steps.map((step) => {
+				const isExpanded = expandedSteps.has(step.number);
+				const { icon: StepIcon, className: iconClass } = getStepIcon(
+					step.status,
+					step.conclusion,
+				);
+				const rawLines = step.logs ? step.logs.split("\n") : [];
+
+				// Filter lines by search query
+				const filteredLines =
+					lowerQuery && rawLines.length > 0
+						? rawLines.filter((l) =>
+								l.toLowerCase().includes(lowerQuery),
+							)
+						: rawLines;
+
+				const matchesSearch =
+					!lowerQuery ||
+					step.name.toLowerCase().includes(lowerQuery) ||
+					filteredLines.length > 0;
+
+				if (!matchesSearch) return null;
+
+				return (
+					<div key={step.number}>
+						<button
+							type="button"
+							className={cn(
+								"flex w-full items-center gap-2 px-3 py-1.5 text-left text-[13px] transition-colors hover:bg-accent/50",
+								isExpanded && "bg-accent/30",
+							)}
+							onClick={() => toggleStep(step.number)}
+						>
+							<LuChevronRight
+								className={cn(
+									"size-3.5 shrink-0 text-muted-foreground transition-transform",
+									isExpanded && "rotate-90",
+								)}
+							/>
+							<StepIcon
+								className={cn("size-4 shrink-0", iconClass)}
+							/>
+							<span className="min-w-0 flex-1 truncate">
+								{step.name}
+							</span>
+							{step.durationSeconds !== null && (
+								<span className="shrink-0 text-xs text-muted-foreground">
+									{formatDuration(step.durationSeconds)}
+								</span>
+							)}
+						</button>
+						{isExpanded && filteredLines.length > 0 && (
+							<div className="border-b border-border bg-[hsl(var(--background))]/50">
+								<pre className="overflow-x-auto p-0 font-mono text-[11px] leading-[1.6]">
+									{filteredLines.map((line, i) => {
+										// Parse timestamp from original line if showTimestamps
+										const tsMatch = showTimestamps
+											? line.match(
+													/^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z)\s/,
+												)
+											: null;
+										const displayLine = tsMatch
+											? line
+											: line.replace(
+													/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z\s/,
+													"",
+												);
+
+										return (
+											<div
+												key={i}
+												className="flex hover:bg-accent/30"
+											>
+												<span className="w-10 shrink-0 select-none pr-2 text-right text-muted-foreground/50">
+													{i + 1}
+												</span>
+												<span
+													className="min-w-0 whitespace-pre-wrap break-all pr-3"
+													dangerouslySetInnerHTML={{
+														__html: renderAnsiLine(
+															displayLine,
+														),
+													}}
+												/>
+											</div>
+										);
+									})}
+								</pre>
+							</div>
+						)}
+						{isExpanded && filteredLines.length === 0 && (
+							<div className="border-b border-border px-3 py-2 text-xs text-muted-foreground">
+								{lowerQuery
+									? "No matching lines"
+									: "No log output"}
+							</div>
+						)}
+					</div>
+				);
+			})}
+		</div>
+	);
+}
+
+// ── Main pane ──
+
+interface ActionLogsPaneProps {
+	paneId: string;
+	path: MosaicBranch[];
+	tabId: string;
+	workspaceId: string;
+	splitPaneAuto: (
+		tabId: string,
+		sourcePaneId: string,
+		dimensions: { width: number; height: number },
+		path?: MosaicBranch[],
+	) => void;
+	removePane: (paneId: string) => void;
+	setFocusedPane: (tabId: string, paneId: string) => void;
+	onPopOut?: () => void;
+}
+
+export function ActionLogsPane({
+	paneId,
+	path,
+	tabId,
+	workspaceId,
+	splitPaneAuto,
+	removePane,
+	setFocusedPane,
+	onPopOut,
+}: ActionLogsPaneProps) {
+	const pane = useTabsStore((s) => s.panes[paneId]);
+	const jobs: ActionLogsJob[] = pane?.actionLogs?.jobs ?? [];
+	const initialIndex = pane?.actionLogs?.initialJobIndex ?? 0;
+	const [selectedIndex, setSelectedIndex] = useState(initialIndex);
+	const [showTimestamps, setShowTimestamps] = useState(false);
+	const [searchQuery, setSearchQuery] = useState("");
+	const [searchOpen, setSearchOpen] = useState(false);
+	const searchInputRef = useRef<HTMLInputElement>(null);
+	const [sidebarWidth, setSidebarWidth] = useState(208);
+	const isDragging = useRef(false);
+	const selectedJob = jobs[selectedIndex];
+
+	const browserUrl = selectedJob?.detailsUrl?.match(
+		/(https:\/\/github\.com\/[^/]+\/[^/]+\/actions\/runs\/\d+\/job\/\d+)/,
+	)?.[1];
+
+	const runUrl = selectedJob?.detailsUrl?.match(
+		/(https:\/\/github\.com\/[^/]+\/[^/]+\/actions\/runs\/\d+)/,
+	)?.[1];
+
+	const handleResizeStart = useCallback(
+		(e: React.MouseEvent) => {
+			e.preventDefault();
+			isDragging.current = true;
+			const startX = e.clientX;
+			const startWidth = sidebarWidth;
+
+			const onMouseMove = (ev: MouseEvent) => {
+				const newWidth = Math.min(
+					400,
+					Math.max(120, startWidth + ev.clientX - startX),
+				);
+				setSidebarWidth(newWidth);
+			};
+			const onMouseUp = () => {
+				isDragging.current = false;
+				document.removeEventListener("mousemove", onMouseMove);
+				document.removeEventListener("mouseup", onMouseUp);
+			};
+			document.addEventListener("mousemove", onMouseMove);
+			document.addEventListener("mouseup", onMouseUp);
+		},
+		[sidebarWidth],
+	);
+
+	const handleToggleSearch = useCallback(() => {
+		setSearchOpen((prev) => {
+			if (!prev) {
+				setTimeout(() => searchInputRef.current?.focus(), 0);
+			} else {
+				setSearchQuery("");
+			}
+			return !prev;
+		});
+	}, []);
+
+	// Get raw logs URL for "View raw logs"
+	const rawLogsUrl = browserUrl ? `${browserUrl}?pr=` : undefined;
+
+	return (
+		<BasePaneWindow
+			paneId={paneId}
+			path={path}
+			tabId={tabId}
+			splitPaneAuto={splitPaneAuto}
+			removePane={removePane}
+			setFocusedPane={setFocusedPane}
+			onPopOut={onPopOut}
+			renderToolbar={(handlers) => (
+				<div className="flex h-full w-full items-center gap-2 px-2">
+					<span className="truncate text-sm text-muted-foreground">
+						Action Logs
+					</span>
+
+					<div className="ml-auto flex items-center gap-1">
+						{/* Search */}
+						{searchOpen && (
+							<div className="flex items-center gap-1 rounded-sm border border-border bg-background px-1.5">
+								<LuSearch className="size-3 text-muted-foreground" />
+								<input
+									ref={searchInputRef}
+									type="text"
+									placeholder="Search logs"
+									value={searchQuery}
+									onChange={(e) =>
+										setSearchQuery(e.target.value)
+									}
+									className="h-5 w-36 bg-transparent text-xs outline-none placeholder:text-muted-foreground/60"
+									onKeyDown={(e) => {
+										if (e.key === "Escape") {
+											handleToggleSearch();
+										}
+									}}
+								/>
+								{searchQuery && (
+									<button
+										type="button"
+										onClick={() => setSearchQuery("")}
+										className="text-muted-foreground hover:text-foreground"
+									>
+										<LuX className="size-3" />
+									</button>
+								)}
+							</div>
+						)}
+						<Button
+							type="button"
+							variant="ghost"
+							size="sm"
+							className="size-6 p-0"
+							onClick={handleToggleSearch}
+							title="Search logs"
+						>
+							<LuSearch className="size-3.5" />
+						</Button>
+
+						{/* Settings dropdown */}
+						<DropdownMenu>
+							<DropdownMenuTrigger asChild>
+								<Button
+									type="button"
+									variant="ghost"
+									size="sm"
+									className="size-6 p-0"
+								>
+									<LuSettings className="size-3.5" />
+								</Button>
+							</DropdownMenuTrigger>
+							<DropdownMenuContent align="end" className="w-48">
+								<DropdownMenuItem
+									onClick={() =>
+										setShowTimestamps((p) => !p)
+									}
+								>
+									{showTimestamps ? "Hide" : "Show"}{" "}
+									timestamps
+								</DropdownMenuItem>
+								<DropdownMenuSeparator />
+								{browserUrl && (
+									<DropdownMenuItem asChild>
+										<a
+											href={browserUrl}
+											target="_blank"
+											rel="noopener noreferrer"
+										>
+											View on GitHub
+										</a>
+									</DropdownMenuItem>
+								)}
+								{rawLogsUrl && (
+									<DropdownMenuItem asChild>
+										<a
+											href={rawLogsUrl}
+											target="_blank"
+											rel="noopener noreferrer"
+										>
+											View raw logs
+										</a>
+									</DropdownMenuItem>
+								)}
+							</DropdownMenuContent>
+						</DropdownMenu>
+
+						<PaneToolbarActions
+							splitOrientation={handlers.splitOrientation}
+							onSplitPane={handlers.onSplitPane}
+							onClosePane={handlers.onClosePane}
+							onPopOut={handlers.onPopOut}
+						/>
+					</div>
+				</div>
+			)}
+		>
+			{jobs.length === 0 ? (
+				<div className="flex h-full items-center justify-center text-xs text-muted-foreground">
+					No jobs configured
+				</div>
+			) : (
+				<div className="flex h-full">
+					{/* Job sidebar */}
+					<div
+						className="relative flex shrink-0 flex-col overflow-y-auto"
+						style={{ width: sidebarWidth }}
+					>
+						<div className="px-3 py-2 text-xs font-medium text-muted-foreground">
+							All jobs
+						</div>
+						{jobs.map((job, i) => {
+							const { icon: JobIcon, className: jobIconClass } =
+								statusIcon[job.status];
+							return (
+								<button
+									key={job.detailsUrl}
+									type="button"
+									className={cn(
+										"flex items-center gap-2 border-l-2 px-3 py-1.5 text-left text-[13px] transition-colors hover:bg-accent/50",
+										i === selectedIndex
+											? "border-l-primary bg-accent/40"
+											: "border-l-transparent",
+									)}
+									onClick={() => setSelectedIndex(i)}
+								>
+									<JobIcon
+										className={cn(
+											"size-3.5 shrink-0",
+											jobIconClass,
+										)}
+									/>
+									<span className="min-w-0 truncate">
+										{job.name}
+									</span>
+								</button>
+							);
+						})}
+						{/* Resize handle */}
+						<div
+							className="absolute right-0 top-0 h-full w-1 cursor-col-resize hover:bg-primary/30 active:bg-primary/50"
+							onMouseDown={handleResizeStart}
+						/>
+					</div>
+					{/* Step detail */}
+					<div className="min-w-0 flex-1">
+						{selectedJob && (
+							<JobSteps
+								key={selectedJob.detailsUrl}
+								workspaceId={workspaceId}
+								detailsUrl={selectedJob.detailsUrl}
+								jobName={selectedJob.name}
+								jobStatus={selectedJob.status}
+								showTimestamps={showTimestamps}
+								searchQuery={searchQuery}
+							/>
+						)}
+					</div>
+				</div>
+			)}
+		</BasePaneWindow>
+	);
+}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ActionLogsPane/ActionLogsPane.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ActionLogsPane/ActionLogsPane.tsx
@@ -1,18 +1,4 @@
-import { AnsiUp } from "ansi_up";
-import { useCallback, useRef, useState } from "react";
-import type { MosaicBranch } from "react-mosaic-component";
-import {
-	LuCheck,
-	LuChevronRight,
-	LuCircleSlash,
-	LuExternalLink,
-	LuLoaderCircle,
-	LuMinus,
-	LuRefreshCw,
-	LuSearch,
-	LuSettings,
-	LuX,
-} from "react-icons/lu";
+import { Button } from "@superset/ui/button";
 import {
 	DropdownMenu,
 	DropdownMenuContent,
@@ -20,11 +6,24 @@ import {
 	DropdownMenuSeparator,
 	DropdownMenuTrigger,
 } from "@superset/ui/dropdown-menu";
-import { Button } from "@superset/ui/button";
+import { toast } from "@superset/ui/sonner";
+import { cn } from "@superset/ui/utils";
+import { AnsiUp } from "ansi_up";
+import { useCallback, useRef, useState } from "react";
+import {
+	LuCheck,
+	LuChevronRight,
+	LuCircleSlash,
+	LuLoaderCircle,
+	LuMinus,
+	LuRefreshCw,
+	LuSearch,
+	LuSettings,
+	LuX,
+} from "react-icons/lu";
+import type { MosaicBranch } from "react-mosaic-component";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { useTabsStore } from "renderer/stores/tabs/store";
-import { cn } from "@superset/ui/utils";
-import { toast } from "@superset/ui/sonner";
 import type { ActionLogsJob } from "shared/tabs-types";
 import { BasePaneWindow, PaneToolbarActions } from "../components";
 
@@ -80,6 +79,13 @@ function renderAnsiLine(line: string): string {
 		"",
 	);
 	return ansiUp.ansi_to_html(cleaned);
+}
+
+function AnsiLine({ html, className }: { html: string; className?: string }) {
+	return (
+		// biome-ignore lint/security/noDangerouslySetInnerHtml: ansi_up escapes HTML entities
+		<span className={className} dangerouslySetInnerHTML={{ __html: html }} />
+	);
 }
 
 // ── Job steps component ──
@@ -167,12 +173,8 @@ function JobSteps({
 			<div className="flex items-center justify-between border-b border-border px-4 py-3">
 				<div>
 					<div className="flex items-center gap-2">
-						<JobIcon
-							className={cn("size-4 shrink-0", jobIconClass)}
-						/>
-						<span className="text-sm font-medium text-primary">
-							{jobName}
-						</span>
+						<JobIcon className={cn("size-4 shrink-0", jobIconClass)} />
+						<span className="text-sm font-medium text-primary">{jobName}</span>
 					</div>
 					{totalSeconds > 0 && (
 						<p className="mt-0.5 pl-6 text-xs text-muted-foreground">
@@ -228,9 +230,7 @@ function JobSteps({
 				// Filter lines by search query
 				const filteredLines =
 					lowerQuery && rawLines.length > 0
-						? rawLines.filter((l) =>
-								l.toLowerCase().includes(lowerQuery),
-							)
+						? rawLines.filter((l) => l.toLowerCase().includes(lowerQuery))
 						: rawLines;
 
 				const matchesSearch =
@@ -256,12 +256,8 @@ function JobSteps({
 									isExpanded && "rotate-90",
 								)}
 							/>
-							<StepIcon
-								className={cn("size-4 shrink-0", iconClass)}
-							/>
-							<span className="min-w-0 flex-1 truncate">
-								{step.name}
-							</span>
+							<StepIcon className={cn("size-4 shrink-0", iconClass)} />
+							<span className="min-w-0 flex-1 truncate">{step.name}</span>
 							{step.durationSeconds !== null && (
 								<span className="shrink-0 text-xs text-muted-foreground">
 									{formatDuration(step.durationSeconds)}
@@ -286,20 +282,14 @@ function JobSteps({
 												);
 
 										return (
-											<div
-												key={i}
-												className="flex hover:bg-accent/30"
-											>
+											// biome-ignore lint/suspicious/noArrayIndexKey: log lines are static read-only content
+											<div key={i} className="flex hover:bg-accent/30">
 												<span className="w-10 shrink-0 select-none pr-2 text-right text-muted-foreground/50">
 													{i + 1}
 												</span>
-												<span
+												<AnsiLine
 													className="min-w-0 whitespace-pre-wrap break-all pr-3"
-													dangerouslySetInnerHTML={{
-														__html: renderAnsiLine(
-															displayLine,
-														),
-													}}
+													html={renderAnsiLine(displayLine)}
 												/>
 											</div>
 										);
@@ -309,9 +299,7 @@ function JobSteps({
 						)}
 						{isExpanded && filteredLines.length === 0 && (
 							<div className="border-b border-border px-3 py-2 text-xs text-muted-foreground">
-								{lowerQuery
-									? "No matching lines"
-									: "No log output"}
+								{lowerQuery ? "No matching lines" : "No log output"}
 							</div>
 						)}
 					</div>
@@ -365,7 +353,7 @@ export function ActionLogsPane({
 		/(https:\/\/github\.com\/[^/]+\/[^/]+\/actions\/runs\/\d+\/job\/\d+)/,
 	)?.[1];
 
-	const runUrl = selectedJob?.detailsUrl?.match(
+	const _runUrl = selectedJob?.detailsUrl?.match(
 		/(https:\/\/github\.com\/[^/]+\/[^/]+\/actions\/runs\/\d+)/,
 	)?.[1];
 
@@ -433,9 +421,7 @@ export function ActionLogsPane({
 									type="text"
 									placeholder="Search logs"
 									value={searchQuery}
-									onChange={(e) =>
-										setSearchQuery(e.target.value)
-									}
+									onChange={(e) => setSearchQuery(e.target.value)}
 									className="h-5 w-36 bg-transparent text-xs outline-none placeholder:text-muted-foreground/60"
 									onKeyDown={(e) => {
 										if (e.key === "Escape") {
@@ -478,13 +464,8 @@ export function ActionLogsPane({
 								</Button>
 							</DropdownMenuTrigger>
 							<DropdownMenuContent align="end" className="w-48">
-								<DropdownMenuItem
-									onClick={() =>
-										setShowTimestamps((p) => !p)
-									}
-								>
-									{showTimestamps ? "Hide" : "Show"}{" "}
-									timestamps
+								<DropdownMenuItem onClick={() => setShowTimestamps((p) => !p)}>
+									{showTimestamps ? "Hide" : "Show"} timestamps
 								</DropdownMenuItem>
 								<DropdownMenuSeparator />
 								{browserUrl && (
@@ -530,7 +511,7 @@ export function ActionLogsPane({
 				<div className="flex h-full">
 					{/* Job sidebar */}
 					<div
-						className="relative flex shrink-0 flex-col overflow-y-auto"
+						className="relative flex shrink-0 flex-col overflow-y-auto border-r border-border bg-muted/30"
 						style={{ width: sidebarWidth }}
 					>
 						<div className="px-3 py-2 text-xs font-medium text-muted-foreground">
@@ -551,21 +532,16 @@ export function ActionLogsPane({
 									)}
 									onClick={() => setSelectedIndex(i)}
 								>
-									<JobIcon
-										className={cn(
-											"size-3.5 shrink-0",
-											jobIconClass,
-										)}
-									/>
-									<span className="min-w-0 truncate">
-										{job.name}
-									</span>
+									<JobIcon className={cn("size-3.5 shrink-0", jobIconClass)} />
+									<span className="min-w-0 truncate">{job.name}</span>
 								</button>
 							);
 						})}
 						{/* Resize handle */}
-						<div
-							className="absolute right-0 top-0 h-full w-1 cursor-col-resize hover:bg-primary/30 active:bg-primary/50"
+						<button
+							type="button"
+							aria-label="Resize sidebar"
+							className="absolute right-0 top-0 h-full w-1 cursor-col-resize border-none bg-transparent p-0 hover:bg-primary/30 active:bg-primary/50"
 							onMouseDown={handleResizeStart}
 						/>
 					</div>

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ActionLogsPane/index.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ActionLogsPane/index.ts
@@ -1,0 +1,1 @@
+export { ActionLogsPane } from "./ActionLogsPane";

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/index.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/index.tsx
@@ -20,13 +20,13 @@ import {
 	getPaneIdSetForTab,
 } from "renderer/stores/tabs/utils";
 import { useTheme } from "renderer/stores/theme";
+import { ActionLogsPane } from "./ActionLogsPane";
 import { BrowserPane } from "./BrowserPane";
 import { ChatPane } from "./ChatPane";
 import { MosaicSplitOverlay } from "./components";
 import { DatabaseExplorerPane } from "./DatabaseExplorerPane";
 import { DevToolsPane } from "./DevToolsPane";
 import { FileViewerPane } from "./FileViewerPane";
-import { ActionLogsPane } from "./ActionLogsPane";
 import { GitGraphPane } from "./GitGraphPane";
 import { TabPane } from "./TabPane";
 

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/index.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/index.tsx
@@ -26,6 +26,7 @@ import { MosaicSplitOverlay } from "./components";
 import { DatabaseExplorerPane } from "./DatabaseExplorerPane";
 import { DevToolsPane } from "./DevToolsPane";
 import { FileViewerPane } from "./FileViewerPane";
+import { ActionLogsPane } from "./ActionLogsPane";
 import { GitGraphPane } from "./GitGraphPane";
 import { TabPane } from "./TabPane";
 
@@ -306,6 +307,22 @@ export function TabView({ tab }: TabViewProps) {
 						paneId={paneId}
 						path={path}
 						tabId={tab.id}
+						splitPaneAuto={splitPaneAuto}
+						removePane={removePane}
+						setFocusedPane={setFocusedPane}
+						onPopOut={isTearoff ? undefined : () => handlePopOut(paneId)}
+					/>
+				);
+			}
+
+			// Route action-logs panes
+			if (paneInfo.type === "action-logs") {
+				return (
+					<ActionLogsPane
+						paneId={paneId}
+						path={path}
+						tabId={tab.id}
+						workspaceId={tab.workspaceId}
 						splitPaneAuto={splitPaneAuto}
 						removePane={removePane}
 						setFocusedPane={setFocusedPane}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/ReviewPanel/ReviewPanel.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/ReviewPanel/ReviewPanel.tsx
@@ -26,6 +26,7 @@ import {
 	LuChevronDown,
 	LuCode,
 	LuCopy,
+	LuExternalLink,
 	LuLoaderCircle,
 	LuRefreshCw,
 	LuX,
@@ -136,6 +137,7 @@ export function ReviewPanel({
 	const resolvedWorkspaceId = useWorkspaceId();
 	const trpcUtils = electronTrpc.useUtils();
 	const addBrowserTab = useTabsStore((s) => s.addBrowserTab);
+	const addActionLogsTab = useTabsStore((s) => s.addActionLogsTab);
 	const handleOpenUrl = useCallback(
 		(url: string, e: React.MouseEvent) => {
 			e.preventDefault();
@@ -1094,6 +1096,34 @@ export function ReviewPanel({
 				<CollapsibleContent className="px-0.5 pb-1 min-w-0 overflow-hidden">
 					{actionChecks.length > 0 ? (
 						<div className="flex flex-wrap items-center justify-end gap-1 px-1.5 py-1">
+							{resolvedWorkspaceId && (
+								<Button
+									type="button"
+									variant="outline"
+									size="sm"
+									className="h-6 px-2 text-[10px]"
+									onClick={() => {
+										const jobs = actionChecks
+											.filter((c) => c.url)
+											.map((c) => ({
+												detailsUrl: c.url!,
+												name: c.name,
+												status: c.status,
+											}));
+										const failedIdx = jobs.findIndex(
+											(j) => j.status === "failure",
+										);
+										addActionLogsTab(
+											resolvedWorkspaceId,
+											jobs,
+											failedIdx >= 0 ? failedIdx : undefined,
+										);
+									}}
+								>
+									<LuExternalLink className="mr-1 size-3" />
+									View logs
+								</Button>
+							)}
 							<Button
 								type="button"
 								variant="outline"

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/ReviewPanel/ReviewPanel.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/ReviewPanel/ReviewPanel.tsx
@@ -1104,9 +1104,9 @@ export function ReviewPanel({
 									className="h-6 px-2 text-[10px]"
 									onClick={() => {
 										const jobs = actionChecks
-											.filter((c) => c.url)
+											.filter((c): c is typeof c & { url: string } => !!c.url)
 											.map((c) => ({
-												detailsUrl: c.url!,
+												detailsUrl: c.url,
 												name: c.name,
 												status: c.status,
 											}));

--- a/apps/desktop/src/renderer/stores/tabs/store.ts
+++ b/apps/desktop/src/renderer/stores/tabs/store.ts
@@ -32,6 +32,7 @@ import {
 	applyFileViewerOpenOptionsToPane,
 	buildMultiPaneLayout,
 	type CreatePaneOptions,
+	createActionLogsTabWithPane,
 	createBrowserPane,
 	createBrowserTabWithPane,
 	createChatPane,
@@ -39,7 +40,6 @@ import {
 	createDatabaseExplorerTabWithPane,
 	createDevToolsPane,
 	createFileViewerPane,
-	createActionLogsTabWithPane,
 	createGitGraphTabWithPane,
 	createPane,
 	createTabWithPane,
@@ -1760,7 +1760,11 @@ export const useTabsStore = create<TabsStore>()(
 
 				addActionLogsTab: (
 					workspaceId: string,
-					jobs: Array<{ detailsUrl: string; name: string; status: "success" | "failure" | "pending" | "skipped" | "cancelled" }>,
+					jobs: Array<{
+						detailsUrl: string;
+						name: string;
+						status: "success" | "failure" | "pending" | "skipped" | "cancelled";
+					}>,
 					initialJobIndex?: number,
 				) => {
 					const state = get();
@@ -1772,14 +1776,11 @@ export const useTabsStore = create<TabsStore>()(
 					);
 
 					const currentActiveId = state.activeTabIds[workspaceId];
-					const historyStack =
-						state.tabHistoryStacks[workspaceId] || [];
+					const historyStack = state.tabHistoryStacks[workspaceId] || [];
 					const newHistoryStack = currentActiveId
 						? [
 								currentActiveId,
-								...historyStack.filter(
-									(id) => id !== currentActiveId,
-								),
+								...historyStack.filter((id) => id !== currentActiveId),
 							]
 						: historyStack;
 

--- a/apps/desktop/src/renderer/stores/tabs/store.ts
+++ b/apps/desktop/src/renderer/stores/tabs/store.ts
@@ -39,6 +39,7 @@ import {
 	createDatabaseExplorerTabWithPane,
 	createDevToolsPane,
 	createFileViewerPane,
+	createActionLogsTabWithPane,
 	createGitGraphTabWithPane,
 	createPane,
 	createTabWithPane,
@@ -1752,6 +1753,57 @@ export const useTabsStore = create<TabsStore>()(
 							...state.tabHistoryStacks,
 							[workspaceId]: newHistoryStack,
 						},
+					});
+
+					return { tabId: tab.id, paneId: pane.id };
+				},
+
+				addActionLogsTab: (
+					workspaceId: string,
+					jobs: Array<{ detailsUrl: string; name: string; status: "success" | "failure" | "pending" | "skipped" | "cancelled" }>,
+					initialJobIndex?: number,
+				) => {
+					const state = get();
+
+					const { tab, pane } = createActionLogsTabWithPane(
+						workspaceId,
+						jobs,
+						initialJobIndex,
+					);
+
+					const currentActiveId = state.activeTabIds[workspaceId];
+					const historyStack =
+						state.tabHistoryStacks[workspaceId] || [];
+					const newHistoryStack = currentActiveId
+						? [
+								currentActiveId,
+								...historyStack.filter(
+									(id) => id !== currentActiveId,
+								),
+							]
+						: historyStack;
+
+					set({
+						tabs: [...state.tabs, tab],
+						panes: { ...state.panes, [pane.id]: pane },
+						activeTabIds: {
+							...state.activeTabIds,
+							[workspaceId]: tab.id,
+						},
+						focusedPaneIds: {
+							...state.focusedPaneIds,
+							[tab.id]: pane.id,
+						},
+						tabHistoryStacks: {
+							...state.tabHistoryStacks,
+							[workspaceId]: newHistoryStack,
+						},
+					});
+
+					posthog.capture("panel_opened", {
+						panel_type: "action-logs",
+						workspace_id: workspaceId,
+						pane_id: pane.id,
 					});
 
 					return { tabId: tab.id, paneId: pane.id };

--- a/apps/desktop/src/renderer/stores/tabs/types.ts
+++ b/apps/desktop/src/renderer/stores/tabs/types.ts
@@ -217,7 +217,11 @@ export interface TabsStore extends TabsState {
 	) => { tabId: string; paneId: string };
 	addActionLogsTab: (
 		workspaceId: string,
-		jobs: Array<{ detailsUrl: string; name: string; status: "success" | "failure" | "pending" | "skipped" | "cancelled" }>,
+		jobs: Array<{
+			detailsUrl: string;
+			name: string;
+			status: "success" | "failure" | "pending" | "skipped" | "cancelled";
+		}>,
 		initialJobIndex?: number,
 	) => { tabId: string; paneId: string };
 	openInBrowserPane: (workspaceId: string, url: string) => void;

--- a/apps/desktop/src/renderer/stores/tabs/types.ts
+++ b/apps/desktop/src/renderer/stores/tabs/types.ts
@@ -215,6 +215,11 @@ export interface TabsStore extends TabsState {
 		workspaceId: string,
 		worktreePath: string,
 	) => { tabId: string; paneId: string };
+	addActionLogsTab: (
+		workspaceId: string,
+		jobs: Array<{ detailsUrl: string; name: string; status: "success" | "failure" | "pending" | "skipped" | "cancelled" }>,
+		initialJobIndex?: number,
+	) => { tabId: string; paneId: string };
 	openInBrowserPane: (workspaceId: string, url: string) => void;
 	setDatabaseExplorerConnection: (
 		paneId: string,

--- a/apps/desktop/src/renderer/stores/tabs/utils.ts
+++ b/apps/desktop/src/renderer/stores/tabs/utils.ts
@@ -19,6 +19,8 @@ import {
 	type FileViewerMode,
 	type FileViewerState,
 	type GitGraphPaneState,
+	type ActionLogsJob,
+	type ActionLogsPaneState,
 } from "shared/tabs-types";
 import type {
 	AddChatTabOptions,
@@ -413,6 +415,41 @@ export const createDatabaseExplorerTabWithPane = (
 	const tab: Tab = {
 		id: tabId,
 		name: "Database Explorer",
+		workspaceId,
+		layout: pane.id,
+		createdAt: Date.now(),
+	};
+
+	return { tab, pane };
+};
+
+export const createActionLogsPane = (
+	tabId: string,
+	jobs: ActionLogsJob[],
+	initialJobIndex?: number,
+): Pane => {
+	const id = generateId("pane");
+	const actionLogs: ActionLogsPaneState = { jobs, initialJobIndex };
+	return {
+		id,
+		tabId,
+		type: "action-logs",
+		name: "Action Logs",
+		actionLogs,
+	};
+};
+
+export const createActionLogsTabWithPane = (
+	workspaceId: string,
+	jobs: ActionLogsJob[],
+	initialJobIndex?: number,
+): { tab: Tab; pane: Pane } => {
+	const tabId = generateId("tab");
+	const pane = createActionLogsPane(tabId, jobs, initialJobIndex);
+
+	const tab: Tab = {
+		id: tabId,
+		name: "Action Logs",
 		workspaceId,
 		layout: pane.id,
 		createdAt: Date.now(),

--- a/apps/desktop/src/renderer/stores/tabs/utils.ts
+++ b/apps/desktop/src/renderer/stores/tabs/utils.ts
@@ -11,6 +11,8 @@ import {
 } from "shared/changes-types";
 import { hasRenderedPreview, isHtmlFile, isImageFile } from "shared/file-types";
 import {
+	type ActionLogsJob,
+	type ActionLogsPaneState,
 	acknowledgedStatus,
 	type BrowserPaneState,
 	type DatabaseExplorerPaneState,
@@ -19,8 +21,6 @@ import {
 	type FileViewerMode,
 	type FileViewerState,
 	type GitGraphPaneState,
-	type ActionLogsJob,
-	type ActionLogsPaneState,
 } from "shared/tabs-types";
 import type {
 	AddChatTabOptions,

--- a/apps/desktop/src/shared/tabs-types.ts
+++ b/apps/desktop/src/shared/tabs-types.ts
@@ -15,7 +15,8 @@ export type PaneType =
 	| "chat"
 	| "devtools"
 	| "git-graph"
-	| "database-explorer";
+	| "database-explorer"
+	| "action-logs";
 
 /**
  * Pane status for agent lifecycle indicators
@@ -146,6 +147,7 @@ export interface Pane {
 	devtools?: DevToolsPaneState; // For devtools panes
 	gitGraph?: GitGraphPaneState; // For git-graph panes
 	databaseExplorer?: DatabaseExplorerPaneState; // For database explorer panes
+	actionLogs?: ActionLogsPaneState; // For GitHub Actions log panes
 	workspaceRun?: {
 		workspaceId: string;
 		state: "running" | "stopped-by-user" | "stopped-by-exit";
@@ -232,6 +234,25 @@ export interface GitGraphPaneState {
  */
 export interface DatabaseExplorerPaneState {
 	connectionId: string | null;
+}
+
+/**
+ * Action Logs pane-specific properties
+ */
+export interface ActionLogsJob {
+	/** The GitHub Actions job details URL */
+	detailsUrl: string;
+	/** Display name for the job */
+	name: string;
+	/** Check status */
+	status: "success" | "failure" | "pending" | "skipped" | "cancelled";
+}
+
+export interface ActionLogsPaneState {
+	/** All action jobs to display */
+	jobs: ActionLogsJob[];
+	/** Initially selected job index */
+	initialJobIndex?: number;
 }
 
 /**

--- a/bun.lock
+++ b/bun.lock
@@ -226,6 +226,7 @@
         "@xterm/headless": "6.1.0-beta.195",
         "@xterm/xterm": "6.1.0-beta.195",
         "ai": "^6.0.0",
+        "ansi_up": "^6.0.6",
         "better-auth": "1.4.18",
         "better-sqlite3": "12.6.2",
         "bindings": "^1.5.0",
@@ -3018,6 +3019,8 @@
     "ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
     "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
+    "ansi_up": ["ansi_up@6.0.6", "", {}, "sha512-yIa1x3Ecf8jWP4UWEunNjqNX6gzE4vg2gGz+xqRGY+TBSucnYp6RRdPV4brmtg6bQ1ljD48mZ5iGSEj7QEpRKA=="],
 
     "ansis": ["ansis@4.2.0", "", {}, "sha512-HqZ5rWlFjGiV0tDm3UxxgNRqsOTniqoKZu0pIAfh7TZQMGuZK+hH0drySty0si0QXj1ieop4+SkSfPZBPPkHig=="],
 


### PR DESCRIPTION
## 概要

Review タブの Checks セクションに「View logs」ボタンを追加し、GitHub Actions のジョブログをブラウザではなくアプリ内のネイティブペインで閲覧できるようにした。

## 変更内容

- 新しいペインタイプ `action-logs` を追加（タブシステムに統合）
- **左サイドバー**: 全ジョブ一覧（ステータスアイコン付き、ドラッグでリサイズ可能）
- **右メイン**: ステップごとの開閉式ログビューア（GitHub 風 UI）
- **ANSI カラー対応**: `ansi_up` で色付き表示
- **Re-run ボタン**: ジョブヘッダーから Re-run failed / Re-run all を実行可能
- **ログ検索**: ツールバーから全ログを横断検索
- **設定メニュー**: タイムスタンプ表示切替、GitHub で開く、raw ログ表示
- **バックエンド**: ステップメタデータとログを並列取得し、タイムスタンプベースでステップごとに分割

## 対象ファイル

- `apps/desktop/src/shared/tabs-types.ts` — `action-logs` ペインタイプ追加
- `apps/desktop/src/lib/trpc/routers/ui-state/index.ts` — Zod スキーマ更新
- `apps/desktop/src/lib/trpc/routers/workspaces/` — 構造化ログ取得 tRPC プロシージャ
- `apps/desktop/src/renderer/.../ActionLogsPane/` — 新ペインコンポーネント
- `apps/desktop/src/renderer/.../ReviewPanel/` — View logs ボタン追加
- `apps/desktop/src/renderer/stores/tabs/` — ストア・ユーティリティ拡張

## テストプラン

- [ ] Review タブの Checks セクションで「View logs」をクリックし、ネイティブペインが開くことを確認
- [ ] 左サイドバーでジョブを切り替えてステップが正しく表示されることを確認
- [ ] ステップをクリックして開閉し、ログが正しく表示されることを確認
- [ ] ANSI カラーコードが色付きで描画されることを確認
- [ ] Re-run ボタンが正しく動作することを確認
- [ ] 検索で該当行がフィルタされることを確認
- [ ] サイドバーのリサイズが動作することを確認
- [ ] 設定メニューのタイムスタンプ表示切替が動作することを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新機能
* GitHub Actionsのジョブログを表示する専用パネルを追加しました。ステップごとのログ詳細、実行時間、ステータスが確認できます
* Reviewパネルの「Checks」セクションに「View logs」ボタンを追加し、ジョブログへのすばやいアクセスが可能になりました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->