### PR TITLE
feat(desktop): Dockerfile単体プロジェクトのDockerタブ対応

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/docker/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/docker/index.ts
@@ -24,6 +24,23 @@ const COMPOSE_FILE_NAMES = new Set([
 	"compose.yaml",
 ]);
 
+const DOCKERFILE_EXACT_NAMES = new Set(["Dockerfile", "Containerfile"]);
+
+function isDockerfileName(name: string): boolean {
+	if (DOCKERFILE_EXACT_NAMES.has(name)) {
+		return true;
+	}
+	// Dockerfile.dev, Dockerfile.prod, etc.
+	if (name.startsWith("Dockerfile.") || name.startsWith("Containerfile.")) {
+		return true;
+	}
+	// foo.dockerfile
+	if (name.endsWith(".dockerfile")) {
+		return true;
+	}
+	return false;
+}
+
 const IGNORED_DIRECTORIES = new Set([
 	".git",
 	".next",
@@ -57,6 +74,13 @@ interface ComposeFileSummary {
 	absolutePath: string;
 	directoryPath: string;
 	projectName: string;
+	relativePath: string;
+}
+
+interface DockerfileSummary {
+	absolutePath: string;
+	directoryPath: string;
+	name: string;
 	relativePath: string;
 }
 
@@ -246,6 +270,58 @@ async function findComposeFiles(
 	);
 }
 
+async function findDockerfiles(rootPath: string): Promise<DockerfileSummary[]> {
+	const queue: string[] = [rootPath];
+	const dockerfiles: DockerfileSummary[] = [];
+
+	while (queue.length > 0) {
+		const currentDir = queue.shift();
+		if (!currentDir) {
+			continue;
+		}
+
+		let entries: Dirent[];
+		try {
+			entries = await readdir(currentDir, { withFileTypes: true });
+		} catch {
+			continue;
+		}
+
+		for (const entry of entries) {
+			if (entry.isSymbolicLink()) {
+				continue;
+			}
+
+			const absolutePath = path.join(currentDir, entry.name);
+			if (entry.isDirectory()) {
+				if (isIgnoredDirectory(entry.name)) {
+					continue;
+				}
+				queue.push(absolutePath);
+				continue;
+			}
+
+			if (!entry.isFile() || !isDockerfileName(entry.name)) {
+				continue;
+			}
+
+			const directoryPath = path.dirname(absolutePath);
+			const relativePath = path.relative(rootPath, absolutePath) || entry.name;
+
+			dockerfiles.push({
+				absolutePath,
+				directoryPath,
+				name: entry.name,
+				relativePath,
+			});
+		}
+	}
+
+	return dockerfiles.sort((left, right) =>
+		left.relativePath.localeCompare(right.relativePath),
+	);
+}
+
 function getWorkspaceRootPath(workspaceId: string): string {
 	const workspace = localDb
 		.select()
@@ -327,10 +403,14 @@ export const createDockerRouter = () => {
 			.input(z.object({ workspaceId: z.string() }))
 			.query(async ({ input }) => {
 				const workspaceRoot = getWorkspaceRootPath(input.workspaceId);
-				const composeFiles = await findComposeFiles(workspaceRoot);
+				const [composeFiles, dockerfiles] = await Promise.all([
+					findComposeFiles(workspaceRoot),
+					findDockerfiles(workspaceRoot),
+				]);
 				return {
 					workspaceRoot,
 					composeFiles,
+					dockerfiles,
 				};
 			}),
 
@@ -338,11 +418,15 @@ export const createDockerRouter = () => {
 			.input(z.object({ workspaceId: z.string() }))
 			.query(async ({ input }) => {
 				const workspaceRoot = getWorkspaceRootPath(input.workspaceId);
-				const composeFiles = await findComposeFiles(workspaceRoot);
+				const [composeFiles, dockerfiles] = await Promise.all([
+					findComposeFiles(workspaceRoot),
+					findDockerfiles(workspaceRoot),
+				]);
 
-				if (composeFiles.length === 0) {
+				if (composeFiles.length === 0 && dockerfiles.length === 0) {
 					return {
 						composeFiles: [],
+						dockerfiles: [],
 						dockerAvailable: true,
 						dockerError: null,
 						workspaceRoot,
@@ -391,6 +475,7 @@ export const createDockerRouter = () => {
 							totalContainers: matchingContainers.length,
 						};
 					}),
+					dockerfiles,
 					dockerAvailable,
 					dockerError,
 					workspaceRoot,
@@ -527,6 +612,57 @@ export const createDockerRouter = () => {
 						{ cwd: getWorkspaceRootPath(input.workspaceId) },
 					);
 					return JSON.parse(stdout) as unknown;
+				} catch (error) {
+					normalizeExecError(error);
+				}
+			}),
+
+		buildDockerfile: publicProcedure
+			.input(
+				z.object({
+					workspaceId: z.string(),
+					dockerfilePath: z.string().min(1),
+					tag: z.string().min(1),
+				}),
+			)
+			.mutation(async ({ input }) => {
+				const workspaceRoot = getWorkspaceRootPath(input.workspaceId);
+				const dockerfiles = await findDockerfiles(workspaceRoot);
+				const dockerfile = dockerfiles.find(
+					(entry) => entry.absolutePath === input.dockerfilePath,
+				);
+
+				if (!dockerfile) {
+					throw new TRPCError({
+						code: "BAD_REQUEST",
+						message: "Selected Dockerfile does not belong to this workspace",
+					});
+				}
+
+				try {
+					await execDocker(
+						["build", "-f", dockerfile.absolutePath, "-t", input.tag, "."],
+						{ cwd: dockerfile.directoryPath },
+					);
+					return { success: true };
+				} catch (error) {
+					normalizeExecError(error);
+				}
+			}),
+
+		removeDockerImage: publicProcedure
+			.input(
+				z.object({
+					workspaceId: z.string(),
+					imageTag: z.string().min(1),
+				}),
+			)
+			.mutation(async ({ input }) => {
+				getWorkspaceRootPath(input.workspaceId);
+
+				try {
+					await execDocker(["rmi", input.imageTag]);
+					return { success: true };
 				} catch (error) {
 					normalizeExecError(error);
 				}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/DockerView/DockerView.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/DockerView/DockerView.tsx
@@ -18,6 +18,8 @@ import {
 	LuBox,
 	LuBug,
 	LuChevronRight,
+	LuFileCode,
+	LuHammer,
 	LuLoaderCircle,
 	LuPlay,
 	LuRefreshCw,
@@ -40,6 +42,7 @@ interface DockerViewProps {
 type DockerListResult = ElectronRouterOutputs["docker"]["list"];
 type DockerComposeGroup = DockerListResult["composeFiles"][number];
 type DockerContainer = DockerComposeGroup["containers"][number];
+type DockerfileEntry = DockerListResult["dockerfiles"][number];
 
 function quoteShellLiteral(value: string): string {
 	return `'${value.replaceAll("'", `'"'"'`)}'`;
@@ -211,6 +214,39 @@ export function DockerView({ isActive = true }: DockerViewProps) {
 			},
 		});
 
+	const buildDockerfileMutation =
+		electronTrpc.docker.buildDockerfile.useMutation({
+			onMutate: () => {
+				return { toastId: toast.loading("イメージをビルド中...") };
+			},
+			onSuccess: (_data, _variables, context) => {
+				toast.success("ビルドが完了しました", { id: context?.toastId });
+				void invalidateDockerQueries();
+			},
+			onError: (error, _variables, context) => {
+				toast.error("Docker build に失敗しました", {
+					id: context?.toastId,
+					description: error.message,
+				});
+			},
+		});
+
+	const removeDockerImageMutation =
+		electronTrpc.docker.removeDockerImage.useMutation({
+			onMutate: () => {
+				return { toastId: toast.loading("イメージを削除中...") };
+			},
+			onSuccess: (_data, _variables, context) => {
+				toast.success("イメージを削除しました", { id: context?.toastId });
+			},
+			onError: (error, _variables, context) => {
+				toast.error("イメージの削除に失敗しました", {
+					id: context?.toastId,
+					description: error.message,
+				});
+			},
+		});
+
 	const openCommandInTerminal = useCallback(
 		async ({
 			command,
@@ -321,7 +357,7 @@ export function DockerView({ isActive = true }: DockerViewProps) {
 					<div>
 						<h2 className="text-sm font-medium">Docker</h2>
 						<p className="text-xs text-muted-foreground">
-							Compose files in this workspace
+							Docker files in this workspace
 						</p>
 					</div>
 					<Button
@@ -355,13 +391,111 @@ export function DockerView({ isActive = true }: DockerViewProps) {
 					) : null}
 
 					{dockerListQuery.data &&
-					dockerListQuery.data.composeFiles.length === 0 ? (
+					dockerListQuery.data.composeFiles.length === 0 &&
+					dockerListQuery.data.dockerfiles.length === 0 ? (
 						<div className="p-3 text-sm text-muted-foreground">
-							この workspace では compose file が見つかりませんでした。
+							この workspace では Docker 関連ファイルが見つかりませんでした。
 						</div>
 					) : null}
 
 					<div className="space-y-3 p-3">
+						{dockerListQuery.data?.dockerfiles.map(
+							(dockerfile: DockerfileEntry) => {
+								const defaultTag = `${dockerfile.name.toLowerCase().replace(/\./g, "-")}:latest`;
+
+								return (
+									<div
+										key={dockerfile.absolutePath}
+										className="rounded-lg border bg-card/40"
+									>
+										<div className="flex flex-col gap-2 px-3 py-2">
+											<div className="flex items-start justify-between gap-2">
+												<div className="flex min-w-0 flex-1 items-start gap-2">
+													<LuFileCode className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+													<div className="min-w-0">
+														<span className="truncate text-sm font-medium">
+															{dockerfile.name}
+														</span>
+														<div className="mt-1 text-xs text-muted-foreground">
+															{dockerfile.relativePath}
+														</div>
+													</div>
+												</div>
+												<div className="flex items-center gap-1">
+													<Tooltip>
+														<TooltipTrigger asChild>
+															<Button
+																size="icon"
+																variant="outline"
+																className="size-7"
+																onClick={() =>
+																	buildDockerfileMutation.mutate({
+																		dockerfilePath: dockerfile.absolutePath,
+																		tag: defaultTag,
+																		workspaceId,
+																	})
+																}
+																disabled={buildDockerfileMutation.isPending}
+															>
+																{buildDockerfileMutation.isPending ? (
+																	<LuLoaderCircle className="size-3.5 animate-spin" />
+																) : (
+																	<LuHammer className="size-3.5" />
+																)}
+															</Button>
+														</TooltipTrigger>
+														<TooltipContent>Build</TooltipContent>
+													</Tooltip>
+													<Tooltip>
+														<TooltipTrigger asChild>
+															<Button
+																size="icon"
+																variant="outline"
+																className="size-7"
+																onClick={() =>
+																	void openCommandInTerminal({
+																		command: `docker run --rm -it ${quoteShellLiteral(defaultTag)}`,
+																		cwd: dockerfile.directoryPath,
+																		title: `Run: ${dockerfile.name}`,
+																	})
+																}
+															>
+																<LuPlay className="size-3.5" />
+															</Button>
+														</TooltipTrigger>
+														<TooltipContent>Run</TooltipContent>
+													</Tooltip>
+													<Tooltip>
+														<TooltipTrigger asChild>
+															<Button
+																size="icon"
+																variant="outline"
+																className="size-7 text-destructive"
+																onClick={() =>
+																	removeDockerImageMutation.mutate({
+																		imageTag: defaultTag,
+																		workspaceId,
+																	})
+																}
+																disabled={removeDockerImageMutation.isPending}
+															>
+																{removeDockerImageMutation.isPending ? (
+																	<LuLoaderCircle className="size-3.5 animate-spin" />
+																) : (
+																	<LuTrash2 className="size-3.5" />
+																)}
+															</Button>
+														</TooltipTrigger>
+														<TooltipContent>Remove Image</TooltipContent>
+													</Tooltip>
+												</div>
+											</div>
+										</div>
+									</div>
+								);
+							},
+						)}
+
 						{dockerListQuery.data?.composeFiles.map((group) => {
 							const isExpanded =
 								expandedComposeGroups[group.absolutePath] ?? true;

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/index.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/index.tsx
@@ -273,7 +273,8 @@ export function RightSidebar({ isActive = true }: { isActive?: boolean }) {
 		dockerComposeFilesQuery.status === "pending";
 	const showDockerTab = isResolvingDockerVisibility
 		? true
-		: (dockerComposeFiles?.composeFiles.length ?? 0) > 0;
+		: (dockerComposeFiles?.composeFiles.length ?? 0) > 0 ||
+			(dockerComposeFiles?.dockerfiles?.length ?? 0) > 0;
 	const tabSensors = useSensors(
 		useSensor(MouseSensor, {
 			activationConstraint: { distance: 8 },


### PR DESCRIPTION
## Summary
- Dockerfile単体のプロジェクトでもDockerタブが表示されるように拡張
- `Dockerfile`, `Containerfile`, `Dockerfile.*`, `*.dockerfile` パターンを検出
- Dockerfile用のBuild / Run / Remove Image操作ボタンを追加
- 既存のcompose機能には影響なし

## Changes
- `docker/index.ts`: `findDockerfiles()` 検出ロジック、`buildDockerfile` / `removeDockerImage` mutation追加
- `RightSidebar/index.tsx`: タブ表示条件に `dockerfiles.length > 0` を追加
- `DockerView.tsx`: Dockerfileセクション UI追加

## Test plan
- [ ] DockerfileのみのワークスペースでDockerタブが表示される
- [ ] compose + Dockerfileの両方があるワークスペースで両セクション表示される
- [ ] Buildボタンでイメージがビルドされる
- [ ] Runボタンでターミナルが開きコンテナが実行される
- [ ] Remove Imageボタンでイメージが削除される
- [ ] composeのみのワークスペースで既存動作に影響がない