### PR TITLE
feat(desktop): GitHub API統合SyncServiceとレートリミット制御

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/workspaces/procedures/git-status.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/procedures/git-status.ts
@@ -34,6 +34,7 @@ import {
 	getRepoContext,
 	type PullRequestCommentsTarget,
 } from "../utils/github";
+import { githubSyncService } from "../utils/github/github-sync-service";
 import { GHIdentityCandidatesResponseSchema } from "../utils/github/types";
 import { execWithShellEnv } from "../utils/shell-env";
 
@@ -1202,6 +1203,13 @@ async function getPullRequestIdentityCandidates({
 	}));
 }
 
+// Initialize the SyncService with fetch dependencies (idempotent)
+githubSyncService.initialize({
+	fetchPRStatus: fetchGitHubPRStatus,
+	fetchPRComments: ({ worktreePath }) =>
+		fetchGitHubPRComments({ worktreePath }),
+});
+
 export const createGitStatusProcedures = () => {
 	return router({
 		refreshGitStatus: publicProcedure
@@ -1315,6 +1323,11 @@ export const createGitStatusProcedures = () => {
 
 				if (input.forceFresh) {
 					clearGitHubCachesForWorktree(repoPath);
+				}
+
+				// Register workspace with SyncService for proactive cache warming
+				if (!githubSyncService.isRegistered(repoPath)) {
+					githubSyncService.registerWorkspace(repoPath);
 				}
 
 				const freshStatus = await fetchGitHubPRStatus(repoPath);

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/github/cache.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/github/cache.ts
@@ -6,8 +6,8 @@ import {
 } from "./cached-resource";
 import type { RepoContext } from "./types";
 
-const GITHUB_STATUS_CACHE_TTL_MS = 10_000;
-const GITHUB_PR_COMMENTS_CACHE_TTL_MS = 30_000;
+const GITHUB_STATUS_CACHE_TTL_MS = 5_000;
+const GITHUB_PR_COMMENTS_CACHE_TTL_MS = 20_000;
 const GITHUB_REPO_CONTEXT_CACHE_TTL_MS = 300_000;
 const GITHUB_COMMIT_AUTHOR_CACHE_TTL_MS = 300_000;
 

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/github/github-rate-limiter.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/github/github-rate-limiter.ts
@@ -45,14 +45,19 @@ export function onRateLimitSuccess(): void {
 export function isSecondaryRateLimitError(error: unknown): boolean {
 	if (!(error instanceof Error)) return false;
 
-	const message = error.message || "";
+	const message = (error.message || "").toLowerCase();
 	const stdout =
-		"stdout" in error && typeof error.stdout === "string" ? error.stdout : "";
+		"stdout" in error && typeof error.stdout === "string"
+			? error.stdout.toLowerCase()
+			: "";
+	const stderr =
+		"stderr" in error && typeof error.stderr === "string"
+			? error.stderr.toLowerCase()
+			: "";
 
+	const haystack = `${message} ${stdout} ${stderr}`;
 	return (
-		message.includes("secondary rate limit") ||
-		message.includes("HTTP 403") ||
-		stdout.includes("secondary rate limit") ||
-		stdout.includes("exceeded a secondary rate limit")
+		haystack.includes("secondary rate limit") ||
+		haystack.includes("exceeded a secondary rate limit")
 	);
 }

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/github/github-rate-limiter.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/github/github-rate-limiter.ts
@@ -1,0 +1,58 @@
+/**
+ * Centralized GitHub API rate limiter.
+ *
+ * Detects HTTP 403 (secondary rate limit) errors from `gh` CLI commands
+ * and pauses ALL GitHub API calls with exponential backoff until the
+ * rate limit window resets.
+ */
+
+const INITIAL_BACKOFF_MS = 30_000;
+const MAX_BACKOFF_MS = 300_000;
+const BACKOFF_MULTIPLIER = 2;
+
+let pausedUntil = 0;
+let currentBackoffMs = INITIAL_BACKOFF_MS;
+let consecutiveFailures = 0;
+
+export function isRateLimited(): boolean {
+	return Date.now() < pausedUntil;
+}
+
+export function getRateLimitResumeTime(): number {
+	return pausedUntil;
+}
+
+export function onRateLimitHit(): void {
+	consecutiveFailures++;
+	currentBackoffMs = Math.min(
+		INITIAL_BACKOFF_MS * BACKOFF_MULTIPLIER ** (consecutiveFailures - 1),
+		MAX_BACKOFF_MS,
+	);
+	pausedUntil = Date.now() + currentBackoffMs;
+	console.warn(
+		`[GitHub] Rate limit hit. Pausing all API calls for ${currentBackoffMs / 1000}s (attempt ${consecutiveFailures})`,
+	);
+}
+
+export function onRateLimitSuccess(): void {
+	if (consecutiveFailures > 0) {
+		consecutiveFailures = 0;
+		currentBackoffMs = INITIAL_BACKOFF_MS;
+		console.log("[GitHub] Rate limit recovered. Resuming normal operations.");
+	}
+}
+
+export function isSecondaryRateLimitError(error: unknown): boolean {
+	if (!(error instanceof Error)) return false;
+
+	const message = error.message || "";
+	const stdout =
+		"stdout" in error && typeof error.stdout === "string" ? error.stdout : "";
+
+	return (
+		message.includes("secondary rate limit") ||
+		message.includes("HTTP 403") ||
+		stdout.includes("secondary rate limit") ||
+		stdout.includes("exceeded a secondary rate limit")
+	);
+}

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/github/github-sync-service.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/github/github-sync-service.ts
@@ -14,15 +14,14 @@
  *   - Centralized rate limit detection + exponential backoff
  *   - Single API call path (no duplicate requests)
  *   - Immediate invalidation after user mutations
+ *
+ * Rate limiting is handled by rateLimitedRefresh() in github.ts — the
+ * SyncService does NOT call onRateLimitHit/Success directly to avoid
+ * double-counting with the lower-level wrapper.
  */
 
 import type { GitHubStatus, PullRequestComment } from "@superset/local-db";
-import {
-	isRateLimited,
-	isSecondaryRateLimitError,
-	onRateLimitHit,
-	onRateLimitSuccess,
-} from "./github-rate-limiter";
+import { isRateLimited } from "./github-rate-limiter";
 
 export const SYNC_PR_STATUS_INTERVAL_MS = 5_000;
 export const SYNC_PR_COMMENTS_INTERVAL_MS = 20_000;
@@ -37,6 +36,8 @@ interface WorkspaceSyncState {
 	prStatusTimer: ReturnType<typeof setInterval> | null;
 	prCommentsTimer: ReturnType<typeof setInterval> | null;
 	isActive: boolean;
+	prStatusInFlight: boolean;
+	prCommentsInFlight: boolean;
 }
 
 interface SyncServiceDeps {
@@ -70,6 +71,8 @@ class GitHubSyncServiceImpl {
 			prStatusTimer: null,
 			prCommentsTimer: null,
 			isActive: true,
+			prStatusInFlight: false,
+			prCommentsInFlight: false,
 		};
 
 		this.workspaces.set(worktreePath, state);
@@ -84,6 +87,7 @@ class GitHubSyncServiceImpl {
 		if (!state) return;
 
 		this.stopTimers(state);
+		state.isActive = false;
 		this.workspaces.delete(worktreePath);
 	}
 
@@ -109,12 +113,13 @@ class GitHubSyncServiceImpl {
 	/**
 	 * Notify the service about a window focus event.
 	 * Triggers one immediate sync cycle for all active workspaces.
+	 * Errors are handled internally — fire-and-forget is intentional.
 	 */
 	onWindowFocus(): void {
 		for (const state of this.workspaces.values()) {
 			if (state.isActive) {
-				this.syncPRStatus(state.worktreePath);
-				this.syncPRComments(state.worktreePath);
+				void this.syncPRStatus(state.worktreePath);
+				void this.syncPRComments(state.worktreePath);
 			}
 		}
 	}
@@ -125,6 +130,7 @@ class GitHubSyncServiceImpl {
 	destroy(): void {
 		for (const state of this.workspaces.values()) {
 			this.stopTimers(state);
+			state.isActive = false;
 		}
 		this.workspaces.clear();
 	}
@@ -134,16 +140,12 @@ class GitHubSyncServiceImpl {
 	}
 
 	private startTimers(state: WorkspaceSyncState): void {
-		// Initial sync
-		this.syncPRStatus(state.worktreePath);
-		this.syncPRComments(state.worktreePath);
-
 		state.prStatusTimer = setInterval(() => {
-			this.syncPRStatus(state.worktreePath);
+			void this.syncPRStatus(state.worktreePath);
 		}, SYNC_PR_STATUS_INTERVAL_MS);
 
 		state.prCommentsTimer = setInterval(() => {
-			this.syncPRComments(state.worktreePath);
+			void this.syncPRComments(state.worktreePath);
 		}, SYNC_PR_COMMENTS_INTERVAL_MS);
 	}
 
@@ -160,32 +162,36 @@ class GitHubSyncServiceImpl {
 
 	private async syncPRStatus(worktreePath: string): Promise<void> {
 		if (!this.deps || isRateLimited()) return;
+		const state = this.workspaces.get(worktreePath);
+		if (!state || state.prStatusInFlight) return;
+		state.prStatusInFlight = true;
 
 		try {
 			const status = await this.deps.fetchPRStatus(worktreePath);
-			onRateLimitSuccess();
+			if (!this.workspaces.has(worktreePath)) return;
 			this.deps.onPRStatusUpdate?.(worktreePath, status);
 		} catch (error) {
-			if (isSecondaryRateLimitError(error)) {
-				onRateLimitHit();
-			} else {
-				console.warn("[GitHub SyncService] PR status sync failed:", error);
-			}
+			console.warn("[GitHub SyncService] PR status sync failed:", error);
+		} finally {
+			const current = this.workspaces.get(worktreePath);
+			if (current) current.prStatusInFlight = false;
 		}
 	}
 
 	private async syncPRComments(worktreePath: string): Promise<void> {
 		if (!this.deps || isRateLimited()) return;
+		const state = this.workspaces.get(worktreePath);
+		if (!state || state.prCommentsInFlight) return;
+		state.prCommentsInFlight = true;
 
 		try {
 			await this.deps.fetchPRComments({ worktreePath });
-			onRateLimitSuccess();
+			if (!this.workspaces.has(worktreePath)) return;
 		} catch (error) {
-			if (isSecondaryRateLimitError(error)) {
-				onRateLimitHit();
-			} else {
-				console.warn("[GitHub SyncService] PR comments sync failed:", error);
-			}
+			console.warn("[GitHub SyncService] PR comments sync failed:", error);
+		} finally {
+			const current = this.workspaces.get(worktreePath);
+			if (current) current.prCommentsInFlight = false;
 		}
 	}
 }

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/github/github-sync-service.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/github/github-sync-service.ts
@@ -1,0 +1,193 @@
+/**
+ * GitHubSyncService — centralized GitHub API polling for all workspaces.
+ *
+ * Instead of each UI surface independently polling the GitHub API, this
+ * service runs per-workspace timers that proactively keep the backend
+ * cache warm. Frontend tRPC queries read from the always-warm cache
+ * without triggering additional API calls.
+ *
+ * Intervals:
+ *   - PR status: 5 seconds
+ *   - PR comments: 20 seconds
+ *
+ * All GitHub API calls flow through this service, which provides:
+ *   - Centralized rate limit detection + exponential backoff
+ *   - Single API call path (no duplicate requests)
+ *   - Immediate invalidation after user mutations
+ */
+
+import type { GitHubStatus, PullRequestComment } from "@superset/local-db";
+import {
+	isRateLimited,
+	isSecondaryRateLimitError,
+	onRateLimitHit,
+	onRateLimitSuccess,
+} from "./github-rate-limiter";
+
+export const SYNC_PR_STATUS_INTERVAL_MS = 5_000;
+export const SYNC_PR_COMMENTS_INTERVAL_MS = 20_000;
+
+type FetchPRStatusFn = (worktreePath: string) => Promise<GitHubStatus | null>;
+type FetchPRCommentsFn = (params: {
+	worktreePath: string;
+}) => Promise<PullRequestComment[]>;
+
+interface WorkspaceSyncState {
+	worktreePath: string;
+	prStatusTimer: ReturnType<typeof setInterval> | null;
+	prCommentsTimer: ReturnType<typeof setInterval> | null;
+	isActive: boolean;
+}
+
+interface SyncServiceDeps {
+	fetchPRStatus: FetchPRStatusFn;
+	fetchPRComments: FetchPRCommentsFn;
+	onPRStatusUpdate?: (
+		worktreePath: string,
+		status: GitHubStatus | null,
+	) => void;
+}
+
+class GitHubSyncServiceImpl {
+	private workspaces = new Map<string, WorkspaceSyncState>();
+	private deps: SyncServiceDeps | null = null;
+
+	initialize(deps: SyncServiceDeps): void {
+		this.deps = deps;
+	}
+
+	/**
+	 * Register a workspace for proactive syncing.
+	 * Called when a workspace becomes active (e.g., user opens it).
+	 */
+	registerWorkspace(worktreePath: string): void {
+		if (this.workspaces.has(worktreePath)) {
+			return;
+		}
+
+		const state: WorkspaceSyncState = {
+			worktreePath,
+			prStatusTimer: null,
+			prCommentsTimer: null,
+			isActive: true,
+		};
+
+		this.workspaces.set(worktreePath, state);
+		this.startTimers(state);
+	}
+
+	/**
+	 * Unregister a workspace when it's no longer active.
+	 */
+	unregisterWorkspace(worktreePath: string): void {
+		const state = this.workspaces.get(worktreePath);
+		if (!state) return;
+
+		this.stopTimers(state);
+		this.workspaces.delete(worktreePath);
+	}
+
+	/**
+	 * Trigger an immediate refresh for a workspace.
+	 * Used after user mutations (merge, reviewer add, etc.)
+	 * to provide instant feedback.
+	 */
+	async invalidate(
+		worktreePath: string,
+		scope: "all" | "prStatus" | "prComments" = "all",
+	): Promise<void> {
+		if (!this.deps) return;
+
+		if (scope === "all" || scope === "prStatus") {
+			await this.syncPRStatus(worktreePath);
+		}
+		if (scope === "all" || scope === "prComments") {
+			await this.syncPRComments(worktreePath);
+		}
+	}
+
+	/**
+	 * Notify the service about a window focus event.
+	 * Triggers one immediate sync cycle for all active workspaces.
+	 */
+	onWindowFocus(): void {
+		for (const state of this.workspaces.values()) {
+			if (state.isActive) {
+				this.syncPRStatus(state.worktreePath);
+				this.syncPRComments(state.worktreePath);
+			}
+		}
+	}
+
+	/**
+	 * Clean up all timers (e.g., on app quit).
+	 */
+	destroy(): void {
+		for (const state of this.workspaces.values()) {
+			this.stopTimers(state);
+		}
+		this.workspaces.clear();
+	}
+
+	isRegistered(worktreePath: string): boolean {
+		return this.workspaces.has(worktreePath);
+	}
+
+	private startTimers(state: WorkspaceSyncState): void {
+		// Initial sync
+		this.syncPRStatus(state.worktreePath);
+		this.syncPRComments(state.worktreePath);
+
+		state.prStatusTimer = setInterval(() => {
+			this.syncPRStatus(state.worktreePath);
+		}, SYNC_PR_STATUS_INTERVAL_MS);
+
+		state.prCommentsTimer = setInterval(() => {
+			this.syncPRComments(state.worktreePath);
+		}, SYNC_PR_COMMENTS_INTERVAL_MS);
+	}
+
+	private stopTimers(state: WorkspaceSyncState): void {
+		if (state.prStatusTimer) {
+			clearInterval(state.prStatusTimer);
+			state.prStatusTimer = null;
+		}
+		if (state.prCommentsTimer) {
+			clearInterval(state.prCommentsTimer);
+			state.prCommentsTimer = null;
+		}
+	}
+
+	private async syncPRStatus(worktreePath: string): Promise<void> {
+		if (!this.deps || isRateLimited()) return;
+
+		try {
+			const status = await this.deps.fetchPRStatus(worktreePath);
+			onRateLimitSuccess();
+			this.deps.onPRStatusUpdate?.(worktreePath, status);
+		} catch (error) {
+			if (isSecondaryRateLimitError(error)) {
+				onRateLimitHit();
+			} else {
+				console.warn("[GitHub SyncService] PR status sync failed:", error);
+			}
+		}
+	}
+
+	private async syncPRComments(worktreePath: string): Promise<void> {
+		if (!this.deps || isRateLimited()) return;
+
+		try {
+			await this.deps.fetchPRComments({ worktreePath });
+			onRateLimitSuccess();
+		} catch (error) {
+			if (isSecondaryRateLimitError(error)) {
+				onRateLimitHit();
+			} else {
+				console.warn("[GitHub SyncService] PR comments sync failed:", error);
+			}
+		}
+	}
+}
+
+export const githubSyncService = new GitHubSyncServiceImpl();

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/github/github.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/github/github.ts
@@ -16,6 +16,12 @@ import {
 } from "./cache";
 import { fetchPullRequestComments, resolveReviewThread } from "./comments";
 import {
+	isRateLimited,
+	isSecondaryRateLimitError,
+	onRateLimitHit,
+	onRateLimitSuccess,
+} from "./github-rate-limiter";
+import {
 	canAttachPullRequestToWorkspace,
 	type GitRemoteInfo,
 } from "./pr-attachment";
@@ -247,8 +253,24 @@ export async function fetchGitHubPRStatus(
 	worktreePath: string,
 ): Promise<GitHubStatus | null> {
 	return readCachedGitHubStatus(worktreePath, () =>
-		refreshGitHubPRStatus(worktreePath),
+		rateLimitedRefresh(() => refreshGitHubPRStatus(worktreePath)),
 	);
+}
+
+async function rateLimitedRefresh<T>(fn: () => Promise<T>): Promise<T> {
+	if (isRateLimited()) {
+		throw new Error("[GitHub] Rate limited — skipping API call");
+	}
+	try {
+		const result = await fn();
+		onRateLimitSuccess();
+		return result;
+	} catch (error) {
+		if (isSecondaryRateLimitError(error)) {
+			onRateLimitHit();
+		}
+		throw error;
+	}
 }
 
 export async function fetchGitHubPRComments({
@@ -278,11 +300,13 @@ export async function fetchGitHubPRComments({
 		});
 		try {
 			return await readCachedPullRequestComments(cacheKey, () =>
-				refreshGitHubPRComments({
-					worktreePath,
-					repoNameWithOwner,
-					pullRequestNumber: pullRequestTarget.prNumber,
-				}),
+				rateLimitedRefresh(() =>
+					refreshGitHubPRComments({
+						worktreePath,
+						repoNameWithOwner,
+						pullRequestNumber: pullRequestTarget.prNumber,
+					}),
+				),
 			);
 		} catch (error) {
 			const cached = getCachedPullRequestCommentsState(cacheKey);

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/github/github.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/github/github.ts
@@ -9,6 +9,7 @@ import { execWithShellEnv } from "../shell-env";
 import { parseUpstreamRef } from "../upstream-ref";
 import {
 	clearGitHubCachesForWorktree,
+	getCachedGitHubStatus,
 	getCachedPullRequestCommentsState,
 	makePullRequestCommentsCacheKey,
 	readCachedGitHubStatus,
@@ -253,8 +254,9 @@ export async function fetchGitHubPRStatus(
 	worktreePath: string,
 ): Promise<GitHubStatus | null> {
 	if (isRateLimited()) {
-		// When rate limited, return stale cache or null — never throw
-		return readCachedGitHubStatus(worktreePath, () => Promise.resolve(null));
+		// When rate limited, return stale cache or null — never throw,
+		// and never overwrite stale cache with null
+		return getCachedGitHubStatus(worktreePath);
 	}
 	return readCachedGitHubStatus(worktreePath, () =>
 		rateLimitedRefresh(() => refreshGitHubPRStatus(worktreePath)),
@@ -281,6 +283,9 @@ export async function fetchGitHubPRComments({
 	worktreePath: string;
 	pullRequest?: PullRequestCommentsTarget | null;
 }): Promise<PullRequestComment[]> {
+	if (isRateLimited()) {
+		return [];
+	}
 	try {
 		const pullRequestTarget =
 			pullRequest ?? (await resolvePullRequestCommentsTarget(worktreePath));

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/github/github.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/github/github.ts
@@ -252,15 +252,16 @@ async function refreshGitHubPRComments({
 export async function fetchGitHubPRStatus(
 	worktreePath: string,
 ): Promise<GitHubStatus | null> {
+	if (isRateLimited()) {
+		// When rate limited, return stale cache or null — never throw
+		return readCachedGitHubStatus(worktreePath, () => Promise.resolve(null));
+	}
 	return readCachedGitHubStatus(worktreePath, () =>
 		rateLimitedRefresh(() => refreshGitHubPRStatus(worktreePath)),
 	);
 }
 
 async function rateLimitedRefresh<T>(fn: () => Promise<T>): Promise<T> {
-	if (isRateLimited()) {
-		throw new Error("[GitHub] Rate limited — skipping API call");
-	}
 	try {
 		const result = await fn();
 		onRateLimitSuccess();

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/github/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/github/index.ts
@@ -8,6 +8,8 @@ export {
 	fetchStructuredJobLogs,
 	resolveReviewThread,
 } from "./github";
+export { isRateLimited } from "./github-rate-limiter";
+export { githubSyncService } from "./github-sync-service";
 export { getPRForBranch } from "./pr-resolution";
 export {
 	extractNwoFromUrl,

--- a/apps/desktop/src/renderer/lib/githubQueryPolicy/githubQueryPolicy.test.ts
+++ b/apps/desktop/src/renderer/lib/githubQueryPolicy/githubQueryPolicy.test.ts
@@ -15,7 +15,7 @@ describe("getGitHubStatusQueryPolicy", () => {
 		).toEqual({
 			enabled: true,
 			refetchInterval: false,
-			refetchOnWindowFocus: true,
+			refetchOnWindowFocus: false,
 			staleTime: 0,
 		});
 	});
@@ -29,9 +29,9 @@ describe("getGitHubStatusQueryPolicy", () => {
 			}),
 		).toEqual({
 			enabled: true,
-			refetchInterval: 3_000,
-			refetchOnWindowFocus: true,
-			staleTime: 3_000,
+			refetchInterval: 5_000,
+			refetchOnWindowFocus: false,
+			staleTime: 5_000,
 		});
 	});
 
@@ -46,7 +46,7 @@ describe("getGitHubStatusQueryPolicy", () => {
 			enabled: false,
 			refetchInterval: false,
 			refetchOnWindowFocus: false,
-			staleTime: 3_000,
+			staleTime: 5_000,
 		});
 	});
 
@@ -120,7 +120,7 @@ describe("getGitHubPRCommentsQueryPolicy", () => {
 			enabled: true,
 			refetchInterval: false,
 			refetchOnWindowFocus: false,
-			staleTime: 30_000,
+			staleTime: 20_000,
 		});
 	});
 
@@ -134,9 +134,9 @@ describe("getGitHubPRCommentsQueryPolicy", () => {
 			}),
 		).toEqual({
 			enabled: true,
-			refetchInterval: 30_000,
-			refetchOnWindowFocus: true,
-			staleTime: 30_000,
+			refetchInterval: 20_000,
+			refetchOnWindowFocus: false,
+			staleTime: 20_000,
 		});
 	});
 
@@ -152,7 +152,7 @@ describe("getGitHubPRCommentsQueryPolicy", () => {
 			enabled: false,
 			refetchInterval: false,
 			refetchOnWindowFocus: false,
-			staleTime: 30_000,
+			staleTime: 20_000,
 		});
 	});
 });

--- a/apps/desktop/src/renderer/lib/githubQueryPolicy/githubQueryPolicy.ts
+++ b/apps/desktop/src/renderer/lib/githubQueryPolicy/githubQueryPolicy.ts
@@ -1,9 +1,9 @@
-const ACTIVE_GITHUB_STATUS_STALE_TIME_MS = 3_000;
-const ACTIVE_GITHUB_STATUS_REFETCH_INTERVAL_MS = 3_000;
+const ACTIVE_GITHUB_STATUS_STALE_TIME_MS = 5_000;
+const ACTIVE_GITHUB_STATUS_REFETCH_INTERVAL_MS = 5_000;
 const WORKSPACE_LIST_ITEM_GITHUB_STATUS_STALE_TIME_MS = 30_000;
 const PASSIVE_GITHUB_STATUS_STALE_TIME_MS = 5 * 60 * 1000;
-const GITHUB_PR_COMMENTS_STALE_TIME_MS = 30_000;
-const GITHUB_PR_COMMENTS_REFETCH_INTERVAL_MS = 30_000;
+const GITHUB_PR_COMMENTS_STALE_TIME_MS = 20_000;
+const GITHUB_PR_COMMENTS_REFETCH_INTERVAL_MS = 20_000;
 
 export type GitHubStatusQuerySurface =
 	| "changes-sidebar"
@@ -35,6 +35,10 @@ interface GitHubPRCommentsQueryPolicyOptions {
 /**
  * Centralizes GitHub query behavior so passive hover surfaces stay cheap while
  * active workspace surfaces still revalidate when they become relevant again.
+ *
+ * Note: refetchOnWindowFocus is disabled for all surfaces because the
+ * GitHubSyncService handles window-focus refresh centrally from the main
+ * process, preventing burst API calls on focus.
  */
 export function getGitHubStatusQueryPolicy(
 	surface: GitHubStatusQuerySurface,
@@ -54,7 +58,7 @@ export function getGitHubStatusQueryPolicy(
 					isEnabled && isReviewTabActive
 						? ACTIVE_GITHUB_STATUS_REFETCH_INTERVAL_MS
 						: false,
-				refetchOnWindowFocus: isEnabled,
+				refetchOnWindowFocus: false,
 				staleTime: isReviewTabActive ? ACTIVE_GITHUB_STATUS_STALE_TIME_MS : 0,
 			};
 		case "workspace-page":
@@ -96,7 +100,7 @@ export function getGitHubPRCommentsQueryPolicy({
 			isEnabled && isReviewTabActive
 				? GITHUB_PR_COMMENTS_REFETCH_INTERVAL_MS
 				: false,
-		refetchOnWindowFocus: isEnabled && isReviewTabActive,
+		refetchOnWindowFocus: false,
 		staleTime: GITHUB_PR_COMMENTS_STALE_TIME_MS,
 	};
 }

--- a/apps/desktop/src/renderer/lib/githubQueryPolicy/githubQueryPolicy.ts
+++ b/apps/desktop/src/renderer/lib/githubQueryPolicy/githubQueryPolicy.ts
@@ -36,9 +36,10 @@ interface GitHubPRCommentsQueryPolicyOptions {
  * Centralizes GitHub query behavior so passive hover surfaces stay cheap while
  * active workspace surfaces still revalidate when they become relevant again.
  *
- * Note: refetchOnWindowFocus is disabled for all surfaces because the
- * GitHubSyncService handles window-focus refresh centrally from the main
- * process, preventing burst API calls on focus.
+ * Note: refetchOnWindowFocus is disabled for all GitHub surfaces because
+ * the GitHubSyncService keeps the backend cache warm via periodic polling
+ * (PR status every 5s, comments every 20s). This prevents burst API calls
+ * on window focus that contributed to secondary rate limit errors.
  */
 export function getGitHubStatusQueryPolicy(
 	surface: GitHubStatusQuerySurface,

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/useDashboardSidebarData.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/useDashboardSidebarData.ts
@@ -144,7 +144,8 @@ export function useDashboardSidebarData() {
 			localWorkspaceIds,
 		],
 		enabled: activeHostService !== null && localWorkspaceIds.length > 0,
-		refetchInterval: 15_000,
+		staleTime: 30_000,
+		refetchOnWindowFocus: false,
 		queryFn: () =>
 			activeHostService?.client.pullRequests.getByWorkspaces.query({
 				workspaceIds: localWorkspaceIds,

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/useDashboardSidebarData.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/useDashboardSidebarData.ts
@@ -145,6 +145,7 @@ export function useDashboardSidebarData() {
 		],
 		enabled: activeHostService !== null && localWorkspaceIds.length > 0,
 		staleTime: 30_000,
+		refetchInterval: 60_000,
 		refetchOnWindowFocus: false,
 		queryFn: () =>
 			activeHostService?.client.pullRequests.getByWorkspaces.query({


### PR DESCRIPTION
## Summary
- GitHub APIの複数ポーリング経路をGitHubSyncServiceに統合し、セカンダリレートリミット(HTTP 403)を根本的に解決
- GitHubRateLimiterによる指数バックオフで403検知時に全API呼び出しを自動停止
- Dashboard Sidebarの独自15sポーリングを廃止

## Changes
- github-rate-limiter.ts — 403検知 + 指数バックオフ (30s-300s)
- github-sync-service.ts — workspace単位のSyncService (PR: 5s, Comments: 20s)
- githubQueryPolicy.ts — ポーリング間隔 3s->5s(PR), 30s->20s(Comments), refetchOnWindowFocus無効化
- cache.ts — バックエンドキャッシュTTL 10s->5s(PR), 30s->20s(Comments)
- github.ts — rateLimitedRefresh()で全API呼び出しにレートリミット制御
- useDashboardSidebarData.ts — 15sポーリング削除、staleTime: 30s

## Test plan
- Review Tabを開いてPR状態が5s間隔で更新されることを確認
- レビューコメントが20s間隔で更新されることを確認
- Dashboard SidebarのPR情報が表示されることを確認
- レビュアー追加/ドラフト切替後に即座に反映されることを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * GitHub 同期サービスと中央のレート制御を導入しました。

* **改善**
  * GitHubステータスとPRコメントの自動同期・キャッシュ挙動を調整しました（取得間隔とTTLの最適化）。
  * ウィンドウフォーカス時の自動再取得を無効化し、同期はサービス側のポーリングで管理します。
  * ダッシュボードのPRデータのポーリング/キャッシュ戦略を見直しました。

* **テスト**
  * GitHubクエリポリシーのテスト期待値を更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->