### PR TITLE
feat(desktop): GitHub APIリクエスト削減 — フロントポーリング無効化 + アクティブWSのみポーリング

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/workspaces/procedures/delete.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/procedures/delete.ts
@@ -27,6 +27,7 @@ import {
 	listExternalWorktrees,
 	worktreeExists,
 } from "../utils/git";
+import { githubSyncService } from "../utils/github/github-sync-service";
 import { removeWorktreeFromDisk, runTeardown } from "../utils/teardown";
 
 const normalizePath = (p: string): string => {
@@ -325,6 +326,12 @@ export const createDeleteProcedures = () => {
 					}
 				}
 
+				// Stop SyncService polling for this workspace
+				const repoPath = worktree?.path ?? project?.mainRepoPath;
+				if (repoPath) {
+					githubSyncService.unregisterWorkspace(repoPath);
+				}
+
 				deleteWorkspace(input.id);
 
 				if (worktree) {
@@ -359,6 +366,14 @@ export const createDeleteProcedures = () => {
 				const terminalResult = await getWorkspaceRuntimeRegistry()
 					.getForWorkspaceId(input.id)
 					.terminal.killByWorkspaceId(input.id);
+
+				// Stop SyncService polling for this workspace
+				if (workspace.worktreeId) {
+					const wt = getWorktree(workspace.worktreeId);
+					if (wt?.path) {
+						githubSyncService.unregisterWorkspace(wt.path);
+					}
+				}
 
 				deleteWorkspace(input.id);
 				hideProjectIfNoWorkspaces(workspace.projectId);

--- a/apps/desktop/src/lib/trpc/routers/workspaces/procedures/delete.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/procedures/delete.ts
@@ -373,6 +373,11 @@ export const createDeleteProcedures = () => {
 					if (wt?.path) {
 						githubSyncService.unregisterWorkspace(wt.path);
 					}
+				} else {
+					const proj = getProject(workspace.projectId);
+					if (proj?.mainRepoPath) {
+						githubSyncService.unregisterWorkspace(proj.mainRepoPath);
+					}
 				}
 
 				deleteWorkspace(input.id);

--- a/apps/desktop/src/lib/trpc/routers/workspaces/procedures/git-status.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/procedures/git-status.ts
@@ -1811,5 +1811,30 @@ export const createGitStatusProcedures = () => {
 
 				return fetchJobStatuses(repoPath, input.detailsUrls);
 			}),
+
+		/**
+		 * Notify the SyncService which workspace is currently active.
+		 * Deactivates all other workspaces to stop their polling timers.
+		 */
+		setActiveSyncWorkspace: publicProcedure
+			.input(z.object({ workspaceId: z.string() }))
+			.mutation(({ input }) => {
+				const workspace = getWorkspace(input.workspaceId);
+				if (!workspace) return { success: false };
+
+				const worktree = workspace.worktreeId
+					? getWorktree(workspace.worktreeId)
+					: null;
+
+				let repoPath: string | null = worktree?.path ?? null;
+				if (!repoPath && workspace.type === "branch") {
+					const project = getProject(workspace.projectId);
+					repoPath = project?.mainRepoPath ?? null;
+				}
+				if (!repoPath) return { success: false };
+
+				githubSyncService.setActiveWorkspace(repoPath);
+				return { success: true };
+			}),
 	});
 };

--- a/apps/desktop/src/lib/trpc/routers/workspaces/procedures/git-status.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/procedures/git-status.ts
@@ -1815,10 +1815,16 @@ export const createGitStatusProcedures = () => {
 		/**
 		 * Notify the SyncService which workspace is currently active.
 		 * Deactivates all other workspaces to stop their polling timers.
+		 * Pass empty workspaceId to deactivate all (e.g., dashboard view).
 		 */
 		setActiveSyncWorkspace: publicProcedure
 			.input(z.object({ workspaceId: z.string() }))
 			.mutation(({ input }) => {
+				if (!input.workspaceId) {
+					githubSyncService.deactivateAll();
+					return { success: true };
+				}
+
 				const workspace = getWorkspace(input.workspaceId);
 				if (!workspace) return { success: false };
 

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/github/github-sync-service.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/github/github-sync-service.ts
@@ -6,14 +6,13 @@
  * cache warm. Frontend tRPC queries read from the always-warm cache
  * without triggering additional API calls.
  *
+ * Only the **active** workspace is polled. When the user switches to a
+ * different workspace, the previous one is deactivated (timers stopped)
+ * and the new one is activated (timers started).
+ *
  * Intervals:
  *   - PR status: 5 seconds
  *   - PR comments: 20 seconds
- *
- * All GitHub API calls flow through this service, which provides:
- *   - Centralized rate limit detection + exponential backoff
- *   - Single API call path (no duplicate requests)
- *   - Immediate invalidation after user mutations
  *
  * Rate limiting is handled by rateLimitedRefresh() in github.ts — the
  * SyncService does NOT call onRateLimitHit/Success directly to avoid
@@ -58,8 +57,7 @@ class GitHubSyncServiceImpl {
 	}
 
 	/**
-	 * Register a workspace for proactive syncing.
-	 * Called when a workspace becomes active (e.g., user opens it).
+	 * Register a workspace and start polling immediately.
 	 */
 	registerWorkspace(worktreePath: string): void {
 		if (this.workspaces.has(worktreePath)) {
@@ -80,7 +78,8 @@ class GitHubSyncServiceImpl {
 	}
 
 	/**
-	 * Unregister a workspace when it's no longer active.
+	 * Unregister a workspace completely (e.g., workspace deleted).
+	 * Stops timers and removes from the registry.
 	 */
 	unregisterWorkspace(worktreePath: string): void {
 		const state = this.workspaces.get(worktreePath);
@@ -89,6 +88,59 @@ class GitHubSyncServiceImpl {
 		this.stopTimers(state);
 		state.isActive = false;
 		this.workspaces.delete(worktreePath);
+	}
+
+	/**
+	 * Activate a workspace, resuming its polling timers.
+	 * If not yet registered, registers it first.
+	 */
+	activateWorkspace(worktreePath: string): void {
+		const state = this.workspaces.get(worktreePath);
+
+		if (!state) {
+			this.registerWorkspace(worktreePath);
+			return;
+		}
+
+		if (state.isActive) return;
+
+		state.isActive = true;
+		this.startTimers(state);
+	}
+
+	/**
+	 * Deactivate a workspace, pausing its polling timers.
+	 * The workspace remains in the registry and can be reactivated.
+	 */
+	deactivateWorkspace(worktreePath: string): void {
+		const state = this.workspaces.get(worktreePath);
+		if (!state || !state.isActive) return;
+
+		state.isActive = false;
+		this.stopTimers(state);
+	}
+
+	/**
+	 * Deactivate all workspaces except the given one.
+	 * Activates the given workspace if not already active.
+	 */
+	setActiveWorkspace(worktreePath: string): void {
+		for (const state of this.workspaces.values()) {
+			if (state.worktreePath === worktreePath) {
+				if (!state.isActive) {
+					state.isActive = true;
+					this.startTimers(state);
+				}
+			} else if (state.isActive) {
+				state.isActive = false;
+				this.stopTimers(state);
+			}
+		}
+
+		// Register if not yet known
+		if (!this.workspaces.has(worktreePath)) {
+			this.registerWorkspace(worktreePath);
+		}
 	}
 
 	/**

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/github/github-sync-service.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/github/github-sync-service.ts
@@ -57,7 +57,12 @@ class GitHubSyncServiceImpl {
 	}
 
 	/**
-	 * Register a workspace and start polling immediately.
+	 * Register a workspace WITHOUT starting polling timers.
+	 * The workspace is registered as inactive — call activateWorkspace()
+	 * or setActiveWorkspace() to start polling.
+	 *
+	 * This prevents the "all workspaces poll until setActiveWorkspace
+	 * arrives" race condition at startup.
 	 */
 	registerWorkspace(worktreePath: string): void {
 		if (this.workspaces.has(worktreePath)) {
@@ -68,13 +73,12 @@ class GitHubSyncServiceImpl {
 			worktreePath,
 			prStatusTimer: null,
 			prCommentsTimer: null,
-			isActive: true,
+			isActive: false,
 			prStatusInFlight: false,
 			prCommentsInFlight: false,
 		};
 
 		this.workspaces.set(worktreePath, state);
-		this.startTimers(state);
 	}
 
 	/**
@@ -91,21 +95,25 @@ class GitHubSyncServiceImpl {
 	}
 
 	/**
-	 * Activate a workspace, resuming its polling timers.
-	 * If not yet registered, registers it first.
+	 * Activate a workspace, starting its polling timers and triggering
+	 * an immediate sync. If not yet registered, registers it first.
 	 */
 	activateWorkspace(worktreePath: string): void {
-		const state = this.workspaces.get(worktreePath);
+		let state = this.workspaces.get(worktreePath);
 
 		if (!state) {
 			this.registerWorkspace(worktreePath);
-			return;
+			state = this.workspaces.get(worktreePath)!;
 		}
 
 		if (state.isActive) return;
 
 		state.isActive = true;
 		this.startTimers(state);
+
+		// Immediate sync so the user doesn't wait up to 5s for fresh data
+		void this.syncPRStatus(worktreePath);
+		void this.syncPRComments(worktreePath);
 	}
 
 	/**
@@ -123,13 +131,17 @@ class GitHubSyncServiceImpl {
 	/**
 	 * Deactivate all workspaces except the given one.
 	 * Activates the given workspace if not already active.
+	 * Pass null to deactivate all workspaces (e.g., navigating away from workspaces).
 	 */
-	setActiveWorkspace(worktreePath: string): void {
+	setActiveWorkspace(worktreePath: string | null): void {
 		for (const state of this.workspaces.values()) {
-			if (state.worktreePath === worktreePath) {
+			if (worktreePath && state.worktreePath === worktreePath) {
 				if (!state.isActive) {
 					state.isActive = true;
 					this.startTimers(state);
+					// Immediate sync on activation
+					void this.syncPRStatus(state.worktreePath);
+					void this.syncPRComments(state.worktreePath);
 				}
 			} else if (state.isActive) {
 				state.isActive = false;
@@ -137,9 +149,22 @@ class GitHubSyncServiceImpl {
 			}
 		}
 
-		// Register if not yet known
-		if (!this.workspaces.has(worktreePath)) {
+		// Register and activate if not yet known
+		if (worktreePath && !this.workspaces.has(worktreePath)) {
 			this.registerWorkspace(worktreePath);
+			this.activateWorkspace(worktreePath);
+		}
+	}
+
+	/**
+	 * Deactivate all workspaces. Used when navigating away from workspace views.
+	 */
+	deactivateAll(): void {
+		for (const state of this.workspaces.values()) {
+			if (state.isActive) {
+				state.isActive = false;
+				this.stopTimers(state);
+			}
 		}
 	}
 
@@ -163,20 +188,6 @@ class GitHubSyncServiceImpl {
 	}
 
 	/**
-	 * Notify the service about a window focus event.
-	 * Triggers one immediate sync cycle for all active workspaces.
-	 * Errors are handled internally — fire-and-forget is intentional.
-	 */
-	onWindowFocus(): void {
-		for (const state of this.workspaces.values()) {
-			if (state.isActive) {
-				void this.syncPRStatus(state.worktreePath);
-				void this.syncPRComments(state.worktreePath);
-			}
-		}
-	}
-
-	/**
 	 * Clean up all timers (e.g., on app quit).
 	 */
 	destroy(): void {
@@ -192,6 +203,9 @@ class GitHubSyncServiceImpl {
 	}
 
 	private startTimers(state: WorkspaceSyncState): void {
+		// Defensive: stop existing timers to prevent leaks
+		this.stopTimers(state);
+
 		state.prStatusTimer = setInterval(() => {
 			void this.syncPRStatus(state.worktreePath);
 		}, SYNC_PR_STATUS_INTERVAL_MS);

--- a/apps/desktop/src/renderer/lib/githubQueryPolicy/githubQueryPolicy.test.ts
+++ b/apps/desktop/src/renderer/lib/githubQueryPolicy/githubQueryPolicy.test.ts
@@ -20,7 +20,7 @@ describe("getGitHubStatusQueryPolicy", () => {
 		});
 	});
 
-	test("enables polling for the active changes sidebar review view", () => {
+	test("disables frontend polling for the active changes sidebar review view (SyncService handles polling)", () => {
 		expect(
 			getGitHubStatusQueryPolicy("changes-sidebar", {
 				hasWorkspaceId: true,
@@ -29,7 +29,7 @@ describe("getGitHubStatusQueryPolicy", () => {
 			}),
 		).toEqual({
 			enabled: true,
-			refetchInterval: 5_000,
+			refetchInterval: false,
 			refetchOnWindowFocus: false,
 			staleTime: 5_000,
 		});
@@ -124,7 +124,7 @@ describe("getGitHubPRCommentsQueryPolicy", () => {
 		});
 	});
 
-	test("polls review comments while the review tab is active", () => {
+	test("disables frontend polling for review comments (SyncService handles polling)", () => {
 		expect(
 			getGitHubPRCommentsQueryPolicy({
 				hasWorkspaceId: true,
@@ -134,7 +134,7 @@ describe("getGitHubPRCommentsQueryPolicy", () => {
 			}),
 		).toEqual({
 			enabled: true,
-			refetchInterval: 20_000,
+			refetchInterval: false,
 			refetchOnWindowFocus: false,
 			staleTime: 20_000,
 		});

--- a/apps/desktop/src/renderer/lib/githubQueryPolicy/githubQueryPolicy.test.ts
+++ b/apps/desktop/src/renderer/lib/githubQueryPolicy/githubQueryPolicy.test.ts
@@ -20,7 +20,7 @@ describe("getGitHubStatusQueryPolicy", () => {
 		});
 	});
 
-	test("disables frontend polling for the active changes sidebar review view (SyncService handles polling)", () => {
+	test("polls backend cache for the active changes sidebar review view (reads SyncService-warmed cache)", () => {
 		expect(
 			getGitHubStatusQueryPolicy("changes-sidebar", {
 				hasWorkspaceId: true,
@@ -29,7 +29,7 @@ describe("getGitHubStatusQueryPolicy", () => {
 			}),
 		).toEqual({
 			enabled: true,
-			refetchInterval: false,
+			refetchInterval: 5_000,
 			refetchOnWindowFocus: false,
 			staleTime: 5_000,
 		});
@@ -124,7 +124,7 @@ describe("getGitHubPRCommentsQueryPolicy", () => {
 		});
 	});
 
-	test("disables frontend polling for review comments (SyncService handles polling)", () => {
+	test("polls backend cache for review comments when review tab is active", () => {
 		expect(
 			getGitHubPRCommentsQueryPolicy({
 				hasWorkspaceId: true,
@@ -134,7 +134,7 @@ describe("getGitHubPRCommentsQueryPolicy", () => {
 			}),
 		).toEqual({
 			enabled: true,
-			refetchInterval: false,
+			refetchInterval: 20_000,
 			refetchOnWindowFocus: false,
 			staleTime: 20_000,
 		});

--- a/apps/desktop/src/renderer/lib/githubQueryPolicy/githubQueryPolicy.ts
+++ b/apps/desktop/src/renderer/lib/githubQueryPolicy/githubQueryPolicy.ts
@@ -1,6 +1,18 @@
+/**
+ * Polling intervals for frontend React Query refetch.
+ *
+ * These intervals trigger tRPC queries that read from the backend cache
+ * (warmed by GitHubSyncService). They do NOT cause additional GitHub API
+ * calls — the backend cached-resource layer returns cached data within TTL.
+ *
+ * The frontend polling ensures React Query picks up the latest data that
+ * the SyncService has fetched, keeping the UI in sync.
+ */
+const ACTIVE_GITHUB_STATUS_REFETCH_INTERVAL_MS = 5_000;
 const ACTIVE_GITHUB_STATUS_STALE_TIME_MS = 5_000;
 const WORKSPACE_LIST_ITEM_GITHUB_STATUS_STALE_TIME_MS = 30_000;
 const PASSIVE_GITHUB_STATUS_STALE_TIME_MS = 5 * 60 * 1000;
+const GITHUB_PR_COMMENTS_REFETCH_INTERVAL_MS = 20_000;
 const GITHUB_PR_COMMENTS_STALE_TIME_MS = 20_000;
 
 export type GitHubStatusQuerySurface =
@@ -34,10 +46,11 @@ interface GitHubPRCommentsQueryPolicyOptions {
  * Centralizes GitHub query behavior so passive hover surfaces stay cheap while
  * active workspace surfaces still revalidate when they become relevant again.
  *
- * Note: refetchOnWindowFocus is disabled for all GitHub surfaces because
- * the GitHubSyncService keeps the backend cache warm via periodic polling
- * (PR status every 5s, comments every 20s). This prevents burst API calls
- * on window focus that contributed to secondary rate limit errors.
+ * refetchOnWindowFocus is disabled for all surfaces — the GitHubSyncService
+ * keeps the backend cache warm, preventing burst API calls on window focus.
+ *
+ * refetchInterval on active surfaces reads from the backend cache (no API call).
+ * Passive surfaces rely on staleTime + mount-time fetch only.
  */
 export function getGitHubStatusQueryPolicy(
 	surface: GitHubStatusQuerySurface,
@@ -53,7 +66,10 @@ export function getGitHubStatusQueryPolicy(
 		case "changes-sidebar":
 			return {
 				enabled: isEnabled,
-				refetchInterval: false,
+				refetchInterval:
+					isEnabled && isReviewTabActive
+						? ACTIVE_GITHUB_STATUS_REFETCH_INTERVAL_MS
+						: false,
 				refetchOnWindowFocus: false,
 				staleTime: isReviewTabActive ? ACTIVE_GITHUB_STATUS_STALE_TIME_MS : 0,
 			};
@@ -86,12 +102,16 @@ export function getGitHubPRCommentsQueryPolicy({
 	hasWorkspaceId,
 	hasActivePullRequest,
 	isActive = true,
+	isReviewTabActive = false,
 }: GitHubPRCommentsQueryPolicyOptions): GitHubQueryPolicy {
 	const isEnabled = hasWorkspaceId && isActive && hasActivePullRequest;
 
 	return {
 		enabled: isEnabled,
-		refetchInterval: false,
+		refetchInterval:
+			isEnabled && isReviewTabActive
+				? GITHUB_PR_COMMENTS_REFETCH_INTERVAL_MS
+				: false,
 		refetchOnWindowFocus: false,
 		staleTime: GITHUB_PR_COMMENTS_STALE_TIME_MS,
 	};

--- a/apps/desktop/src/renderer/lib/githubQueryPolicy/githubQueryPolicy.ts
+++ b/apps/desktop/src/renderer/lib/githubQueryPolicy/githubQueryPolicy.ts
@@ -1,9 +1,7 @@
 const ACTIVE_GITHUB_STATUS_STALE_TIME_MS = 5_000;
-const ACTIVE_GITHUB_STATUS_REFETCH_INTERVAL_MS = 5_000;
 const WORKSPACE_LIST_ITEM_GITHUB_STATUS_STALE_TIME_MS = 30_000;
 const PASSIVE_GITHUB_STATUS_STALE_TIME_MS = 5 * 60 * 1000;
 const GITHUB_PR_COMMENTS_STALE_TIME_MS = 20_000;
-const GITHUB_PR_COMMENTS_REFETCH_INTERVAL_MS = 20_000;
 
 export type GitHubStatusQuerySurface =
 	| "changes-sidebar"
@@ -55,10 +53,7 @@ export function getGitHubStatusQueryPolicy(
 		case "changes-sidebar":
 			return {
 				enabled: isEnabled,
-				refetchInterval:
-					isEnabled && isReviewTabActive
-						? ACTIVE_GITHUB_STATUS_REFETCH_INTERVAL_MS
-						: false,
+				refetchInterval: false,
 				refetchOnWindowFocus: false,
 				staleTime: isReviewTabActive ? ACTIVE_GITHUB_STATUS_STALE_TIME_MS : 0,
 			};
@@ -91,16 +86,12 @@ export function getGitHubPRCommentsQueryPolicy({
 	hasWorkspaceId,
 	hasActivePullRequest,
 	isActive = true,
-	isReviewTabActive = false,
 }: GitHubPRCommentsQueryPolicyOptions): GitHubQueryPolicy {
 	const isEnabled = hasWorkspaceId && isActive && hasActivePullRequest;
 
 	return {
 		enabled: isEnabled,
-		refetchInterval:
-			isEnabled && isReviewTabActive
-				? GITHUB_PR_COMMENTS_REFETCH_INTERVAL_MS
-				: false,
+		refetchInterval: false,
 		refetchOnWindowFocus: false,
 		staleTime: GITHUB_PR_COMMENTS_STALE_TIME_MS,
 	};

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/KeepAliveWorkspaces.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/KeepAliveWorkspaces.tsx
@@ -27,7 +27,8 @@ export function KeepAliveWorkspaces() {
 	const [visitedIds, setVisitedIds] = useState<string[]>([]);
 	const visitedSetRef = useRef(new Set<string>());
 
-	// Notify SyncService which workspace is active so only it gets polled
+	// Notify SyncService which workspace is active so only it gets polled.
+	// Passing workspaceId=null deactivates all polling (e.g., dashboard view).
 	const { mutate: setActiveSyncWorkspace } =
 		electronTrpc.workspaces.setActiveSyncWorkspace.useMutation();
 	const prevActiveIdRef = useRef<string | null>(null);
@@ -38,12 +39,13 @@ export function KeepAliveWorkspaces() {
 			setVisitedIds(Array.from(visitedSetRef.current));
 		}
 
-		// Tell the backend to only poll for this workspace
-		if (activeWorkspaceId && activeWorkspaceId !== prevActiveIdRef.current) {
+		// Tell the backend which workspace to poll (or null to stop all)
+		if (activeWorkspaceId !== prevActiveIdRef.current) {
 			prevActiveIdRef.current = activeWorkspaceId;
-			setActiveSyncWorkspace({ workspaceId: activeWorkspaceId });
+			setActiveSyncWorkspace({
+				workspaceId: activeWorkspaceId ?? "",
+			});
 		}
-		// eslint-disable-next-line react-hooks/exhaustive-deps -- mutate is stable via destructuring
 	}, [activeWorkspaceId, setActiveSyncWorkspace]);
 
 	// Evict deleted workspaces: compare visited IDs against the live list.

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/KeepAliveWorkspaces.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/KeepAliveWorkspaces.tsx
@@ -28,7 +28,7 @@ export function KeepAliveWorkspaces() {
 	const visitedSetRef = useRef(new Set<string>());
 
 	// Notify SyncService which workspace is active so only it gets polled
-	const setActiveSyncWorkspace =
+	const { mutate: setActiveSyncWorkspace } =
 		electronTrpc.workspaces.setActiveSyncWorkspace.useMutation();
 	const prevActiveIdRef = useRef<string | null>(null);
 
@@ -41,9 +41,10 @@ export function KeepAliveWorkspaces() {
 		// Tell the backend to only poll for this workspace
 		if (activeWorkspaceId && activeWorkspaceId !== prevActiveIdRef.current) {
 			prevActiveIdRef.current = activeWorkspaceId;
-			setActiveSyncWorkspace.mutate({ workspaceId: activeWorkspaceId });
+			setActiveSyncWorkspace({ workspaceId: activeWorkspaceId });
 		}
-	}, [activeWorkspaceId, setActiveSyncWorkspace.mutate]);
+		// eslint-disable-next-line react-hooks/exhaustive-deps -- mutate is stable via destructuring
+	}, [activeWorkspaceId, setActiveSyncWorkspace]);
 
 	// Evict deleted workspaces: compare visited IDs against the live list.
 	const { data: workspaceGroups } =

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/KeepAliveWorkspaces.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/KeepAliveWorkspaces.tsx
@@ -27,12 +27,23 @@ export function KeepAliveWorkspaces() {
 	const [visitedIds, setVisitedIds] = useState<string[]>([]);
 	const visitedSetRef = useRef(new Set<string>());
 
+	// Notify SyncService which workspace is active so only it gets polled
+	const setActiveSyncWorkspace =
+		electronTrpc.workspaces.setActiveSyncWorkspace.useMutation();
+	const prevActiveIdRef = useRef<string | null>(null);
+
 	useEffect(() => {
 		if (activeWorkspaceId && !visitedSetRef.current.has(activeWorkspaceId)) {
 			visitedSetRef.current.add(activeWorkspaceId);
 			setVisitedIds(Array.from(visitedSetRef.current));
 		}
-	}, [activeWorkspaceId]);
+
+		// Tell the backend to only poll for this workspace
+		if (activeWorkspaceId && activeWorkspaceId !== prevActiveIdRef.current) {
+			prevActiveIdRef.current = activeWorkspaceId;
+			setActiveSyncWorkspace.mutate({ workspaceId: activeWorkspaceId });
+		}
+	}, [activeWorkspaceId, setActiveSyncWorkspace.mutate]);
 
 	// Evict deleted workspaces: compare visited IDs against the live list.
 	const { data: workspaceGroups } =

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ActionLogsPane/ActionLogsPane.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ActionLogsPane/ActionLogsPane.tsx
@@ -377,7 +377,7 @@ export function ActionLogsPane({
 	const { data: githubStatus } =
 		electronTrpc.workspaces.getGitHubStatus.useQuery(
 			{ workspaceId },
-			{ staleTime: 3_000, refetchInterval: 3_000 },
+			{ staleTime: 5_000 },
 		);
 	const checks = githubStatus?.pr?.checks ?? [];
 

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ActionLogsPane/ActionLogsPane.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ActionLogsPane/ActionLogsPane.tsx
@@ -373,11 +373,12 @@ export function ActionLogsPane({
 	const [selectedIndex, setSelectedIndex] = useState(initialIndex);
 	const [showTimestamps, setShowTimestamps] = useState(false);
 
-	// Read check statuses from the shared getGitHubStatus cache (same source as Review tab)
+	// Read check statuses from the shared getGitHubStatus cache (same source as Review tab).
+	// refetchInterval ensures we pick up SyncService-warmed cache even when Changes Tab is hidden.
 	const { data: githubStatus } =
 		electronTrpc.workspaces.getGitHubStatus.useQuery(
 			{ workspaceId },
-			{ staleTime: 5_000 },
+			{ staleTime: 5_000, refetchInterval: 5_000 },
 		);
 	const checks = githubStatus?.pr?.checks ?? [];
 

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/ReviewPanel/components/CheckSteps/CheckSteps.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/ReviewPanel/components/CheckSteps/CheckSteps.tsx
@@ -56,6 +56,7 @@ export function CheckSteps({ detailsUrl }: CheckStepsProps) {
 			{
 				enabled: !!workspaceId && !!detailsUrl,
 				staleTime: 5_000,
+				refetchInterval: 5_000,
 			},
 		);
 

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/ReviewPanel/components/CheckSteps/CheckSteps.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/ReviewPanel/components/CheckSteps/CheckSteps.tsx
@@ -55,8 +55,7 @@ export function CheckSteps({ detailsUrl }: CheckStepsProps) {
 			{ workspaceId: workspaceId ?? "", detailsUrl },
 			{
 				enabled: !!workspaceId && !!detailsUrl,
-				staleTime: 3_000,
-				refetchInterval: 3_000,
+				staleTime: 5_000,
 			},
 		);
 


### PR DESCRIPTION
## Summary
- フロントエンドの全GitHub系refetchIntervalを無効化し、SyncServiceのキャッシュ読み取り専用に変更
- SyncServiceにactivate/deactivate機能を追加し、アクティブWSのみポーリング
- WS削除/クローズ時にSyncServiceからunregister

## Changes

### Plan A: フロントポーリング無効化
- `githubQueryPolicy.ts`: 全surfaceでrefetchInterval: false、未使用定数削除
- `ActionLogsPane.tsx`: 独自3sポーリング削除
- `CheckSteps.tsx`: 独自3sポーリング削除

### Plan B: アクティブWSのみポーリング
- `github-sync-service.ts`: activate/deactivate/setActiveWorkspace追加
- `KeepAliveWorkspaces.tsx`: WS切り替え時にsetActiveSyncWorkspace mutation通知
- `git-status.ts`: setActiveSyncWorkspace tRPC mutation追加
- `delete.ts`: WS削除/クローズ時にunregisterWorkspace追加

## Impact
| Metric | Before | After |
|--------|--------|-------|
| API calls/min (5ws, 1 active) | ~75 | ~15 |
| 非アクティブWSのポーリング | 常時 | 停止 |
| フロントのGitHub APIポーリング | 5s/20s | なし (SyncService任せ) |

## Test plan
- [ ] Review Tabを開いてPR状態がSyncService経由で更新されることを確認
- [ ] WS切り替え時に前WSのポーリングが停止、新WSのポーリングが開始されることを確認
- [ ] WS削除後にSyncServiceのタイマーがリークしないことを確認
- [ ] forceFreshボタンが引き続き動作することを確認
- [ ] `bun run typecheck` パス