### PR TITLE
feat(desktop): add zoom controls to HTML file preview

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/FileViewerPane.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/FileViewerPane.tsx
@@ -150,6 +150,8 @@ export function FileViewerPane({
 	const preserveDocumentStateRef = useRef(false);
 	const [isResolvingIntent, setIsResolvingIntent] = useState(false);
 
+	const [htmlZoomLevel, setHtmlZoomLevel] = useState(0);
+
 	const filePath = fileViewer?.filePath ?? "";
 	const viewMode = fileViewer?.viewMode ?? "raw";
 	const isPinned = fileViewer?.isPinned ?? false;
@@ -676,6 +678,8 @@ export function FileViewerPane({
 							onPin={handlePin}
 							onClosePane={handlers.onClosePane}
 							onPopOut={handlers.onPopOut}
+							htmlZoomLevel={htmlZoomLevel}
+							onHtmlZoomChange={setHtmlZoomLevel}
 						/>
 					</div>
 				)}
@@ -757,6 +761,7 @@ export function FileViewerPane({
 							diffSearch={diffSearch}
 							markdownContainerRef={markdownContainerRef}
 							markdownSearch={markdownSearch}
+							htmlZoomLevel={htmlZoomLevel}
 						/>
 					</div>
 				</div>

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/components/FileViewerContent/FileViewerContent.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/components/FileViewerContent/FileViewerContent.tsx
@@ -33,8 +33,15 @@ import {
 	mapDiffLocationToRawPosition,
 } from "./utils/diff-location";
 
-function HtmlPreviewWebview({ absolutePath }: { absolutePath: string }) {
+function HtmlPreviewWebview({
+	absolutePath,
+	zoomLevel,
+}: {
+	absolutePath: string;
+	zoomLevel: number;
+}) {
 	const containerRef = useRef<HTMLDivElement>(null);
+	const webviewRef = useRef<Electron.WebviewTag | null>(null);
 
 	useEffect(() => {
 		const container = containerRef.current;
@@ -54,9 +61,15 @@ function HtmlPreviewWebview({ absolutePath }: { absolutePath: string }) {
 			e.preventDefault();
 		});
 
+		webview.addEventListener("dom-ready", () => {
+			webviewRef.current = webview;
+			webview.setZoomLevel(zoomLevel);
+		});
+
 		container.appendChild(webview);
 
 		return () => {
+			webviewRef.current = null;
 			try {
 				if (webview.isConnected) {
 					webview.stop();
@@ -66,7 +79,14 @@ function HtmlPreviewWebview({ absolutePath }: { absolutePath: string }) {
 				// already removed
 			}
 		};
+		// biome-ignore lint/correctness/useExhaustiveDependencies: zoomLevel is handled by a separate effect to avoid recreating the webview
 	}, [absolutePath]);
+
+	useEffect(() => {
+		if (webviewRef.current) {
+			webviewRef.current.setZoomLevel(zoomLevel);
+		}
+	}, [zoomLevel]);
 
 	return <div ref={containerRef} className="h-full w-full bg-white" />;
 }
@@ -179,6 +199,7 @@ interface FileViewerContentProps {
 	diffSearch: TextSearchState;
 	markdownContainerRef: RefObject<HTMLDivElement | null>;
 	markdownSearch: TextSearchState;
+	htmlZoomLevel?: number;
 }
 
 export function FileViewerContent({
@@ -219,6 +240,7 @@ export function FileViewerContent({
 	diffSearch,
 	markdownContainerRef,
 	markdownSearch,
+	htmlZoomLevel = 0,
 }: FileViewerContentProps) {
 	const isImage = isImageFile(filePath);
 	const isHtml = isHtmlFile(filePath);
@@ -531,7 +553,11 @@ export function FileViewerContent({
 		}
 
 		return (
-			<HtmlPreviewWebview key={filePath} absolutePath={absoluteFilePath} />
+			<HtmlPreviewWebview
+				key={filePath}
+				absolutePath={absoluteFilePath}
+				zoomLevel={htmlZoomLevel}
+			/>
 		);
 	}
 

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/components/FileViewerContent/FileViewerContent.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/components/FileViewerContent/FileViewerContent.tsx
@@ -42,6 +42,8 @@ function HtmlPreviewWebview({
 }) {
 	const containerRef = useRef<HTMLDivElement>(null);
 	const webviewRef = useRef<Electron.WebviewTag | null>(null);
+	const zoomLevelRef = useRef(zoomLevel);
+	zoomLevelRef.current = zoomLevel;
 
 	useEffect(() => {
 		const container = containerRef.current;
@@ -63,7 +65,7 @@ function HtmlPreviewWebview({
 
 		webview.addEventListener("dom-ready", () => {
 			webviewRef.current = webview;
-			webview.setZoomLevel(zoomLevel);
+			webview.setZoomLevel(zoomLevelRef.current);
 		});
 
 		container.appendChild(webview);
@@ -79,7 +81,6 @@ function HtmlPreviewWebview({
 				// already removed
 			}
 		};
-		// biome-ignore lint/correctness/useExhaustiveDependencies: zoomLevel is handled by a separate effect to avoid recreating the webview
 	}, [absolutePath]);
 
 	useEffect(() => {

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/components/FileViewerToolbar/FileViewerToolbar.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/components/FileViewerToolbar/FileViewerToolbar.tsx
@@ -1,7 +1,8 @@
 import { ToggleGroup, ToggleGroupItem } from "@superset/ui/toggle-group";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { cn } from "@superset/ui/utils";
-
+import { useCallback, useMemo } from "react";
+import { LuMinus, LuPlus } from "react-icons/lu";
 import {
 	TbFold,
 	TbLayoutSidebarRightFilled,
@@ -10,6 +11,7 @@ import {
 } from "react-icons/tb";
 import { useCopyToClipboard } from "renderer/hooks/useCopyToClipboard";
 import type { DiffViewMode } from "shared/changes-types";
+import { isHtmlFile } from "shared/file-types";
 import type { FileViewerMode } from "shared/tabs-types";
 import { PaneToolbarActions } from "../../../components";
 import type { SplitOrientation } from "../../../hooks";
@@ -36,6 +38,8 @@ interface FileViewerToolbarProps {
 	onPin: () => void;
 	onClosePane: (e: React.MouseEvent) => void;
 	onPopOut?: (e: React.MouseEvent) => void;
+	htmlZoomLevel?: number;
+	onHtmlZoomChange?: (level: number) => void;
 }
 
 export function FileViewerToolbar({
@@ -56,8 +60,28 @@ export function FileViewerToolbar({
 	onPin,
 	onClosePane,
 	onPopOut,
+	htmlZoomLevel = 0,
+	onHtmlZoomChange,
 }: FileViewerToolbarProps) {
 	const { copyToClipboard, copied } = useCopyToClipboard(1500);
+
+	const ZOOM_STEP = 1;
+	const ZOOM_MIN = -3;
+	const ZOOM_MAX = 5;
+	const zoomPercent = useMemo(
+		() => Math.round(1.2 ** htmlZoomLevel * 100),
+		[htmlZoomLevel],
+	);
+	const isHtml = isHtmlFile(filePath);
+	const showHtmlZoom = viewMode === "rendered" && isHtml && onHtmlZoomChange;
+
+	const applyZoom = useCallback(
+		(level: number) => {
+			const clamped = Math.max(ZOOM_MIN, Math.min(ZOOM_MAX, level));
+			onHtmlZoomChange?.(clamped);
+		},
+		[onHtmlZoomChange],
+	);
 
 	const handleCopyPath = () => {
 		copyToClipboard(filePath);
@@ -165,6 +189,54 @@ export function FileViewerToolbar({
 							</TooltipContent>
 						</Tooltip>
 					</>
+				)}
+				{showHtmlZoom && (
+					<div className="flex items-center gap-0.5">
+						<Tooltip>
+							<TooltipTrigger asChild>
+								<button
+									type="button"
+									onClick={() => applyZoom(htmlZoomLevel - ZOOM_STEP)}
+									disabled={htmlZoomLevel <= ZOOM_MIN}
+									className="rounded p-0.5 text-muted-foreground/60 transition-colors hover:text-muted-foreground disabled:opacity-30"
+								>
+									<LuMinus className="size-3.5" />
+								</button>
+							</TooltipTrigger>
+							<TooltipContent side="bottom" showArrow={false}>
+								Zoom Out
+							</TooltipContent>
+						</Tooltip>
+						<Tooltip>
+							<TooltipTrigger asChild>
+								<button
+									type="button"
+									onClick={() => applyZoom(0)}
+									className="rounded px-1 py-0.5 text-[10px] tabular-nums text-muted-foreground/60 transition-colors hover:text-muted-foreground"
+								>
+									{zoomPercent}%
+								</button>
+							</TooltipTrigger>
+							<TooltipContent side="bottom" showArrow={false}>
+								Reset Zoom
+							</TooltipContent>
+						</Tooltip>
+						<Tooltip>
+							<TooltipTrigger asChild>
+								<button
+									type="button"
+									onClick={() => applyZoom(htmlZoomLevel + ZOOM_STEP)}
+									disabled={htmlZoomLevel >= ZOOM_MAX}
+									className="rounded p-0.5 text-muted-foreground/60 transition-colors hover:text-muted-foreground disabled:opacity-30"
+								>
+									<LuPlus className="size-3.5" />
+								</button>
+							</TooltipTrigger>
+							<TooltipContent side="bottom" showArrow={false}>
+								Zoom In
+							</TooltipContent>
+						</Tooltip>
+					</div>
 				)}
 				<PaneToolbarActions
 					splitOrientation={splitOrientation}


### PR DESCRIPTION
## Summary
- HTMLファイルのRenderedモードプレビューにズーム機能（+/-/リセット）を追加
- BrowserPaneと同じズーム範囲（-3〜+5）・UI パターンを採用
- Electron webviewの`setZoomLevel` APIを使用し、メインプロセスIPCは不要

## Test plan
- [ ] HTMLファイルをFileViewerのRenderedモードで開く
- [ ] ツールバーに `-` / `%` / `+` ボタンが表示されることを確認
- [ ] `-` ボタンで縮小、`+` ボタンで拡大されることを確認
- [ ] `%` ボタンクリックで100%にリセットされることを確認
- [ ] min/maxでボタンが無効化されることを確認
- [ ] Rawモードやdiffモードではズームボタンが非表示であることを確認
- [ ] Markdownファイルのrenderedモードではズームボタンが非表示であることを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * HTML表示時のズーム機能を追加しました。レンダリング表示でツールバーにズームアウト・リセット・ズームインが表示され、HTMLプレビューの拡大率を即時反映して調整できます。既定値は0で、上限・下限でボタンが無効になります。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->