### PR TITLE
merge: upstream全要検討コミット取り込み (fuzzy scorer + ターミナル系 + Host Service + ファイルツリー)

### DIFF
--- a/.agents/commands/deslop.md
+++ b/.agents/commands/deslop.md
@@ -17,9 +17,13 @@ Apply clean code philosophy to the code, with special emphasis on comments:
 
 **Keep or add comments only when:**
 - Explaining *why* a non-obvious decision was made
+- Documenting design intent or architectural decisions (e.g., "shared by X and Y paths", "deferred because Z")
 - Documenting external constraints or business rules not evident from code
 - Warning about non-intuitive behavior or edge cases
+- Noting the origin of a pattern when it aids future maintenance (e.g., "VS Code pattern")
 - Required for public API documentation (JSDoc, docstrings)
+
+**When in doubt, keep the comment.** Removing a comment that captured intent is destructive — the reasoning is lost and cannot be recovered from code alone. Only remove a comment when you are confident the code *fully* communicates the same information.
 
 ## Code Simplification
 

--- a/apps/desktop/HOST_SERVICE_ARCHITECTURE.md
+++ b/apps/desktop/HOST_SERVICE_ARCHITECTURE.md
@@ -1,0 +1,62 @@
+# Host Service Architecture
+
+What a host service is, how it's layered, and what needs to change.
+
+## What is a host service?
+
+A process that runs workspaces on a machine — laptop or remote server. It clones repos, runs terminals, watches filesystems, runs AI chat, and registers itself with the cloud as a **host**.
+
+A **device** is anything that connects (phone, browser, desktop app). A **host** is something that runs workspaces. A MacBook is both. A phone is only a device. A remote server is only a host.
+
+The host service must be deployable standalone with zero Electron awareness.
+
+## Layering
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│  ELECTRON DESKTOP (apps/desktop)                             │
+│                                                              │
+│  Owns:                                                       │
+│  - Spawning / adopting / releasing host service processes    │
+│  - Desktop-specific credential providers                     │
+│  - Session config (auth token, cloud API URL)                │
+│  - System tray UI                                            │
+│  - Quit flow (release vs stop)                               │
+│  - Manifest files (on-disk persistence for process adoption) │
+│                                                              │
+│  Does NOT own:                                               │
+│  - Workspace CRUD, host registration, terminal sessions      │
+│  - Organization metadata (the host service knows its own)    │
+│  - Any business logic a remote host would also need          │
+├──────────────────────────────────────────────────────────────┤
+│  HOST SERVICE (packages/host-service)                        │
+│                                                              │
+│  Owns:                                                       │
+│  - Workspace lifecycle (create, delete, list)                │
+│  - Host registration with the cloud                          │
+│  - Terminal PTY management                                   │
+│  - Filesystem watching                                       │
+│  - Git operations                                            │
+│  - AI chat runtime                                           │
+│  - Its own identity and metadata (host.info endpoint)        │
+│                                                              │
+│  Does NOT own:                                               │
+│  - How it was started (Electron vs systemd vs docker)        │
+│  - Credential discovery (keychain, ~/.claude, git cred mgr) │
+│  - Default paths like ~/.superset/host.db                    │
+│  - Electron concepts (resourcesPath, manifests, etc.)        │
+└──────────────────────────────────────────────────────────────┘
+```
+
+## Host vs Device
+
+Rename in host service context:
+- `deviceClientId` → `hostId` (generated internally from machine identity)
+- `deviceName` → `hostName` (generated internally from `os.hostname()`)
+- `device.ensureV2Host` → `host.register`
+
+Host identity is intrinsic — the host service generates it at startup, not passed in as config.
+
+---
+
+For API shapes, boundaries, and concrete migration steps, see [HOST_SERVICE_BOUNDARIES.md](./HOST_SERVICE_BOUNDARIES.md).

--- a/apps/desktop/HOST_SERVICE_BOUNDARIES.md
+++ b/apps/desktop/HOST_SERVICE_BOUNDARIES.md
@@ -1,0 +1,397 @@
+# Host Service Boundaries
+
+API shapes and boundaries between the host service, the Electron desktop layer, and the tray.
+
+---
+
+## 1. Host Service (`packages/host-service`)
+
+### `createApp()` — the sole entry point
+
+```ts
+createApp({
+  config: {
+    dbPath: string,            // where the SQLite database lives
+    cloudApiUrl: string,       // where the cloud API is
+    migrationsPath: string,    // where Drizzle migration files live
+    allowedOrigins: string[],  // CORS allowlist
+  },
+  providers: {
+    auth: ApiAuthProvider,                // outbound: how to authenticate with the cloud API
+    hostAuth: HostAuthProvider,           // inbound: how to validate requests to this service
+    credentials: GitCredentialProvider,   // how to get git/GitHub credentials
+    modelResolver: ModelProviderResolver, // how to resolve AI model credentials
+  },
+});
+```
+
+All fields required. No optional fields. No defaults that assume a desktop environment.
+
+**Config** = static values (strings, paths, URLs). **Providers** = injectable behavior (interfaces with different implementations per deployment).
+
+**Not config, not providers:**
+
+- `hostId` / `hostName` — generated internally by the host service from machine identity
+- Version — the service reads its own version from package.json, not from a passed-in string.
+
+### Provider interfaces
+
+```ts
+interface ApiAuthProvider {
+  getHeaders(): Promise<Record<string, string>>;
+}
+
+interface HostAuthProvider {
+  validate(request: Request): Promise<boolean>;
+  validateToken(token: string): Promise<boolean>;
+}
+
+interface GitCredentialProvider {
+  getToken(host: string): Promise<string | null>;
+}
+
+interface ModelProviderResolver {
+  resolve(cwd: string): Promise<RuntimeEnv>;
+  // Returns env vars — does NOT mutate process.env
+}
+```
+
+### tRPC endpoints
+
+**Unauthenticated (liveness probes):**
+
+```ts
+health.check → { status: "ok" }
+```
+
+**Authenticated (PSK) — host identity and metadata:**
+
+This is how the tray gets the information it needs. `host.info` is the single source of truth for "who is this host" — no metadata passed through the Electron layer.
+
+```ts
+host.info → {
+  hostId: string,
+  hostName: string,
+  organization: {
+    id: string,
+    name: string,
+    slug: string,
+  },
+  version: string,    // from package.json
+  platform: string,
+  uptime: number,
+}
+```
+
+**Authenticated (PSK) — workspace and project management:**
+
+```ts
+workspace.create → ...
+workspace.delete → ...
+workspace.list   → ...
+project.remove   → ...   // renamed from removeFromDevice
+```
+
+**Authenticated (PSK) — WebSocket routes:**
+
+```ts
+terminal/*       → WebSocket
+filesystem/*     → WebSocket
+```
+
+### What the host service is NOT
+
+`createApp()` is a factory — it wires config + providers into a Hono server and returns it. There is no "host service manager" inside the package. The complexity of the current `createApp()` (~150 lines) is just plumbing: create DB, create git factory, create API client, register routes. Provider construction is one-liners (`new PskHostAuthProvider(secret)`, etc.) — the callers are simple.
+
+---
+
+## 2. Electron Coordinator (`apps/desktop`)
+
+Manages host service child processes. This is the only complex piece on the Electron side.
+
+### Interface
+
+```ts
+interface HostServiceCoordinator {
+  // Lifecycle
+  start(organizationId: string, config: SpawnConfig): Promise<{ port: number; secret: string }>;
+  stop(organizationId: string): void;
+  restart(organizationId: string, config: SpawnConfig): Promise<{ port: number; secret: string }>;
+  stopAll(): void;
+  releaseAll(): void;
+
+  // Discovery
+  discoverAll(): Promise<void>;              // scan manifests, adopt running services
+
+  // Queries
+  getConnection(organizationId: string): { port: number; secret: string } | null;
+  getProcessStatus(organizationId: string): ProcessStatus;
+  getActiveOrganizationIds(): string[];
+  hasActiveInstances(): boolean;
+
+  // Events
+  on(event: "status-changed", handler: (e: StatusEvent) => void): void;
+}
+
+interface SpawnConfig {
+  authToken: string;
+  cloudApiUrl: string;
+  dbPath: string;
+  migrationsPath: string;
+  allowedOrigins: string[];
+}
+
+type ProcessStatus = "starting" | "running" | "degraded" | "restarting" | "stopped";
+
+interface StatusEvent {
+  organizationId: string;
+  status: ProcessStatus;
+  previousStatus: ProcessStatus | null;
+}
+```
+
+### Per-instance state
+
+After a service is running (whether spawned or adopted), the coordinator holds:
+
+```ts
+{
+  pid: number,       // the OS process ID — used for liveness checks and SIGTERM
+  port: number,      // from ready message (spawned) or manifest (adopted)
+  secret: string,    // PSK for authenticating with this instance
+}
+```
+
+That's the steady-state. During spawn, the coordinator picks a free port, passes it to the host service as config (env var), then polls `health.check` on that port until the service is up. No Node IPC channel needed — the host service just starts on the port it's told. Once healthy, the coordinator records the pid/port/secret and discards the `ChildProcess` handle (`unref`'d so it survives app quit). From that point, spawned and adopted processes are treated identically: just a PID to check liveness and signal, a port to connect to, and a secret to authenticate.
+
+### Where the complexity lives
+
+The coordinator is ~500 lines. This is irreducible complexity from managing processes that survive app restarts:
+
+| Concern | Why it's unavoidable |
+|---------|---------------------|
+| Spawn + health poll | Must start the child, poll health.check until ready, handle timeout |
+| Adoption from manifests | Must read disk, health-check the process, verify it's reachable |
+| Liveness polling | Adopted processes have no exit event — must poll PID |
+| Restart with backoff | Crashed services need exponential backoff, not immediate retry |
+| Pending start dedup | Concurrent `start()` calls for the same org must coalesce |
+| Release vs stop | Quit flow needs to either detach or kill each service |
+
+The current 800-line manager mixes these with org metadata, session config, display formatting, compatibility checks, and version tracking. The coordinator drops all of that — it only manages processes. The ~300 lines saved aren't from removing complexity; they're from removing concerns that don't belong.
+
+### What the coordinator does NOT hold
+
+| Data | Where it lives instead |
+|------|----------------------|
+| Organization name/metadata | Host service (`host.info` endpoint) |
+| Auth token, cloud API URL | Passed per-call as `SpawnConfig`, not stored |
+| Service version | Host service (`host.info` endpoint) |
+| Uptime | Host service (`host.info` endpoint) |
+| Compatibility / pending restart | Derived at query time by comparing `host.info` version vs app version |
+
+### Config passing
+
+```ts
+// Before (mutate-then-call anti-pattern)
+manager.setAuthToken(token);
+manager.setCloudApiUrl(url);
+manager.setOrganizationName(organizationId, name);
+await manager.start(organizationId);
+
+// After (pass config per-call)
+await coordinator.start(organizationId, {
+  authToken: token,
+  cloudApiUrl: url,
+  dbPath: path.join(orgDir, "host.db"),
+  migrationsPath: getMigrationsPath(),
+  allowedOrigins: [`http://localhost:${vitePort}`],
+});
+```
+
+---
+
+## 3. Tray (`apps/desktop`)
+
+Pure view. Reads from two sources, writes to coordinator.
+
+### Data sources
+
+```
+From host.info (HTTP to each service, authenticated with PSK):
+  - organization.name        → menu section header
+  - version                  → display label
+  - uptime                   → display label
+
+From coordinator (in-process):
+  - status                   → "Running" / "Starting..." / "Degraded"
+  - hasActiveInstances       → controls quit menu options
+```
+
+### Actions
+
+```
+Restart  → coordinator.restart(organizationId, config)
+Stop     → coordinator.stop(organizationId)
+Quit (keep services)   → coordinator.releaseAll() + app.exit()
+Quit (stop services)   → coordinator.stopAll() + app.exit()
+```
+
+### Menu structure
+
+```
+Host Service (N)
+├── <org name>                          ← from host.info
+│   ├── Running (v1.2.3)               ← status from coordinator, version from host.info
+│   ├── Uptime: 2h 15m                 ← from host.info
+│   ├── Restart
+│   └── Stop
+├── ─────────
+├── <another org>
+│   └── ...
+├── ─────────
+├── Open Superset
+├── Settings
+├── Check for Updates
+├── ─────────
+├── Quit (Keep Services Running)        ← only if hasActiveInstances
+└── Quit & Stop Services                ← only if hasActiveInstances
+```
+
+---
+
+## 4. Renderer HostServiceProvider (`apps/desktop`)
+
+Queries the coordinator for connection info, then talks directly to host services over HTTP/WS.
+
+```ts
+// From coordinator (via tRPC IPC)
+const { port, secret } = await trpc.hostService.getConnection.query({ organizationId });
+
+// Direct to host service (HTTP/WS)
+const client = createHostServiceClient(port, secret);
+await client.workspace.list.query();
+```
+
+The provider maintains `Map<organizationId, { port, url, client }>` — just connection info. No metadata caching.
+
+---
+
+## 5. Manifest (`apps/desktop` — Electron-only concept)
+
+On-disk JSON file per org. Written by the coordinator once the spawned service reports it's ready (pid, port). Read by the coordinator for adoption on next app launch. The host service itself has no knowledge of manifests.
+
+```ts
+interface Manifest {
+  pid: number,
+  endpoint: string,          // e.g. "http://127.0.0.1:4832"
+  authToken: string,         // PSK secret for this instance
+  startedAt: number,
+  organizationId: string,
+}
+```
+
+Minimal — just enough to reconnect. No version or protocol fields; the coordinator queries `host.info` after adoption for metadata if needed.
+
+Lives at `~/.superset/host/<organizationId>/manifest.json`. The coordinator writes and reads it. Remote deployments don't use manifests.
+
+---
+
+## 6. What moves where
+
+### Out of `packages/host-service`
+
+| Item | Current location | Moves to | Reason |
+| --- | --- | --- | --- |
+| `process.resourcesPath` / `ELECTRON_RUN_AS_NODE` | `db.ts` | Electron entry point | `migrationsPath` is now required config |
+| `ORGANIZATION_ID` from `process.env` | `health.ts` | Removed | Org info served via `host.info`, fetched from cloud at registration |
+| `LocalModelProvider` as default | `app.ts` | Injected by caller | `modelResolver` is required, no default |
+| `LocalGitCredentialProvider` as default | `app.ts` | Injected by caller | `credentials` is required, no default |
+| Default `~/.superset/host.db` | `app.ts` | Injected by caller | `dbPath` is required, no default |
+| `~/.superset/chat-anthropic-env.json` | `anthropic-runtime-env.ts` | Moves with `LocalModelProvider` | Desktop-only path |
+| macOS Keychain reads | `resolveAnthropicCredential.ts` | Moves with `LocalModelProvider` | macOS-only |
+| `~/.claude/` credential reads | `resolveAnthropicCredential.ts` | Moves with `LocalModelProvider` | Claude Desktop-only |
+| `project.removeFromDevice` | `project.ts` | Rename to `project.remove` | "Device" framing is wrong |
+| `process.env` mutations in `applyRuntimeEnv()` | `runtime-env.ts` | Model providers return env, don't mutate | Dangerous in multi-tenant context |
+| `health.info` (current combined endpoint) | `health.ts` | Split into `health.check` + `host.info` | Liveness vs metadata are different concerns |
+
+### Stays in `packages/host-service`
+
+| Item | Why |
+| --- | --- |
+| Workspace CRUD | Core host responsibility |
+| Host registration (renamed from device) | Host registers itself as a network node |
+| Terminal PTY management | Core host responsibility |
+| Filesystem watching | Core host responsibility |
+| Git operations | Core host responsibility |
+| AI chat runtime | Core host responsibility |
+| `health.check` (liveness only) | Every service needs this |
+| `host.info` (new, authenticated) | Host is the source of truth for its own identity |
+| `PskHostAuthProvider` | Pure validation, works everywhere |
+| `CloudGitCredentialProvider` / `CloudModelProvider` | Cloud-backed, environment-agnostic |
+| Shell resolution (`process.platform` in terminal) | Terminals inherently need to know the OS |
+| `terminal_sessions` table | Session tracking is host-service state |
+
+### Gaps to fix in standalone `serve.ts`
+
+| Gap | Fix |
+| --- | --- |
+| `auth` / `cloudApiUrl` not passed | Make required — standalone needs cloud connectivity |
+| `credentials` defaults to `LocalGitCredentialProvider` | Use `CloudGitCredentialProvider` |
+| `modelResolver` defaults to `LocalModelProvider` | Use `CloudModelProvider` |
+| No terminal session reconciliation at startup | Mark orphaned `"active"` sessions as `"disposed"` on boot |
+| `health.info` unauthenticated | Move metadata to `host.info` behind PSK auth |
+
+---
+
+## 7. Entry point examples
+
+### Electron
+
+```ts
+// apps/desktop/src/main/host-service/index.ts
+import { createApp, PskHostAuthProvider, JwtApiAuthProvider } from "@superset/host-service";
+import { LocalGitCredentialProvider } from "@superset/host-service/providers/desktop";
+import { LocalModelProvider } from "@superset/host-service/providers/desktop";
+
+createApp({
+  config: {
+    dbPath: path.join(orgDir, "host.db"),
+    cloudApiUrl: env.CLOUD_API_URL,
+    migrationsPath: app.isPackaged
+      ? path.join(process.resourcesPath, "resources/host-migrations")
+      : path.join(app.getAppPath(), "../../packages/host-service/drizzle"),
+    allowedOrigins: [`http://localhost:${desktopVitePort}`],
+  },
+  providers: {
+    auth: new JwtApiAuthProvider(authToken),
+    hostAuth: new PskHostAuthProvider(secret),
+    credentials: new LocalGitCredentialProvider(),
+    modelResolver: new LocalModelProvider(),
+  },
+});
+```
+
+### Standalone
+
+```ts
+// packages/host-service/src/serve.ts
+import { createApp, PskHostAuthProvider, JwtApiAuthProvider,
+         CloudGitCredentialProvider, CloudModelProvider } from "./index";
+
+createApp({
+  config: {
+    dbPath: env.HOST_DB_PATH,
+    cloudApiUrl: env.CLOUD_API_URL,
+    migrationsPath: join(import.meta.dirname, "../../drizzle"),
+    allowedOrigins: env.CORS_ORIGINS,
+  },
+  providers: {
+    auth: new JwtApiAuthProvider(env.AUTH_TOKEN),
+    hostAuth: new PskHostAuthProvider(env.HOST_SERVICE_SECRET),
+    credentials: new CloudGitCredentialProvider(),
+    modelResolver: new CloudModelProvider(),
+  },
+});
+```
+
+No `if (process.resourcesPath)`. No `if (platform() === "darwin")`. No `~/.superset` defaults. The host service is a pure server; the caller decides how it's configured.

--- a/apps/desktop/HOST_SERVICE_LIFECYCLE.md
+++ b/apps/desktop/HOST_SERVICE_LIFECYCLE.md
@@ -1,0 +1,75 @@
+# Host Service Lifecycle
+
+## Architecture
+
+Electron main owns app lifecycle, tray, and host-service management. Host-services run as child processes that can outlive the app via manifest-based adoption.
+
+```
+┌─────────────────────────────────────────────────────┐
+│ Electron Main Process                               │
+│                                                     │
+│  ┌──────────┐  ┌──────────────────────┐  ┌───────┐ │
+│  │   Tray   │  │ HostServiceManager   │  │Windows│ │
+│  │ (macOS)  │  │                      │  │       │ │
+│  │          │◄─┤ status events        │  │ hide/ │ │
+│  │ restart  │  │ start/stop/adopt     │  │ show  │ │
+│  │ stop     │  │ per org              │  │       │ │
+│  │ quit ────┼──┼──► requestQuit(mode) │  │       │ │
+│  └──────────┘  └──────┬───────────────┘  └───────┘ │
+└───────────────────────┼─────────────────────────────┘
+                        │ IPC + stdio
+          ┌─────────────┼─────────────┐
+          │             │             │
+          ▼             ▼             ▼
+   ┌────────────┐ ┌────────────┐ ┌────────────┐
+   │host-service│ │host-service│ │host-service│
+   │  (org A)   │ │  (org B)   │ │  (org C)   │
+   │            │ │            │ │            │
+   │ HTTP/tRPC  │ │ HTTP/tRPC  │ │ HTTP/tRPC  │
+   │ port:rand  │ │ port:rand  │ │ port:rand  │
+   │            │ │            │ │            │
+   │ writes     │ │ writes     │ │ writes     │
+   │ manifest   │ │ manifest   │ │ manifest   │
+   └────────────┘ └────────────┘ └────────────┘
+        │              │              │
+        ▼              ▼              ▼
+   ~/.superset/host/{orgId}/manifest.json
+```
+
+### Quit modes
+
+All quit paths use a single `QuitMode` (`"release" | "stop"`):
+
+- **release** — detach from services, they keep running for re-adoption on next launch
+- **stop** — SIGTERM all services, then exit
+- **implicit** (Cmd+Q with active services on macOS) — hide windows to tray
+
+### Manifest adoption
+
+Each host-service child writes `~/.superset/host/{orgId}/manifest.json` on startup (pid, endpoint, authToken, version). It's a pidfile extended with connection info.
+
+- **Release quit** — children keep running, manifests stay on disk
+- **Next launch** — `discoverAndAdoptAll()` scans manifests, health-checks each pid/endpoint, reconnects if healthy, removes and respawns if not
+- **Stop quit** — SIGTERM children, they remove their own manifests on shutdown
+
+```
+App Launch                          App Quit (release)          Next Launch
+─────────                          ──────────────────          ───────────
+spawn child ──► child writes        parent detaches             scan manifests
+               manifest.json        manifests stay on disk      health-check pid/endpoint
+               {pid, endpoint,      child keeps running         ├─ healthy → reconnect
+                authToken, ...}                                 └─ dead/bad → remove, respawn
+```
+
+### v1 vs v2 terminal paths
+
+v1 terminals run on a separate **terminal-host daemon** (`src/main/terminal-host/`) — a persistent background process that owns PTYs over a Unix domain socket. It has its own survival and reconnection model independent of host-service.
+
+v2 terminals run through **host-service** child processes. The quit/adopt/tray lifecycle described here only applies to host-service instances.
+
+### Design decisions
+
+- **No supervisor process.** Electron main owns everything. Simpler while v1 and v2 coexist.
+- **No tray on Windows/Linux.** Services still survive quit and are re-adopted, but there's no persistent UI to manage them.
+- **Tray calls `requestQuit(mode)`.** One function, one codepath — no setter chains or flag mutation.
+- **Manifest handling is single-sourced.** Both parent and child use `host-service-manifest.ts`. Files are written with 0o600 permissions.

--- a/apps/desktop/src/lib/electron-app/factories/app/setup.ts
+++ b/apps/desktop/src/lib/electron-app/factories/app/setup.ts
@@ -33,8 +33,10 @@ export async function makeAppSetup(
 		if (!windows.length) {
 			window = await createWindow();
 		} else {
+			// Show hidden windows (macOS hide-to-tray) or restore minimized ones
 			for (window of windows.reverse()) {
-				window.restore();
+				window.show();
+				window.focus();
 			}
 		}
 	});
@@ -50,8 +52,10 @@ export async function makeAppSetup(
 		});
 	});
 
+	// macOS: keep the app alive (standard behavior) — tray/dock provide re-entry.
+	// Windows/Linux: quit the app UI. Host-services survive via releaseAll()
+	// and will be re-adopted on next launch.
 	app.on("window-all-closed", () => !PLATFORM.IS_MAC && app.quit());
-	app.on("before-quit", () => {});
 
 	return window;
 }

--- a/apps/desktop/src/lib/trpc/routers/host-service-manager/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/host-service-manager/index.ts
@@ -1,5 +1,9 @@
+import { observable } from "@trpc/server/observable";
 import { env } from "main/env.main";
-import { getHostServiceManager } from "main/lib/host-service-manager";
+import {
+	getHostServiceManager,
+	type HostServiceStatusEvent,
+} from "main/lib/host-service-manager";
 import { z } from "zod";
 import { publicProcedure, router } from "../..";
 import { loadToken } from "../auth/utils/auth-functions";
@@ -7,7 +11,12 @@ import { loadToken } from "../auth/utils/auth-functions";
 export const createHostServiceManagerRouter = () => {
 	return router({
 		getLocalPort: publicProcedure
-			.input(z.object({ organizationId: z.string() }))
+			.input(
+				z.object({
+					organizationId: z.string(),
+					organizationName: z.string().optional(),
+				}),
+			)
 			.query(async ({ input }) => {
 				const manager = getHostServiceManager();
 				const { token } = await loadToken();
@@ -15,6 +24,12 @@ export const createHostServiceManagerRouter = () => {
 					manager.setAuthToken(token);
 				}
 				manager.setCloudApiUrl(env.NEXT_PUBLIC_API_URL);
+				if (input.organizationName) {
+					manager.setOrganizationName(
+						input.organizationId,
+						input.organizationName,
+					);
+				}
 				const port = await manager.start(input.organizationId);
 				const secret = manager.getSecret(input.organizationId);
 				return { port, secret };
@@ -27,5 +42,42 @@ export const createHostServiceManagerRouter = () => {
 				const status = manager.getStatus(input.organizationId);
 				return { status };
 			}),
+
+		getServiceInfo: publicProcedure
+			.input(z.object({ organizationId: z.string() }))
+			.query(({ input }) => {
+				const manager = getHostServiceManager();
+				return manager.getServiceInfo(input.organizationId);
+			}),
+
+		restart: publicProcedure
+			.input(z.object({ organizationId: z.string() }))
+			.mutation(async ({ input }) => {
+				const manager = getHostServiceManager();
+				const { token } = await loadToken();
+				if (token) {
+					manager.setAuthToken(token);
+				}
+				manager.setCloudApiUrl(env.NEXT_PUBLIC_API_URL);
+				const port = await manager.restart(input.organizationId);
+				const secret = manager.getSecret(input.organizationId);
+				return { port, secret };
+			}),
+
+		onStatusChange: publicProcedure.subscription(() => {
+			return observable<HostServiceStatusEvent>((emit) => {
+				const manager = getHostServiceManager();
+
+				const handler = (event: HostServiceStatusEvent) => {
+					emit.next(event);
+				};
+
+				manager.on("status-changed", handler);
+
+				return () => {
+					manager.off("status-changed", handler);
+				};
+			});
+		}),
 	});
 };

--- a/apps/desktop/src/lib/trpc/routers/settings/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/settings/index.ts
@@ -17,7 +17,7 @@ import {
 } from "@superset/shared/agent-command";
 import { TRPCError } from "@trpc/server";
 import { app } from "electron";
-import { quitWithoutConfirmation } from "main/index";
+import { exitImmediately } from "main/index";
 import { hasCustomRingtone } from "main/lib/custom-ringtones";
 import { localDb } from "main/lib/local-db";
 import {
@@ -717,7 +717,7 @@ export const createSettingsRouter = () => {
 
 		restartApp: publicProcedure.mutation(() => {
 			app.relaunch();
-			quitWithoutConfirmation();
+			exitImmediately();
 			return { success: true };
 		}),
 

--- a/apps/desktop/src/main/host-service/index.ts
+++ b/apps/desktop/src/main/host-service/index.ts
@@ -5,6 +5,9 @@
  *
  * Starts the host-service HTTP server on a random local port.
  * The parent Electron process reads the port from the IPC channel.
+ *
+ * When KEEP_ALIVE_AFTER_PARENT=1, the service stays running even if the
+ * parent Electron process exits (out-of-app durability mode).
  */
 
 import { serve } from "@hono/node-server";
@@ -14,6 +17,11 @@ import {
 	LocalGitCredentialProvider,
 	PskHostAuthProvider,
 } from "@superset/host-service";
+import {
+	HOST_SERVICE_PROTOCOL_VERSION,
+	removeManifest,
+	writeManifest,
+} from "main/lib/host-service-manifest";
 
 const authToken = process.env.AUTH_TOKEN;
 const cloudApiUrl = process.env.CLOUD_API_URL;
@@ -21,7 +29,11 @@ const dbPath = process.env.HOST_DB_PATH;
 const deviceClientId = process.env.DEVICE_CLIENT_ID;
 const deviceName = process.env.DEVICE_NAME;
 const hostServiceSecret = process.env.HOST_SERVICE_SECRET;
+const serviceVersion = process.env.HOST_SERVICE_VERSION ?? null;
+const protocolVersion = HOST_SERVICE_PROTOCOL_VERSION;
+const organizationId = process.env.ORGANIZATION_ID ?? "";
 const desktopVitePort = process.env.DESKTOP_VITE_PORT ?? "5173";
+const keepAliveAfterParent = process.env.KEEP_ALIVE_AFTER_PARENT === "1";
 
 const auth =
 	authToken && cloudApiUrl ? new JwtApiAuthProvider(authToken) : undefined;
@@ -37,21 +49,49 @@ const { app, injectWebSocket } = createApp({
 	dbPath,
 	deviceClientId,
 	deviceName,
+	serviceVersion,
+	protocolVersion,
 	allowedOrigins: [
 		`http://localhost:${desktopVitePort}`,
 		`http://127.0.0.1:${desktopVitePort}`,
 	],
 });
 
+const startedAt = Date.now();
+
 const server = serve(
 	{ fetch: app.fetch, port: 0, hostname: "127.0.0.1" },
 	(info: { port: number }) => {
-		process.send?.({ type: "ready", port: info.port });
+		if (organizationId) {
+			try {
+				writeManifest({
+					pid: process.pid,
+					endpoint: `http://127.0.0.1:${info.port}`,
+					authToken: hostServiceSecret ?? "",
+					serviceVersion: serviceVersion ?? "",
+					protocolVersion: protocolVersion ?? 0,
+					startedAt,
+					organizationId,
+				});
+			} catch (error) {
+				console.error("[host-service] Failed to write manifest:", error);
+			}
+		}
+		process.send?.({
+			type: "ready",
+			port: info.port,
+			serviceVersion,
+			protocolVersion,
+			startedAt,
+		});
 	},
 );
 injectWebSocket(server);
 
 const shutdown = () => {
+	if (organizationId) {
+		removeManifest(organizationId);
+	}
 	server.close();
 	process.exit(0);
 };
@@ -59,15 +99,18 @@ const shutdown = () => {
 process.on("SIGTERM", shutdown);
 process.on("SIGINT", shutdown);
 
-// Orphan cleanup: exit if parent Electron process dies
-const parentPid = process.ppid;
-const parentCheck = setInterval(() => {
-	try {
-		process.kill(parentPid, 0);
-	} catch {
-		clearInterval(parentCheck);
-		console.log("[host-service] Parent process exited, shutting down");
-		shutdown();
-	}
-}, 2000);
-parentCheck.unref();
+// Orphan cleanup: exit if parent Electron process dies.
+// Disabled in keep-alive mode so the service survives app quit.
+if (!keepAliveAfterParent) {
+	const parentPid = process.ppid;
+	const parentCheck = setInterval(() => {
+		try {
+			process.kill(parentPid, 0);
+		} catch {
+			clearInterval(parentCheck);
+			console.log("[host-service] Parent process exited, shutting down");
+			shutdown();
+		}
+	}, 2000);
+	parentCheck.unref();
+}

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -43,7 +43,7 @@ import {
 	reconcileDaemonSessions,
 } from "./lib/terminal";
 import { disposeTray, initTray } from "./lib/tray";
-import { MainWindow } from "./windows/main";
+import { MainWindow, cleanupMainWindowResources } from "./windows/main";
 
 console.log("[main] Local database ready:", !!localDb);
 const IS_DEV = process.env.NODE_ENV === "development";
@@ -378,6 +378,7 @@ app.on("before-quit", async (event) => {
 		manager.hasActiveInstances()
 	) {
 		event.preventDefault();
+		cleanupMainWindowResources();
 		for (const win of BrowserWindow.getAllWindows()) {
 			win.destroy();
 		}

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -273,7 +273,7 @@ function findDeepLinkInArgv(argv: string[]): string | undefined {
 	return argv.find((arg) => arg.startsWith(`${PROTOCOL_SCHEME}://`));
 }
 
-function focusMainWindow(): void {
+export function focusMainWindow(): void {
 	const windows = BrowserWindow.getAllWindows();
 	if (windows.length > 0) {
 		const mainWindow = windows[0];
@@ -282,6 +282,9 @@ function focusMainWindow(): void {
 		}
 		mainWindow.show();
 		mainWindow.focus();
+	} else {
+		// Triggers window creation via makeAppSetup's activate handler
+		app.emit("activate");
 	}
 }
 
@@ -326,8 +329,29 @@ app.on("open-url", async (event, url) => {
 	}
 });
 
+export type QuitMode = "release" | "stop";
+let pendingQuitMode: QuitMode | null = null;
 let isQuitting = false;
-let skipConfirmation = false;
+
+/** Request the app to quit.
+ *  - "release": keep services running (re-adoptable on next launch)
+ *  - "stop": terminate all services before exit */
+export function requestQuit(mode: QuitMode): void {
+	pendingQuitMode = mode;
+	app.quit();
+}
+
+/** Set quit mode without triggering quit.
+ *  Use when another API (e.g. autoUpdater.quitAndInstall) triggers quit internally. */
+export function prepareQuit(mode: QuitMode): void {
+	pendingQuitMode = mode;
+}
+
+/** Exit the process immediately, bypassing before-quit.
+ *  Services are left running for adoption on next launch. */
+export function exitImmediately(): void {
+	app.exit(0);
+}
 
 function getConfirmOnQuitSetting(): boolean {
 	try {
@@ -338,23 +362,30 @@ function getConfirmOnQuitSetting(): boolean {
 	}
 }
 
-export function setSkipQuitConfirmation(): void {
-	skipConfirmation = true;
-}
-
-export function quitWithoutConfirmation(): void {
-	skipConfirmation = true;
-	app.exit(0);
-}
-
 app.on("before-quit", async (event) => {
 	if (isQuitting) return;
 
-	const isDev = process.env.NODE_ENV === "development";
-	const shouldConfirm =
-		!skipConfirmation && !isDev && getConfirmOnQuitSetting();
+	// Consume the quit mode so it doesn't persist across aborted quits
+	const quitMode = pendingQuitMode;
+	pendingQuitMode = null;
 
-	if (shouldConfirm) {
+	const manager = getHostServiceManager();
+
+	// macOS: close windows & keep tray alive when services should stay running
+	if (
+		PLATFORM.IS_MAC &&
+		(quitMode === null || quitMode === "release") &&
+		manager.hasActiveInstances()
+	) {
+		event.preventDefault();
+		for (const win of BrowserWindow.getAllWindows()) {
+			win.destroy();
+		}
+		return;
+	}
+
+	const isDev = process.env.NODE_ENV === "development";
+	if (quitMode === null && !isDev && getConfirmOnQuitSetting()) {
 		event.preventDefault();
 
 		try {
@@ -367,17 +398,21 @@ app.on("before-quit", async (event) => {
 				message: "Are you sure you want to quit?",
 			});
 
-			if (response === 1) return;
+			if (response === 1) {
+				return;
+			}
 		} catch (error) {
 			console.error("[main] Quit confirmation dialog failed:", error);
 		}
 	}
 
-	// Quit confirmed or no confirmation needed - exit immediately
-	// Let OS clean up child processes, tray, etc.
 	isQuitting = true;
 	closeLocalDb();
-	getHostServiceManager().stopAll();
+	if (quitMode === "stop") {
+		manager.stopAll();
+	} else {
+		manager.releaseAll();
+	}
 	disposeTray();
 	app.exit(0);
 });
@@ -508,7 +543,7 @@ if (!gotTheLock) {
 					try {
 						return await net.fetch(pathToFileURL(fontPath).toString());
 					} catch {
-						// Font not in this directory, try next
+						// Not in this directory
 					}
 				}
 				return new Response("Not found", { status: 404 });
@@ -544,11 +579,14 @@ if (!gotTheLock) {
 			console.error("[main] Failed to set up agent hooks:", error);
 		}
 
+		// Discover and adopt host-services that survived a previous quit
+		// before the tray initializes, so it shows accurate status immediately.
+		await getHostServiceManager().discoverAndAdoptAll();
+
 		await makeAppSetup(() => MainWindow());
 		setupAutoUpdater();
 		initTray();
 
-		// Process any deep links from cold start
 		const coldStartUrl = findDeepLinkInArgv(process.argv);
 		if (coldStartUrl) {
 			await processDeepLink(coldStartUrl);

--- a/apps/desktop/src/main/lib/auto-updater.ts
+++ b/apps/desktop/src/main/lib/auto-updater.ts
@@ -104,8 +104,10 @@ export function installUpdate(): void {
 		emitStatus(AUTO_UPDATE_STATUS.IDLE);
 		return;
 	}
-	// quitAndInstall internally calls app.quit() — set mode beforehand
-	prepareQuit("release");
+	// quitAndInstall internally calls app.quit() — use "stop" mode so
+	// before-quit doesn't prevent exit on macOS with active host services.
+	// "release" would keep services alive and block the quit.
+	prepareQuit("stop");
 	autoUpdater.quitAndInstall(false, true);
 }
 

--- a/apps/desktop/src/main/lib/auto-updater.ts
+++ b/apps/desktop/src/main/lib/auto-updater.ts
@@ -2,6 +2,7 @@ import { EventEmitter } from "node:events";
 import { app, dialog } from "electron";
 import { autoUpdater } from "electron-updater";
 import { env } from "main/env.main";
+import { prepareQuit } from "main/index";
 import { gt, prerelease, valid } from "semver";
 import { AUTO_UPDATE_STATUS, type AutoUpdateStatus } from "shared/auto-update";
 import { PLATFORM } from "shared/constants";
@@ -103,6 +104,8 @@ export function installUpdate(): void {
 		emitStatus(AUTO_UPDATE_STATUS.IDLE);
 		return;
 	}
+	// quitAndInstall internally calls app.quit() — set mode beforehand
+	prepareQuit("release");
 	autoUpdater.quitAndInstall(false, true);
 }
 
@@ -435,6 +438,15 @@ export function setupAutoUpdater(): void {
 			`[auto-updater] Update downloaded: ${app.getVersion()} → ${info.version}. Ready to install.`,
 		);
 		emitStatus(AUTO_UPDATE_STATUS.READY, info.version);
+
+		// After an app update is ready, check if running host-service instances
+		// will need a restart once the new version is installed.
+		try {
+			const { getHostServiceManager } = require("../host-service-manager");
+			getHostServiceManager().checkAllCompatibility();
+		} catch {
+			// Host service manager may not be initialized yet
+		}
 	});
 
 	const interval = setInterval(checkForUpdates, UPDATE_CHECK_INTERVAL_MS);

--- a/apps/desktop/src/main/lib/host-service-manager.test.ts
+++ b/apps/desktop/src/main/lib/host-service-manager.test.ts
@@ -26,6 +26,8 @@ class MockChildProcess extends EventEmitter {
 	stdout = new EventEmitter();
 	stderr = new EventEmitter();
 	kill = mock(() => true);
+	disconnect = mock(() => {});
+	unref = mock(() => {});
 }
 
 const getProcessEnvWithShellPathMock = mock(
@@ -37,6 +39,8 @@ const spawnMock = mock((..._args: unknown[]) => {
 	return lastChild as unknown as ChildProcess;
 });
 let HostServiceManager: typeof import("./host-service-manager").HostServiceManager;
+let checkCompatibility: typeof import("./host-service-manager").checkCompatibility;
+let HOST_SERVICE_PROTOCOL_VERSION: typeof import("./host-service-manifest").HOST_SERVICE_PROTOCOL_VERSION;
 
 describe("HostServiceManager", () => {
 	beforeAll(async () => {
@@ -58,10 +62,16 @@ describe("HostServiceManager", () => {
 			app: {
 				isPackaged: false,
 				getAppPath: () => "/tmp/app",
+				getVersion: () => "1.0.0-test",
 			},
 		}));
 
-		({ HostServiceManager } = await import("./host-service-manager"));
+		({ HostServiceManager, checkCompatibility } = await import(
+			"./host-service-manager"
+		));
+		({ HOST_SERVICE_PROTOCOL_VERSION } = await import(
+			"./host-service-manifest"
+		));
 	});
 
 	afterAll(() => {
@@ -90,6 +100,9 @@ describe("HostServiceManager", () => {
 		const secondStart = manager.start("org-1");
 
 		expect(manager.getStatus("org-1")).toBe("starting");
+
+		// Flush microtasks so tryAdopt completes (no manifest → falls through to spawn)
+		await new Promise((resolve) => setTimeout(resolve, 0));
 		expect(getProcessEnvWithShellPathMock.mock.calls).toHaveLength(1);
 
 		pendingEnv.resolve({ PATH: "/usr/bin:/bin" });
@@ -106,5 +119,81 @@ describe("HostServiceManager", () => {
 		expect(await firstStart).toBe(4242);
 		expect(await secondStart).toBe(4242);
 		expect(manager.getPort("org-1")).toBe(4242);
+	});
+
+	it("stopAll() kills all instances", async () => {
+		const manager = new HostServiceManager();
+
+		const p1 = manager.start("org-1");
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		const child1 = lastChild;
+		child1?.emit("message", { type: "ready", port: 4001 });
+		await p1;
+
+		const p2 = manager.start("org-2");
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		const child2 = lastChild;
+		child2?.emit("message", { type: "ready", port: 4002 });
+		await p2;
+
+		manager.stopAll();
+
+		expect(child1?.kill).toHaveBeenCalledWith("SIGTERM");
+		expect(child2?.kill).toHaveBeenCalledWith("SIGTERM");
+		expect(manager.getStatus("org-1")).toBe("stopped");
+		expect(manager.getStatus("org-2")).toBe("stopped");
+	});
+
+	it("releaseAll() detaches without killing", async () => {
+		const manager = new HostServiceManager();
+
+		const p1 = manager.start("org-1");
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		lastChild?.emit("message", { type: "ready", port: 4001 });
+		await p1;
+
+		const child = lastChild;
+
+		manager.releaseAll();
+
+		expect(child?.kill).not.toHaveBeenCalled();
+		expect(manager.getStatus("org-1")).toBe("stopped");
+	});
+
+	describe("checkCompatibility", () => {
+		it("returns null when protocol version is unknown", () => {
+			const result = checkCompatibility({
+				protocolVersion: null,
+				serviceVersion: null,
+			});
+			expect(result).toBeNull();
+		});
+
+		it("detects protocol mismatch", () => {
+			const result = checkCompatibility({
+				protocolVersion: 999,
+				serviceVersion: "1.0.0",
+			});
+			expect(result).toEqual({
+				compatible: false,
+				reason: expect.stringContaining("Protocol mismatch"),
+			});
+		});
+
+		it("detects compatible with update available", () => {
+			const result = checkCompatibility({
+				protocolVersion: HOST_SERVICE_PROTOCOL_VERSION,
+				serviceVersion: "0.0.1-old",
+			});
+			expect(result).toEqual({ compatible: true, updateAvailable: true });
+		});
+
+		it("detects compatible with same version", () => {
+			const result = checkCompatibility({
+				protocolVersion: HOST_SERVICE_PROTOCOL_VERSION,
+				serviceVersion: "1.0.0-test",
+			});
+			expect(result).toEqual({ compatible: true, updateAvailable: false });
+		});
 	});
 });

--- a/apps/desktop/src/main/lib/host-service-manager.ts
+++ b/apps/desktop/src/main/lib/host-service-manager.ts
@@ -1,15 +1,55 @@
 import type { ChildProcess } from "node:child_process";
 import * as childProcess from "node:child_process";
 import { randomBytes } from "node:crypto";
+import { EventEmitter } from "node:events";
 import path from "node:path";
 import { app } from "electron";
 import { getProcessEnvWithShellPath } from "../../lib/trpc/routers/workspaces/utils/shell-env";
-import { SUPERSET_HOME_DIR } from "./app-environment";
 import { getDeviceName, getHashedDeviceId } from "./device-info";
+import {
+	HOST_SERVICE_PROTOCOL_VERSION,
+	type HostServiceManifest,
+	isProcessAlive,
+	listManifests,
+	manifestDir,
+	readManifest,
+	removeManifest,
+} from "./host-service-manifest";
 
-type HostServiceStatus = "starting" | "running" | "crashed";
+export type HostServiceStatus =
+	| "starting"
+	| "running"
+	| "degraded"
+	| "restarting"
+	| "stopped";
+
+export type CompatibilityResult =
+	| { compatible: true; updateAvailable: boolean }
+	| { compatible: false; reason: string };
+
+export interface HostServiceInfo {
+	organizationId: string;
+	organizationName: string | null;
+	status: HostServiceStatus;
+	port: number | null;
+	serviceVersion: string | null;
+	protocolVersion: number | null;
+	startedAt: number | null;
+	uptime: number | null;
+	restartCount: number;
+	pendingRestart: boolean;
+	compatibility: CompatibilityResult | null;
+	adopted: boolean;
+}
+
+export interface HostServiceStatusEvent {
+	organizationId: string;
+	status: HostServiceStatus;
+	previousStatus: HostServiceStatus | null;
+}
 
 interface HostServiceProcess {
+	/** null when the instance was adopted from a manifest (no child handle). */
 	process: ChildProcess | null;
 	port: number | null;
 	secret: string | null;
@@ -17,6 +57,14 @@ interface HostServiceProcess {
 	restartCount: number;
 	lastCrash?: number;
 	organizationId: string;
+	startedAt: number | null;
+	serviceVersion: string | null;
+	protocolVersion: number | null;
+	pendingRestart: boolean;
+	/** True when this instance was adopted from a running manifest rather than spawned. */
+	adopted: boolean;
+	/** PID of the adopted process (for liveness checks). */
+	adoptedPid: number | null;
 }
 
 interface PendingStart {
@@ -29,6 +77,9 @@ interface PendingStart {
 
 const MAX_RESTART_DELAY = 30_000;
 const BASE_RESTART_DELAY = 1_000;
+
+/** Interval for checking liveness of adopted (non-child) processes. */
+const ADOPTED_LIVENESS_INTERVAL = 5_000;
 
 function createPortDeferred(): {
 	promise: Promise<number>;
@@ -45,9 +96,59 @@ function createPortDeferred(): {
 	return { promise, resolve, reject };
 }
 
-export class HostServiceManager {
+/** Check whether a host-service instance is compatible with this app version. */
+export function checkCompatibility(instance: {
+	protocolVersion: number | null;
+	serviceVersion: string | null;
+}): CompatibilityResult | null {
+	if (instance.protocolVersion === null) return null;
+
+	if (instance.protocolVersion !== HOST_SERVICE_PROTOCOL_VERSION) {
+		return {
+			compatible: false,
+			reason: `Protocol mismatch: service=${instance.protocolVersion}, app=${HOST_SERVICE_PROTOCOL_VERSION}`,
+		};
+	}
+
+	const currentVersion = app.getVersion();
+	const updateAvailable =
+		instance.serviceVersion !== null &&
+		instance.serviceVersion !== currentVersion;
+
+	return { compatible: true, updateAvailable };
+}
+
+async function buildHostServiceEnv(
+	organizationId: string,
+	secret: string,
+): Promise<Record<string, string>> {
+	const orgDir = manifestDir(organizationId);
+	return getProcessEnvWithShellPath({
+		...(process.env as Record<string, string>),
+		ELECTRON_RUN_AS_NODE: "1",
+		ORGANIZATION_ID: organizationId,
+		DEVICE_CLIENT_ID: getHashedDeviceId(),
+		DEVICE_NAME: getDeviceName(),
+		HOST_SERVICE_SECRET: secret,
+		HOST_SERVICE_VERSION: app.getVersion(),
+		HOST_MANIFEST_DIR: orgDir,
+		KEEP_ALIVE_AFTER_PARENT: "1",
+		HOST_DB_PATH: path.join(orgDir, "host.db"),
+		HOST_MIGRATIONS_PATH: app.isPackaged
+			? path.join(process.resourcesPath, "resources/host-migrations")
+			: path.join(app.getAppPath(), "../../packages/host-service/drizzle"),
+	});
+}
+
+export class HostServiceManager extends EventEmitter {
 	private instances = new Map<string, HostServiceProcess>();
 	private pendingStarts = new Map<string, PendingStart>();
+	private scheduledRestarts = new Map<string, ReturnType<typeof setTimeout>>();
+	private adoptedLivenessTimers = new Map<
+		string,
+		ReturnType<typeof setInterval>
+	>();
+	private organizationNames = new Map<string, string>();
 	private scriptPath = path.join(__dirname, "host-service.js");
 	private authToken: string | null = null;
 	private cloudApiUrl: string | null = null;
@@ -60,33 +161,128 @@ export class HostServiceManager {
 		this.cloudApiUrl = url;
 	}
 
+	setOrganizationName(organizationId: string, name: string): void {
+		this.organizationNames.set(organizationId, name);
+	}
+
+	getOrganizationName(organizationId: string): string | null {
+		return this.organizationNames.get(organizationId) ?? null;
+	}
+
 	async start(organizationId: string): Promise<number> {
 		const existing = this.instances.get(organizationId);
 		if (existing?.status === "running" && existing.port !== null) {
 			return existing.port;
 		}
-		const pendingStart = this.pendingStarts.get(organizationId);
-		if (pendingStart) {
-			return pendingStart.promise;
+		const existingPending = this.pendingStarts.get(organizationId);
+		if (existingPending) {
+			return existingPending.promise;
 		}
 
+		this.cancelScheduledRestart(organizationId);
+
+		// Register a pending start BEFORE the async tryAdopt so that concurrent
+		// callers see it and dedupe instead of racing through adoption + spawn.
+		const deferred = createPortDeferred();
+		this.pendingStarts.set(organizationId, deferred);
+
+		const adopted = await this.tryAdopt(organizationId);
+		if (adopted !== null) {
+			if (this.pendingStarts.get(organizationId) === deferred) {
+				this.pendingStarts.delete(organizationId);
+			}
+			deferred.resolve(adopted);
+			return adopted;
+		}
+
+		// Adoption failed — spawn() will reuse the deferred already in pendingStarts.
 		return this.spawn(organizationId);
 	}
 
 	stop(organizationId: string): void {
 		const instance = this.instances.get(organizationId);
+		this.cancelScheduledRestart(organizationId);
+		this.cancelPendingStart(organizationId, new Error("Host service stopped"));
+		this.stopAdoptedLivenessCheck(organizationId);
+
 		if (!instance) return;
 
-		instance.status = "crashed"; // prevent restart
-		this.cancelPendingStart(organizationId, new Error("Host service stopped"));
-		instance.process?.kill("SIGTERM");
+		const previousStatus = instance.status;
+		instance.status = "stopped";
+		if (instance.adopted && instance.adoptedPid) {
+			try {
+				process.kill(instance.adoptedPid, "SIGTERM");
+			} catch {
+				// Already dead
+			}
+		} else {
+			instance.process?.kill("SIGTERM");
+		}
 		this.instances.delete(organizationId);
+		removeManifest(organizationId);
+		this.emitStatus(organizationId, "stopped", previousStatus);
 	}
 
 	stopAll(): void {
 		for (const [id] of this.instances) {
 			this.stop(id);
 		}
+	}
+
+	/** Release all instances without killing the underlying processes.
+	 *  The services keep running and can be re-adopted on next app start. */
+	releaseAll(): void {
+		for (const [id] of this.instances) {
+			this.release(id);
+		}
+	}
+
+	/** Scan for on-disk manifests and adopt any running services.
+	 *  Call during startup so the tray shows accurate state immediately. */
+	async discoverAndAdoptAll(): Promise<void> {
+		const manifests = listManifests();
+		for (const manifest of manifests) {
+			if (this.instances.has(manifest.organizationId)) continue;
+			try {
+				await this.tryAdopt(manifest.organizationId);
+			} catch (error) {
+				console.error(
+					`[host-service:${manifest.organizationId}] Failed to adopt, removing bad manifest:`,
+					error,
+				);
+				removeManifest(manifest.organizationId);
+			}
+		}
+	}
+
+	async restart(organizationId: string): Promise<number> {
+		const instance = this.instances.get(organizationId);
+		if (instance) {
+			const previousStatus = instance.status;
+			instance.status = "restarting";
+			this.emitStatus(organizationId, "restarting", previousStatus);
+
+			this.cancelScheduledRestart(organizationId);
+			this.cancelPendingStart(
+				organizationId,
+				new Error("Host service restarting"),
+			);
+			this.stopAdoptedLivenessCheck(organizationId);
+
+			if (instance.adopted && instance.adoptedPid) {
+				try {
+					process.kill(instance.adoptedPid, "SIGTERM");
+				} catch {
+					// Already dead
+				}
+			} else {
+				instance.process?.kill("SIGTERM");
+			}
+			this.instances.delete(organizationId);
+			removeManifest(organizationId);
+		}
+
+		return this.spawn(organizationId);
 	}
 
 	getPort(organizationId: string): number | null {
@@ -97,29 +293,260 @@ export class HostServiceManager {
 		return this.instances.get(organizationId)?.secret ?? null;
 	}
 
-	getStatus(organizationId: string): HostServiceStatus | null {
+	getStatus(organizationId: string): HostServiceStatus {
 		if (this.pendingStarts.has(organizationId)) {
 			return "starting";
 		}
-		return this.instances.get(organizationId)?.status ?? null;
+		return this.instances.get(organizationId)?.status ?? "stopped";
 	}
 
+	getServiceInfo(organizationId: string): HostServiceInfo {
+		const organizationName = this.getOrganizationName(organizationId);
+		const instance = this.instances.get(organizationId);
+		if (!instance) {
+			return {
+				organizationId,
+				organizationName,
+				status: this.pendingStarts.has(organizationId) ? "starting" : "stopped",
+				port: null,
+				serviceVersion: null,
+				protocolVersion: null,
+				startedAt: null,
+				uptime: null,
+				restartCount: 0,
+				pendingRestart: false,
+				compatibility: null,
+				adopted: false,
+			};
+		}
+
+		return {
+			organizationId,
+			organizationName,
+			status: instance.status,
+			port: instance.port,
+			serviceVersion: instance.serviceVersion,
+			protocolVersion: instance.protocolVersion,
+			startedAt: instance.startedAt,
+			uptime: instance.startedAt
+				? Math.floor((Date.now() - instance.startedAt) / 1000)
+				: null,
+			restartCount: instance.restartCount,
+			pendingRestart: instance.pendingRestart,
+			compatibility: checkCompatibility(instance),
+			adopted: instance.adopted,
+		};
+	}
+
+	hasActiveInstances(): boolean {
+		for (const instance of this.instances.values()) {
+			if (instance.status === "running" || instance.status === "starting") {
+				return true;
+			}
+		}
+		return this.pendingStarts.size > 0;
+	}
+
+	getActiveOrganizationIds(): string[] {
+		const ids: string[] = [];
+		for (const [id, instance] of this.instances) {
+			if (instance.status !== "stopped") {
+				ids.push(id);
+			}
+		}
+		return ids;
+	}
+
+	/** Mark a host-service instance for restart when it becomes idle. */
+	markPendingRestart(organizationId: string): void {
+		const instance = this.instances.get(organizationId);
+		if (!instance) return;
+		instance.pendingRestart = true;
+		this.emitStatus(organizationId, instance.status, instance.status);
+	}
+
+	/** Check all instances for compatibility and mark incompatible ones for restart. */
+	checkAllCompatibility(): void {
+		for (const [orgId, instance] of this.instances) {
+			if (instance.status !== "running") continue;
+			const result = checkCompatibility(instance);
+			if (result && !result.compatible) {
+				console.log(`[host-service:${orgId}] Incompatible: ${result.reason}`);
+				instance.pendingRestart = true;
+				this.emitStatus(orgId, instance.status, instance.status);
+			}
+		}
+	}
+
+	// ── Discovery / Adoption ──────────────────────────────────────────
+
+	/** Try to adopt an already-running host-service from its on-disk manifest. */
+	private async tryAdopt(organizationId: string): Promise<number | null> {
+		const manifest = readManifest(organizationId);
+		if (!manifest) return null;
+
+		if (!isProcessAlive(manifest.pid)) {
+			console.log(
+				`[host-service:${organizationId}] Manifest process ${manifest.pid} is dead, removing stale manifest`,
+			);
+			removeManifest(organizationId);
+			return null;
+		}
+
+		const healthy = await this.healthCheck(manifest);
+		if (!healthy) {
+			console.log(
+				`[host-service:${organizationId}] Manifest endpoint ${manifest.endpoint} not reachable, removing stale manifest`,
+			);
+			removeManifest(organizationId);
+			return null;
+		}
+
+		const compat = checkCompatibility({
+			protocolVersion: manifest.protocolVersion,
+			serviceVersion: manifest.serviceVersion,
+		});
+
+		if (compat && !compat.compatible) {
+			console.log(
+				`[host-service:${organizationId}] Manifest service incompatible: ${compat.reason}. Will kill and respawn.`,
+			);
+			try {
+				process.kill(manifest.pid, "SIGTERM");
+			} catch {
+				// Already dead
+			}
+			removeManifest(organizationId);
+			return null;
+		}
+
+		const url = new URL(manifest.endpoint);
+		const port = Number(url.port);
+		const pendingRestart =
+			compat !== null && "updateAvailable" in compat && compat.updateAvailable;
+
+		const instance: HostServiceProcess = {
+			process: null,
+			port,
+			secret: manifest.authToken,
+			status: "running",
+			restartCount: 0,
+			organizationId,
+			startedAt: manifest.startedAt,
+			serviceVersion: manifest.serviceVersion,
+			protocolVersion: manifest.protocolVersion,
+			pendingRestart,
+			adopted: true,
+			adoptedPid: manifest.pid,
+		};
+		this.instances.set(organizationId, instance);
+		this.startAdoptedLivenessCheck(organizationId, manifest.pid);
+
+		console.log(
+			`[host-service:${organizationId}] Adopted existing service pid=${manifest.pid} port=${port} v${manifest.serviceVersion}`,
+		);
+		this.emitStatus(organizationId, "running", null);
+		return port;
+	}
+
+	private async healthCheck(manifest: HostServiceManifest): Promise<boolean> {
+		try {
+			const controller = new AbortController();
+			const timeout = setTimeout(() => controller.abort(), 3_000);
+			const res = await fetch(`${manifest.endpoint}/trpc/health.check`, {
+				signal: controller.signal,
+				headers: {
+					Authorization: `Bearer ${manifest.authToken}`,
+				},
+			});
+			clearTimeout(timeout);
+			return res.ok;
+		} catch {
+			return false;
+		}
+	}
+
+	private startAdoptedLivenessCheck(organizationId: string, pid: number): void {
+		this.stopAdoptedLivenessCheck(organizationId);
+
+		const timer = setInterval(() => {
+			if (!isProcessAlive(pid)) {
+				console.log(
+					`[host-service:${organizationId}] Adopted process ${pid} died`,
+				);
+				this.stopAdoptedLivenessCheck(organizationId);
+
+				const current = this.instances.get(organizationId);
+				if (current?.adopted && current.status !== "stopped") {
+					current.status = "degraded";
+					current.lastCrash = Date.now();
+					this.emitStatus(organizationId, "degraded", "running");
+					this.scheduleRestart(organizationId);
+				}
+			}
+		}, ADOPTED_LIVENESS_INTERVAL);
+		timer.unref();
+		this.adoptedLivenessTimers.set(organizationId, timer);
+	}
+
+	private stopAdoptedLivenessCheck(organizationId: string): void {
+		const timer = this.adoptedLivenessTimers.get(organizationId);
+		if (timer) {
+			clearInterval(timer);
+			this.adoptedLivenessTimers.delete(organizationId);
+		}
+	}
+
+	/** Release an instance without killing it. Allows the process to keep running. */
+	private release(organizationId: string): void {
+		this.cancelScheduledRestart(organizationId);
+		this.cancelPendingStart(organizationId, new Error("Host service released"));
+		this.stopAdoptedLivenessCheck(organizationId);
+
+		const instance = this.instances.get(organizationId);
+		if (!instance) return;
+
+		if (instance.process) {
+			instance.process.disconnect?.();
+			instance.process.unref?.();
+			instance.process = null;
+		}
+		this.instances.delete(organizationId);
+		// Leave the manifest on disk — next app start will adopt it.
+	}
+
+	// ── Spawn ─────────────────────────────────────────────────────────
+
 	private async spawn(organizationId: string): Promise<number> {
-		const pendingStart = createPortDeferred();
+		// Reuse a pending start registered by start(), or create a fresh one
+		// (e.g. when called directly from restart/scheduleRestart).
+		const pendingStart =
+			this.pendingStarts.get(organizationId) ?? createPortDeferred();
 		const secret = randomBytes(32).toString("hex");
+
+		const previousInstance = this.instances.get(organizationId);
+		const restartCount = previousInstance?.restartCount ?? 0;
+
 		const instance: HostServiceProcess = {
 			process: null,
 			port: null,
 			secret,
 			status: "starting",
-			restartCount: 0,
+			restartCount,
 			organizationId,
+			startedAt: null,
+			serviceVersion: null,
+			protocolVersion: null,
+			pendingRestart: false,
+			adopted: false,
+			adoptedPid: null,
 		};
 		this.instances.set(organizationId, instance);
 		this.pendingStarts.set(organizationId, pendingStart);
+		this.emitStatus(organizationId, "starting", null);
 
 		try {
-			const env = await this.buildHostServiceEnv(organizationId, secret);
+			const env = await buildHostServiceEnv(organizationId, secret);
 			if (this.authToken) {
 				env.AUTH_TOKEN = this.authToken;
 			}
@@ -158,29 +585,6 @@ export class HostServiceManager {
 		}
 	}
 
-	private async buildHostServiceEnv(
-		organizationId: string,
-		secret: string,
-	): Promise<Record<string, string>> {
-		return getProcessEnvWithShellPath({
-			...(process.env as Record<string, string>),
-			ELECTRON_RUN_AS_NODE: "1",
-			ORGANIZATION_ID: organizationId,
-			DEVICE_CLIENT_ID: getHashedDeviceId(),
-			DEVICE_NAME: getDeviceName(),
-			HOST_SERVICE_SECRET: secret,
-			HOST_DB_PATH: path.join(
-				SUPERSET_HOME_DIR,
-				"host",
-				organizationId,
-				"host.db",
-			),
-			HOST_MIGRATIONS_PATH: app.isPackaged
-				? path.join(process.resourcesPath, "resources/host-migrations")
-				: path.join(app.getAppPath(), "../../packages/host-service/drizzle"),
-		});
-	}
-
 	private attachProcessHandlers(
 		instance: HostServiceProcess,
 		child: ChildProcess,
@@ -203,7 +607,7 @@ export class HostServiceManager {
 			if (
 				!current ||
 				current.process !== child ||
-				current.status === "crashed"
+				current.status === "stopped"
 			) {
 				return;
 			}
@@ -214,8 +618,17 @@ export class HostServiceManager {
 					new Error("Host service exited before reporting port"),
 				);
 			}
-			current.status = "crashed";
+
+			const previousStatus = current.status;
+			// If we were restarting, a new spawn is already in flight — don't
+			// schedule another restart or overwrite the status.
+			if (previousStatus === "restarting") {
+				return;
+			}
+
+			current.status = "degraded";
 			current.lastCrash = Date.now();
+			this.emitStatus(organizationId, "degraded", previousStatus);
 			this.scheduleRestart(organizationId);
 		});
 	}
@@ -226,10 +639,14 @@ export class HostServiceManager {
 		error: Error,
 	): void {
 		this.clearPendingStart(instance.organizationId, pendingStart);
-		instance.status = "crashed";
+		const previousStatus = instance.status;
+		instance.status = "degraded";
 		pendingStart.reject(error);
-		instance.process?.kill("SIGTERM");
+		const child = instance.process;
+		instance.process = null;
+		child?.kill("SIGTERM");
 		instance.lastCrash = Date.now();
+		this.emitStatus(instance.organizationId, "degraded", previousStatus);
 		this.scheduleRestart(instance.organizationId);
 	}
 
@@ -252,9 +669,35 @@ export class HostServiceManager {
 			this.clearPendingStart(instance.organizationId, pendingStart);
 			instance.port = message.port;
 			instance.status = "running";
+			instance.startedAt = Date.now();
+			instance.restartCount = 0;
+
+			if (
+				"serviceVersion" in message &&
+				typeof message.serviceVersion === "string"
+			) {
+				instance.serviceVersion = message.serviceVersion;
+			}
+			if (
+				"protocolVersion" in message &&
+				typeof message.protocolVersion === "number"
+			) {
+				instance.protocolVersion = message.protocolVersion;
+			}
+
 			console.log(
-				`[host-service:${instance.organizationId}] listening on port ${message.port}`,
+				`[host-service:${instance.organizationId}] listening on port ${message.port} (v${instance.serviceVersion}, protocol=${instance.protocolVersion})`,
 			);
+
+			const compat = checkCompatibility(instance);
+			if (compat && !compat.compatible) {
+				console.warn(
+					`[host-service:${instance.organizationId}] ${compat.reason} — marking for restart`,
+				);
+				instance.pendingRestart = true;
+			}
+
+			this.emitStatus(instance.organizationId, "running", "starting");
 			pendingStart.resolve(message.port);
 		};
 
@@ -296,9 +739,19 @@ export class HostServiceManager {
 		}
 	}
 
+	private cancelScheduledRestart(organizationId: string): void {
+		const timer = this.scheduledRestarts.get(organizationId);
+		if (timer) {
+			clearTimeout(timer);
+			this.scheduledRestarts.delete(organizationId);
+		}
+	}
+
 	private scheduleRestart(organizationId: string): void {
 		const instance = this.instances.get(organizationId);
 		if (!instance) return;
+
+		this.cancelScheduledRestart(organizationId);
 
 		const delay = Math.min(
 			BASE_RESTART_DELAY * 2 ** instance.restartCount,
@@ -310,10 +763,11 @@ export class HostServiceManager {
 			`[host-service:${organizationId}] restarting in ${delay}ms (attempt ${instance.restartCount})`,
 		);
 
-		setTimeout(() => {
+		const timer = setTimeout(() => {
+			this.scheduledRestarts.delete(organizationId);
 			const current = this.instances.get(organizationId);
-			if (current?.status === "crashed") {
-				this.instances.delete(organizationId);
+			if (current?.status === "degraded") {
+				// Don't delete the instance — spawn() reads restartCount from it
 				this.spawn(organizationId).catch((err) => {
 					console.error(
 						`[host-service:${organizationId}] restart failed:`,
@@ -322,6 +776,20 @@ export class HostServiceManager {
 				});
 			}
 		}, delay);
+		this.scheduledRestarts.set(organizationId, timer);
+	}
+
+	private emitStatus(
+		organizationId: string,
+		status: HostServiceStatus,
+		previousStatus: HostServiceStatus | null,
+	): void {
+		const event: HostServiceStatusEvent = {
+			organizationId,
+			status,
+			previousStatus,
+		};
+		this.emit("status-changed", event);
 	}
 }
 

--- a/apps/desktop/src/main/lib/host-service-manifest.ts
+++ b/apps/desktop/src/main/lib/host-service-manifest.ts
@@ -1,0 +1,117 @@
+import {
+	existsSync,
+	mkdirSync,
+	readdirSync,
+	readFileSync,
+	unlinkSync,
+	writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+import { SUPERSET_HOME_DIR } from "./app-environment";
+
+/** Protocol version for the IPC contract between manager and host-service.
+ *  Bump when the ready message shape, env contract, or health API
+ *  changes in a backwards-incompatible way. */
+export const HOST_SERVICE_PROTOCOL_VERSION = 1;
+
+export interface HostServiceManifest {
+	pid: number;
+	endpoint: string;
+	authToken: string;
+	serviceVersion: string;
+	protocolVersion: number;
+	startedAt: number;
+	organizationId: string;
+}
+
+export function manifestDir(organizationId: string): string {
+	return join(SUPERSET_HOME_DIR, "host", organizationId);
+}
+
+function manifestPath(organizationId: string): string {
+	return join(manifestDir(organizationId), "manifest.json");
+}
+
+export function writeManifest(manifest: HostServiceManifest): void {
+	const dir = manifestDir(manifest.organizationId);
+	if (!existsSync(dir)) {
+		mkdirSync(dir, { recursive: true, mode: 0o700 });
+	}
+	writeFileSync(
+		manifestPath(manifest.organizationId),
+		JSON.stringify(manifest),
+		{
+			encoding: "utf-8",
+			mode: 0o600,
+		},
+	);
+}
+
+export function readManifest(
+	organizationId: string,
+): HostServiceManifest | null {
+	const filePath = manifestPath(organizationId);
+	if (!existsSync(filePath)) return null;
+
+	try {
+		const raw = readFileSync(filePath, "utf-8");
+		const data = JSON.parse(raw);
+
+		if (
+			typeof data.pid !== "number" ||
+			typeof data.endpoint !== "string" ||
+			typeof data.authToken !== "string" ||
+			typeof data.serviceVersion !== "string" ||
+			typeof data.protocolVersion !== "number" ||
+			typeof data.startedAt !== "number" ||
+			typeof data.organizationId !== "string"
+		) {
+			return null;
+		}
+
+		return data as HostServiceManifest;
+	} catch {
+		return null;
+	}
+}
+
+/** Scan the host directory for all valid manifests on disk. */
+export function listManifests(): HostServiceManifest[] {
+	const hostDir = join(SUPERSET_HOME_DIR, "host");
+	if (!existsSync(hostDir)) return [];
+
+	const manifests: HostServiceManifest[] = [];
+	try {
+		for (const entry of readdirSync(hostDir, { withFileTypes: true })) {
+			if (!entry.isDirectory()) continue;
+			const manifest = readManifest(entry.name);
+			if (manifest) {
+				manifests.push(manifest);
+			}
+		}
+	} catch {
+		// Best-effort scan
+	}
+	return manifests;
+}
+
+export function removeManifest(organizationId: string): void {
+	const filePath = manifestPath(organizationId);
+	try {
+		if (existsSync(filePath)) {
+			unlinkSync(filePath);
+		}
+	} catch {
+		// Best-effort removal
+	}
+}
+
+/** Check whether a process with the given PID is alive. */
+export function isProcessAlive(pid: number): boolean {
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch {
+		return false;
+	}
+}

--- a/apps/desktop/src/main/lib/tray/index.ts
+++ b/apps/desktop/src/main/lib/tray/index.ts
@@ -1,24 +1,19 @@
 import { existsSync } from "node:fs";
 import { join } from "node:path";
-import { workspaces } from "@superset/local-db";
-import { eq } from "drizzle-orm";
 import {
 	app,
-	BrowserWindow,
-	dialog,
 	Menu,
 	type MenuItemConstructorOptions,
 	nativeImage,
 	Tray,
 } from "electron";
-import { localDb } from "main/lib/local-db";
-import { menuEmitter } from "main/lib/menu-events";
+import { focusMainWindow, requestQuit } from "main/index";
 import {
-	restartDaemon as restartDaemonShared,
-	tryListExistingDaemonSessions,
-} from "main/lib/terminal";
-import { getTerminalHostClient } from "main/lib/terminal-host/client";
-import type { ListSessionsResponse } from "main/lib/terminal-host/types";
+	getHostServiceManager,
+	type HostServiceStatus,
+	type HostServiceStatusEvent,
+} from "main/lib/host-service-manager";
+import { menuEmitter } from "main/lib/menu-events";
 
 const POLL_INTERVAL_MS = 5000;
 
@@ -85,215 +80,179 @@ function createTrayIcon(): Electron.NativeImage | null {
 	}
 }
 
-function showWindow(): void {
-	const windows = BrowserWindow.getAllWindows();
-
-	if (windows.length > 0) {
-		const mainWindow = windows[0];
-		if (mainWindow.isMinimized()) {
-			mainWindow.restore();
-		}
-		mainWindow.show();
-		mainWindow.focus();
-	} else {
-		// Triggers window creation via makeAppSetup's activate handler
-		app.emit("activate");
-	}
-}
-
 function openSettings(): void {
-	showWindow();
+	focusMainWindow();
 	menuEmitter.emit("open-settings");
 }
 
-function openTerminalSettings(): void {
-	showWindow();
-	menuEmitter.emit("open-settings", "terminal");
-}
-
-function openSessionInSuperset(workspaceId: string): void {
-	showWindow();
-	menuEmitter.emit("open-workspace", workspaceId);
-}
-
-async function killSession(paneId: string): Promise<void> {
-	try {
-		const client = getTerminalHostClient();
-		const connected = await client.tryConnectAndAuthenticate();
-		if (connected) {
-			await client.kill({ sessionId: paneId });
-			console.log(`[Tray] Killed session: ${paneId}`);
-		}
-	} catch (error) {
-		console.error(`[Tray] Failed to kill session ${paneId}:`, error);
-	}
-
-	await updateTrayMenu();
-}
-
-function getWorkspaceName(workspaceId: string): string {
-	try {
-		const workspace = localDb
-			.select({ name: workspaces.name })
-			.from(workspaces)
-			.where(eq(workspaces.id, workspaceId))
-			.get();
-		return workspace?.name || workspaceId.slice(0, 8);
-	} catch {
-		return workspaceId.slice(0, 8);
+function formatStatusLabel(status: HostServiceStatus): string {
+	switch (status) {
+		case "running":
+			return "Running";
+		case "starting":
+			return "Starting...";
+		case "degraded":
+			return "Degraded";
+		case "restarting":
+			return "Restarting...";
+		case "stopped":
+			return "Stopped";
 	}
 }
 
-function formatSessionLabel(
-	session: ListSessionsResponse["sessions"][0],
-): string {
-	const attached = session.attachedClients > 0 ? " (attached)" : "";
-	const shellName = session.shell?.split("/").pop() || "shell";
-	return `${shellName}${attached}`;
-}
-
-function buildSessionsSubmenu(
-	sessions: ListSessionsResponse["sessions"],
-): MenuItemConstructorOptions[] {
-	const aliveSessions = sessions.filter((s) => s.isAlive);
+function buildHostServiceSubmenu(): MenuItemConstructorOptions[] {
+	const manager = getHostServiceManager();
+	const orgIds = manager.getActiveOrganizationIds();
 	const menuItems: MenuItemConstructorOptions[] = [];
 
-	if (aliveSessions.length === 0) {
-		menuItems.push({ label: "No active sessions", enabled: false });
+	if (orgIds.length === 0) {
+		menuItems.push({ label: "No active services", enabled: false });
 	} else {
-		const byWorkspace = new Map<string, ListSessionsResponse["sessions"]>();
-		for (const session of aliveSessions) {
-			const existing = byWorkspace.get(session.workspaceId) || [];
-			existing.push(session);
-			byWorkspace.set(session.workspaceId, existing);
-		}
-
 		let isFirst = true;
-		for (const [workspaceId, workspaceSessions] of byWorkspace) {
-			const workspaceName = getWorkspaceName(workspaceId);
-
+		for (const orgId of orgIds) {
 			if (!isFirst) {
 				menuItems.push({ type: "separator" });
 			}
+			isFirst = false;
+
+			const info = manager.getServiceInfo(orgId);
+			const orgName = info.organizationName ?? orgId.slice(0, 8);
+			const statusLabel = formatStatusLabel(info.status);
+			const versionSuffix = info.serviceVersion
+				? ` (v${info.serviceVersion})`
+				: "";
+			const isRunning = info.status === "running";
+
 			menuItems.push({
-				label: workspaceName,
+				label: orgName,
 				enabled: false,
 			});
 
-			for (const session of workspaceSessions) {
+			menuItems.push({
+				label: `  ${statusLabel}${versionSuffix}`,
+				enabled: false,
+			});
+
+			if (info.uptime !== null) {
+				const uptimeStr = formatUptime(info.uptime);
 				menuItems.push({
-					label: formatSessionLabel(session),
-					submenu: [
-						{
-							label: "Open in Superset",
-							click: () => openSessionInSuperset(session.workspaceId),
-						},
-						{
-							label: "Kill",
-							click: () => killSession(session.paneId),
-						},
-					],
+					label: `  Uptime: ${uptimeStr}`,
+					enabled: false,
 				});
 			}
 
-			isFirst = false;
+			if (info.restartCount > 0) {
+				menuItems.push({
+					label: `  Restarts: ${info.restartCount}`,
+					enabled: false,
+				});
+			}
+
+			if (info.pendingRestart) {
+				menuItems.push({
+					label: "  Update required — restart to apply",
+					enabled: false,
+				});
+			} else if (
+				info.compatibility &&
+				"updateAvailable" in info.compatibility &&
+				info.compatibility.updateAvailable
+			) {
+				menuItems.push({
+					label: "  Update available",
+					enabled: false,
+				});
+			}
+
+			menuItems.push({
+				label: "  Restart",
+				enabled: isRunning,
+				click: () => {
+					manager.restart(orgId).catch((err) => {
+						console.error(
+							`[Tray] Failed to restart host-service for ${orgId}:`,
+							err,
+						);
+					});
+					updateTrayMenu();
+				},
+			});
+
+			menuItems.push({
+				label: "  Stop",
+				enabled: isRunning,
+				click: () => {
+					manager.stop(orgId);
+					updateTrayMenu();
+				},
+			});
 		}
 	}
-
-	menuItems.push({ type: "separator" });
-	menuItems.push({
-		label: "Terminal Settings",
-		click: openTerminalSettings,
-	});
 
 	return menuItems;
 }
 
-async function quitApp(): Promise<void> {
-	const { sessions } = await tryListExistingDaemonSessions();
-	const hasActiveSessions = sessions.some((s) => s.isAlive);
-
-	if (!hasActiveSessions) {
-		app.quit();
-		return;
-	}
-
-	const { response } = await dialog.showMessageBox({
-		type: "question",
-		buttons: ["Cancel", "Keep Sessions", "Kill Sessions"],
-		defaultId: 1,
-		cancelId: 0,
-		title: "Quit Superset?",
-		message: "Quit Superset?",
-		detail:
-			"Keep sessions running in the background, or kill all sessions and shut down the daemon?",
-	});
-
-	if (response === 0) {
-		return;
-	}
-
-	if (response === 2) {
-		try {
-			await restartDaemonShared();
-		} catch (error) {
-			console.warn(
-				"[Tray] Failed to restart terminal daemon during quit:",
-				error,
-			);
-			await dialog
-				.showMessageBox({
-					type: "error",
-					buttons: ["OK"],
-					defaultId: 0,
-					title: "Failed to kill sessions",
-					message: "Superset could not kill terminal sessions.",
-					detail:
-						"The app will stay open so you can retry or quit while keeping sessions running in the background.",
-				})
-				.catch((dialogError) => {
-					console.warn(
-						"[Tray] Failed to show terminal quit error dialog:",
-						dialogError,
-					);
-				});
-			return;
-		}
-	}
-
-	app.quit();
+function formatUptime(seconds: number): string {
+	if (seconds < 60) return `${seconds}s`;
+	if (seconds < 3600) return `${Math.floor(seconds / 60)}m`;
+	const hours = Math.floor(seconds / 3600);
+	const mins = Math.floor((seconds % 3600) / 60);
+	return mins > 0 ? `${hours}h ${mins}m` : `${hours}h`;
 }
 
-async function updateTrayMenu(): Promise<void> {
+function updateTrayMenu(): void {
 	if (!tray) return;
 
-	const { sessions } = await tryListExistingDaemonSessions();
-	const sessionCount = sessions.filter((s) => s.isAlive).length;
+	const manager = getHostServiceManager();
+	const orgIds = manager.getActiveOrganizationIds();
 
-	const sessionsSubmenu = buildSessionsSubmenu(sessions);
-	const sessionsLabel =
-		sessionCount > 0
-			? `Background Sessions (${sessionCount})`
-			: "Background Sessions";
+	const hasActive = orgIds.length > 0;
+	const hostServiceLabel = hasActive
+		? `Host Service (${orgIds.length})`
+		: "Host Service";
+
+	const hostServiceSubmenu = buildHostServiceSubmenu();
 
 	const menu = Menu.buildFromTemplate([
 		{
-			label: sessionsLabel,
-			submenu: sessionsSubmenu,
+			label: hostServiceLabel,
+			submenu: hostServiceSubmenu,
 		},
 		{ type: "separator" },
 		{
 			label: "Open Superset",
-			click: showWindow,
+			click: focusMainWindow,
 		},
 		{
 			label: "Settings",
 			click: openSettings,
 		},
 		{
-			label: "Quit",
-			click: quitApp,
+			label: "Check for Updates",
+			click: () => {
+				// Imported lazily to avoid circular dependency
+				const { checkForUpdatesInteractive } = require("../auto-updater");
+				checkForUpdatesInteractive();
+			},
 		},
+		{ type: "separator" },
+		...(hasActive
+			? [
+					{
+						label: "Quit (Keep Services Running)",
+						click: () => requestQuit("release"),
+					},
+					{
+						label: "Quit & Stop Services",
+						click: () => requestQuit("stop"),
+					},
+				]
+			: [
+					{
+						label: "Quit",
+						click: () => requestQuit("release"),
+					},
+				]),
 	]);
 
 	tray.setContextMenu(menu);
@@ -320,14 +279,16 @@ export function initTray(): void {
 		tray = new Tray(icon);
 		tray.setToolTip("Superset");
 
-		updateTrayMenu().catch((error) => {
-			console.error("[Tray] Failed to build initial menu:", error);
+		updateTrayMenu();
+
+		const manager = getHostServiceManager();
+		manager.on("status-changed", (_event: HostServiceStatusEvent) => {
+			updateTrayMenu();
 		});
 
+		// Periodic refresh as a fallback
 		pollIntervalId = setInterval(() => {
-			updateTrayMenu().catch((error) => {
-				console.error("[Tray] Failed to update menu:", error);
-			});
+			updateTrayMenu();
 		}, POLL_INTERVAL_MS);
 		// Don't keep Electron alive just for tray updates
 		pollIntervalId.unref();

--- a/apps/desktop/src/main/windows/main.ts
+++ b/apps/desktop/src/main/windows/main.ts
@@ -365,7 +365,7 @@ export async function MainWindow() {
 		}
 	});
 
-	window.on("close", () => {
+	window.on("close", (event) => {
 		addWindowLifecycleBreadcrumb("main window closing", {
 			isDestroyed: window.isDestroyed(),
 			isVisible: window.isVisible(),
@@ -375,13 +375,20 @@ export async function MainWindow() {
 		saveWindowState(state);
 		persistedZoomLevel = state.zoomLevel;
 
+		// macOS: hide instead of destroy so "Open Superset" can reshow instantly.
+		// The quit flow uses app.exit(0) which bypasses close events entirely,
+		// so this hide path only runs for Cmd+W / red-X.
+		if (PLATFORM.IS_MAC) {
+			event.preventDefault();
+			window.hide();
+			return;
+		}
+
 		browserManager.unregisterAll();
 		server.close();
 		notificationManager.dispose();
 		notificationsEmitter.removeAllListeners();
-		// Remove terminal listeners to prevent duplicates when window reopens on macOS
 		getWorkspaceRuntimeRegistry().getDefault().terminal.detachAllListeners();
-		// Detach window from IPC handler (handler stays alive for window reopen)
 		ipcHandler?.detachWindow(window);
 		windowManager.unregister("main");
 		currentWindow = null;

--- a/apps/desktop/src/main/windows/main.ts
+++ b/apps/desktop/src/main/windows/main.ts
@@ -64,6 +64,15 @@ function getWorkspaceNameFromDb(workspaceId: string | undefined): string {
 }
 
 let currentWindow: BrowserWindow | null = null;
+let mainWindowCleanup: (() => void) | null = null;
+
+/** Tear down main window resources (notification server, IPC, etc.)
+ *  without destroying the BrowserWindow itself. Called from before-quit
+ *  tray-stay-alive path where win.destroy() skips close events. */
+export function cleanupMainWindowResources(): void {
+	mainWindowCleanup?.();
+	mainWindowCleanup = null;
+}
 
 function addWindowLifecycleBreadcrumb(
 	message: string,
@@ -384,6 +393,10 @@ export async function MainWindow() {
 			return;
 		}
 
+		doCleanup();
+	});
+
+	function doCleanup() {
 		browserManager.unregisterAll();
 		server.close();
 		notificationManager.dispose();
@@ -392,7 +405,10 @@ export async function MainWindow() {
 		ipcHandler?.detachWindow(window);
 		windowManager.unregister("main");
 		currentWindow = null;
-	});
+		mainWindowCleanup = null;
+	}
+
+	mainWindowCleanup = doCleanup;
 
 	return window;
 }

--- a/apps/desktop/src/renderer/lib/terminal/appearance/index.ts
+++ b/apps/desktop/src/renderer/lib/terminal/appearance/index.ts
@@ -1,0 +1,91 @@
+import type { ITheme } from "@xterm/xterm";
+import { toXtermTheme } from "renderer/stores/theme/utils";
+import {
+	builtInThemes,
+	DEFAULT_THEME_ID,
+	getTerminalColors,
+} from "shared/themes";
+
+export interface TerminalAppearance {
+	theme: ITheme;
+	background: string;
+	fontFamily: string;
+	fontSize: number;
+}
+
+const GENERIC_FONT_FAMILIES = new Set([
+	"serif",
+	"sans-serif",
+	"monospace",
+	"cursive",
+	"fantasy",
+	"system-ui",
+	"ui-serif",
+	"ui-sans-serif",
+	"ui-monospace",
+	"ui-rounded",
+	"emoji",
+	"math",
+	"fangsong",
+]);
+
+function serializeFontFamilyList(families: string[]): string {
+	return families
+		.map((family) =>
+			GENERIC_FONT_FAMILIES.has(family)
+				? family
+				: `"${family.replaceAll('"', '\\"')}"`,
+		)
+		.join(", ");
+}
+
+export const DEFAULT_TERMINAL_FONT_FAMILIES = [
+	"JetBrains Mono",
+	"JetBrainsMono Nerd Font",
+	"MesloLGM Nerd Font",
+	"MesloLGM NF",
+	"MesloLGS NF",
+	"MesloLGS Nerd Font",
+	"Hack Nerd Font",
+	"FiraCode Nerd Font",
+	"CaskaydiaCove Nerd Font",
+	"Menlo",
+	"Monaco",
+	"Courier New",
+	"monospace",
+] as const;
+
+export const DEFAULT_TERMINAL_FONT_FAMILY = serializeFontFamilyList([
+	...DEFAULT_TERMINAL_FONT_FAMILIES,
+]);
+
+export const DEFAULT_TERMINAL_FONT_SIZE = 14;
+
+/** Reads localStorage theme cache for flash-free first paint. */
+export function getDefaultTerminalAppearance(): TerminalAppearance {
+	const theme = readCachedTerminalTheme();
+	return {
+		theme,
+		background: theme.background ?? "#151110",
+		fontFamily: DEFAULT_TERMINAL_FONT_FAMILY,
+		fontSize: DEFAULT_TERMINAL_FONT_SIZE,
+	};
+}
+
+function readCachedTerminalTheme(): ITheme {
+	try {
+		const cachedTerminal = localStorage.getItem("theme-terminal");
+		if (cachedTerminal) {
+			return toXtermTheme(JSON.parse(cachedTerminal));
+		}
+		const themeId = localStorage.getItem("theme-id") ?? DEFAULT_THEME_ID;
+		const theme = builtInThemes.find((t) => t.id === themeId);
+		if (theme) {
+			return toXtermTheme(getTerminalColors(theme));
+		}
+	} catch {}
+	const defaultTheme = builtInThemes.find((t) => t.id === DEFAULT_THEME_ID);
+	return defaultTheme
+		? toXtermTheme(getTerminalColors(defaultTheme))
+		: { background: "#151110", foreground: "#eae8e6" };
+}

--- a/apps/desktop/src/renderer/lib/terminal/terminal-addons.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-addons.ts
@@ -1,0 +1,57 @@
+import { ClipboardAddon } from "@xterm/addon-clipboard";
+import { ImageAddon } from "@xterm/addon-image";
+import { LigaturesAddon } from "@xterm/addon-ligatures";
+import { Unicode11Addon } from "@xterm/addon-unicode11";
+import { WebglAddon } from "@xterm/addon-webgl";
+import type { Terminal as XTerm } from "@xterm/xterm";
+
+// Once WebGL fails, skip it for all subsequent runtimes (VS Code pattern).
+let suggestedRendererType: "webgl" | "dom" | undefined;
+
+/**
+ * Load optional addons onto an already-opened terminal. Returns a cleanup
+ * function. WebGL is deferred to rAF to avoid racing with xterm's post-open
+ * viewport sync.
+ */
+export function loadAddons(terminal: XTerm): () => void {
+	let disposed = false;
+	let webglAddon: WebglAddon | null = null;
+
+	terminal.loadAddon(new ClipboardAddon());
+
+	const unicode11 = new Unicode11Addon();
+	terminal.loadAddon(unicode11);
+	terminal.unicode.activeVersion = "11";
+
+	terminal.loadAddon(new ImageAddon());
+
+	try {
+		terminal.loadAddon(new LigaturesAddon());
+	} catch {}
+
+	const rafId = requestAnimationFrame(() => {
+		if (disposed || suggestedRendererType === "dom") return;
+
+		try {
+			webglAddon = new WebglAddon();
+			webglAddon.onContextLoss(() => {
+				webglAddon?.dispose();
+				webglAddon = null;
+				terminal.refresh(0, terminal.rows - 1);
+			});
+			terminal.loadAddon(webglAddon);
+		} catch {
+			suggestedRendererType = "dom";
+			webglAddon = null;
+		}
+	});
+
+	return () => {
+		disposed = true;
+		cancelAnimationFrame(rafId);
+		try {
+			webglAddon?.dispose();
+		} catch {}
+		webglAddon = null;
+	};
+}

--- a/apps/desktop/src/renderer/lib/terminal/terminal-runtime-registry.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-runtime-registry.ts
@@ -1,9 +1,11 @@
+import type { TerminalAppearance } from "./appearance";
 import {
 	attachToContainer,
 	createRuntime,
 	detachFromContainer,
 	disposeRuntime,
 	type TerminalRuntime,
+	updateRuntimeAppearance,
 } from "./terminal-runtime";
 import {
 	type ConnectionState,
@@ -16,19 +18,19 @@ import {
 } from "./terminal-ws-transport";
 
 interface RegistryEntry {
-	runtime: TerminalRuntime;
+	runtime: TerminalRuntime | null;
 	transport: TerminalTransport;
 }
 
 class TerminalRuntimeRegistryImpl {
 	private entries = new Map<string, RegistryEntry>();
 
-	private getOrCreate(terminalId: string): RegistryEntry {
+	private getOrCreateEntry(terminalId: string): RegistryEntry {
 		let entry = this.entries.get(terminalId);
 		if (entry) return entry;
 
 		entry = {
-			runtime: createRuntime(terminalId),
+			runtime: null,
 			transport: createTransport(),
 		};
 
@@ -36,8 +38,23 @@ class TerminalRuntimeRegistryImpl {
 		return entry;
 	}
 
-	attach(terminalId: string, container: HTMLDivElement, wsUrl: string) {
-		const { runtime, transport } = this.getOrCreate(terminalId);
+	attach(
+		terminalId: string,
+		container: HTMLDivElement,
+		wsUrl: string,
+		appearance: TerminalAppearance,
+	) {
+		const entry = this.getOrCreateEntry(terminalId);
+
+		if (!entry.runtime) {
+			entry.runtime = createRuntime(terminalId, appearance);
+		} else {
+			// Runtime already exists (reattach) — apply current appearance so
+			// the first fit uses up-to-date font metrics.
+			updateRuntimeAppearance(entry.runtime, appearance);
+		}
+
+		const { runtime, transport } = entry;
 
 		attachToContainer(runtime, container, () => {
 			sendResize(transport, runtime.terminal.cols, runtime.terminal.rows);
@@ -48,9 +65,26 @@ class TerminalRuntimeRegistryImpl {
 
 	detach(terminalId: string) {
 		const entry = this.entries.get(terminalId);
-		if (!entry) return;
+		if (!entry?.runtime) return;
 
 		detachFromContainer(entry.runtime);
+	}
+
+	updateAppearance(terminalId: string, appearance: TerminalAppearance) {
+		const entry = this.entries.get(terminalId);
+		if (!entry?.runtime) return;
+
+		const prevCols = entry.runtime.terminal.cols;
+		const prevRows = entry.runtime.terminal.rows;
+
+		updateRuntimeAppearance(entry.runtime, appearance);
+
+		// Font changes can alter the grid size — forward to the PTY so the
+		// backend shell and TUIs see the correct cols/rows.
+		const { cols, rows } = entry.runtime.terminal;
+		if (cols !== prevCols || rows !== prevRows) {
+			sendResize(entry.transport, cols, rows);
+		}
 	}
 
 	dispose(terminalId: string) {
@@ -59,7 +93,7 @@ class TerminalRuntimeRegistryImpl {
 
 		sendDispose(entry.transport);
 		disposeTransport(entry.transport);
-		disposeRuntime(entry.runtime);
+		if (entry.runtime) disposeRuntime(entry.runtime);
 
 		this.entries.delete(terminalId);
 	}
@@ -79,10 +113,10 @@ class TerminalRuntimeRegistryImpl {
 	}
 
 	onStateChange(terminalId: string, listener: () => void): () => void {
-		const { transport } = this.getOrCreate(terminalId);
-		transport.stateListeners.add(listener);
+		const entry = this.getOrCreateEntry(terminalId);
+		entry.transport.stateListeners.add(listener);
 		return () => {
-			transport.stateListeners.delete(listener);
+			entry.transport.stateListeners.delete(listener);
 		};
 	}
 }

--- a/apps/desktop/src/renderer/lib/terminal/terminal-runtime-registry.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-runtime-registry.ts
@@ -23,21 +23,21 @@ interface RegistryEntry {
 class TerminalRuntimeRegistryImpl {
 	private entries = new Map<string, RegistryEntry>();
 
-	private getOrCreate(paneId: string): RegistryEntry {
-		let entry = this.entries.get(paneId);
+	private getOrCreate(terminalId: string): RegistryEntry {
+		let entry = this.entries.get(terminalId);
 		if (entry) return entry;
 
 		entry = {
-			runtime: createRuntime(paneId),
+			runtime: createRuntime(terminalId),
 			transport: createTransport(),
 		};
 
-		this.entries.set(paneId, entry);
+		this.entries.set(terminalId, entry);
 		return entry;
 	}
 
-	attach(paneId: string, container: HTMLDivElement, wsUrl: string) {
-		const { runtime, transport } = this.getOrCreate(paneId);
+	attach(terminalId: string, container: HTMLDivElement, wsUrl: string) {
+		const { runtime, transport } = this.getOrCreate(terminalId);
 
 		attachToContainer(runtime, container, () => {
 			sendResize(transport, runtime.terminal.cols, runtime.terminal.rows);
@@ -46,49 +46,40 @@ class TerminalRuntimeRegistryImpl {
 		connect(transport, runtime.terminal, wsUrl);
 	}
 
-	/**
-	 * Detach the terminal from its DOM container.
-	 *
-	 * This only removes the DOM attachment (wrapper, resize observer, focus).
-	 * The WebSocket and xterm data flow are intentionally kept alive so output
-	 * written while the pane is hidden is not lost.  Disposal of the transport
-	 * happens exclusively through {@link dispose} when the paneId is removed
-	 * from persisted pane state.
-	 */
-	detach(paneId: string) {
-		const entry = this.entries.get(paneId);
+	detach(terminalId: string) {
+		const entry = this.entries.get(terminalId);
 		if (!entry) return;
 
 		detachFromContainer(entry.runtime);
 	}
 
-	dispose(paneId: string) {
-		const entry = this.entries.get(paneId);
+	dispose(terminalId: string) {
+		const entry = this.entries.get(terminalId);
 		if (!entry) return;
 
 		sendDispose(entry.transport);
 		disposeTransport(entry.transport);
 		disposeRuntime(entry.runtime);
 
-		this.entries.delete(paneId);
+		this.entries.delete(terminalId);
 	}
 
-	getAllPaneIds(): Set<string> {
+	getAllTerminalIds(): Set<string> {
 		return new Set(this.entries.keys());
 	}
 
-	has(paneId: string): boolean {
-		return this.entries.has(paneId);
+	has(terminalId: string): boolean {
+		return this.entries.has(terminalId);
 	}
 
-	getConnectionState(paneId: string): ConnectionState {
+	getConnectionState(terminalId: string): ConnectionState {
 		return (
-			this.entries.get(paneId)?.transport.connectionState ?? "disconnected"
+			this.entries.get(terminalId)?.transport.connectionState ?? "disconnected"
 		);
 	}
 
-	onStateChange(paneId: string, listener: () => void): () => void {
-		const { transport } = this.getOrCreate(paneId);
+	onStateChange(terminalId: string, listener: () => void): () => void {
+		const { transport } = this.getOrCreate(terminalId);
 		transport.stateListeners.add(listener);
 		return () => {
 			transport.stateListeners.delete(listener);

--- a/apps/desktop/src/renderer/lib/terminal/terminal-runtime-registry.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-runtime-registry.ts
@@ -1,0 +1,101 @@
+import {
+	attachToContainer,
+	createRuntime,
+	detachFromContainer,
+	disposeRuntime,
+	type TerminalRuntime,
+} from "./terminal-runtime";
+import {
+	type ConnectionState,
+	connect,
+	createTransport,
+	disposeTransport,
+	sendDispose,
+	sendResize,
+	type TerminalTransport,
+} from "./terminal-ws-transport";
+
+interface RegistryEntry {
+	runtime: TerminalRuntime;
+	transport: TerminalTransport;
+}
+
+class TerminalRuntimeRegistryImpl {
+	private entries = new Map<string, RegistryEntry>();
+
+	private getOrCreate(paneId: string): RegistryEntry {
+		let entry = this.entries.get(paneId);
+		if (entry) return entry;
+
+		entry = {
+			runtime: createRuntime(paneId),
+			transport: createTransport(),
+		};
+
+		this.entries.set(paneId, entry);
+		return entry;
+	}
+
+	attach(paneId: string, container: HTMLDivElement, wsUrl: string) {
+		const { runtime, transport } = this.getOrCreate(paneId);
+
+		attachToContainer(runtime, container, () => {
+			sendResize(transport, runtime.terminal.cols, runtime.terminal.rows);
+		});
+
+		connect(transport, runtime.terminal, wsUrl);
+	}
+
+	/**
+	 * Detach the terminal from its DOM container.
+	 *
+	 * This only removes the DOM attachment (wrapper, resize observer, focus).
+	 * The WebSocket and xterm data flow are intentionally kept alive so output
+	 * written while the pane is hidden is not lost.  Disposal of the transport
+	 * happens exclusively through {@link dispose} when the paneId is removed
+	 * from persisted pane state.
+	 */
+	detach(paneId: string) {
+		const entry = this.entries.get(paneId);
+		if (!entry) return;
+
+		detachFromContainer(entry.runtime);
+	}
+
+	dispose(paneId: string) {
+		const entry = this.entries.get(paneId);
+		if (!entry) return;
+
+		sendDispose(entry.transport);
+		disposeTransport(entry.transport);
+		disposeRuntime(entry.runtime);
+
+		this.entries.delete(paneId);
+	}
+
+	getAllPaneIds(): Set<string> {
+		return new Set(this.entries.keys());
+	}
+
+	has(paneId: string): boolean {
+		return this.entries.has(paneId);
+	}
+
+	getConnectionState(paneId: string): ConnectionState {
+		return (
+			this.entries.get(paneId)?.transport.connectionState ?? "disconnected"
+		);
+	}
+
+	onStateChange(paneId: string, listener: () => void): () => void {
+		const { transport } = this.getOrCreate(paneId);
+		transport.stateListeners.add(listener);
+		return () => {
+			transport.stateListeners.delete(listener);
+		};
+	}
+}
+
+export const terminalRuntimeRegistry = new TerminalRuntimeRegistryImpl();
+
+export type { ConnectionState };

--- a/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
@@ -1,6 +1,9 @@
 import { FitAddon } from "@xterm/addon-fit";
 import { SerializeAddon } from "@xterm/addon-serialize";
 import { Terminal as XTerm } from "@xterm/xterm";
+import { DEFAULT_TERMINAL_SCROLLBACK } from "shared/constants";
+import type { TerminalAppearance } from "./appearance";
+import { loadAddons } from "./terminal-addons";
 
 const SERIALIZE_SCROLLBACK = 1000;
 const STORAGE_KEY_PREFIX = "terminal-buffer:";
@@ -13,18 +16,18 @@ export interface TerminalRuntime {
 	terminal: XTerm;
 	fitAddon: FitAddon;
 	serializeAddon: SerializeAddon;
-	/** Reparented between containers across attach/detach cycles — not recreated. */
 	wrapper: HTMLDivElement;
 	container: HTMLDivElement | null;
 	resizeObserver: ResizeObserver | null;
-	/** Fallback grid size used when the host is not visible. */
 	lastCols: number;
 	lastRows: number;
+	_disposeAddons: (() => void) | null;
 }
 
 function createTerminal(
 	cols: number,
 	rows: number,
+	appearance: TerminalAppearance,
 ): {
 	terminal: XTerm;
 	fitAddon: FitAddon;
@@ -36,13 +39,15 @@ function createTerminal(
 		cols,
 		rows,
 		cursorBlink: true,
-		fontFamily:
-			'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace',
-		fontSize: 12,
-		theme: {
-			background: "#14100f",
-			foreground: "#f5efe9",
-		},
+		fontFamily: appearance.fontFamily,
+		fontSize: appearance.fontSize,
+		theme: appearance.theme,
+		allowProposedApi: true,
+		scrollback: DEFAULT_TERMINAL_SCROLLBACK,
+		macOptionIsMeta: false,
+		cursorStyle: "block",
+		cursorInactiveStyle: "outline",
+		scrollbar: { showScrollbar: false },
 	});
 	terminal.loadAddon(fitAddon);
 	terminal.loadAddon(serializeAddon);
@@ -112,18 +117,27 @@ function measureAndResize(runtime: TerminalRuntime) {
 	runtime.lastRows = runtime.terminal.rows;
 }
 
-export function createRuntime(terminalId: string): TerminalRuntime {
+export function createRuntime(
+	terminalId: string,
+	appearance: TerminalAppearance,
+): TerminalRuntime {
 	const savedDims = loadSavedDimensions(terminalId);
 	const cols = savedDims?.cols ?? DEFAULT_COLS;
 	const rows = savedDims?.rows ?? DEFAULT_ROWS;
 
-	const { terminal, fitAddon, serializeAddon } = createTerminal(cols, rows);
+	const { terminal, fitAddon, serializeAddon } = createTerminal(
+		cols,
+		rows,
+		appearance,
+	);
 
 	const wrapper = document.createElement("div");
 	wrapper.style.width = "100%";
 	wrapper.style.height = "100%";
 	terminal.open(wrapper);
 	restoreBuffer(terminalId, terminal);
+
+	const disposeAddons = loadAddons(terminal);
 
 	return {
 		terminalId,
@@ -135,6 +149,7 @@ export function createRuntime(terminalId: string): TerminalRuntime {
 		resizeObserver: null,
 		lastCols: cols,
 		lastRows: rows,
+		_disposeAddons: disposeAddons,
 	};
 }
 
@@ -147,8 +162,7 @@ export function attachToContainer(
 	container.appendChild(runtime.wrapper);
 	measureAndResize(runtime);
 
-	// Force a full repaint — the renderer may have skipped paint frames while
-	// the wrapper was detached from the DOM and receiving background data.
+	// Renderer may have skipped frames while the wrapper was detached.
 	runtime.terminal.refresh(0, runtime.terminal.rows - 1);
 
 	runtime.resizeObserver?.disconnect();
@@ -171,7 +185,31 @@ export function detachFromContainer(runtime: TerminalRuntime) {
 	runtime.container = null;
 }
 
+export function updateRuntimeAppearance(
+	runtime: TerminalRuntime,
+	appearance: TerminalAppearance,
+) {
+	const { terminal, fitAddon } = runtime;
+	terminal.options.theme = appearance.theme;
+
+	const fontChanged =
+		terminal.options.fontFamily !== appearance.fontFamily ||
+		terminal.options.fontSize !== appearance.fontSize;
+
+	if (fontChanged) {
+		terminal.options.fontFamily = appearance.fontFamily;
+		terminal.options.fontSize = appearance.fontSize;
+		if (hostIsVisible(runtime.container)) {
+			fitAddon.fit();
+			runtime.lastCols = terminal.cols;
+			runtime.lastRows = terminal.rows;
+		}
+	}
+}
+
 export function disposeRuntime(runtime: TerminalRuntime) {
+	runtime._disposeAddons?.();
+	runtime._disposeAddons = null;
 	runtime.resizeObserver?.disconnect();
 	runtime.resizeObserver = null;
 	runtime.wrapper.remove();

--- a/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
@@ -1,0 +1,181 @@
+import { FitAddon } from "@xterm/addon-fit";
+import { SerializeAddon } from "@xterm/addon-serialize";
+import { Terminal as XTerm } from "@xterm/xterm";
+
+const SERIALIZE_SCROLLBACK = 1000;
+const STORAGE_KEY_PREFIX = "terminal-buffer:";
+const DIMS_KEY_PREFIX = "terminal-dims:";
+const DEFAULT_COLS = 120;
+const DEFAULT_ROWS = 32;
+
+export interface TerminalRuntime {
+	paneId: string;
+	terminal: XTerm;
+	fitAddon: FitAddon;
+	serializeAddon: SerializeAddon;
+	/** Reparented between containers across attach/detach cycles — not recreated. */
+	wrapper: HTMLDivElement;
+	container: HTMLDivElement | null;
+	resizeObserver: ResizeObserver | null;
+	/** Fallback grid size used when the host is not visible. */
+	lastCols: number;
+	lastRows: number;
+}
+
+function createTerminal(
+	cols: number,
+	rows: number,
+): {
+	terminal: XTerm;
+	fitAddon: FitAddon;
+	serializeAddon: SerializeAddon;
+} {
+	const fitAddon = new FitAddon();
+	const serializeAddon = new SerializeAddon();
+	const terminal = new XTerm({
+		cols,
+		rows,
+		cursorBlink: true,
+		fontFamily:
+			'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace',
+		fontSize: 12,
+		theme: {
+			background: "#14100f",
+			foreground: "#f5efe9",
+		},
+	});
+	terminal.loadAddon(fitAddon);
+	terminal.loadAddon(serializeAddon);
+	return { terminal, fitAddon, serializeAddon };
+}
+
+function persistBuffer(paneId: string, serializeAddon: SerializeAddon) {
+	try {
+		const data = serializeAddon.serialize({ scrollback: SERIALIZE_SCROLLBACK });
+		localStorage.setItem(`${STORAGE_KEY_PREFIX}${paneId}`, data);
+	} catch {}
+}
+
+function restoreBuffer(paneId: string, terminal: XTerm) {
+	try {
+		const data = localStorage.getItem(`${STORAGE_KEY_PREFIX}${paneId}`);
+		if (data) terminal.write(data);
+	} catch {}
+}
+
+function clearPersistedBuffer(paneId: string) {
+	try {
+		localStorage.removeItem(`${STORAGE_KEY_PREFIX}${paneId}`);
+	} catch {}
+}
+
+function persistDimensions(paneId: string, cols: number, rows: number) {
+	try {
+		localStorage.setItem(
+			`${DIMS_KEY_PREFIX}${paneId}`,
+			JSON.stringify({ cols, rows }),
+		);
+	} catch {}
+}
+
+function loadSavedDimensions(
+	paneId: string,
+): { cols: number; rows: number } | null {
+	try {
+		const raw = localStorage.getItem(`${DIMS_KEY_PREFIX}${paneId}`);
+		if (!raw) return null;
+		const parsed = JSON.parse(raw);
+		if (typeof parsed.cols === "number" && typeof parsed.rows === "number") {
+			return parsed;
+		}
+		return null;
+	} catch {
+		return null;
+	}
+}
+
+function clearPersistedDimensions(paneId: string) {
+	try {
+		localStorage.removeItem(`${DIMS_KEY_PREFIX}${paneId}`);
+	} catch {}
+}
+
+function hostIsVisible(container: HTMLDivElement | null): boolean {
+	if (!container) return false;
+	return container.clientWidth > 0 && container.clientHeight > 0;
+}
+
+function measureAndResize(runtime: TerminalRuntime) {
+	if (!hostIsVisible(runtime.container)) return;
+	runtime.fitAddon.fit();
+	runtime.lastCols = runtime.terminal.cols;
+	runtime.lastRows = runtime.terminal.rows;
+}
+
+export function createRuntime(paneId: string): TerminalRuntime {
+	const savedDims = loadSavedDimensions(paneId);
+	const cols = savedDims?.cols ?? DEFAULT_COLS;
+	const rows = savedDims?.rows ?? DEFAULT_ROWS;
+
+	const { terminal, fitAddon, serializeAddon } = createTerminal(cols, rows);
+
+	const wrapper = document.createElement("div");
+	wrapper.style.width = "100%";
+	wrapper.style.height = "100%";
+	terminal.open(wrapper);
+	restoreBuffer(paneId, terminal);
+
+	return {
+		paneId,
+		terminal,
+		fitAddon,
+		serializeAddon,
+		wrapper,
+		container: null,
+		resizeObserver: null,
+		lastCols: cols,
+		lastRows: rows,
+	};
+}
+
+export function attachToContainer(
+	runtime: TerminalRuntime,
+	container: HTMLDivElement,
+	onResize?: () => void,
+) {
+	runtime.container = container;
+	container.appendChild(runtime.wrapper);
+	measureAndResize(runtime);
+
+	// Force a full repaint — the renderer may have skipped paint frames while
+	// the wrapper was detached from the DOM and receiving background data.
+	runtime.terminal.refresh(0, runtime.terminal.rows - 1);
+
+	runtime.resizeObserver?.disconnect();
+	const observer = new ResizeObserver(() => {
+		measureAndResize(runtime);
+		onResize?.();
+	});
+	observer.observe(container);
+	runtime.resizeObserver = observer;
+
+	runtime.terminal.focus();
+}
+
+export function detachFromContainer(runtime: TerminalRuntime) {
+	persistBuffer(runtime.paneId, runtime.serializeAddon);
+	persistDimensions(runtime.paneId, runtime.lastCols, runtime.lastRows);
+	runtime.resizeObserver?.disconnect();
+	runtime.resizeObserver = null;
+	runtime.wrapper.remove();
+	runtime.container = null;
+}
+
+export function disposeRuntime(runtime: TerminalRuntime) {
+	runtime.resizeObserver?.disconnect();
+	runtime.resizeObserver = null;
+	runtime.wrapper.remove();
+	runtime.terminal.dispose();
+	clearPersistedBuffer(runtime.paneId);
+	clearPersistedDimensions(runtime.paneId);
+}

--- a/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
@@ -9,7 +9,7 @@ const DEFAULT_COLS = 120;
 const DEFAULT_ROWS = 32;
 
 export interface TerminalRuntime {
-	paneId: string;
+	terminalId: string;
 	terminal: XTerm;
 	fitAddon: FitAddon;
 	serializeAddon: SerializeAddon;
@@ -49,40 +49,40 @@ function createTerminal(
 	return { terminal, fitAddon, serializeAddon };
 }
 
-function persistBuffer(paneId: string, serializeAddon: SerializeAddon) {
+function persistBuffer(terminalId: string, serializeAddon: SerializeAddon) {
 	try {
 		const data = serializeAddon.serialize({ scrollback: SERIALIZE_SCROLLBACK });
-		localStorage.setItem(`${STORAGE_KEY_PREFIX}${paneId}`, data);
+		localStorage.setItem(`${STORAGE_KEY_PREFIX}${terminalId}`, data);
 	} catch {}
 }
 
-function restoreBuffer(paneId: string, terminal: XTerm) {
+function restoreBuffer(terminalId: string, terminal: XTerm) {
 	try {
-		const data = localStorage.getItem(`${STORAGE_KEY_PREFIX}${paneId}`);
+		const data = localStorage.getItem(`${STORAGE_KEY_PREFIX}${terminalId}`);
 		if (data) terminal.write(data);
 	} catch {}
 }
 
-function clearPersistedBuffer(paneId: string) {
+function clearPersistedBuffer(terminalId: string) {
 	try {
-		localStorage.removeItem(`${STORAGE_KEY_PREFIX}${paneId}`);
+		localStorage.removeItem(`${STORAGE_KEY_PREFIX}${terminalId}`);
 	} catch {}
 }
 
-function persistDimensions(paneId: string, cols: number, rows: number) {
+function persistDimensions(terminalId: string, cols: number, rows: number) {
 	try {
 		localStorage.setItem(
-			`${DIMS_KEY_PREFIX}${paneId}`,
+			`${DIMS_KEY_PREFIX}${terminalId}`,
 			JSON.stringify({ cols, rows }),
 		);
 	} catch {}
 }
 
 function loadSavedDimensions(
-	paneId: string,
+	terminalId: string,
 ): { cols: number; rows: number } | null {
 	try {
-		const raw = localStorage.getItem(`${DIMS_KEY_PREFIX}${paneId}`);
+		const raw = localStorage.getItem(`${DIMS_KEY_PREFIX}${terminalId}`);
 		if (!raw) return null;
 		const parsed = JSON.parse(raw);
 		if (typeof parsed.cols === "number" && typeof parsed.rows === "number") {
@@ -94,9 +94,9 @@ function loadSavedDimensions(
 	}
 }
 
-function clearPersistedDimensions(paneId: string) {
+function clearPersistedDimensions(terminalId: string) {
 	try {
-		localStorage.removeItem(`${DIMS_KEY_PREFIX}${paneId}`);
+		localStorage.removeItem(`${DIMS_KEY_PREFIX}${terminalId}`);
 	} catch {}
 }
 
@@ -112,8 +112,8 @@ function measureAndResize(runtime: TerminalRuntime) {
 	runtime.lastRows = runtime.terminal.rows;
 }
 
-export function createRuntime(paneId: string): TerminalRuntime {
-	const savedDims = loadSavedDimensions(paneId);
+export function createRuntime(terminalId: string): TerminalRuntime {
+	const savedDims = loadSavedDimensions(terminalId);
 	const cols = savedDims?.cols ?? DEFAULT_COLS;
 	const rows = savedDims?.rows ?? DEFAULT_ROWS;
 
@@ -123,10 +123,10 @@ export function createRuntime(paneId: string): TerminalRuntime {
 	wrapper.style.width = "100%";
 	wrapper.style.height = "100%";
 	terminal.open(wrapper);
-	restoreBuffer(paneId, terminal);
+	restoreBuffer(terminalId, terminal);
 
 	return {
-		paneId,
+		terminalId,
 		terminal,
 		fitAddon,
 		serializeAddon,
@@ -163,8 +163,8 @@ export function attachToContainer(
 }
 
 export function detachFromContainer(runtime: TerminalRuntime) {
-	persistBuffer(runtime.paneId, runtime.serializeAddon);
-	persistDimensions(runtime.paneId, runtime.lastCols, runtime.lastRows);
+	persistBuffer(runtime.terminalId, runtime.serializeAddon);
+	persistDimensions(runtime.terminalId, runtime.lastCols, runtime.lastRows);
 	runtime.resizeObserver?.disconnect();
 	runtime.resizeObserver = null;
 	runtime.wrapper.remove();
@@ -176,6 +176,6 @@ export function disposeRuntime(runtime: TerminalRuntime) {
 	runtime.resizeObserver = null;
 	runtime.wrapper.remove();
 	runtime.terminal.dispose();
-	clearPersistedBuffer(runtime.paneId);
-	clearPersistedDimensions(runtime.paneId);
+	clearPersistedBuffer(runtime.terminalId);
+	clearPersistedDimensions(runtime.terminalId);
 }

--- a/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.ts
@@ -15,6 +15,14 @@ export interface TerminalTransport {
 	currentUrl: string | null;
 	onDataDisposable: { dispose(): void } | null;
 	stateListeners: Set<() => void>;
+	/** Internal: auto-reconnect timer. */
+	_reconnectTimer: ReturnType<typeof setTimeout> | null;
+	/** Internal: reconnect attempt count for backoff. */
+	_reconnectAttempt: number;
+	/** The xterm instance used for reconnection. */
+	_terminal: XTerm | null;
+	/** Set when the server sends an exit message — no reconnect after this. */
+	_exited: boolean;
 }
 
 function setConnectionState(
@@ -27,6 +35,10 @@ function setConnectionState(
 	}
 }
 
+const MAX_RECONNECT_DELAY = 10_000;
+const BASE_RECONNECT_DELAY = 500;
+const MAX_RECONNECT_ATTEMPTS = 10;
+
 export function createTransport(): TerminalTransport {
 	return {
 		socket: null,
@@ -34,7 +46,42 @@ export function createTransport(): TerminalTransport {
 		currentUrl: null,
 		onDataDisposable: null,
 		stateListeners: new Set(),
+		_reconnectTimer: null,
+		_reconnectAttempt: 0,
+		_terminal: null,
+		_exited: false,
 	};
+}
+
+function scheduleReconnect(transport: TerminalTransport) {
+	if (transport._reconnectTimer) return;
+	if (transport._exited) return;
+	if (!transport.currentUrl || !transport._terminal) return;
+	if (transport._reconnectAttempt >= MAX_RECONNECT_ATTEMPTS) return;
+
+	const delay = Math.min(
+		BASE_RECONNECT_DELAY * 2 ** transport._reconnectAttempt,
+		MAX_RECONNECT_DELAY,
+	);
+	transport._reconnectAttempt++;
+
+	transport._reconnectTimer = setTimeout(() => {
+		transport._reconnectTimer = null;
+		if (
+			transport.connectionState === "closed" &&
+			transport.currentUrl &&
+			transport._terminal
+		) {
+			connect(transport, transport._terminal, transport.currentUrl);
+		}
+	}, delay);
+}
+
+function cancelReconnect(transport: TerminalTransport) {
+	if (transport._reconnectTimer) {
+		clearTimeout(transport._reconnectTimer);
+		transport._reconnectTimer = null;
+	}
 }
 
 export function connect(
@@ -53,13 +100,17 @@ export function connect(
 		transport.socket = null;
 	}
 
+	cancelReconnect(transport);
 	transport.currentUrl = wsUrl;
+	transport._terminal = terminal;
+	transport._exited = false;
 	setConnectionState(transport, "connecting");
 	const socket = new WebSocket(wsUrl);
 	transport.socket = socket;
 
 	socket.addEventListener("open", () => {
 		if (transport.socket !== socket) return;
+		transport._reconnectAttempt = 0;
 		setConnectionState(transport, "open");
 		sendResize(transport, terminal.cols, terminal.rows);
 	});
@@ -85,6 +136,8 @@ export function connect(
 		}
 
 		if (message.type === "exit") {
+			transport._exited = true;
+			cancelReconnect(transport);
 			terminal.writeln(
 				`\r\n[terminal] exited with code ${message.exitCode} (signal ${message.signal})`,
 			);
@@ -95,6 +148,8 @@ export function connect(
 		if (transport.socket !== socket) return;
 		setConnectionState(transport, "closed");
 		transport.socket = null;
+		// Auto-reconnect on unexpected close (host-service restart, network blip)
+		scheduleReconnect(transport);
 	});
 
 	socket.addEventListener("error", () => {
@@ -110,11 +165,14 @@ export function connect(
 }
 
 export function disconnect(transport: TerminalTransport) {
+	cancelReconnect(transport);
 	if (transport.socket) {
 		transport.socket.close();
 		transport.socket = null;
 	}
 	transport.currentUrl = null;
+	transport._terminal = null;
+	transport._reconnectAttempt = 0;
 	setConnectionState(transport, "disconnected");
 	transport.onDataDisposable?.dispose();
 	transport.onDataDisposable = null;
@@ -137,11 +195,14 @@ export function sendDispose(transport: TerminalTransport) {
 }
 
 export function disposeTransport(transport: TerminalTransport) {
+	cancelReconnect(transport);
 	if (transport.socket) {
 		transport.socket.close();
 		transport.socket = null;
 	}
 	transport.currentUrl = null;
+	transport._terminal = null;
+	transport._reconnectAttempt = 0;
 	transport.onDataDisposable?.dispose();
 	transport.onDataDisposable = null;
 	transport.stateListeners.clear();

--- a/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.ts
@@ -1,0 +1,148 @@
+import type { Terminal as XTerm } from "@xterm/xterm";
+
+export type ConnectionState = "disconnected" | "connecting" | "open" | "closed";
+
+type TerminalServerMessage =
+	| { type: "data"; data: string }
+	| { type: "error"; message: string }
+	| { type: "exit"; exitCode: number; signal: number }
+	| { type: "replay"; data: string };
+
+export interface TerminalTransport {
+	socket: WebSocket | null;
+	connectionState: ConnectionState;
+	/** The URL the socket is currently connected (or connecting) to. */
+	currentUrl: string | null;
+	onDataDisposable: { dispose(): void } | null;
+	stateListeners: Set<() => void>;
+}
+
+function setConnectionState(
+	transport: TerminalTransport,
+	state: ConnectionState,
+) {
+	transport.connectionState = state;
+	for (const listener of transport.stateListeners) {
+		listener();
+	}
+}
+
+export function createTransport(): TerminalTransport {
+	return {
+		socket: null,
+		connectionState: "disconnected",
+		currentUrl: null,
+		onDataDisposable: null,
+		stateListeners: new Set(),
+	};
+}
+
+export function connect(
+	transport: TerminalTransport,
+	terminal: XTerm,
+	wsUrl: string,
+) {
+	// Idempotent: skip if already connected/connecting to the same endpoint.
+	const isActive =
+		transport.connectionState === "open" ||
+		transport.connectionState === "connecting";
+	if (isActive && transport.currentUrl === wsUrl) return;
+
+	if (transport.socket) {
+		transport.socket.close();
+		transport.socket = null;
+	}
+
+	transport.currentUrl = wsUrl;
+	setConnectionState(transport, "connecting");
+	const socket = new WebSocket(wsUrl);
+	transport.socket = socket;
+
+	socket.addEventListener("open", () => {
+		if (transport.socket !== socket) return;
+		setConnectionState(transport, "open");
+		sendResize(transport, terminal.cols, terminal.rows);
+	});
+
+	socket.addEventListener("message", (event) => {
+		if (transport.socket !== socket) return;
+		let message: TerminalServerMessage;
+		try {
+			message = JSON.parse(String(event.data)) as TerminalServerMessage;
+		} catch {
+			terminal.writeln("\r\n[terminal] invalid server payload");
+			return;
+		}
+
+		if (message.type === "data" || message.type === "replay") {
+			terminal.write(message.data);
+			return;
+		}
+
+		if (message.type === "error") {
+			terminal.writeln(`\r\n[terminal] ${message.message}`);
+			return;
+		}
+
+		if (message.type === "exit") {
+			terminal.writeln(
+				`\r\n[terminal] exited with code ${message.exitCode} (signal ${message.signal})`,
+			);
+		}
+	});
+
+	socket.addEventListener("close", () => {
+		if (transport.socket !== socket) return;
+		setConnectionState(transport, "closed");
+		transport.socket = null;
+	});
+
+	socket.addEventListener("error", () => {
+		if (transport.socket !== socket) return;
+		terminal.writeln("\r\n[terminal] websocket error");
+	});
+
+	transport.onDataDisposable?.dispose();
+	transport.onDataDisposable = terminal.onData((data) => {
+		if (socket.readyState !== WebSocket.OPEN) return;
+		socket.send(JSON.stringify({ type: "input", data }));
+	});
+}
+
+export function disconnect(transport: TerminalTransport) {
+	if (transport.socket) {
+		transport.socket.close();
+		transport.socket = null;
+	}
+	transport.currentUrl = null;
+	setConnectionState(transport, "disconnected");
+	transport.onDataDisposable?.dispose();
+	transport.onDataDisposable = null;
+}
+
+export function sendResize(
+	transport: TerminalTransport,
+	cols: number,
+	rows: number,
+) {
+	if (!transport.socket || transport.socket.readyState !== WebSocket.OPEN)
+		return;
+	transport.socket.send(JSON.stringify({ type: "resize", cols, rows }));
+}
+
+export function sendDispose(transport: TerminalTransport) {
+	if (transport.socket?.readyState === WebSocket.OPEN) {
+		transport.socket.send(JSON.stringify({ type: "dispose" }));
+	}
+}
+
+export function disposeTransport(transport: TerminalTransport) {
+	if (transport.socket) {
+		transport.socket.close();
+		transport.socket = null;
+	}
+	transport.currentUrl = null;
+	transport.onDataDisposable?.dispose();
+	transport.onDataDisposable = null;
+	transport.stateListeners.clear();
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarProjectSection/hooks/useDashboardSidebarProjectSectionActions/useDashboardSidebarProjectSectionActions.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarProjectSection/hooks/useDashboardSidebarProjectSectionActions/useDashboardSidebarProjectSectionActions.ts
@@ -61,12 +61,18 @@ export function useDashboardSidebarProjectSectionActions({
 	};
 
 	const confirmRemoveFromSidebar = () => {
-		alert.destructive({
+		alert({
 			title: "Remove project from sidebar?",
 			description:
 				"This will remove workspaces from the sidebar and delete all project sections. The workspaces or projects won't be deleted.",
-			confirmText: "Remove",
-			onConfirm: () => removeProjectFromSidebar(project.id),
+			actions: [
+				{ label: "Cancel", variant: "outline", onClick: () => {} },
+				{
+					label: "Remove",
+					variant: "destructive",
+					onClick: () => removeProjectFromSidebar(project.id),
+				},
+			],
 		});
 	};
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/OpenInMenuButton/OpenInMenuButton.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/OpenInMenuButton/OpenInMenuButton.tsx
@@ -17,7 +17,7 @@ import {
 } from "renderer/components/OpenInExternalDropdown";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { useThemeStore } from "renderer/stores";
-import { useHotkeyText } from "renderer/stores/hotkeys";
+import { useAppHotkey, useHotkeyText } from "renderer/stores/hotkeys";
 
 interface OpenInMenuButtonProps {
 	worktreePath: string;
@@ -79,6 +79,10 @@ export const OpenInMenuButton = memo(function OpenInMenuButton({
 		if (openInApp.isPending || copyPath.isPending) return;
 		copyPath.mutate(worktreePath);
 	}, [worktreePath, copyPath, openInApp.isPending]);
+
+	useAppHotkey("OPEN_IN_APP", handleOpenInEditor, undefined, [
+		handleOpenInEditor,
+	]);
 
 	return (
 		<div className="flex items-center no-drag">

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/WorkspaceSidebar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/WorkspaceSidebar.tsx
@@ -1,0 +1,92 @@
+import { Button } from "@superset/ui/button";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
+import { Search } from "lucide-react";
+import { type ReactNode, useState } from "react";
+import { FilesTab } from "./components/FilesTab";
+import { SidebarHeader } from "./components/SidebarHeader";
+
+type SidebarTab = "files" | "changes" | "checks";
+
+interface WorkspaceSidebarProps {
+	onSelectFile: (absolutePath: string) => void;
+	onSearch?: () => void;
+	selectedFilePath?: string;
+	workspaceId: string;
+	workspaceName?: string;
+}
+
+function IconButton({
+	icon: Icon,
+	tooltip,
+	onClick,
+}: {
+	icon: React.ComponentType<{ className?: string }>;
+	tooltip: string;
+	onClick?: () => void;
+}) {
+	return (
+		<Tooltip>
+			<TooltipTrigger asChild>
+				<Button
+					variant="ghost"
+					size="icon"
+					className="size-6"
+					onClick={onClick}
+				>
+					<Icon className="size-3.5" />
+				</Button>
+			</TooltipTrigger>
+			<TooltipContent side="bottom">{tooltip}</TooltipContent>
+		</Tooltip>
+	);
+}
+
+export function WorkspaceSidebar({
+	onSelectFile,
+	onSearch,
+	selectedFilePath,
+	workspaceId,
+	workspaceName,
+}: WorkspaceSidebarProps) {
+	const [activeTab, setActiveTab] = useState<SidebarTab>("files");
+
+	const tabActions: Record<SidebarTab, ReactNode> = {
+		files: <IconButton icon={Search} tooltip="Search" onClick={onSearch} />,
+		changes: null,
+		checks: null,
+	};
+
+	return (
+		<div className="flex h-full min-h-0 flex-col overflow-hidden border-l border-border bg-background">
+			<SidebarHeader
+				tabs={[
+					{ id: "files", label: "All files" },
+					{ id: "changes", label: "Changes" },
+					{ id: "checks", label: "Checks" },
+				]}
+				activeTab={activeTab}
+				onTabChange={(id) => setActiveTab(id as SidebarTab)}
+				actions={tabActions[activeTab]}
+			/>
+
+			<div className={activeTab === "files" ? "min-h-0 flex-1" : "hidden"}>
+				<FilesTab
+					onSelectFile={onSelectFile}
+					selectedFilePath={selectedFilePath}
+					workspaceId={workspaceId}
+					workspaceName={workspaceName}
+				/>
+			</div>
+			<div className={activeTab === "changes" ? "min-h-0 flex-1" : "hidden"}>
+				<div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+					Coming soon
+				</div>
+			</div>
+			<div className={activeTab === "checks" ? "min-h-0 flex-1" : "hidden"}>
+				<div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+					Coming soon
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/FilesTab.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/FilesTab.tsx
@@ -1,0 +1,562 @@
+import { alert } from "@superset/ui/atoms/Alert";
+import { Button } from "@superset/ui/button";
+import { toast } from "@superset/ui/sonner";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
+import {
+	type FileTreeNode,
+	useFileTree,
+	useWorkspaceFsEventBridge,
+	useWorkspaceFsEvents,
+	workspaceTrpc,
+} from "@superset/workspace-client";
+import { FilePlus, FolderPlus, FoldVertical, RefreshCw } from "lucide-react";
+import { Fragment, useCallback, useEffect, useRef, useState } from "react";
+import {
+	ROW_HEIGHT,
+	TREE_INDENT,
+} from "renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/constants";
+import { NewItemInput } from "./components/NewItemInput";
+import { WorkspaceFilesTreeItem } from "./components/WorkspaceFilesTreeItem";
+
+type InlineEditState =
+	| { kind: "create"; mode: "file" | "folder"; parentPath: string }
+	| { kind: "rename"; absolutePath: string; name: string; isDirectory: boolean }
+	| null;
+
+interface FilesTabProps {
+	onSelectFile: (absolutePath: string) => void;
+	selectedFilePath?: string;
+	workspaceId: string;
+	workspaceName?: string;
+}
+
+function TreeNode({
+	node,
+	depth,
+	indent,
+	rowHeight,
+	selectedFilePath,
+	hoveredPath,
+	inlineEdit,
+	onSelectFile,
+	onToggleDirectory,
+	onInlineEditSubmit,
+	onInlineEditCancel,
+	onNewFile,
+	onNewFolder,
+	onRename,
+	onDelete,
+}: {
+	node: FileTreeNode;
+	depth: number;
+	indent: number;
+	rowHeight: number;
+	selectedFilePath?: string;
+	hoveredPath?: string | null;
+	inlineEdit: InlineEditState;
+	onSelectFile: (absolutePath: string) => void;
+	onToggleDirectory: (absolutePath: string) => void;
+	onInlineEditSubmit: (name: string) => void;
+	onInlineEditCancel: () => void;
+	onNewFile: (parentPath: string) => void;
+	onNewFolder: (parentPath: string) => void;
+	onRename: (absolutePath: string, name: string, isDirectory: boolean) => void;
+	onDelete: (absolutePath: string, name: string, isDirectory: boolean) => void;
+}) {
+	const isCreating = inlineEdit?.kind === "create";
+	const isCreatingHere =
+		isCreating && inlineEdit.parentPath === node.absolutePath;
+	const isCreatingFile = isCreatingHere && inlineEdit.mode === "file";
+	const isRenaming =
+		inlineEdit?.kind === "rename" &&
+		inlineEdit.absolutePath === node.absolutePath;
+	const lastFolderIndex = node.children.findLastIndex(
+		(n) => n.kind === "directory",
+	);
+
+	return (
+		<div>
+			{isRenaming ? (
+				<NewItemInput
+					mode={node.kind === "directory" ? "folder" : "file"}
+					depth={depth}
+					initialValue={inlineEdit.name}
+					onSubmit={onInlineEditSubmit}
+					onCancel={onInlineEditCancel}
+				/>
+			) : (
+				<WorkspaceFilesTreeItem
+					node={node}
+					depth={depth}
+					indent={indent}
+					rowHeight={rowHeight}
+					selectedFilePath={selectedFilePath}
+					isHovered={hoveredPath === node.absolutePath}
+					onSelectFile={onSelectFile}
+					onToggleDirectory={onToggleDirectory}
+					onNewFile={onNewFile}
+					onNewFolder={onNewFolder}
+					onRename={onRename}
+					onDelete={onDelete}
+				/>
+			)}
+			{node.kind === "directory" && node.isExpanded && (
+				<>
+					{isCreatingHere && inlineEdit.mode === "folder" && (
+						<NewItemInput
+							mode="folder"
+							depth={depth + 1}
+							onSubmit={onInlineEditSubmit}
+							onCancel={onInlineEditCancel}
+						/>
+					)}
+					{node.children.map((child, index) => (
+						<Fragment key={child.absolutePath}>
+							<TreeNode
+								node={child}
+								depth={depth + 1}
+								indent={indent}
+								rowHeight={rowHeight}
+								selectedFilePath={selectedFilePath}
+								hoveredPath={hoveredPath}
+								inlineEdit={inlineEdit}
+								onSelectFile={onSelectFile}
+								onToggleDirectory={onToggleDirectory}
+								onInlineEditSubmit={onInlineEditSubmit}
+								onInlineEditCancel={onInlineEditCancel}
+								onNewFile={onNewFile}
+								onNewFolder={onNewFolder}
+								onRename={onRename}
+								onDelete={onDelete}
+							/>
+							{isCreatingFile && index === lastFolderIndex && (
+								<NewItemInput
+									mode="file"
+									depth={depth + 1}
+									onSubmit={onInlineEditSubmit}
+									onCancel={onInlineEditCancel}
+								/>
+							)}
+						</Fragment>
+					))}
+					{isCreatingFile && lastFolderIndex === -1 && (
+						<NewItemInput
+							mode="file"
+							depth={depth + 1}
+							onSubmit={onInlineEditSubmit}
+							onCancel={onInlineEditCancel}
+						/>
+					)}
+				</>
+			)}
+		</div>
+	);
+}
+
+export function FilesTab({
+	onSelectFile,
+	selectedFilePath,
+	workspaceId,
+	workspaceName,
+}: FilesTabProps) {
+	const [_isRefreshing, setIsRefreshing] = useState(false);
+	const [hoveredPath, setHoveredPath] = useState<string | null>(null);
+	const [inlineEdit, setInlineEdit] = useState<InlineEditState>(null);
+	const utils = workspaceTrpc.useUtils();
+	const workspaceQuery = workspaceTrpc.workspace.get.useQuery({
+		id: workspaceId,
+	});
+	const rootPath = workspaceQuery.data?.worktreePath ?? "";
+
+	const writeFile = workspaceTrpc.filesystem.writeFile.useMutation();
+	const createDirectory =
+		workspaceTrpc.filesystem.createDirectory.useMutation();
+	const movePath = workspaceTrpc.filesystem.movePath.useMutation();
+
+	useWorkspaceFsEventBridge(
+		workspaceId,
+		Boolean(workspaceId && workspaceQuery.data?.worktreePath),
+	);
+
+	const fileTree = useFileTree({ workspaceId, rootPath });
+
+	useWorkspaceFsEvents(
+		workspaceId,
+		() => void utils.filesystem.searchFiles.invalidate(),
+		Boolean(workspaceId),
+	);
+
+	const scrollContainerRef = useRef<HTMLDivElement>(null);
+	const lastMousePos = useRef<{ x: number; y: number } | null>(null);
+	const prevSelectedRef = useRef(selectedFilePath);
+
+	const updateHoverFromPoint = useCallback((x: number, y: number) => {
+		const el = document.elementFromPoint(x, y)?.closest("[data-filepath]");
+		setHoveredPath(el?.getAttribute("data-filepath") ?? null);
+	}, []);
+
+	const handleMouseMove = useCallback(
+		(e: React.MouseEvent) => {
+			lastMousePos.current = { x: e.clientX, y: e.clientY };
+			updateHoverFromPoint(e.clientX, e.clientY);
+		},
+		[updateHoverFromPoint],
+	);
+
+	const handleScroll = useCallback(() => {
+		if (lastMousePos.current)
+			updateHoverFromPoint(lastMousePos.current.x, lastMousePos.current.y);
+	}, [updateHoverFromPoint]);
+
+	const handleMouseLeave = useCallback(() => {
+		lastMousePos.current = null;
+		setHoveredPath(null);
+	}, []);
+
+	useEffect(() => {
+		if (
+			selectedFilePath &&
+			selectedFilePath !== prevSelectedRef.current &&
+			rootPath
+		) {
+			void fileTree.reveal(selectedFilePath).then(() => {
+				requestAnimationFrame(() => {
+					scrollContainerRef.current
+						?.querySelector(`[data-filepath="${CSS.escape(selectedFilePath)}"]`)
+						?.scrollIntoView({ block: "center" });
+				});
+			});
+		}
+		prevSelectedRef.current = selectedFilePath;
+	}, [selectedFilePath, rootPath, fileTree]);
+
+	const handleRefresh = useCallback(async () => {
+		setIsRefreshing(true);
+		try {
+			await fileTree.refreshAll();
+		} finally {
+			setIsRefreshing(false);
+		}
+	}, [fileTree]);
+
+	const getParentForCreation = useCallback((): string => {
+		if (!selectedFilePath || !rootPath) return rootPath;
+		// Walk tree to check if selected is a directory
+		function isDirectory(nodes: FileTreeNode[]): boolean {
+			for (const n of nodes) {
+				if (n.absolutePath === selectedFilePath) return n.kind === "directory";
+				if (n.children.length > 0 && isDirectory(n.children)) return true;
+			}
+			return false;
+		}
+		if (isDirectory(fileTree.rootEntries)) return selectedFilePath;
+		const lastSlash = selectedFilePath.lastIndexOf("/");
+		return lastSlash > 0 ? selectedFilePath.slice(0, lastSlash) : rootPath;
+	}, [selectedFilePath, rootPath, fileTree.rootEntries]);
+
+	const startCreating = useCallback(
+		async (mode: "file" | "folder", targetPath?: string) => {
+			const parentPath = targetPath ?? getParentForCreation();
+			if (parentPath !== rootPath) await fileTree.expand(parentPath);
+			setInlineEdit({ kind: "create", mode, parentPath });
+
+			scrollContainerRef.current
+				?.querySelector("[data-new-item-input]")
+				?.scrollIntoView({ block: "nearest" });
+			setTimeout(() => {
+				scrollContainerRef.current
+					?.querySelector<HTMLInputElement>("[data-new-item-input] input")
+					?.focus();
+			}, 200);
+		},
+		[getParentForCreation, rootPath, fileTree],
+	);
+
+	const startRenaming = useCallback(
+		(absolutePath: string, name: string, isDirectory: boolean) => {
+			setInlineEdit({ kind: "rename", absolutePath, name, isDirectory });
+			setTimeout(() => {
+				scrollContainerRef.current
+					?.querySelector<HTMLInputElement>("[data-new-item-input] input")
+					?.focus();
+			}, 200);
+		},
+		[],
+	);
+
+	const handleInlineEditSubmit = useCallback(
+		async (name: string) => {
+			if (!inlineEdit || !rootPath) return;
+
+			try {
+				if (inlineEdit.kind === "create") {
+					const { mode, parentPath } = inlineEdit;
+					const segments = name.split("/").filter(Boolean);
+					if (segments.length === 0) return;
+
+					const absolutePath = `${parentPath}/${name}`;
+
+					if (mode === "folder") {
+						await createDirectory.mutateAsync({
+							workspaceId,
+							absolutePath,
+							recursive: true,
+						});
+					} else {
+						if (segments.length > 1) {
+							const dirPath = `${parentPath}/${segments.slice(0, -1).join("/")}`;
+							await createDirectory.mutateAsync({
+								workspaceId,
+								absolutePath: dirPath,
+								recursive: true,
+							});
+						}
+						await writeFile.mutateAsync({
+							workspaceId,
+							absolutePath,
+							content: "",
+							options: { create: true, overwrite: false },
+						});
+						onSelectFile(absolutePath);
+					}
+				} else {
+					const { absolutePath } = inlineEdit;
+					const parentDir = absolutePath.slice(
+						0,
+						absolutePath.lastIndexOf("/"),
+					);
+					const destinationPath = `${parentDir}/${name}`;
+					await movePath.mutateAsync({
+						workspaceId,
+						sourceAbsolutePath: absolutePath,
+						destinationAbsolutePath: destinationPath,
+					});
+				}
+			} catch (error) {
+				toast.error(
+					inlineEdit.kind === "create"
+						? "Failed to create item"
+						: "Failed to rename",
+					{
+						description: error instanceof Error ? error.message : undefined,
+					},
+				);
+			}
+			setInlineEdit(null);
+		},
+		[
+			inlineEdit,
+			rootPath,
+			workspaceId,
+			writeFile,
+			createDirectory,
+			movePath,
+			onSelectFile,
+		],
+	);
+
+	const handleInlineEditCancel = useCallback(() => setInlineEdit(null), []);
+
+	const deletePath = workspaceTrpc.filesystem.deletePath.useMutation();
+
+	const handleDelete = useCallback(
+		(absolutePath: string, name: string, isDirectory: boolean) => {
+			const itemType = isDirectory ? "folder" : "file";
+			alert({
+				title: `Delete ${name}?`,
+				description: `Are you sure you want to delete this ${itemType}? This action cannot be undone.`,
+				actions: [
+					{
+						label: "Delete",
+						variant: "destructive",
+						onClick: () => {
+							toast.promise(
+								deletePath.mutateAsync({
+									workspaceId,
+									absolutePath,
+								}),
+								{
+									loading: `Deleting ${name}...`,
+									success: `Deleted ${name}`,
+									error: `Failed to delete ${name}`,
+								},
+							);
+						},
+					},
+					{
+						label: "Cancel",
+						variant: "ghost",
+					},
+				],
+			});
+		},
+		[workspaceId, deletePath],
+	);
+
+	if (!workspaceQuery.data?.worktreePath) {
+		return (
+			<div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+				Workspace worktree not available
+			</div>
+		);
+	}
+
+	const isCreatingAtRoot =
+		inlineEdit?.kind === "create" && inlineEdit.parentPath === rootPath;
+	const isCreatingFileAtRoot =
+		isCreatingAtRoot &&
+		inlineEdit?.kind === "create" &&
+		inlineEdit.mode === "file";
+	const isCreatingFolderAtRoot =
+		isCreatingAtRoot &&
+		inlineEdit?.kind === "create" &&
+		inlineEdit.mode === "folder";
+	const rootLastFolderIndex = fileTree.rootEntries.findLastIndex(
+		(n) => n.kind === "directory",
+	);
+
+	return (
+		<div className="flex h-full min-h-0 flex-col overflow-hidden">
+			{/* biome-ignore lint/a11y/noStaticElementInteractions: mouse tracking for hover state */}
+			<div
+				ref={scrollContainerRef}
+				className="min-h-0 flex-1 overflow-y-auto"
+				onMouseMove={handleMouseMove}
+				onMouseLeave={handleMouseLeave}
+				onScroll={handleScroll}
+			>
+				<div
+					className="group flex items-center justify-between bg-background px-2 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground"
+					style={{
+						height: ROW_HEIGHT,
+						position: "sticky",
+						top: 0,
+						zIndex: 20,
+					}}
+				>
+					<span className="truncate">{workspaceName ?? "Explorer"}</span>
+					<div className="flex items-center gap-0.5">
+						<Tooltip>
+							<TooltipTrigger asChild>
+								<Button
+									variant="ghost"
+									size="icon"
+									className="size-5"
+									onClick={() => void startCreating("file")}
+								>
+									<FilePlus className="size-3" />
+								</Button>
+							</TooltipTrigger>
+							<TooltipContent side="bottom">New File</TooltipContent>
+						</Tooltip>
+						<Tooltip>
+							<TooltipTrigger asChild>
+								<Button
+									variant="ghost"
+									size="icon"
+									className="size-5"
+									onClick={() => void startCreating("folder")}
+								>
+									<FolderPlus className="size-3" />
+								</Button>
+							</TooltipTrigger>
+							<TooltipContent side="bottom">New Folder</TooltipContent>
+						</Tooltip>
+						<Tooltip>
+							<TooltipTrigger asChild>
+								<Button
+									variant="ghost"
+									size="icon"
+									className="size-5"
+									onClick={() => void handleRefresh()}
+								>
+									<RefreshCw className="size-3" />
+								</Button>
+							</TooltipTrigger>
+							<TooltipContent side="bottom">Refresh</TooltipContent>
+						</Tooltip>
+						<Tooltip>
+							<TooltipTrigger asChild>
+								<Button
+									variant="ghost"
+									size="icon"
+									className="size-5"
+									onClick={fileTree.collapseAll}
+								>
+									<FoldVertical className="size-3" />
+								</Button>
+							</TooltipTrigger>
+							<TooltipContent side="bottom">Collapse All</TooltipContent>
+						</Tooltip>
+					</div>
+				</div>
+
+				{fileTree.isLoadingRoot && fileTree.rootEntries.length === 0 ? (
+					<div className="px-2 py-3 text-sm text-muted-foreground">
+						Loading files...
+					</div>
+				) : fileTree.rootEntries.length === 0 && !isCreatingAtRoot ? (
+					<div className="px-2 py-3 text-sm text-muted-foreground">
+						No files found
+					</div>
+				) : (
+					<>
+						{isCreatingFolderAtRoot && (
+							<NewItemInput
+								mode="folder"
+								depth={1}
+								onSubmit={handleInlineEditSubmit}
+								onCancel={handleInlineEditCancel}
+							/>
+						)}
+						{fileTree.rootEntries.map((node, index) => (
+							<Fragment key={node.absolutePath}>
+								<TreeNode
+									node={node}
+									depth={1}
+									indent={TREE_INDENT}
+									rowHeight={ROW_HEIGHT}
+									selectedFilePath={selectedFilePath}
+									hoveredPath={hoveredPath}
+									inlineEdit={inlineEdit}
+									onSelectFile={onSelectFile}
+									onToggleDirectory={(absolutePath) =>
+										void fileTree.toggle(absolutePath)
+									}
+									onInlineEditSubmit={handleInlineEditSubmit}
+									onInlineEditCancel={handleInlineEditCancel}
+									onNewFile={(parentPath) =>
+										void startCreating("file", parentPath)
+									}
+									onNewFolder={(parentPath) =>
+										void startCreating("folder", parentPath)
+									}
+									onRename={(absolutePath, name, isDirectory) =>
+										startRenaming(absolutePath, name, isDirectory)
+									}
+									onDelete={handleDelete}
+								/>
+								{isCreatingFileAtRoot && index === rootLastFolderIndex && (
+									<NewItemInput
+										mode="file"
+										depth={1}
+										onSubmit={handleInlineEditSubmit}
+										onCancel={handleInlineEditCancel}
+									/>
+								)}
+							</Fragment>
+						))}
+						{isCreatingFileAtRoot && rootLastFolderIndex === -1 && (
+							<NewItemInput
+								mode="file"
+								depth={1}
+								onSubmit={handleInlineEditSubmit}
+								onCancel={handleInlineEditCancel}
+							/>
+						)}
+					</>
+				)}
+			</div>
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/components/NewItemInput/NewItemInput.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/components/NewItemInput/NewItemInput.tsx
@@ -1,0 +1,90 @@
+import { useEffect, useRef, useState } from "react";
+import { LuChevronDown } from "react-icons/lu";
+import {
+	ROW_HEIGHT,
+	TREE_INDENT,
+} from "renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/constants";
+import { FileIcon } from "renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/utils";
+
+interface NewItemInputProps {
+	mode: "file" | "folder";
+	depth: number;
+	initialValue?: string;
+	onSubmit: (name: string) => void;
+	onCancel: () => void;
+}
+
+export function NewItemInput({
+	mode,
+	depth,
+	initialValue = "",
+	onSubmit,
+	onCancel,
+}: NewItemInputProps) {
+	const [value, setValue] = useState(initialValue);
+	const inputRef = useRef<HTMLInputElement>(null);
+
+	useEffect(() => {
+		const input = inputRef.current;
+		if (!input) return;
+		// For rename: select the name up to the extension so user can type to replace
+		if (initialValue) {
+			const dotIndex = initialValue.lastIndexOf(".");
+			if (dotIndex > 0 && mode === "file") {
+				input.setSelectionRange(0, dotIndex);
+			} else {
+				input.select();
+			}
+		}
+	}, [initialValue, mode]);
+
+	const handleKeyDown = (e: React.KeyboardEvent) => {
+		if (e.key === "Enter") {
+			e.preventDefault();
+			const trimmed = value.trim();
+			if (trimmed && trimmed !== initialValue) onSubmit(trimmed);
+			else onCancel();
+		} else if (e.key === "Escape") {
+			e.preventDefault();
+			onCancel();
+		}
+	};
+
+	const displayName = value.includes("/")
+		? (value.split("/").pop() ?? "")
+		: value;
+
+	return (
+		<div
+			data-new-item-input
+			className="flex w-full items-center gap-1 px-1"
+			style={{
+				height: ROW_HEIGHT,
+				paddingLeft: 4 + depth * TREE_INDENT,
+			}}
+		>
+			<span className="flex h-4 w-4 shrink-0 items-center justify-center">
+				{mode === "folder" ? (
+					<LuChevronDown className="size-3.5 text-muted-foreground" />
+				) : null}
+			</span>
+
+			<FileIcon
+				className="size-4 shrink-0"
+				fileName={displayName || (mode === "folder" ? "folder" : "file")}
+				isDirectory={mode === "folder"}
+				isOpen={false}
+			/>
+
+			<input
+				ref={inputRef}
+				value={value}
+				onChange={(e) => setValue(e.target.value)}
+				onKeyDown={handleKeyDown}
+				onBlur={onCancel}
+				className="min-w-0 flex-1 bg-transparent text-xs outline-none ring-1 ring-ring rounded-sm px-1"
+				style={{ height: ROW_HEIGHT - 4 }}
+			/>
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/components/NewItemInput/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/components/NewItemInput/index.ts
@@ -1,0 +1,1 @@
+export { NewItemInput } from "./NewItemInput";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/components/WorkspaceFilesTreeItem/WorkspaceFilesTreeItem.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/components/WorkspaceFilesTreeItem/WorkspaceFilesTreeItem.tsx
@@ -1,0 +1,115 @@
+import { ContextMenu, ContextMenuTrigger } from "@superset/ui/context-menu";
+import { cn } from "@superset/ui/utils";
+import type { FileTreeNode } from "@superset/workspace-client";
+import { LuChevronDown, LuChevronRight } from "react-icons/lu";
+import { FileIcon } from "renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/utils";
+
+import { FileContextMenu } from "./components/FileContextMenu";
+import { FolderContextMenu } from "./components/FolderContextMenu";
+
+interface WorkspaceFilesTreeItemProps {
+	node: FileTreeNode;
+	depth: number;
+	rowHeight: number;
+	indent: number;
+	selectedFilePath?: string;
+	isHovered?: boolean;
+	onSelectFile: (absolutePath: string) => void;
+	onToggleDirectory: (absolutePath: string) => void;
+	onNewFile: (parentPath: string) => void;
+	onNewFolder: (parentPath: string) => void;
+	onRename: (absolutePath: string, name: string, isDirectory: boolean) => void;
+	onDelete: (absolutePath: string, name: string, isDirectory: boolean) => void;
+}
+
+export function WorkspaceFilesTreeItem({
+	node,
+	depth,
+	rowHeight,
+	indent,
+	selectedFilePath,
+	isHovered,
+	onSelectFile,
+	onToggleDirectory,
+	onNewFile,
+	onNewFolder,
+	onRename,
+	onDelete,
+}: WorkspaceFilesTreeItemProps) {
+	const isFolder = node.kind === "directory";
+	const isSelected = selectedFilePath === node.absolutePath;
+
+	return (
+		<ContextMenu>
+			<ContextMenuTrigger asChild>
+				<button
+					data-filepath={node.absolutePath}
+					aria-expanded={isFolder ? node.isExpanded : undefined}
+					className={cn(
+						"flex w-full cursor-pointer select-none items-center gap-1 pr-2 text-left transition-colors",
+						isFolder ? "bg-background" : undefined,
+						isHovered && !isSelected
+							? isFolder
+								? "!bg-muted"
+								: "!bg-accent/50"
+							: undefined,
+						isSelected ? "!bg-accent" : undefined,
+					)}
+					onClick={() =>
+						isFolder
+							? onToggleDirectory(node.absolutePath)
+							: onSelectFile(node.absolutePath)
+					}
+					style={{
+						height: rowHeight,
+						paddingLeft: 4 + depth * indent,
+						...(isFolder
+							? {
+									position: "sticky" as const,
+									top: depth * rowHeight,
+									zIndex: 10 - depth,
+								}
+							: {}),
+					}}
+					type="button"
+				>
+					<span className="flex h-4 w-4 shrink-0 items-center justify-center">
+						{isFolder ? (
+							node.isExpanded ? (
+								<LuChevronDown className="size-3.5 text-muted-foreground" />
+							) : (
+								<LuChevronRight className="size-3.5 text-muted-foreground" />
+							)
+						) : null}
+					</span>
+
+					<FileIcon
+						className="size-4 shrink-0"
+						fileName={node.name}
+						isDirectory={isFolder}
+						isOpen={node.isExpanded}
+					/>
+
+					<span className="min-w-0 flex-1 truncate text-xs">{node.name}</span>
+				</button>
+			</ContextMenuTrigger>
+			{isFolder ? (
+				<FolderContextMenu
+					absolutePath={node.absolutePath}
+					relativePath={node.relativePath}
+					onNewFile={() => onNewFile(node.absolutePath)}
+					onNewFolder={() => onNewFolder(node.absolutePath)}
+					onRename={() => onRename(node.absolutePath, node.name, true)}
+					onDelete={() => onDelete(node.absolutePath, node.name, true)}
+				/>
+			) : (
+				<FileContextMenu
+					absolutePath={node.absolutePath}
+					relativePath={node.relativePath}
+					onRename={() => onRename(node.absolutePath, node.name, false)}
+					onDelete={() => onDelete(node.absolutePath, node.name, false)}
+				/>
+			)}
+		</ContextMenu>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/components/WorkspaceFilesTreeItem/components/FileContextMenu/FileContextMenu.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/components/WorkspaceFilesTreeItem/components/FileContextMenu/FileContextMenu.tsx
@@ -1,0 +1,61 @@
+import {
+	ContextMenuContent,
+	ContextMenuItem,
+	ContextMenuSeparator,
+} from "@superset/ui/context-menu";
+import { toast } from "@superset/ui/sonner";
+import { electronTrpcClient } from "renderer/lib/trpc-client";
+
+interface FileContextMenuProps {
+	absolutePath: string;
+	relativePath?: string;
+	onRename: () => void;
+	onDelete: () => void;
+}
+
+export function FileContextMenu({
+	absolutePath,
+	relativePath,
+	onRename,
+	onDelete,
+}: FileContextMenuProps) {
+	return (
+		<ContextMenuContent className="w-56">
+			<ContextMenuItem>Open to the Side</ContextMenuItem>
+			<ContextMenuSeparator />
+			<ContextMenuItem
+				onSelect={() =>
+					electronTrpcClient.external.openInFinder.mutate(absolutePath)
+				}
+			>
+				Reveal in Finder
+			</ContextMenuItem>
+			<ContextMenuSeparator />
+			<ContextMenuItem
+				onSelect={() => {
+					navigator.clipboard.writeText(absolutePath);
+					toast.success("Path copied");
+				}}
+			>
+				Copy Path
+			</ContextMenuItem>
+			{relativePath && (
+				<ContextMenuItem
+					onSelect={() => {
+						navigator.clipboard.writeText(relativePath);
+						toast.success("Relative path copied");
+					}}
+				>
+					Copy Relative Path
+				</ContextMenuItem>
+			)}
+			<ContextMenuSeparator />
+			<ContextMenuItem onSelect={() => setTimeout(onRename, 0)}>
+				Rename...
+			</ContextMenuItem>
+			<ContextMenuItem variant="destructive" onSelect={onDelete}>
+				Delete
+			</ContextMenuItem>
+		</ContextMenuContent>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/components/WorkspaceFilesTreeItem/components/FileContextMenu/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/components/WorkspaceFilesTreeItem/components/FileContextMenu/index.ts
@@ -1,0 +1,1 @@
+export { FileContextMenu } from "./FileContextMenu";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/components/WorkspaceFilesTreeItem/components/FolderContextMenu/FolderContextMenu.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/components/WorkspaceFilesTreeItem/components/FolderContextMenu/FolderContextMenu.tsx
@@ -1,0 +1,70 @@
+import {
+	ContextMenuContent,
+	ContextMenuItem,
+	ContextMenuSeparator,
+} from "@superset/ui/context-menu";
+import { toast } from "@superset/ui/sonner";
+import { electronTrpcClient } from "renderer/lib/trpc-client";
+
+interface FolderContextMenuProps {
+	absolutePath: string;
+	relativePath?: string;
+	onNewFile: () => void;
+	onNewFolder: () => void;
+	onRename: () => void;
+	onDelete: () => void;
+}
+
+export function FolderContextMenu({
+	absolutePath,
+	relativePath,
+	onNewFile,
+	onNewFolder,
+	onRename,
+	onDelete,
+}: FolderContextMenuProps) {
+	return (
+		<ContextMenuContent className="w-56">
+			<ContextMenuItem onSelect={() => setTimeout(onNewFile, 0)}>
+				New File...
+			</ContextMenuItem>
+			<ContextMenuItem onSelect={() => setTimeout(onNewFolder, 0)}>
+				New Folder...
+			</ContextMenuItem>
+			<ContextMenuSeparator />
+			<ContextMenuItem
+				onSelect={() =>
+					electronTrpcClient.external.openInFinder.mutate(absolutePath)
+				}
+			>
+				Reveal in Finder
+			</ContextMenuItem>
+			<ContextMenuSeparator />
+			<ContextMenuItem
+				onSelect={() => {
+					navigator.clipboard.writeText(absolutePath);
+					toast.success("Path copied");
+				}}
+			>
+				Copy Path
+			</ContextMenuItem>
+			{relativePath && (
+				<ContextMenuItem
+					onSelect={() => {
+						navigator.clipboard.writeText(relativePath);
+						toast.success("Relative path copied");
+					}}
+				>
+					Copy Relative Path
+				</ContextMenuItem>
+			)}
+			<ContextMenuSeparator />
+			<ContextMenuItem onSelect={() => setTimeout(onRename, 0)}>
+				Rename...
+			</ContextMenuItem>
+			<ContextMenuItem variant="destructive" onSelect={onDelete}>
+				Delete
+			</ContextMenuItem>
+		</ContextMenuContent>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/components/WorkspaceFilesTreeItem/components/FolderContextMenu/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/components/WorkspaceFilesTreeItem/components/FolderContextMenu/index.ts
@@ -1,0 +1,1 @@
+export { FolderContextMenu } from "./FolderContextMenu";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/components/WorkspaceFilesTreeItem/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/components/WorkspaceFilesTreeItem/index.ts
@@ -1,0 +1,1 @@
+export { WorkspaceFilesTreeItem } from "./WorkspaceFilesTreeItem";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/index.ts
@@ -1,0 +1,1 @@
+export { FilesTab } from "./FilesTab";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/SidebarHeader/SidebarHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/SidebarHeader/SidebarHeader.tsx
@@ -1,0 +1,52 @@
+import { cn } from "@superset/ui/utils";
+import type { ReactNode } from "react";
+
+interface Tab {
+	id: string;
+	label: string;
+	icon?: ReactNode;
+	badge?: number;
+}
+
+interface SidebarHeaderProps {
+	tabs: Tab[];
+	activeTab: string;
+	onTabChange: (id: string) => void;
+	actions?: ReactNode;
+}
+
+export function SidebarHeader({
+	tabs,
+	activeTab,
+	onTabChange,
+	actions,
+}: SidebarHeaderProps) {
+	return (
+		<div className="flex h-10 shrink-0 items-stretch border-b border-border">
+			<div className="flex flex-1 items-stretch">
+				{tabs.map((tab) => (
+					<button
+						key={tab.id}
+						type="button"
+						onClick={() => onTabChange(tab.id)}
+						className={cn(
+							"flex h-full shrink-0 items-center gap-2 px-3 text-sm transition-all",
+							activeTab === tab.id
+								? "bg-border/30 text-foreground"
+								: "text-muted-foreground/70 hover:text-muted-foreground hover:bg-tertiary/20",
+						)}
+					>
+						{tab.icon}
+						{tab.label}
+						{tab.badge != null && tab.badge > 0 && (
+							<span className="text-xs tabular-nums">{tab.badge}</span>
+						)}
+					</button>
+				))}
+			</div>
+			{actions && (
+				<div className="flex items-center gap-0.5 px-1">{actions}</div>
+			)}
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/SidebarHeader/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/SidebarHeader/index.ts
@@ -1,0 +1,1 @@
+export { SidebarHeader } from "./SidebarHeader";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/index.ts
@@ -1,0 +1,1 @@
+export { WorkspaceSidebar } from "./WorkspaceSidebar";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatPane/components/SessionSelector/components/SessionSelectorItem/SessionSelectorItem.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatPane/components/SessionSelector/components/SessionSelectorItem/SessionSelectorItem.tsx
@@ -36,17 +36,23 @@ export function SessionSelectorItem({
 					className="shrink-0 rounded p-0.5 opacity-0 transition-opacity hover:bg-destructive/10 hover:text-destructive group-hover:opacity-100"
 					onClick={(event) => {
 						event.stopPropagation();
-						alert.destructive({
+						alert({
 							title: "Delete Chat Session",
 							description: "Are you sure you want to delete this session?",
-							confirmText: "Delete",
-							onConfirm: () => {
-								toast.promise(onDeleteSession(sessionId), {
-									loading: "Deleting session...",
-									success: "Session deleted",
-									error: "Failed to delete session",
-								});
-							},
+							actions: [
+								{ label: "Cancel", variant: "outline", onClick: () => {} },
+								{
+									label: "Delete",
+									variant: "destructive",
+									onClick: () => {
+										toast.promise(onDeleteSession(sessionId), {
+											loading: "Deleting session...",
+											success: "Session deleted",
+											error: "Failed to delete session",
+										});
+									},
+								},
+							],
 						});
 					}}
 				>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/FilePane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/FilePane.tsx
@@ -17,6 +17,24 @@ export function FilePane({ context, workspaceId }: FilePaneProps) {
 	const data = context.pane.data as FilePaneData;
 	const { filePath } = data;
 
+	// Spreadsheet files bypass useFileDocument entirely (own data loading)
+	if (isSpreadsheetFile(filePath)) {
+		return (
+			<SpreadsheetViewer
+				workspaceId={workspaceId}
+				filePath={filePath}
+				absoluteFilePath={filePath}
+			/>
+		);
+	}
+
+	return <FilePaneContent context={context} workspaceId={workspaceId} />;
+}
+
+function FilePaneContent({ context, workspaceId }: FilePaneProps) {
+	const data = context.pane.data as FilePaneData;
+	const { filePath } = data;
+
 	const document = useFileDocument({
 		workspaceId,
 		absolutePath: filePath,
@@ -73,15 +91,6 @@ export function FilePane({ context, workspaceId }: FilePaneProps) {
 		if (isImageFile(filePath) && document.state.kind === "bytes") {
 			return (
 				<ImageRenderer content={document.state.content} filePath={filePath} />
-			);
-		}
-		if (isSpreadsheetFile(filePath)) {
-			return (
-				<SpreadsheetViewer
-					workspaceId={workspaceId}
-					filePath={filePath}
-					absoluteFilePath={filePath}
-				/>
 			);
 		}
 		return (

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/FilePane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/FilePane.tsx
@@ -1,0 +1,116 @@
+import type { RendererContext } from "@superset/panes";
+import { useFileDocument } from "@superset/workspace-client";
+import { useCallback } from "react";
+import { isImageFile, isMarkdownFile, isSpreadsheetFile } from "shared/file-types";
+import { SpreadsheetViewer } from "renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/components/SpreadsheetViewer";
+import type { FilePaneData, PaneViewerData } from "../../../../types";
+import { CodeRenderer } from "./renderers/CodeRenderer";
+import { ImageRenderer } from "./renderers/ImageRenderer";
+import { MarkdownRenderer } from "./renderers/MarkdownRenderer";
+
+interface FilePaneProps {
+	context: RendererContext<PaneViewerData>;
+	workspaceId: string;
+}
+
+export function FilePane({ context, workspaceId }: FilePaneProps) {
+	const data = context.pane.data as FilePaneData;
+	const { filePath } = data;
+
+	const document = useFileDocument({
+		workspaceId,
+		absolutePath: filePath,
+		mode: isImageFile(filePath) ? "bytes" : "auto",
+		maxBytes: isImageFile(filePath) ? 10 * 1024 * 1024 : 2 * 1024 * 1024,
+		hasLocalChanges: data.hasChanges,
+		autoReloadWhenClean: true,
+	});
+
+	const handleDirtyChange = useCallback(
+		(dirty: boolean) => {
+			if (dirty !== data.hasChanges) {
+				context.actions.updateData({
+					...data,
+					hasChanges: dirty,
+				} as PaneViewerData);
+			}
+		},
+		[context.actions, data],
+	);
+
+	const handleSave = useCallback(
+		async (content: string) => {
+			const result = await document.save({ content });
+			if (result.status === "saved") {
+				handleDirtyChange(false);
+			}
+			return result;
+		},
+		[document, handleDirtyChange],
+	);
+
+	if (document.state.kind === "loading") {
+		return null;
+	}
+
+	if (document.state.kind === "not-found") {
+		return (
+			<div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+				File not found
+			</div>
+		);
+	}
+
+	if (document.state.kind === "too-large") {
+		return (
+			<div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+				File is too large to display
+			</div>
+		);
+	}
+
+	if (document.state.kind === "binary" || document.state.kind === "bytes") {
+		if (isImageFile(filePath) && document.state.kind === "bytes") {
+			return (
+				<ImageRenderer content={document.state.content} filePath={filePath} />
+			);
+		}
+		if (isSpreadsheetFile(filePath)) {
+			return (
+				<SpreadsheetViewer
+					workspaceId={workspaceId}
+					filePath={filePath}
+					absoluteFilePath={filePath}
+				/>
+			);
+		}
+		return (
+			<div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+				Binary file — cannot display
+			</div>
+		);
+	}
+
+	if (isMarkdownFile(filePath)) {
+		return (
+			<MarkdownRenderer
+				content={document.state.content}
+				hasExternalChange={document.hasExternalChange}
+				onDirtyChange={handleDirtyChange}
+				onReload={document.reload}
+				onSave={handleSave}
+			/>
+		);
+	}
+
+	return (
+		<CodeRenderer
+			content={document.state.content}
+			filePath={filePath}
+			hasExternalChange={document.hasExternalChange}
+			onDirtyChange={handleDirtyChange}
+			onReload={document.reload}
+			onSave={handleSave}
+		/>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/components/ExternalChangeBar/ExternalChangeBar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/components/ExternalChangeBar/ExternalChangeBar.tsx
@@ -1,0 +1,18 @@
+interface ExternalChangeBarProps {
+	onReload: () => Promise<void>;
+}
+
+export function ExternalChangeBar({ onReload }: ExternalChangeBarProps) {
+	return (
+		<div className="flex items-center gap-2 border-b border-border bg-warning/10 px-3 py-1.5 text-xs text-warning-foreground">
+			<span>File changed on disk.</span>
+			<button
+				type="button"
+				className="underline hover:no-underline"
+				onClick={() => void onReload()}
+			>
+				Reload
+			</button>
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/components/ExternalChangeBar/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/components/ExternalChangeBar/index.ts
@@ -1,0 +1,1 @@
+export { ExternalChangeBar } from "./ExternalChangeBar";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/index.ts
@@ -1,0 +1,1 @@
+export { FilePane } from "./FilePane";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/renderers/CodeRenderer/CodeRenderer.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/renderers/CodeRenderer/CodeRenderer.tsx
@@ -1,0 +1,59 @@
+import { useCallback, useRef, useState } from "react";
+import { CodeEditor } from "renderer/screens/main/components/WorkspaceView/components/CodeEditor";
+import { detectLanguage } from "shared/detect-language";
+import { ExternalChangeBar } from "../../components/ExternalChangeBar";
+
+interface CodeRendererProps {
+	content: string;
+	filePath: string;
+	hasExternalChange: boolean;
+	onDirtyChange: (dirty: boolean) => void;
+	onReload: () => Promise<void>;
+	onSave: (content: string) => Promise<unknown>;
+}
+
+export function CodeRenderer({
+	content,
+	filePath,
+	hasExternalChange,
+	onDirtyChange,
+	onReload,
+	onSave,
+}: CodeRendererProps) {
+	const language = detectLanguage(filePath);
+	const currentContentRef = useRef(content);
+	const [savedContent, setSavedContent] = useState(content);
+
+	// Track the initial/saved content to detect dirty state
+	if (content !== savedContent && !onDirtyChange) {
+		setSavedContent(content);
+	}
+
+	const handleChange = useCallback(
+		(value: string) => {
+			currentContentRef.current = value;
+			onDirtyChange(value !== savedContent);
+		},
+		[onDirtyChange, savedContent],
+	);
+
+	const handleSave = useCallback(async () => {
+		await onSave(currentContentRef.current);
+		setSavedContent(currentContentRef.current);
+	}, [onSave]);
+
+	return (
+		<div className="flex h-full flex-col">
+			{hasExternalChange && <ExternalChangeBar onReload={onReload} />}
+			<div className="min-h-0 flex-1">
+				<CodeEditor
+					value={content}
+					language={language}
+					onChange={handleChange}
+					onSave={handleSave}
+					fillHeight
+				/>
+			</div>
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/renderers/CodeRenderer/CodeRenderer.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/renderers/CodeRenderer/CodeRenderer.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { CodeEditor } from "renderer/screens/main/components/WorkspaceView/components/CodeEditor";
 import { detectLanguage } from "shared/detect-language";
 import { ExternalChangeBar } from "../../components/ExternalChangeBar";
@@ -24,10 +24,11 @@ export function CodeRenderer({
 	const currentContentRef = useRef(content);
 	const [savedContent, setSavedContent] = useState(content);
 
-	// Track the initial/saved content to detect dirty state
-	if (content !== savedContent && !onDirtyChange) {
+	// Sync savedContent when external content changes (e.g. after reload)
+	useEffect(() => {
 		setSavedContent(content);
-	}
+		onDirtyChange(currentContentRef.current !== content);
+	}, [content, onDirtyChange]);
 
 	const handleChange = useCallback(
 		(value: string) => {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/renderers/CodeRenderer/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/renderers/CodeRenderer/index.ts
@@ -1,0 +1,1 @@
+export { CodeRenderer } from "./CodeRenderer";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/renderers/ImageRenderer/ImageRenderer.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/renderers/ImageRenderer/ImageRenderer.tsx
@@ -1,0 +1,30 @@
+import { useMemo } from "react";
+import { getImageMimeType } from "shared/file-types";
+
+interface ImageRendererProps {
+	content: Uint8Array;
+	filePath: string;
+}
+
+export function ImageRenderer({ content, filePath }: ImageRendererProps) {
+	const dataUrl = useMemo(() => {
+		const mimeType = getImageMimeType(filePath) ?? "image/png";
+		const base64 = btoa(
+			Array.from(content)
+				.map((b) => String.fromCharCode(b))
+				.join(""),
+		);
+		return `data:${mimeType};base64,${base64}`;
+	}, [content, filePath]);
+
+	return (
+		<div className="flex h-full items-center justify-center overflow-auto bg-background p-4">
+			<img
+				src={dataUrl}
+				alt={filePath.split("/").pop() ?? ""}
+				className="max-h-full max-w-full object-contain"
+				draggable={false}
+			/>
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/renderers/ImageRenderer/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/renderers/ImageRenderer/index.ts
@@ -1,0 +1,1 @@
+export { ImageRenderer } from "./ImageRenderer";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/renderers/MarkdownRenderer/MarkdownRenderer.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/renderers/MarkdownRenderer/MarkdownRenderer.tsx
@@ -1,0 +1,97 @@
+import { useCallback, useRef, useState } from "react";
+import { TipTapMarkdownRenderer } from "renderer/components/MarkdownRenderer/components/TipTapMarkdownRenderer";
+import { CodeEditor } from "renderer/screens/main/components/WorkspaceView/components/CodeEditor";
+import { ExternalChangeBar } from "../../components/ExternalChangeBar";
+
+export type MarkdownViewMode = "rendered" | "raw";
+
+interface MarkdownRendererProps {
+	content: string;
+	hasExternalChange: boolean;
+	onDirtyChange: (dirty: boolean) => void;
+	onReload: () => Promise<void>;
+	onSave: (content: string) => Promise<unknown>;
+}
+
+export function MarkdownRenderer({
+	content,
+	hasExternalChange,
+	onDirtyChange,
+	onReload,
+	onSave,
+}: MarkdownRendererProps) {
+	const [viewMode, _setViewMode] = useState<MarkdownViewMode>("rendered");
+	const currentContentRef = useRef(content);
+	const [savedContent, setSavedContent] = useState(content);
+
+	const handleChange = useCallback(
+		(value: string) => {
+			currentContentRef.current = value;
+			onDirtyChange(value !== savedContent);
+		},
+		[onDirtyChange, savedContent],
+	);
+
+	const handleSave = useCallback(async () => {
+		await onSave(currentContentRef.current);
+		setSavedContent(currentContentRef.current);
+	}, [onSave]);
+
+	return (
+		<div className="flex h-full flex-col">
+			{hasExternalChange && <ExternalChangeBar onReload={onReload} />}
+			<div className="min-h-0 flex-1">
+				{viewMode === "rendered" ? (
+					<div className="h-full overflow-y-auto p-4">
+						<TipTapMarkdownRenderer
+							value={content}
+							editable
+							onChange={handleChange}
+							onSave={handleSave}
+						/>
+					</div>
+				) : (
+					<CodeEditor
+						value={content}
+						language="markdown"
+						onChange={handleChange}
+						onSave={handleSave}
+						fillHeight
+					/>
+				)}
+			</div>
+		</div>
+	);
+}
+
+// Exported for use in renderHeaderExtras
+export type { MarkdownViewMode as ViewMode };
+
+interface ViewModeToggleProps {
+	viewMode: MarkdownViewMode;
+	onViewModeChange: (mode: MarkdownViewMode) => void;
+}
+
+export function MarkdownViewModeToggle({
+	viewMode,
+	onViewModeChange,
+}: ViewModeToggleProps) {
+	return (
+		<div className="flex items-center gap-0.5 text-xs">
+			<button
+				type="button"
+				className={`rounded px-1.5 py-0.5 ${viewMode === "rendered" ? "bg-accent text-foreground" : "text-muted-foreground hover:text-foreground"}`}
+				onClick={() => onViewModeChange("rendered")}
+			>
+				Rendered
+			</button>
+			<button
+				type="button"
+				className={`rounded px-1.5 py-0.5 ${viewMode === "raw" ? "bg-accent text-foreground" : "text-muted-foreground hover:text-foreground"}`}
+				onClick={() => onViewModeChange("raw")}
+			>
+				Raw
+			</button>
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/renderers/MarkdownRenderer/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/renderers/MarkdownRenderer/index.ts
@@ -1,0 +1,5 @@
+export {
+	MarkdownRenderer,
+	type MarkdownViewMode,
+	MarkdownViewModeToggle,
+} from "./MarkdownRenderer";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx
@@ -10,6 +10,7 @@ import type {
 	TerminalPaneData,
 } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/types";
 import { useWorkspaceWsUrl } from "renderer/routes/_authenticated/_dashboard/v2-workspace/providers/WorkspaceTrpcProvider/WorkspaceTrpcProvider";
+import { useTerminalAppearance } from "./hooks/useTerminalAppearance";
 
 interface TerminalPaneProps {
 	ctx: RendererContext<PaneViewerData>;
@@ -29,6 +30,10 @@ export function TerminalPane({ ctx, workspaceId }: TerminalPaneProps) {
 	const { terminalId } = ctx.pane.data as TerminalPaneData;
 	const containerRef = useRef<HTMLDivElement | null>(null);
 
+	const appearance = useTerminalAppearance();
+	const appearanceRef = useRef(appearance);
+	appearanceRef.current = appearance;
+
 	const websocketUrl = useWorkspaceWsUrl(`/terminal/${terminalId}`, {
 		workspaceId,
 	});
@@ -38,22 +43,33 @@ export function TerminalPane({ ctx, workspaceId }: TerminalPaneProps) {
 		() => getConnectionState(terminalId),
 	);
 
+	// Appearance read from ref to avoid re-attach on theme/font change.
 	useEffect(() => {
 		const container = containerRef.current;
 		if (!container) return;
 
-		terminalRuntimeRegistry.attach(terminalId, container, websocketUrl);
+		terminalRuntimeRegistry.attach(
+			terminalId,
+			container,
+			websocketUrl,
+			appearanceRef.current,
+		);
 
 		return () => {
 			terminalRuntimeRegistry.detach(terminalId);
 		};
 	}, [terminalId, websocketUrl]);
 
+	useEffect(() => {
+		terminalRuntimeRegistry.updateAppearance(terminalId, appearance);
+	}, [terminalId, appearance]);
+
 	return (
-		<div className="flex h-full w-full flex-col">
+		<div className="flex h-full w-full flex-col p-2">
 			<div
 				ref={containerRef}
-				className="min-h-0 flex-1 overflow-hidden bg-[#14100f]"
+				className="min-h-0 flex-1 overflow-hidden"
+				style={{ backgroundColor: appearance.background }}
 			/>
 			{connectionState === "closed" && (
 				<div className="flex items-center gap-2 border-t border-border px-3 py-1.5 text-xs text-muted-foreground">

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx
@@ -1,46 +1,53 @@
+import type { RendererContext } from "@superset/panes";
 import "@xterm/xterm/css/xterm.css";
 import { useEffect, useRef, useSyncExternalStore } from "react";
 import {
 	type ConnectionState,
 	terminalRuntimeRegistry,
 } from "renderer/lib/terminal/terminal-runtime-registry";
-import { useWorkspaceWsUrl } from "../../../../../providers/WorkspaceTrpcProvider/WorkspaceTrpcProvider";
+import type {
+	PaneViewerData,
+	TerminalPaneData,
+} from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/types";
+import { useWorkspaceWsUrl } from "renderer/routes/_authenticated/_dashboard/v2-workspace/providers/WorkspaceTrpcProvider/WorkspaceTrpcProvider";
 
 interface TerminalPaneProps {
-	paneId: string;
+	ctx: RendererContext<PaneViewerData>;
 	workspaceId: string;
 }
 
-function subscribeToState(paneId: string) {
+function subscribeToState(terminalId: string) {
 	return (callback: () => void) =>
-		terminalRuntimeRegistry.onStateChange(paneId, callback);
+		terminalRuntimeRegistry.onStateChange(terminalId, callback);
 }
 
-function getConnectionState(paneId: string): ConnectionState {
-	return terminalRuntimeRegistry.getConnectionState(paneId);
+function getConnectionState(terminalId: string): ConnectionState {
+	return terminalRuntimeRegistry.getConnectionState(terminalId);
 }
 
-export function TerminalPane({ paneId, workspaceId }: TerminalPaneProps) {
+export function TerminalPane({ ctx, workspaceId }: TerminalPaneProps) {
+	const { terminalId } = ctx.pane.data as TerminalPaneData;
 	const containerRef = useRef<HTMLDivElement | null>(null);
 
-	const websocketUrl = useWorkspaceWsUrl(`/terminal/${paneId}`, {
+	const websocketUrl = useWorkspaceWsUrl(`/terminal/${terminalId}`, {
 		workspaceId,
 	});
 
-	const connectionState = useSyncExternalStore(subscribeToState(paneId), () =>
-		getConnectionState(paneId),
+	const connectionState = useSyncExternalStore(
+		subscribeToState(terminalId),
+		() => getConnectionState(terminalId),
 	);
 
 	useEffect(() => {
 		const container = containerRef.current;
 		if (!container) return;
 
-		terminalRuntimeRegistry.attach(paneId, container, websocketUrl);
+		terminalRuntimeRegistry.attach(terminalId, container, websocketUrl);
 
 		return () => {
-			terminalRuntimeRegistry.detach(paneId);
+			terminalRuntimeRegistry.detach(terminalId);
 		};
-	}, [paneId, websocketUrl]);
+	}, [terminalId, websocketUrl]);
 
 	return (
 		<div className="flex h-full w-full flex-col">

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx
@@ -1,168 +1,58 @@
-import { Button } from "@superset/ui/button";
-import { FitAddon } from "@xterm/addon-fit";
-import { Terminal as XTerm } from "@xterm/xterm";
 import "@xterm/xterm/css/xterm.css";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useSyncExternalStore } from "react";
+import {
+	type ConnectionState,
+	terminalRuntimeRegistry,
+} from "renderer/lib/terminal/terminal-runtime-registry";
 import { useWorkspaceWsUrl } from "../../../../../providers/WorkspaceTrpcProvider/WorkspaceTrpcProvider";
 
-interface WorkspaceTerminalProps {
+interface TerminalPaneProps {
+	paneId: string;
 	workspaceId: string;
 }
 
-type TerminalServerMessage =
-	| {
-			type: "data";
-			data: string;
-	  }
-	| {
-			type: "error";
-			message: string;
-	  }
-	| {
-			type: "exit";
-			exitCode: number;
-			signal: number;
-	  };
+function subscribeToState(paneId: string) {
+	return (callback: () => void) =>
+		terminalRuntimeRegistry.onStateChange(paneId, callback);
+}
 
-export function TerminalPane({ workspaceId }: WorkspaceTerminalProps) {
+function getConnectionState(paneId: string): ConnectionState {
+	return terminalRuntimeRegistry.getConnectionState(paneId);
+}
+
+export function TerminalPane({ paneId, workspaceId }: TerminalPaneProps) {
 	const containerRef = useRef<HTMLDivElement | null>(null);
-	const [connectionState, setConnectionState] = useState<
-		"connecting" | "open" | "closed"
-	>("connecting");
-	const [reconnectKey, setReconnectKey] = useState(0);
 
-	const websocketUrl = useWorkspaceWsUrl(`/terminal/${workspaceId}`, {
-		reconnect: String(reconnectKey),
+	const websocketUrl = useWorkspaceWsUrl(`/terminal/${paneId}`, {
+		workspaceId,
 	});
+
+	const connectionState = useSyncExternalStore(subscribeToState(paneId), () =>
+		getConnectionState(paneId),
+	);
 
 	useEffect(() => {
 		const container = containerRef.current;
-		if (!container) {
-			return;
-		}
+		if (!container) return;
 
-		const fitAddon = new FitAddon();
-		const terminal = new XTerm({
-			cursorBlink: true,
-			fontFamily:
-				'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace',
-			fontSize: 12,
-			theme: {
-				background: "#14100f",
-				foreground: "#f5efe9",
-			},
-		});
-		terminal.loadAddon(fitAddon);
-		terminal.open(container);
-		fitAddon.fit();
-		terminal.focus();
-
-		setConnectionState("connecting");
-		const socket = new WebSocket(websocketUrl);
-
-		const sendResize = () => {
-			if (socket.readyState !== WebSocket.OPEN) {
-				return;
-			}
-
-			socket.send(
-				JSON.stringify({
-					type: "resize",
-					cols: terminal.cols,
-					rows: terminal.rows,
-				}),
-			);
-		};
-
-		const resizeObserver = new ResizeObserver(() => {
-			fitAddon.fit();
-			sendResize();
-		});
-		resizeObserver.observe(container);
-
-		const onTerminalDataDispose = terminal.onData((data) => {
-			if (socket.readyState !== WebSocket.OPEN) {
-				return;
-			}
-
-			socket.send(
-				JSON.stringify({
-					type: "input",
-					data,
-				}),
-			);
-		});
-
-		socket.addEventListener("open", () => {
-			setConnectionState("open");
-			sendResize();
-		});
-
-		socket.addEventListener("message", (event) => {
-			let message: TerminalServerMessage;
-			try {
-				message = JSON.parse(String(event.data)) as TerminalServerMessage;
-			} catch {
-				terminal.writeln("\r\n[terminal] invalid server payload");
-				return;
-			}
-
-			if (message.type === "data") {
-				terminal.write(message.data);
-				return;
-			}
-
-			if (message.type === "error") {
-				terminal.writeln(`\r\n[terminal] ${message.message}`);
-				return;
-			}
-
-			terminal.writeln(
-				`\r\n[terminal] exited with code ${message.exitCode} (signal ${message.signal})`,
-			);
-		});
-
-		socket.addEventListener("close", () => {
-			setConnectionState("closed");
-		});
-
-		socket.addEventListener("error", () => {
-			terminal.writeln("\r\n[terminal] websocket error");
-		});
+		terminalRuntimeRegistry.attach(paneId, container, websocketUrl);
 
 		return () => {
-			resizeObserver.disconnect();
-			onTerminalDataDispose.dispose();
-			socket.close();
-			terminal.dispose();
+			terminalRuntimeRegistry.detach(paneId);
 		};
-	}, [websocketUrl]);
+	}, [paneId, websocketUrl]);
 
 	return (
-		<div className="w-full p-4">
-			<div className="mb-3 flex items-center justify-between gap-3">
-				<div>
-					<h2 className="text-sm font-medium">terminal</h2>
-					<p className="text-xs text-muted-foreground">
-						{connectionState === "open"
-							? "Connected"
-							: connectionState === "connecting"
-								? "Connecting..."
-								: "Disconnected"}
-					</p>
-				</div>
-				<Button
-					size="sm"
-					variant="outline"
-					onClick={() => setReconnectKey((value) => value + 1)}
-				>
-					Reconnect
-				</Button>
-			</div>
+		<div className="flex h-full w-full flex-col">
 			<div
 				ref={containerRef}
-				className="h-[360px] overflow-hidden bg-[#14100f] p-2"
+				className="min-h-0 flex-1 overflow-hidden bg-[#14100f]"
 			/>
+			{connectionState === "closed" && (
+				<div className="flex items-center gap-2 border-t border-border px-3 py-1.5 text-xs text-muted-foreground">
+					<span>Disconnected</span>
+				</div>
+			)}
 		</div>
 	);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx
@@ -27,7 +27,10 @@ function getConnectionState(terminalId: string): ConnectionState {
 }
 
 export function TerminalPane({ ctx, workspaceId }: TerminalPaneProps) {
-	const { terminalId } = ctx.pane.data as TerminalPaneData;
+	const data = ctx.pane.data as TerminalPaneData;
+	// Guard against legacy pane data format {sessionKey, cwd, launchMode}
+	// saved in local DB before the terminalId migration.
+	const terminalId = data.terminalId ?? crypto.randomUUID();
 	const containerRef = useRef<HTMLDivElement | null>(null);
 
 	const appearance = useTerminalAppearance();

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx
@@ -1,6 +1,6 @@
 import type { RendererContext } from "@superset/panes";
 import "@xterm/xterm/css/xterm.css";
-import { useEffect, useRef, useSyncExternalStore } from "react";
+import { useEffect, useMemo, useRef, useSyncExternalStore } from "react";
 import {
 	type ConnectionState,
 	terminalRuntimeRegistry,
@@ -30,7 +30,11 @@ export function TerminalPane({ ctx, workspaceId }: TerminalPaneProps) {
 	const data = ctx.pane.data as TerminalPaneData;
 	// Guard against legacy pane data format {sessionKey, cwd, launchMode}
 	// saved in local DB before the terminalId migration.
-	const terminalId = data.terminalId ?? crypto.randomUUID();
+	// useMemo ensures a stable ID across re-renders.
+	const terminalId = useMemo(
+		() => data.terminalId ?? crypto.randomUUID(),
+		[data.terminalId],
+	);
 	const containerRef = useRef<HTMLDivElement | null>(null);
 
 	const appearance = useTerminalAppearance();

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/hooks/useTerminalAppearance/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/hooks/useTerminalAppearance/index.ts
@@ -1,0 +1,1 @@
+export { useTerminalAppearance } from "./useTerminalAppearance";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/hooks/useTerminalAppearance/useTerminalAppearance.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/hooks/useTerminalAppearance/useTerminalAppearance.ts
@@ -1,0 +1,36 @@
+import { useMemo } from "react";
+import { electronTrpc } from "renderer/lib/electron-trpc";
+import {
+	DEFAULT_TERMINAL_FONT_FAMILY,
+	DEFAULT_TERMINAL_FONT_SIZE,
+	getDefaultTerminalAppearance,
+	type TerminalAppearance,
+} from "renderer/lib/terminal/appearance";
+import { useTerminalTheme } from "renderer/stores/theme";
+
+const fallbackTheme = getDefaultTerminalAppearance().theme;
+
+export function useTerminalAppearance(): TerminalAppearance {
+	const terminalTheme = useTerminalTheme();
+	const { data: fontSettings } = electronTrpc.settings.getFontSettings.useQuery(
+		undefined,
+		{
+			staleTime: 30_000,
+		},
+	);
+
+	return useMemo(() => {
+		const theme = terminalTheme ?? fallbackTheme;
+		const fontFamily =
+			fontSettings?.terminalFontFamily || DEFAULT_TERMINAL_FONT_FAMILY;
+		const fontSize =
+			fontSettings?.terminalFontSize ?? DEFAULT_TERMINAL_FONT_SIZE;
+
+		return {
+			theme,
+			background: theme.background ?? "#151110",
+			fontFamily,
+			fontSize,
+		};
+	}, [terminalTheme, fontSettings]);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/usePaneRegistry.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/usePaneRegistry.tsx
@@ -1,6 +1,8 @@
 import type { PaneRegistry, RendererContext } from "@superset/panes";
-import { FileCode2, Globe, MessageSquare, TerminalSquare } from "lucide-react";
+import { alert } from "@superset/ui/atoms/Alert";
+import { Circle, Globe, MessageSquare, TerminalSquare } from "lucide-react";
 import { useMemo } from "react";
+import { FileIcon } from "renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/utils";
 import type {
 	BrowserPaneData,
 	ChatPaneData,
@@ -9,10 +11,10 @@ import type {
 	PaneViewerData,
 } from "../../types";
 import { ChatPane } from "./components/ChatPane";
-import { WorkspaceFilePreview } from "./components/FilesPane/components/WorkspaceFilePreview/WorkspaceFilePreview";
+import { FilePane } from "./components/FilePane";
 import { TerminalPane } from "./components/TerminalPane";
 
-function getFileTitle(filePath: string): string {
+function getFileName(filePath: string): string {
 	return filePath.split("/").pop() ?? filePath;
 }
 
@@ -22,19 +24,59 @@ export function usePaneRegistry(
 	return useMemo<PaneRegistry<PaneViewerData>>(
 		() => ({
 			file: {
-				getIcon: () => <FileCode2 className="size-4" />,
+				getIcon: (ctx: RendererContext<PaneViewerData>) => {
+					const data = ctx.pane.data as FilePaneData;
+					const name = getFileName(data.filePath);
+					return <FileIcon fileName={name} className="size-4" />;
+				},
 				getTitle: (ctx: RendererContext<PaneViewerData>) => {
 					const data = ctx.pane.data as FilePaneData;
-					return getFileTitle(data.filePath);
-				},
-				renderPane: (ctx: RendererContext<PaneViewerData>) => {
-					const data = ctx.pane.data as FilePaneData;
+					const name = getFileName(data.filePath);
 					return (
-						<WorkspaceFilePreview
-							selectedFilePath={data.filePath}
-							workspaceId={workspaceId}
-						/>
+						<div className="flex items-center space-x-2">
+							<span className={ctx.pane.pinned ? undefined : "italic"}>
+								{name}
+							</span>
+							{data.hasChanges && (
+								<Circle className="size-2 shrink-0 fill-current text-muted-foreground" />
+							)}
+						</div>
 					);
+				},
+				renderPane: (ctx: RendererContext<PaneViewerData>) => (
+					<FilePane context={ctx} workspaceId={workspaceId} />
+				),
+				onHeaderClick: (ctx: RendererContext<PaneViewerData>) =>
+					ctx.actions.pin(),
+				onBeforeClose: (pane) => {
+					const data = pane.data as FilePaneData;
+					if (!data.hasChanges) return true;
+					const name = data.filePath.split("/").pop();
+					return new Promise<boolean>((resolve) => {
+						alert({
+							title: `Do you want to save the changes you made to ${name}?`,
+							description: "Your changes will be lost if you don't save them.",
+							actions: [
+								{
+									label: "Save",
+									onClick: () => {
+										// TODO: wire up save via editor ref
+										resolve(true);
+									},
+								},
+								{
+									label: "Don't Save",
+									variant: "secondary",
+									onClick: () => resolve(true),
+								},
+								{
+									label: "Cancel",
+									variant: "ghost",
+									onClick: () => resolve(false),
+								},
+							],
+						});
+					});
 				},
 			},
 			terminal: {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/usePaneRegistry.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/usePaneRegistry.tsx
@@ -68,6 +68,7 @@ export function usePaneRegistry(
 									onClick: () => resolve(true),
 								},
 							],
+							onDismiss: () => resolve(false),
 						});
 					});
 				},

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/usePaneRegistry.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/usePaneRegistry.tsx
@@ -41,7 +41,7 @@ export function usePaneRegistry(
 				getIcon: () => <TerminalSquare className="size-4" />,
 				getTitle: () => "Terminal",
 				renderPane: (ctx: RendererContext<PaneViewerData>) => (
-					<TerminalPane paneId={ctx.pane.id} workspaceId={workspaceId} />
+					<TerminalPane ctx={ctx} workspaceId={workspaceId} />
 				),
 			},
 			browser: {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/usePaneRegistry.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/usePaneRegistry.tsx
@@ -58,21 +58,14 @@ export function usePaneRegistry(
 							description: "Your changes will be lost if you don't save them.",
 							actions: [
 								{
-									label: "Save",
-									onClick: () => {
-										// TODO: wire up save via editor ref
-										resolve(true);
-									},
-								},
-								{
-									label: "Don't Save",
-									variant: "secondary",
-									onClick: () => resolve(true),
-								},
-								{
 									label: "Cancel",
-									variant: "ghost",
+									variant: "outline",
 									onClick: () => resolve(false),
+								},
+								{
+									label: "Discard Changes",
+									variant: "destructive",
+									onClick: () => resolve(true),
 								},
 							],
 						});

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/usePaneRegistry.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/usePaneRegistry.tsx
@@ -40,7 +40,9 @@ export function usePaneRegistry(
 			terminal: {
 				getIcon: () => <TerminalSquare className="size-4" />,
 				getTitle: () => "Terminal",
-				renderPane: () => <TerminalPane workspaceId={workspaceId} />,
+				renderPane: (ctx: RendererContext<PaneViewerData>) => (
+					<TerminalPane paneId={ctx.pane.id} workspaceId={workspaceId} />
+				),
 			},
 			browser: {
 				getIcon: () => <Globe className="size-4" />,

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
@@ -1,4 +1,10 @@
 import { type PaneActionConfig, Workspace } from "@superset/panes";
+import { alert } from "@superset/ui/atoms/Alert";
+import {
+	ResizableHandle,
+	ResizablePanel,
+	ResizablePanelGroup,
+} from "@superset/ui/resizable";
 import { eq } from "@tanstack/db";
 import { useLiveQuery } from "@tanstack/react-db";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
@@ -15,9 +21,11 @@ import {
 } from "renderer/screens/main/components/CommandPalette";
 import { PresetsBar } from "renderer/screens/main/components/WorkspaceView/ContentView/components/PresetsBar";
 import { useAppHotkey } from "renderer/stores/hotkeys";
+import { useStore } from "zustand";
 import { AddTabMenu } from "./components/AddTabMenu";
 import { WorkspaceEmptyState } from "./components/WorkspaceEmptyState";
 import { WorkspaceNotFoundState } from "./components/WorkspaceNotFoundState";
+import { WorkspaceSidebar } from "./components/WorkspaceSidebar";
 import { usePaneRegistry } from "./hooks/usePaneRegistry";
 import { useV2WorkspacePaneLayout } from "./hooks/useV2WorkspacePaneLayout";
 import type {
@@ -74,7 +82,10 @@ function WorkspaceContent({
 	workspaceName: string;
 }) {
 	const navigate = useNavigate();
-	const { store } = useV2WorkspacePaneLayout({ projectId, workspaceId });
+	const { localWorkspaceState, store } = useV2WorkspacePaneLayout({
+		projectId,
+		workspaceId,
+	});
 	const paneRegistry = usePaneRegistry(workspaceId);
 
 	const utils = electronTrpc.useUtils();
@@ -99,9 +110,26 @@ function WorkspaceContent({
 		},
 	);
 
+	const selectedFilePath = useStore(store, (s) => {
+		const tab = s.tabs.find((t) => t.id === s.activeTabId);
+		if (!tab?.activePaneId) return undefined;
+		const pane = tab.panes[tab.activePaneId];
+		if (pane?.kind === "file") return (pane.data as FilePaneData).filePath;
+		return undefined;
+	});
+
 	const openFilePane = useCallback(
 		(filePath: string) => {
-			store.getState().openPane({
+			const state = store.getState();
+			const active = state.getActivePane();
+			if (
+				active?.pane.kind === "file" &&
+				(active.pane.data as FilePaneData).filePath === filePath
+			) {
+				state.setPanePinned({ paneId: active.pane.id, pinned: true });
+				return;
+			}
+			state.openPane({
 				pane: {
 					kind: "file",
 					data: {
@@ -213,6 +241,16 @@ function WorkspaceContent({
 		[],
 	);
 
+	const collections = useCollections();
+	const sidebarOpen = localWorkspaceState?.rightSidebarOpen ?? false;
+	const toggleSidebar = useCallback(() => {
+		if (!collections.v2WorkspaceLocalState.get(workspaceId)) return;
+		collections.v2WorkspaceLocalState.update(workspaceId, (draft) => {
+			draft.rightSidebarOpen = !draft.rightSidebarOpen;
+		});
+	}, [collections, workspaceId]);
+
+	useAppHotkey("TOGGLE_SIDEBAR", toggleSidebar, undefined, [toggleSidebar]);
 	useAppHotkey("NEW_GROUP", addTerminalTab, undefined, [addTerminalTab]);
 	useAppHotkey("NEW_CHAT", addChatTab, undefined, [addChatTab]);
 	useAppHotkey("NEW_BROWSER", addBrowserTab, undefined, [addBrowserTab]);
@@ -238,36 +276,95 @@ function WorkspaceContent({
 
 	return (
 		<>
-			<div
-				className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden"
-				data-workspace-id={workspaceId}
-			>
-				{!isLoadingPresetsBar && showPresetsBar ? <PresetsBar /> : null}
-				<Workspace<PaneViewerData>
-					registry={paneRegistry}
-					paneActions={defaultPaneActions}
-					renderAddTabMenu={() => (
-						<AddTabMenu
-							onAddTerminal={addTerminalTab}
-							onAddChat={addChatTab}
-							onAddBrowser={addBrowserTab}
-							showPresetsBar={showPresetsBar ?? false}
-							onTogglePresetsBar={(enabled) =>
-								setShowPresetsBar.mutate({ enabled })
-							}
+			<ResizablePanelGroup direction="horizontal" className="flex-1">
+				<ResizablePanel defaultSize={80} minSize={30}>
+					<div
+						className="flex min-h-0 min-w-0 h-full flex-col overflow-hidden"
+						data-workspace-id={workspaceId}
+					>
+						{!isLoadingPresetsBar && showPresetsBar ? <PresetsBar /> : null}
+						<Workspace<PaneViewerData>
+							registry={paneRegistry}
+							paneActions={defaultPaneActions}
+							renderAddTabMenu={() => (
+								<AddTabMenu
+									onAddTerminal={addTerminalTab}
+									onAddChat={addChatTab}
+									onAddBrowser={addBrowserTab}
+									showPresetsBar={showPresetsBar ?? false}
+									onTogglePresetsBar={(enabled) =>
+										setShowPresetsBar.mutate({ enabled })
+									}
+								/>
+							)}
+							renderEmptyState={() => (
+								<WorkspaceEmptyState
+									onOpenBrowser={addBrowserTab}
+									onOpenChat={addChatTab}
+									onOpenQuickOpen={handleQuickOpen}
+									onOpenTerminal={addTerminalTab}
+								/>
+							)}
+							onBeforeCloseTab={(tab) => {
+								const dirtyFiles = Object.values(tab.panes)
+									.filter(
+										(p) =>
+											p.kind === "file" && (p.data as FilePaneData).hasChanges,
+									)
+									.map((p) =>
+										(p.data as FilePaneData).filePath.split("/").pop(),
+									);
+								if (dirtyFiles.length === 0) return true;
+								const title =
+									dirtyFiles.length === 1
+										? `Do you want to save the changes you made to ${dirtyFiles[0]}?`
+										: `Do you want to save changes to ${dirtyFiles.length} files?`;
+								return new Promise<boolean>((resolve) => {
+									alert({
+										title,
+										description:
+											"Your changes will be lost if you don't save them.",
+										actions: [
+											{
+												label: "Save All",
+												onClick: () => {
+													// TODO: wire up save via editor refs
+													resolve(true);
+												},
+											},
+											{
+												label: "Don't Save",
+												variant: "secondary",
+												onClick: () => resolve(true),
+											},
+											{
+												label: "Cancel",
+												variant: "ghost",
+												onClick: () => resolve(false),
+											},
+										],
+									});
+								});
+							}}
+							store={store}
 						/>
-					)}
-					renderEmptyState={() => (
-						<WorkspaceEmptyState
-							onOpenBrowser={addBrowserTab}
-							onOpenChat={addChatTab}
-							onOpenQuickOpen={handleQuickOpen}
-							onOpenTerminal={addTerminalTab}
-						/>
-					)}
-					store={store}
-				/>
-			</div>
+					</div>
+				</ResizablePanel>
+				{sidebarOpen && (
+					<>
+						<ResizableHandle />
+						<ResizablePanel defaultSize={20} minSize={15} maxSize={40}>
+							<WorkspaceSidebar
+								workspaceId={workspaceId}
+								workspaceName={workspaceName}
+								onSelectFile={openFilePane}
+								onSearch={handleQuickOpen}
+								selectedFilePath={selectedFilePath}
+							/>
+						</ResizablePanel>
+					</>
+				)}
+			</ResizablePanelGroup>
 			<CommandPalette
 				excludePattern={commandPalette.excludePattern}
 				filtersOpen={commandPalette.filtersOpen}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
@@ -59,7 +59,6 @@ function V2WorkspacePage() {
 		<WorkspaceContent
 			projectId={workspace.projectId}
 			workspaceId={workspace.id}
-			workspaceName={workspace.name}
 		/>
 	);
 }
@@ -67,11 +66,9 @@ function V2WorkspacePage() {
 function WorkspaceContent({
 	projectId,
 	workspaceId,
-	workspaceName,
 }: {
 	projectId: string;
 	workspaceId: string;
-	workspaceName: string;
 }) {
 	const navigate = useNavigate();
 	const { store } = useV2WorkspacePaneLayout({ projectId, workspaceId });
@@ -123,14 +120,12 @@ function WorkspaceContent({
 				{
 					kind: "terminal",
 					data: {
-						sessionKey: `${workspaceId}:${crypto.randomUUID()}`,
-						cwd: `/workspace/${workspaceName}`,
-						launchMode: "workspace-shell",
+						terminalId: crypto.randomUUID(),
 					} as TerminalPaneData,
 				},
 			],
 		});
-	}, [store, workspaceId, workspaceName]);
+	}, [store]);
 
 	const addChatTab = useCallback(() => {
 		store.getState().addTab({
@@ -198,9 +193,7 @@ function WorkspaceContent({
 					ctx.actions.split(position, {
 						kind: "terminal",
 						data: {
-							sessionKey: `${workspaceId}:${crypto.randomUUID()}`,
-							cwd: `/workspace/${workspaceName}`,
-							launchMode: "workspace-shell",
+							terminalId: crypto.randomUUID(),
 						} as TerminalPaneData,
 					});
 				},
@@ -214,7 +207,7 @@ function WorkspaceContent({
 				onClick: (ctx) => ctx.actions.close(),
 			},
 		],
-		[workspaceId, workspaceName],
+		[],
 	);
 
 	useAppHotkey("NEW_GROUP", addTerminalTab, undefined, [addTerminalTab]);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
@@ -59,6 +59,7 @@ function V2WorkspacePage() {
 		<WorkspaceContent
 			projectId={workspace.projectId}
 			workspaceId={workspace.id}
+			workspaceName={workspace.name}
 		/>
 	);
 }
@@ -66,9 +67,11 @@ function V2WorkspacePage() {
 function WorkspaceContent({
 	projectId,
 	workspaceId,
+	workspaceName,
 }: {
 	projectId: string;
 	workspaceId: string;
+	workspaceName: string;
 }) {
 	const navigate = useNavigate();
 	const { store } = useV2WorkspacePaneLayout({ projectId, workspaceId });

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
@@ -326,21 +326,14 @@ function WorkspaceContent({
 											"Your changes will be lost if you don't save them.",
 										actions: [
 											{
-												label: "Save All",
-												onClick: () => {
-													// TODO: wire up save via editor refs
-													resolve(true);
-												},
-											},
-											{
-												label: "Don't Save",
-												variant: "secondary",
-												onClick: () => resolve(true),
-											},
-											{
 												label: "Cancel",
-												variant: "ghost",
+												variant: "outline",
 												onClick: () => resolve(false),
+											},
+											{
+												label: "Discard Changes",
+												variant: "destructive",
+												onClick: () => resolve(true),
 											},
 										],
 									});

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
@@ -336,6 +336,7 @@ function WorkspaceContent({
 												onClick: () => resolve(true),
 											},
 										],
+										onDismiss: () => resolve(false),
 									});
 								});
 							}}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/types.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/types.ts
@@ -6,10 +6,7 @@ export interface FilePaneData {
 }
 
 export interface TerminalPaneData {
-	sessionKey: string;
-	cwd: string;
-	launchMode: "workspace-shell" | "command" | "agent";
-	command?: string;
+	terminalId: string;
 }
 
 export interface ChatPaneData {

--- a/apps/desktop/src/renderer/routes/_authenticated/components/GlobalTerminalLifecycle/GlobalTerminalLifecycle.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/GlobalTerminalLifecycle/GlobalTerminalLifecycle.tsx
@@ -1,0 +1,6 @@
+import { useGlobalTerminalLifecycle } from "./hooks/useGlobalTerminalLifecycle";
+
+export function GlobalTerminalLifecycle() {
+	useGlobalTerminalLifecycle();
+	return null;
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/components/GlobalTerminalLifecycle/hooks/useGlobalTerminalLifecycle/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/GlobalTerminalLifecycle/hooks/useGlobalTerminalLifecycle/index.ts
@@ -1,0 +1,1 @@
+export { useGlobalTerminalLifecycle } from "./useGlobalTerminalLifecycle";

--- a/apps/desktop/src/renderer/routes/_authenticated/components/GlobalTerminalLifecycle/hooks/useGlobalTerminalLifecycle/useGlobalTerminalLifecycle.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/GlobalTerminalLifecycle/hooks/useGlobalTerminalLifecycle/useGlobalTerminalLifecycle.ts
@@ -1,0 +1,84 @@
+import type { WorkspaceState } from "@superset/panes";
+import { useLiveQuery } from "@tanstack/react-db";
+import { useEffect, useRef } from "react";
+import { terminalRuntimeRegistry } from "renderer/lib/terminal/terminal-runtime-registry";
+import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
+
+/** Cross-workspace moves temporarily remove a paneId then re-add it. Wait before disposing. */
+const DISPOSE_DELAY_MS = 500;
+
+function extractTerminalPaneIds(rows: { paneLayout: unknown }[]): Set<string> {
+	const ids = new Set<string>();
+	for (const row of rows) {
+		const layout = row.paneLayout as WorkspaceState<unknown> | undefined;
+		if (!layout?.tabs) continue;
+		for (const tab of layout.tabs) {
+			for (const [paneId, pane] of Object.entries(tab.panes)) {
+				if (pane.kind === "terminal") {
+					ids.add(paneId);
+				}
+			}
+		}
+	}
+	return ids;
+}
+
+export function useGlobalTerminalLifecycle() {
+	const collections = useCollections();
+	const prevPaneIdsRef = useRef<Set<string>>(new Set());
+	const pendingDisposals = useRef<Map<string, ReturnType<typeof setTimeout>>>(
+		new Map(),
+	);
+
+	const { data: allWorkspaceRows = [] } = useLiveQuery(
+		(query) =>
+			query.from({
+				v2WorkspaceLocalState: collections.v2WorkspaceLocalState,
+			}),
+		[collections],
+	);
+
+	useEffect(() => {
+		const currentPaneIds = extractTerminalPaneIds(allWorkspaceRows);
+		const prevPaneIds = prevPaneIdsRef.current;
+
+		for (const paneId of currentPaneIds) {
+			const timer = pendingDisposals.current.get(paneId);
+			if (timer) {
+				clearTimeout(timer);
+				pendingDisposals.current.delete(paneId);
+			}
+		}
+
+		for (const paneId of prevPaneIds) {
+			if (currentPaneIds.has(paneId)) continue;
+			if (pendingDisposals.current.has(paneId)) continue;
+
+			const timer = setTimeout(() => {
+				pendingDisposals.current.delete(paneId);
+
+				const freshRows = Array.from(
+					collections.v2WorkspaceLocalState.state.values(),
+				);
+				const freshIds = extractTerminalPaneIds(freshRows);
+
+				if (!freshIds.has(paneId)) {
+					terminalRuntimeRegistry.dispose(paneId);
+				}
+			}, DISPOSE_DELAY_MS);
+
+			pendingDisposals.current.set(paneId, timer);
+		}
+
+		prevPaneIdsRef.current = currentPaneIds;
+	}, [allWorkspaceRows, collections]);
+
+	useEffect(() => {
+		return () => {
+			for (const timer of pendingDisposals.current.values()) {
+				clearTimeout(timer);
+			}
+			pendingDisposals.current.clear();
+		};
+	}, []);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/components/GlobalTerminalLifecycle/hooks/useGlobalTerminalLifecycle/useGlobalTerminalLifecycle.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/GlobalTerminalLifecycle/hooks/useGlobalTerminalLifecycle/useGlobalTerminalLifecycle.ts
@@ -4,18 +4,25 @@ import { useEffect, useRef } from "react";
 import { terminalRuntimeRegistry } from "renderer/lib/terminal/terminal-runtime-registry";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 
-/** Cross-workspace moves temporarily remove a paneId then re-add it. Wait before disposing. */
+/** Grace period for cross-workspace pane moves before disposing. */
 const DISPOSE_DELAY_MS = 500;
 
-function extractTerminalPaneIds(rows: { paneLayout: unknown }[]): Set<string> {
+interface TerminalPaneData {
+	terminalId: string;
+}
+
+function extractTerminalIds(rows: { paneLayout: unknown }[]): Set<string> {
 	const ids = new Set<string>();
 	for (const row of rows) {
 		const layout = row.paneLayout as WorkspaceState<unknown> | undefined;
 		if (!layout?.tabs) continue;
 		for (const tab of layout.tabs) {
-			for (const [paneId, pane] of Object.entries(tab.panes)) {
+			for (const pane of Object.values(tab.panes)) {
 				if (pane.kind === "terminal") {
-					ids.add(paneId);
+					const data = pane.data as TerminalPaneData;
+					if (data.terminalId) {
+						ids.add(data.terminalId);
+					}
 				}
 			}
 		}
@@ -25,7 +32,7 @@ function extractTerminalPaneIds(rows: { paneLayout: unknown }[]): Set<string> {
 
 export function useGlobalTerminalLifecycle() {
 	const collections = useCollections();
-	const prevPaneIdsRef = useRef<Set<string>>(new Set());
+	const prevTerminalIdsRef = useRef<Set<string>>(new Set());
 	const pendingDisposals = useRef<Map<string, ReturnType<typeof setTimeout>>>(
 		new Map(),
 	);
@@ -39,38 +46,38 @@ export function useGlobalTerminalLifecycle() {
 	);
 
 	useEffect(() => {
-		const currentPaneIds = extractTerminalPaneIds(allWorkspaceRows);
-		const prevPaneIds = prevPaneIdsRef.current;
+		const currentTerminalIds = extractTerminalIds(allWorkspaceRows);
+		const prevTerminalIds = prevTerminalIdsRef.current;
 
-		for (const paneId of currentPaneIds) {
-			const timer = pendingDisposals.current.get(paneId);
+		for (const terminalId of currentTerminalIds) {
+			const timer = pendingDisposals.current.get(terminalId);
 			if (timer) {
 				clearTimeout(timer);
-				pendingDisposals.current.delete(paneId);
+				pendingDisposals.current.delete(terminalId);
 			}
 		}
 
-		for (const paneId of prevPaneIds) {
-			if (currentPaneIds.has(paneId)) continue;
-			if (pendingDisposals.current.has(paneId)) continue;
+		for (const terminalId of prevTerminalIds) {
+			if (currentTerminalIds.has(terminalId)) continue;
+			if (pendingDisposals.current.has(terminalId)) continue;
 
 			const timer = setTimeout(() => {
-				pendingDisposals.current.delete(paneId);
+				pendingDisposals.current.delete(terminalId);
 
 				const freshRows = Array.from(
 					collections.v2WorkspaceLocalState.state.values(),
 				);
-				const freshIds = extractTerminalPaneIds(freshRows);
+				const freshIds = extractTerminalIds(freshRows);
 
-				if (!freshIds.has(paneId)) {
-					terminalRuntimeRegistry.dispose(paneId);
+				if (!freshIds.has(terminalId)) {
+					terminalRuntimeRegistry.dispose(terminalId);
 				}
 			}, DISPOSE_DELAY_MS);
 
-			pendingDisposals.current.set(paneId, timer);
+			pendingDisposals.current.set(terminalId, timer);
 		}
 
-		prevPaneIdsRef.current = currentPaneIds;
+		prevTerminalIdsRef.current = currentTerminalIds;
 	}, [allWorkspaceRows, collections]);
 
 	useEffect(() => {

--- a/apps/desktop/src/renderer/routes/_authenticated/components/GlobalTerminalLifecycle/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/GlobalTerminalLifecycle/index.ts
@@ -1,0 +1,1 @@
+export { GlobalTerminalLifecycle } from "./GlobalTerminalLifecycle";

--- a/apps/desktop/src/renderer/routes/_authenticated/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/layout.tsx
@@ -34,6 +34,7 @@ import { setPaneWorkspaceRunState } from "renderer/stores/tabs/workspace-run";
 import { useWorkspaceInitStore } from "renderer/stores/workspace-init";
 import { MOCK_ORG_ID, NOTIFICATION_EVENTS } from "shared/constants";
 import { AgentHooks } from "./components/AgentHooks";
+import { GlobalTerminalLifecycle } from "./components/GlobalTerminalLifecycle";
 import { TeardownLogsDialog } from "./components/TeardownLogsDialog";
 import { CollectionsProvider } from "./providers/CollectionsProvider";
 import { HostServiceProvider } from "./providers/HostServiceProvider";
@@ -198,6 +199,7 @@ function AuthenticatedLayout() {
 	return (
 		<DndProvider manager={dragDropManager}>
 			<CollectionsProvider>
+				<GlobalTerminalLifecycle />
 				<HostServiceProvider>
 					<LanguageServicesProvider />
 					<AgentHooks />

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema.ts
@@ -23,6 +23,7 @@ export const workspaceLocalStateSchema = z.object({
 		sectionId: z.string().uuid().nullable().default(null),
 	}),
 	paneLayout: paneWorkspaceStateSchema,
+	rightSidebarOpen: z.boolean().default(false),
 });
 
 export const dashboardSidebarSectionSchema = z.object({

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/HostServiceProvider/HostServiceProvider.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/HostServiceProvider/HostServiceProvider.tsx
@@ -52,8 +52,12 @@ export function HostServiceProvider({ children }: { children: ReactNode }) {
 	// Start a host service for every org
 	useEffect(() => {
 		for (const orgId of orgIds) {
+			const org = organizations?.find((o) => o.id === orgId);
 			utils.hostServiceManager.getLocalPort
-				.ensureData({ organizationId: orgId })
+				.ensureData({
+					organizationId: orgId,
+					organizationName: org?.name ?? undefined,
+				})
 				.catch((err) => {
 					console.error(
 						`[host-service] Failed to start for org ${orgId}:`,
@@ -61,12 +65,18 @@ export function HostServiceProvider({ children }: { children: ReactNode }) {
 					);
 				});
 		}
-	}, [orgIds, utils]);
+	}, [orgIds, organizations, utils]);
 
 	// Query the active org's port reactively
+	const activeOrgName = organizations?.find(
+		(o) => o.id === activeOrganizationId,
+	)?.name;
 	const { data: activePortData } =
 		electronTrpc.hostServiceManager.getLocalPort.useQuery(
-			{ organizationId: activeOrganizationId as string },
+			{
+				organizationId: activeOrganizationId as string,
+				organizationName: activeOrgName ?? undefined,
+			},
 			{ enabled: !!activeOrganizationId },
 		);
 
@@ -87,8 +97,10 @@ export function HostServiceProvider({ children }: { children: ReactNode }) {
 		};
 
 		for (const orgId of orgIds) {
+			const org = organizations?.find((o) => o.id === orgId);
 			const cached = utils.hostServiceManager.getLocalPort.getData({
 				organizationId: orgId,
+				organizationName: org?.name ?? undefined,
 			});
 			if (cached?.port) {
 				addOrg(orgId, cached.port, cached.secret ?? null);
@@ -109,7 +121,7 @@ export function HostServiceProvider({ children }: { children: ReactNode }) {
 		}
 
 		return map;
-	}, [orgIds, utils, activeOrganizationId, activePortData]);
+	}, [orgIds, organizations, utils, activeOrganizationId, activePortData]);
 
 	const value = useMemo(() => ({ services }), [services]);
 

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/api-keys/components/ApiKeysSettings/ApiKeysSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/api-keys/components/ApiKeysSettings/ApiKeysSettings.tsx
@@ -88,14 +88,20 @@ export function ApiKeysSettings({ visibleItems }: ApiKeysSettingsProps) {
 	};
 
 	const handleRevokeKey = (id: string, name: string | null) => {
-		alert.destructive({
+		alert({
 			title: "Revoke API Key",
 			description: `Are you sure you want to revoke "${name ?? "Unnamed Key"}"? This action cannot be undone.`,
-			confirmText: "Revoke",
-			onConfirm: async () => {
-				await authClient.apiKey.delete({ keyId: id });
-				toast.success("API key revoked");
-			},
+			actions: [
+				{ label: "Cancel", variant: "outline", onClick: () => {} },
+				{
+					label: "Revoke",
+					variant: "destructive",
+					onClick: async () => {
+						await authClient.apiKey.delete({ keyId: id });
+						toast.success("API key revoked");
+					},
+				},
+			],
 		});
 	};
 

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/members/components/MembersSettings/components/InviteMemberButton/InviteMemberButton.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/members/components/MembersSettings/components/InviteMemberButton/InviteMemberButton.tsx
@@ -36,9 +36,10 @@ export function InviteMemberButton({
 				title: "This will affect your billing",
 				description:
 					"Adding members will increase your subscription cost, prorated to your billing cycle.",
-				confirmText: "Continue",
-				cancelText: "Cancel",
-				onConfirm: () => setOpen(true),
+				actions: [
+					{ label: "Cancel", variant: "outline", onClick: () => {} },
+					{ label: "Continue", onClick: () => setOpen(true) },
+				],
 			});
 		});
 	};

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/members/components/MembersSettings/components/MemberActions/MemberActions.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/members/components/MembersSettings/components/MemberActions/MemberActions.tsx
@@ -90,16 +90,21 @@ export function MemberActions({
 				? " Your subscription will be adjusted accordingly."
 				: "";
 
-		alert.destructive({
+		alert({
 			title: isCurrentUser ? "Leave organization?" : "Remove team member?",
 			description: isCurrentUser
 				? `Are you sure you want to leave this organization? You will lose access immediately.${billingNote}`
 				: `Are you sure you want to remove ${member.name} (${member.email}) from the organization? They will lose access immediately.${billingNote}`,
-			confirmText: isCurrentUser ? "Leave Organization" : "Remove Member",
-			cancelText: "Cancel",
-			onConfirm: () => {
-				handleRemove();
-			},
+			actions: [
+				{ label: "Cancel", variant: "outline", onClick: () => {} },
+				{
+					label: isCurrentUser ? "Leave Organization" : "Remove Member",
+					variant: "destructive",
+					onClick: () => {
+						handleRemove();
+					},
+				},
+			],
 		});
 	};
 
@@ -126,14 +131,19 @@ export function MemberActions({
 			isCurrentUser && getRoleLevel(newRole) < getRoleLevel(member.role);
 
 		if (isSelfDemotion) {
-			alert.destructive({
+			alert({
 				title: "Demote yourself?",
 				description: `You're about to change your role from ${ORGANIZATION_ROLES[member.role].name} to ${ORGANIZATION_ROLES[newRole].name}. Another owner will need to restore your permissions. Are you sure?`,
-				confirmText: "Yes, demote me",
-				cancelText: "Cancel",
-				onConfirm: async () => {
-					await handleChangeRole(newRole);
-				},
+				actions: [
+					{ label: "Cancel", variant: "outline", onClick: () => {} },
+					{
+						label: "Yes, demote me",
+						variant: "destructive",
+						onClick: async () => {
+							await handleChangeRole(newRole);
+						},
+					},
+				],
 			});
 		} else {
 			handleChangeRole(newRole);

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/project/$projectId/cloud/secrets/components/SecretsSettings/components/AddSecretSheet/AddSecretSheet.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/project/$projectId/cloud/secrets/components/SecretsSettings/components/AddSecretSheet/AddSecretSheet.tsx
@@ -73,12 +73,18 @@ export function AddSecretSheet({
 
 	const handleOpenChange = (nextOpen: boolean) => {
 		if (!nextOpen && hasContent) {
-			alert.destructive({
+			alert({
 				title: "Discard unsaved changes?",
 				description:
 					"You have unsaved environment variables. Are you sure you want to close?",
-				confirmText: "Discard",
-				onConfirm: () => onOpenChange(false),
+				actions: [
+					{ label: "Cancel", variant: "outline", onClick: () => {} },
+					{
+						label: "Discard",
+						variant: "destructive",
+						onClick: () => onOpenChange(false),
+					},
+				],
 			});
 			return;
 		}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatPane/components/SessionSelector/components/SessionSelectorItem/SessionSelectorItem.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatPane/components/SessionSelector/components/SessionSelectorItem/SessionSelectorItem.tsx
@@ -36,17 +36,23 @@ export function SessionSelectorItem({
 					className="shrink-0 rounded p-0.5 opacity-0 transition-opacity hover:bg-destructive/10 hover:text-destructive group-hover:opacity-100"
 					onClick={(event) => {
 						event.stopPropagation();
-						alert.destructive({
+						alert({
 							title: "Delete Chat Session",
 							description: "Are you sure you want to delete this session?",
-							confirmText: "Delete",
-							onConfirm: () => {
-								toast.promise(onDeleteSession(sessionId), {
-									loading: "Deleting session...",
-									success: "Session deleted",
-									error: "Failed to delete session",
-								});
-							},
+							actions: [
+								{ label: "Cancel", variant: "outline", onClick: () => {} },
+								{
+									label: "Delete",
+									variant: "destructive",
+									onClick: () => {
+										toast.promise(onDeleteSession(sessionId), {
+											loading: "Deleting session...",
+											success: "Session deleted",
+											error: "Failed to delete session",
+										});
+									},
+								},
+							],
 						});
 					}}
 				>

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/config.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/config.ts
@@ -1,4 +1,8 @@
 import type { ITerminalOptions } from "@xterm/xterm";
+import {
+	DEFAULT_TERMINAL_FONT_FAMILY as SHARED_DEFAULT_TERMINAL_FONT_FAMILY,
+	DEFAULT_TERMINAL_FONT_SIZE as SHARED_DEFAULT_TERMINAL_FONT_SIZE,
+} from "renderer/lib/terminal/appearance";
 import { DEFAULT_TERMINAL_SCROLLBACK } from "shared/constants";
 
 // Use user's theme
@@ -13,23 +17,10 @@ export const DEBUG_TERMINAL =
 	typeof localStorage !== "undefined" &&
 	localStorage.getItem("SUPERSET_TERMINAL_DEBUG") === "1";
 
-// Nerd Fonts first for shell theme compatibility (Oh My Posh, Powerlevel10k, etc.)
-export const DEFAULT_TERMINAL_FONT_FAMILY = [
-	"MesloLGM Nerd Font",
-	"MesloLGM NF",
-	"MesloLGS NF",
-	"MesloLGS Nerd Font",
-	"Hack Nerd Font",
-	"FiraCode Nerd Font",
-	"JetBrainsMono Nerd Font",
-	"CaskaydiaCove Nerd Font",
-	"Menlo",
-	"Monaco",
-	'"Courier New"',
-	"monospace",
-].join(", ");
+// Shared terminal font defaults are serialized as a valid CSS font-family value.
+export const DEFAULT_TERMINAL_FONT_FAMILY = SHARED_DEFAULT_TERMINAL_FONT_FAMILY;
 
-export const DEFAULT_TERMINAL_FONT_SIZE = 14;
+export const DEFAULT_TERMINAL_FONT_SIZE = SHARED_DEFAULT_TERMINAL_FONT_SIZE;
 
 export const TERMINAL_OPTIONS: ITerminalOptions = {
 	cursorBlink: true,

--- a/package.json
+++ b/package.json
@@ -52,5 +52,16 @@
 	"patchedDependencies": {
 		"@durable-streams/state@0.2.1": "patches/@durable-streams%2Fstate@0.2.1.patch",
 		"fstream@1.0.12": "patches/fstream@1.0.12.patch"
-	}
+	},
+	"trustedDependencies": [
+		"better-sqlite3",
+		"bufferutil",
+		"electron",
+		"esbuild",
+		"koffi",
+		"node-pty",
+		"sharp",
+		"utf-8-validate",
+		"workerd"
+	]
 }

--- a/packages/host-service/drizzle/0002_add_terminal_sessions.sql
+++ b/packages/host-service/drizzle/0002_add_terminal_sessions.sql
@@ -1,0 +1,12 @@
+CREATE TABLE `terminal_sessions` (
+	`id` text PRIMARY KEY NOT NULL,
+	`origin_workspace_id` text,
+	`status` text DEFAULT 'active' NOT NULL,
+	`created_at` integer NOT NULL,
+	`last_attached_at` integer,
+	`ended_at` integer,
+	FOREIGN KEY (`origin_workspace_id`) REFERENCES `workspaces`(`id`) ON UPDATE no action ON DELETE set null
+);
+--> statement-breakpoint
+CREATE INDEX `terminal_sessions_origin_workspace_id_idx` ON `terminal_sessions` (`origin_workspace_id`);--> statement-breakpoint
+CREATE INDEX `terminal_sessions_status_idx` ON `terminal_sessions` (`status`);

--- a/packages/host-service/drizzle/meta/0002_snapshot.json
+++ b/packages/host-service/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,470 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "a2434e05-3865-4783-9247-7bda589c8806",
+  "prevId": "f5887d62-b5ad-4441-9648-d4456be25acb",
+  "tables": {
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repo_path": {
+          "name": "repo_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repo_provider": {
+          "name": "repo_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "repo_owner": {
+          "name": "repo_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "repo_name": {
+          "name": "repo_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "repo_url": {
+          "name": "repo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "remote_name": {
+          "name": "remote_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "projects_repo_path_idx": {
+          "name": "projects_repo_path_idx",
+          "columns": [
+            "repo_path"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "pull_requests": {
+      "name": "pull_requests",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repo_provider": {
+          "name": "repo_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repo_owner": {
+          "name": "repo_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repo_name": {
+          "name": "repo_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_draft": {
+          "name": "is_draft",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "head_branch": {
+          "name": "head_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "review_decision": {
+          "name": "review_decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "checks_status": {
+          "name": "checks_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'none'"
+        },
+        "checks_json": {
+          "name": "checks_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "last_fetched_at": {
+          "name": "last_fetched_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "pull_requests_project_id_idx": {
+          "name": "pull_requests_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "pull_requests_repo_branch_idx": {
+          "name": "pull_requests_repo_branch_idx",
+          "columns": [
+            "repo_provider",
+            "repo_owner",
+            "repo_name",
+            "head_branch"
+          ],
+          "isUnique": false
+        },
+        "pull_requests_repo_pr_unique": {
+          "name": "pull_requests_repo_pr_unique",
+          "columns": [
+            "repo_provider",
+            "repo_owner",
+            "repo_name",
+            "pr_number"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "pull_requests_project_id_projects_id_fk": {
+          "name": "pull_requests_project_id_projects_id_fk",
+          "tableFrom": "pull_requests",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "terminal_sessions": {
+      "name": "terminal_sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "origin_workspace_id": {
+          "name": "origin_workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_attached_at": {
+          "name": "last_attached_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "terminal_sessions_origin_workspace_id_idx": {
+          "name": "terminal_sessions_origin_workspace_id_idx",
+          "columns": [
+            "origin_workspace_id"
+          ],
+          "isUnique": false
+        },
+        "terminal_sessions_status_idx": {
+          "name": "terminal_sessions_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "terminal_sessions_origin_workspace_id_workspaces_id_fk": {
+          "name": "terminal_sessions_origin_workspace_id_workspaces_id_fk",
+          "tableFrom": "terminal_sessions",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "origin_workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "workspaces": {
+      "name": "workspaces",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "worktree_path": {
+          "name": "worktree_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pull_request_id": {
+          "name": "pull_request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "workspaces_project_id_idx": {
+          "name": "workspaces_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "workspaces_branch_idx": {
+          "name": "workspaces_branch_idx",
+          "columns": [
+            "branch"
+          ],
+          "isUnique": false
+        },
+        "workspaces_pull_request_id_idx": {
+          "name": "workspaces_pull_request_id_idx",
+          "columns": [
+            "pull_request_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "workspaces_project_id_projects_id_fk": {
+          "name": "workspaces_project_id_projects_id_fk",
+          "tableFrom": "workspaces",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workspaces_pull_request_id_pull_requests_id_fk": {
+          "name": "workspaces_pull_request_id_pull_requests_id_fk",
+          "tableFrom": "workspaces",
+          "tableTo": "pull_requests",
+          "columnsFrom": [
+            "pull_request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/host-service/drizzle/meta/_journal.json
+++ b/packages/host-service/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1773705162679,
       "tag": "0001_famous_mindworm",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "6",
+      "when": 1775239013772,
+      "tag": "0002_add_terminal_sessions",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/host-service/src/app.ts
+++ b/packages/host-service/src/app.ts
@@ -33,6 +33,8 @@ export interface CreateAppOptions {
 	dbPath?: string;
 	deviceClientId?: string;
 	deviceName?: string;
+	serviceVersion?: string | null;
+	protocolVersion?: number | null;
 	allowedOrigins?: string[];
 }
 
@@ -133,6 +135,8 @@ export function createApp(options?: CreateAppOptions): CreateAppResult {
 					runtime,
 					deviceClientId: options?.deviceClientId ?? null,
 					deviceName: options?.deviceName ?? null,
+					serviceVersion: options?.serviceVersion ?? null,
+					protocolVersion: options?.protocolVersion ?? null,
 					isAuthenticated,
 				} as Record<string, unknown>;
 			},

--- a/packages/host-service/src/db/schema.ts
+++ b/packages/host-service/src/db/schema.ts
@@ -6,6 +6,29 @@ import {
 	uniqueIndex,
 } from "drizzle-orm/sqlite-core";
 
+export const terminalSessions = sqliteTable(
+	"terminal_sessions",
+	{
+		id: text().primaryKey(),
+		originWorkspaceId: text("origin_workspace_id").references(
+			() => workspaces.id,
+			{ onDelete: "set null" },
+		),
+		status: text().notNull().default("active"),
+		createdAt: integer("created_at")
+			.notNull()
+			.$defaultFn(() => Date.now()),
+		lastAttachedAt: integer("last_attached_at"),
+		endedAt: integer("ended_at"),
+	},
+	(table) => [
+		index("terminal_sessions_origin_workspace_id_idx").on(
+			table.originWorkspaceId,
+		),
+		index("terminal_sessions_status_idx").on(table.status),
+	],
+);
+
 export const projects = sqliteTable(
 	"projects",
 	{

--- a/packages/host-service/src/terminal/terminal.ts
+++ b/packages/host-service/src/terminal/terminal.ts
@@ -5,7 +5,7 @@ import { eq } from "drizzle-orm";
 import type { Hono } from "hono";
 import { type IPty, spawn } from "node-pty";
 import type { HostDb } from "../db";
-import { workspaces } from "../db/schema";
+import { terminalSessions, workspaces } from "../db/schema";
 
 interface RegisterWorkspaceTerminalRouteOptions {
 	app: Hono;
@@ -27,7 +27,7 @@ type TerminalServerMessage =
 const MAX_BUFFER_BYTES = 64 * 1024;
 
 interface TerminalSession {
-	paneId: string;
+	terminalId: string;
 	pty: IPty;
 	socket: {
 		send: (data: string) => void;
@@ -80,8 +80,8 @@ function replayBuffer(
 	sendMessage(socket, { type: "replay", data: combined });
 }
 
-function disposeSession(paneId: string) {
-	const session = sessions.get(paneId);
+function disposeSession(terminalId: string, db: HostDb) {
+	const session = sessions.get(terminalId);
 	if (!session) return;
 
 	if (!session.exited) {
@@ -91,7 +91,114 @@ function disposeSession(paneId: string) {
 			// PTY may already be dead
 		}
 	}
-	sessions.delete(paneId);
+	sessions.delete(terminalId);
+
+	db.update(terminalSessions)
+		.set({ status: "disposed", endedAt: Date.now() })
+		.where(eq(terminalSessions.id, terminalId))
+		.run();
+}
+
+interface CreateTerminalSessionOptions {
+	terminalId: string;
+	workspaceId: string;
+	db: HostDb;
+}
+
+function createTerminalSessionInternal({
+	terminalId,
+	workspaceId,
+	db,
+}: CreateTerminalSessionOptions): TerminalSession | { error: string } {
+	const existing = sessions.get(terminalId);
+	if (existing) {
+		return existing;
+	}
+
+	const workspace = db.query.workspaces
+		.findFirst({ where: eq(workspaces.id, workspaceId) })
+		.sync();
+
+	if (!workspace || !existsSync(workspace.worktreePath)) {
+		return { error: "Workspace worktree not found" };
+	}
+
+	const cwd = workspace.worktreePath;
+
+	let pty: IPty;
+	try {
+		pty = spawn(resolveShell(), [], {
+			name: "xterm-256color",
+			cwd,
+			cols: 120,
+			rows: 32,
+			env: {
+				...process.env,
+				TERM: "xterm-256color",
+				COLORTERM: "truecolor",
+				HOME: process.env.HOME || homedir(),
+				PWD: cwd,
+			},
+		});
+	} catch (error) {
+		return {
+			error:
+				error instanceof Error ? error.message : "Failed to start terminal",
+		};
+	}
+
+	db.insert(terminalSessions)
+		.values({
+			id: terminalId,
+			originWorkspaceId: workspaceId,
+			status: "active",
+		})
+		.onConflictDoUpdate({
+			target: terminalSessions.id,
+			set: { status: "active", endedAt: null },
+		})
+		.run();
+
+	const session: TerminalSession = {
+		terminalId,
+		pty,
+		socket: null,
+		buffer: [],
+		bufferBytes: 0,
+		exited: false,
+		exitCode: 0,
+		exitSignal: 0,
+	};
+	sessions.set(terminalId, session);
+
+	pty.onData((data) => {
+		if (session.socket?.readyState === 1) {
+			sendMessage(session.socket, { type: "data", data });
+		} else {
+			bufferOutput(session, data);
+		}
+	});
+
+	pty.onExit(({ exitCode, signal }) => {
+		session.exited = true;
+		session.exitCode = exitCode ?? 0;
+		session.exitSignal = signal ?? 0;
+
+		db.update(terminalSessions)
+			.set({ status: "exited", endedAt: Date.now() })
+			.where(eq(terminalSessions.id, terminalId))
+			.run();
+
+		if (session.socket?.readyState === 1) {
+			sendMessage(session.socket, {
+				type: "exit",
+				exitCode: session.exitCode,
+				signal: session.exitSignal,
+			});
+		}
+	});
+
+	return session;
 }
 
 export function registerWorkspaceTerminalRoute({
@@ -99,29 +206,54 @@ export function registerWorkspaceTerminalRoute({
 	db,
 	upgradeWebSocket,
 }: RegisterWorkspaceTerminalRouteOptions) {
+	app.post("/terminal/sessions", async (c) => {
+		const body = await c.req.json<{
+			terminalId: string;
+			workspaceId: string;
+		}>();
+
+		if (!body.terminalId || !body.workspaceId) {
+			return c.json({ error: "Missing terminalId or workspaceId" }, 400);
+		}
+
+		const result = createTerminalSessionInternal({
+			terminalId: body.terminalId,
+			workspaceId: body.workspaceId,
+			db,
+		});
+
+		if ("error" in result) {
+			return c.json({ error: result.error }, 500);
+		}
+
+		return c.json({ terminalId: result.terminalId, status: "active" });
+	});
+
 	app.get(
-		"/terminal/:paneId",
+		"/terminal/:terminalId",
 		upgradeWebSocket((c) => {
-			const paneId = c.req.param("paneId");
+			const terminalId = c.req.param("terminalId") ?? "";
 			const workspaceId = c.req.query("workspaceId") ?? null;
 
 			return {
 				onOpen: (_event, ws) => {
-					if (!paneId) {
-						sendMessage(ws, {
-							type: "error",
-							message: "Missing paneId",
-						});
-						ws.close(1011, "Missing paneId");
+					if (!terminalId) {
+						ws.close(1011, "Missing terminalId");
 						return;
 					}
 
-					const existing = sessions.get(paneId);
+					const existing = sessions.get(terminalId);
 					if (existing) {
 						if (existing.socket && existing.socket !== ws) {
 							existing.socket.close(4000, "Displaced by new connection");
 						}
 						existing.socket = ws;
+
+						db.update(terminalSessions)
+							.set({ lastAttachedAt: Date.now() })
+							.where(eq(terminalSessions.id, terminalId))
+							.run();
+
 						replayBuffer(existing, ws);
 						if (existing.exited) {
 							sendMessage(ws, {
@@ -142,83 +274,28 @@ export function registerWorkspaceTerminalRoute({
 						return;
 					}
 
-					const workspace = db.query.workspaces
-						.findFirst({ where: eq(workspaces.id, workspaceId) })
-						.sync();
+					const result = createTerminalSessionInternal({
+						terminalId,
+						workspaceId,
+						db,
+					});
 
-					if (!workspace || !existsSync(workspace.worktreePath)) {
-						sendMessage(ws, {
-							type: "error",
-							message: "Workspace worktree not found",
-						});
-						ws.close(1011, "Workspace worktree not found");
+					if ("error" in result) {
+						sendMessage(ws, { type: "error", message: result.error });
+						ws.close(1011, result.error);
 						return;
 					}
 
-					let pty: IPty;
-					try {
-						pty = spawn(resolveShell(), [], {
-							name: "xterm-256color",
-							cwd: workspace.worktreePath,
-							cols: 120,
-							rows: 32,
-							env: {
-								...process.env,
-								TERM: "xterm-256color",
-								COLORTERM: "truecolor",
-								HOME: process.env.HOME || homedir(),
-								PWD: workspace.worktreePath,
-							},
-						});
-					} catch (error) {
-						sendMessage(ws, {
-							type: "error",
-							message:
-								error instanceof Error
-									? error.message
-									: "Failed to start terminal",
-						});
-						ws.close(1011, "Failed to start terminal");
-						return;
-					}
+					result.socket = ws;
 
-					const session: TerminalSession = {
-						paneId,
-						pty,
-						socket: ws,
-						buffer: [],
-						bufferBytes: 0,
-						exited: false,
-						exitCode: 0,
-						exitSignal: 0,
-					};
-					sessions.set(paneId, session);
-
-					pty.onData((data) => {
-						if (session.socket?.readyState === 1) {
-							sendMessage(session.socket, { type: "data", data });
-						} else {
-							bufferOutput(session, data);
-						}
-					});
-
-					pty.onExit(({ exitCode, signal }) => {
-						session.exited = true;
-						session.exitCode = exitCode ?? 0;
-						session.exitSignal = signal ?? 0;
-
-						if (session.socket?.readyState === 1) {
-							sendMessage(session.socket, {
-								type: "exit",
-								exitCode: session.exitCode,
-								signal: session.exitSignal,
-							});
-						}
-					});
+					db.update(terminalSessions)
+						.set({ lastAttachedAt: Date.now() })
+						.where(eq(terminalSessions.id, terminalId))
+						.run();
 				},
 
 				onMessage: (event, ws) => {
-					const session = sessions.get(paneId ?? "");
+					const session = sessions.get(terminalId ?? "");
 					if (!session || session.socket !== ws) return;
 
 					let message: TerminalClientMessage;
@@ -235,7 +312,7 @@ export function registerWorkspaceTerminalRoute({
 					}
 
 					if (message.type === "dispose") {
-						disposeSession(paneId ?? "");
+						disposeSession(terminalId ?? "", db);
 						return;
 					}
 
@@ -254,14 +331,14 @@ export function registerWorkspaceTerminalRoute({
 				},
 
 				onClose: (_event, ws) => {
-					const session = sessions.get(paneId ?? "");
+					const session = sessions.get(terminalId ?? "");
 					if (session?.socket === ws) {
 						session.socket = null;
 					}
 				},
 
 				onError: (_event, ws) => {
-					const session = sessions.get(paneId ?? "");
+					const session = sessions.get(terminalId ?? "");
 					if (session?.socket === ws) {
 						session.socket = null;
 					}

--- a/packages/host-service/src/terminal/terminal.ts
+++ b/packages/host-service/src/terminal/terminal.ts
@@ -229,6 +229,33 @@ export function registerWorkspaceTerminalRoute({
 		return c.json({ terminalId: result.terminalId, status: "active" });
 	});
 
+	// REST dispose — does not require an open WebSocket
+	app.delete("/terminal/sessions/:terminalId", (c) => {
+		const terminalId = c.req.param("terminalId");
+		if (!terminalId) {
+			return c.json({ error: "Missing terminalId" }, 400);
+		}
+
+		const session = sessions.get(terminalId);
+		if (!session) {
+			return c.json({ error: "Session not found" }, 404);
+		}
+
+		disposeSession(terminalId, db);
+		return c.json({ terminalId, status: "disposed" });
+	});
+
+	// REST list — enumerate live terminal sessions
+	app.get("/terminal/sessions", (c) => {
+		const result = Array.from(sessions.values()).map((s) => ({
+			terminalId: s.terminalId,
+			exited: s.exited,
+			exitCode: s.exitCode,
+			attached: s.socket !== null,
+		}));
+		return c.json({ sessions: result });
+	});
+
 	app.get(
 		"/terminal/:terminalId",
 		upgradeWebSocket((c) => {

--- a/packages/host-service/src/terminal/terminal.ts
+++ b/packages/host-service/src/terminal/terminal.ts
@@ -14,41 +14,41 @@ interface RegisterWorkspaceTerminalRouteOptions {
 }
 
 type TerminalClientMessage =
-	| {
-			type: "input";
-			data: string;
-	  }
-	| {
-			type: "resize";
-			cols: number;
-			rows: number;
-	  };
+	| { type: "input"; data: string }
+	| { type: "resize"; cols: number; rows: number }
+	| { type: "dispose" };
 
 type TerminalServerMessage =
-	| {
-			type: "data";
-			data: string;
-	  }
-	| {
-			type: "error";
-			message: string;
-	  }
-	| {
-			type: "exit";
-			exitCode: number;
-			signal: number;
-	  };
+	| { type: "data"; data: string }
+	| { type: "error"; message: string }
+	| { type: "exit"; exitCode: number; signal: number }
+	| { type: "replay"; data: string };
 
-function sendMessage(
+const MAX_BUFFER_BYTES = 64 * 1024;
+
+interface TerminalSession {
+	paneId: string;
+	pty: IPty;
 	socket: {
 		send: (data: string) => void;
+		close: (code?: number, reason?: string) => void;
 		readyState: number;
-	},
+	} | null;
+	buffer: string[];
+	bufferBytes: number;
+	exited: boolean;
+	exitCode: number;
+	exitSignal: number;
+}
+
+/** PTY lifetime is independent of socket lifetime — sockets detach/reattach freely. */
+const sessions = new Map<string, TerminalSession>();
+
+function sendMessage(
+	socket: { send: (data: string) => void; readyState: number },
 	message: TerminalServerMessage,
 ) {
-	if (socket.readyState !== 1) {
-		return;
-	}
+	if (socket.readyState !== 1) return;
 	socket.send(JSON.stringify(message));
 }
 
@@ -56,8 +56,42 @@ function resolveShell(): string {
 	if (process.platform === "win32") {
 		return process.env.COMSPEC || "cmd.exe";
 	}
-
 	return process.env.SHELL || "/bin/zsh";
+}
+
+function bufferOutput(session: TerminalSession, data: string) {
+	session.buffer.push(data);
+	session.bufferBytes += data.length;
+
+	while (session.bufferBytes > MAX_BUFFER_BYTES && session.buffer.length > 1) {
+		const removed = session.buffer.shift();
+		if (removed) session.bufferBytes -= removed.length;
+	}
+}
+
+function replayBuffer(
+	session: TerminalSession,
+	socket: { send: (data: string) => void; readyState: number },
+) {
+	if (session.buffer.length === 0) return;
+	const combined = session.buffer.join("");
+	session.buffer.length = 0;
+	session.bufferBytes = 0;
+	sendMessage(socket, { type: "replay", data: combined });
+}
+
+function disposeSession(paneId: string) {
+	const session = sessions.get(paneId);
+	if (!session) return;
+
+	if (!session.exited) {
+		try {
+			session.pty.kill();
+		} catch {
+			// PTY may already be dead
+		}
+	}
+	sessions.delete(paneId);
 }
 
 export function registerWorkspaceTerminalRoute({
@@ -66,34 +100,53 @@ export function registerWorkspaceTerminalRoute({
 	upgradeWebSocket,
 }: RegisterWorkspaceTerminalRouteOptions) {
 	app.get(
-		"/terminal/:workspaceId",
+		"/terminal/:paneId",
 		upgradeWebSocket((c) => {
-			const workspaceId = c.req.param("workspaceId");
-			const workspace = workspaceId
-				? db.query.workspaces
-						.findFirst({ where: eq(workspaces.id, workspaceId) })
-						.sync()
-				: null;
-
-			let terminal: IPty | null = null;
-			let disposed = false;
-
-			const disposeTerminal = () => {
-				if (disposed) {
-					return;
-				}
-				disposed = true;
-				terminal?.kill();
-				terminal = null;
-			};
+			const paneId = c.req.param("paneId");
+			const workspaceId = c.req.query("workspaceId") ?? null;
 
 			return {
 				onOpen: (_event, ws) => {
-					if (
-						!workspaceId ||
-						!workspace ||
-						!existsSync(workspace.worktreePath)
-					) {
+					if (!paneId) {
+						sendMessage(ws, {
+							type: "error",
+							message: "Missing paneId",
+						});
+						ws.close(1011, "Missing paneId");
+						return;
+					}
+
+					const existing = sessions.get(paneId);
+					if (existing) {
+						if (existing.socket && existing.socket !== ws) {
+							existing.socket.close(4000, "Displaced by new connection");
+						}
+						existing.socket = ws;
+						replayBuffer(existing, ws);
+						if (existing.exited) {
+							sendMessage(ws, {
+								type: "exit",
+								exitCode: existing.exitCode,
+								signal: existing.exitSignal,
+							});
+						}
+						return;
+					}
+
+					if (!workspaceId) {
+						sendMessage(ws, {
+							type: "error",
+							message: "Missing workspaceId for new terminal session",
+						});
+						ws.close(1011, "Missing workspaceId");
+						return;
+					}
+
+					const workspace = db.query.workspaces
+						.findFirst({ where: eq(workspaces.id, workspaceId) })
+						.sync();
+
+					if (!workspace || !existsSync(workspace.worktreePath)) {
 						sendMessage(ws, {
 							type: "error",
 							message: "Workspace worktree not found",
@@ -102,8 +155,9 @@ export function registerWorkspaceTerminalRoute({
 						return;
 					}
 
+					let pty: IPty;
 					try {
-						terminal = spawn(resolveShell(), [], {
+						pty = spawn(resolveShell(), [], {
 							name: "xterm-256color",
 							cwd: workspace.worktreePath,
 							cols: 120,
@@ -128,55 +182,89 @@ export function registerWorkspaceTerminalRoute({
 						return;
 					}
 
-					terminal.onData((data) => {
-						sendMessage(ws, {
-							type: "data",
-							data,
-						});
+					const session: TerminalSession = {
+						paneId,
+						pty,
+						socket: ws,
+						buffer: [],
+						bufferBytes: 0,
+						exited: false,
+						exitCode: 0,
+						exitSignal: 0,
+					};
+					sessions.set(paneId, session);
+
+					pty.onData((data) => {
+						if (session.socket?.readyState === 1) {
+							sendMessage(session.socket, { type: "data", data });
+						} else {
+							bufferOutput(session, data);
+						}
 					});
 
-					terminal.onExit(({ exitCode, signal }) => {
-						sendMessage(ws, {
-							type: "exit",
-							exitCode: exitCode ?? 0,
-							signal: signal ?? 0,
-						});
-						ws.close(1000, "Terminal exited");
-						disposeTerminal();
+					pty.onExit(({ exitCode, signal }) => {
+						session.exited = true;
+						session.exitCode = exitCode ?? 0;
+						session.exitSignal = signal ?? 0;
+
+						if (session.socket?.readyState === 1) {
+							sendMessage(session.socket, {
+								type: "exit",
+								exitCode: session.exitCode,
+								signal: session.exitSignal,
+							});
+						}
 					});
 				},
+
 				onMessage: (event, ws) => {
-					if (!terminal) {
-						return;
-					}
+					const session = sessions.get(paneId ?? "");
+					if (!session || session.socket !== ws) return;
 
 					let message: TerminalClientMessage;
 					try {
 						message = JSON.parse(String(event.data)) as TerminalClientMessage;
 					} catch {
-						sendMessage(ws, {
-							type: "error",
-							message: "Invalid terminal message payload",
-						});
+						if (session.socket) {
+							sendMessage(session.socket, {
+								type: "error",
+								message: "Invalid terminal message payload",
+							});
+						}
 						return;
 					}
 
+					if (message.type === "dispose") {
+						disposeSession(paneId ?? "");
+						return;
+					}
+
+					if (session.exited) return;
+
 					if (message.type === "input") {
-						terminal.write(message.data);
+						session.pty.write(message.data);
 						return;
 					}
 
 					if (message.type === "resize") {
 						const cols = Math.max(20, Math.floor(message.cols));
 						const rows = Math.max(5, Math.floor(message.rows));
-						terminal.resize(cols, rows);
+						session.pty.resize(cols, rows);
 					}
 				},
-				onClose: () => {
-					disposeTerminal();
+
+				onClose: (_event, ws) => {
+					const session = sessions.get(paneId ?? "");
+					if (session?.socket === ws) {
+						session.socket = null;
+					}
 				},
-				onError: () => {
-					disposeTerminal();
+
+				onError: (_event, ws) => {
+					const session = sessions.get(paneId ?? "");
+					if (session?.socket === ws) {
+						session.socket = null;
+					}
 				},
 			};
 		}),

--- a/packages/host-service/src/trpc/router/health/health.ts
+++ b/packages/host-service/src/trpc/router/health/health.ts
@@ -1,17 +1,23 @@
 import os from "node:os";
 import { publicProcedure, router } from "../../index";
 
+const processStartedAt = Date.now();
+
 export const healthRouter = router({
 	check: publicProcedure.query(() => {
 		return { status: "ok" as const };
 	}),
 
-	info: publicProcedure.query(() => {
+	info: publicProcedure.query(({ ctx }) => {
 		return {
 			platform: os.platform(),
 			arch: os.arch(),
 			nodeVersion: process.version,
 			uptime: process.uptime(),
+			serviceVersion: ctx.serviceVersion ?? null,
+			protocolVersion: ctx.protocolVersion ?? null,
+			organizationId: process.env.ORGANIZATION_ID ?? null,
+			startedAt: processStartedAt,
 		};
 	}),
 });

--- a/packages/host-service/src/types.ts
+++ b/packages/host-service/src/types.ts
@@ -23,5 +23,7 @@ export interface HostServiceContext {
 	runtime: HostServiceRuntime;
 	deviceClientId: string | null;
 	deviceName: string | null;
+	serviceVersion: string | null;
+	protocolVersion: number | null;
 	isAuthenticated: boolean;
 }

--- a/packages/panes/src/core/store/store.test.ts
+++ b/packages/panes/src/core/store/store.test.ts
@@ -138,7 +138,6 @@ describe("pane operations", () => {
 		store.getState().addTab({ id: "t1", panes: [tp("p1")] });
 
 		store.getState().setPanePinned({
-			tabId: "t1",
 			paneId: "p1",
 			pinned: true,
 		});

--- a/packages/panes/src/core/store/store.ts
+++ b/packages/panes/src/core/store/store.ts
@@ -105,11 +105,7 @@ export interface WorkspaceStore<TData> extends WorkspaceState<TData> {
 		paneId: string;
 		titleOverride?: string;
 	}) => void;
-	setPanePinned: (args: {
-		tabId: string;
-		paneId: string;
-		pinned: boolean;
-	}) => void;
+	setPanePinned: (args: { paneId: string; pinned: boolean }) => void;
 	replacePane: (args: {
 		tabId: string;
 		paneId: string;
@@ -334,26 +330,25 @@ export function createWorkspaceStore<TData>(
 
 		setPanePinned: (args) => {
 			set((s) => {
-				const tab = s.tabs.find((t) => t.id === args.tabId);
-				const pane = tab?.panes[args.paneId];
-				if (!tab || !pane) return s;
-
-				return {
-					tabs: s.tabs.map((t) =>
-						t.id === args.tabId
-							? {
-									...t,
-									panes: {
-										...t.panes,
-										[args.paneId]: {
-											...pane,
-											pinned: args.pinned,
-										},
-									},
-								}
-							: t,
-					),
-				};
+				for (const tab of s.tabs) {
+					const pane = tab.panes[args.paneId];
+					if (pane) {
+						return {
+							tabs: s.tabs.map((t) =>
+								t.id === tab.id
+									? {
+											...t,
+											panes: {
+												...t.panes,
+												[args.paneId]: { ...pane, pinned: args.pinned },
+											},
+										}
+									: t,
+							),
+						};
+					}
+				}
+				return s;
 			});
 		},
 

--- a/packages/panes/src/react/components/Workspace/components/Tab/components/Pane/Pane.tsx
+++ b/packages/panes/src/react/components/Workspace/components/Tab/components/Pane/Pane.tsx
@@ -81,8 +81,13 @@ export function Pane<TData>({
 			isActive,
 			store,
 			actions: {
-				close: () =>
-					store.getState().closePane({ tabId: tab.id, paneId: pane.id }),
+				close: async () => {
+					if (definition?.onBeforeClose) {
+						const allowed = await definition.onBeforeClose(pane);
+						if (!allowed) return;
+					}
+					store.getState().closePane({ tabId: tab.id, paneId: pane.id });
+				},
 				focus: () =>
 					store.getState().setActivePane({ tabId: tab.id, paneId: pane.id }),
 				setTitle: (title: string) =>
@@ -93,7 +98,6 @@ export function Pane<TData>({
 					}),
 				pin: () =>
 					store.getState().setPanePinned({
-						tabId: tab.id,
 						paneId: pane.id,
 						pinned: true,
 					}),
@@ -216,6 +220,12 @@ export function Pane<TData>({
 				toolbar={toolbar}
 				actionsContent={<context.components.PaneHeaderActions />}
 				paneId={pane.id}
+				onClick={
+					definition?.onHeaderClick
+						? () => definition.onHeaderClick?.(context)
+						: context.actions.pin
+				}
+				onMiddleClick={context.actions.close}
 			/>
 			<PaneContent>
 				{definition ? (

--- a/packages/panes/src/react/components/Workspace/components/Tab/components/Pane/components/PaneHeader/PaneHeader.tsx
+++ b/packages/panes/src/react/components/Workspace/components/Tab/components/Pane/components/PaneHeader/PaneHeader.tsx
@@ -12,6 +12,8 @@ interface PaneHeaderProps {
 	actionsContent: ReactNode;
 	toolbar?: ReactNode;
 	paneId?: string;
+	onClick?: () => void;
+	onMiddleClick?: () => void;
 }
 
 export const PANE_DRAG_TYPE = "pane";
@@ -25,6 +27,8 @@ export function PaneHeader({
 	actionsContent,
 	toolbar,
 	paneId,
+	onClick,
+	onMiddleClick,
 }: PaneHeaderProps) {
 	const [{ isDragging }, connectDrag] = useDrag(
 		() => ({
@@ -48,6 +52,8 @@ export function PaneHeader({
 	);
 
 	return (
+		// biome-ignore lint/a11y/useKeyWithClickEvents: pane header click-to-pin doesn't need keyboard equivalent
+		// biome-ignore lint/a11y/noStaticElementInteractions: click to pin, middle-click to close
 		<div
 			ref={setRef}
 			className={cn(
@@ -55,6 +61,13 @@ export function PaneHeader({
 				isActive ? "bg-secondary" : "bg-tertiary",
 				isDragging && "opacity-30",
 			)}
+			onClick={onClick}
+			onAuxClick={(e) => {
+				if (e.button === 1 && onMiddleClick) {
+					e.preventDefault();
+					onMiddleClick();
+				}
+			}}
 		>
 			{toolbar ?? (
 				<DefaultHeaderContent

--- a/packages/panes/src/react/components/Workspace/components/Tab/components/Pane/components/PaneHeader/PaneHeader.tsx
+++ b/packages/panes/src/react/components/Workspace/components/Tab/components/Pane/components/PaneHeader/PaneHeader.tsx
@@ -61,7 +61,11 @@ export function PaneHeader({
 				isActive ? "bg-secondary" : "bg-tertiary",
 				isDragging && "opacity-30",
 			)}
-			onClick={onClick}
+			onClick={(e) => {
+				// Don't trigger pin when clicking action buttons inside the header
+				if (e.target instanceof HTMLElement && e.target.closest("button")) return;
+				onClick?.();
+			}}
 			onAuxClick={(e) => {
 				if (e.button === 1 && onMiddleClick) {
 					e.preventDefault();

--- a/packages/panes/src/react/types.ts
+++ b/packages/panes/src/react/types.ts
@@ -48,6 +48,8 @@ export interface PaneDefinition<TData> {
 	renderTitle?(context: RendererContext<TData>): ReactNode;
 	renderHeaderExtras?(context: RendererContext<TData>): ReactNode;
 	renderToolbar?(context: RendererContext<TData>): ReactNode;
+	onHeaderClick?(context: RendererContext<TData>): void;
+	onBeforeClose?(pane: Pane<TData>): boolean | Promise<boolean>;
 	paneActions?:
 		| PaneActionConfig<TData>[]
 		| ((

--- a/packages/ui/src/atoms/Alert/Alert.tsx
+++ b/packages/ui/src/atoms/Alert/Alert.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Button } from "@superset/ui/button";
+import { Button, type buttonVariants } from "@superset/ui/button";
 import {
 	Dialog,
 	DialogContent,
@@ -9,100 +9,95 @@ import {
 	DialogHeader,
 	DialogTitle,
 } from "@superset/ui/dialog";
+import type { VariantProps } from "class-variance-authority";
 import { useState } from "react";
+
+type AlertActionVariant = NonNullable<
+	VariantProps<typeof buttonVariants>["variant"]
+>;
+
+interface AlertAction {
+	label: string;
+	variant?: AlertActionVariant;
+	onClick?: () => void | Promise<void>;
+}
 
 type AlertOptions = {
 	title: string;
 	description: string;
-	confirmText?: string;
-	cancelText?: string;
-	onConfirm: () => void | Promise<void>;
-	onCancel?: () => void;
+	actions: AlertAction[];
 };
 
-type InternalAlertOptions = AlertOptions & {
-	variant: "default" | "destructive";
-};
-
-let showAlertFn: ((options: InternalAlertOptions) => void) | null = null;
+let showAlertFn: ((options: AlertOptions) => void) | null = null;
 
 const Alerter = () => {
-	const [alertOptions, setAlertOptions] = useState<InternalAlertOptions | null>(
-		null,
-	);
+	const [alertOptions, setAlertOptions] = useState<AlertOptions | null>(null);
 	const [isOpen, setIsOpen] = useState(false);
-	const [isLoading, setIsLoading] = useState(false);
+	const [loadingIndex, setLoadingIndex] = useState<number | null>(null);
 
 	showAlertFn = (options) => {
 		setAlertOptions(options);
+		setLoadingIndex(null);
 		setIsOpen(true);
 	};
 
-	const handleConfirm = async () => {
-		if (!alertOptions) return;
-
-		setIsLoading(true);
+	const handleAction = async (action: AlertAction, index: number) => {
+		setLoadingIndex(index);
 		try {
-			await alertOptions.onConfirm();
+			await action.onClick?.();
 			setIsOpen(false);
 		} catch (error) {
-			console.error("[alert] Confirmation failed:", error);
+			console.error("[alert] Action failed:", error);
 		} finally {
-			setIsLoading(false);
+			setLoadingIndex(null);
 		}
 	};
 
-	const handleCancel = () => {
-		if (!alertOptions) return;
-		alertOptions.onCancel?.();
+	const handleClose = () => {
 		setIsOpen(false);
 	};
+
+	if (!alertOptions) return null;
+
+	const actions = [...alertOptions.actions].reverse();
 
 	return (
 		<Dialog
 			modal={true}
 			open={isOpen}
-			onOpenChange={(open) => !open && handleCancel()}
+			onOpenChange={(open) => !open && handleClose()}
 		>
 			<DialogContent>
 				<DialogHeader>
-					<DialogTitle>{alertOptions?.title}</DialogTitle>
-					<DialogDescription>{alertOptions?.description}</DialogDescription>
+					<DialogTitle>{alertOptions.title}</DialogTitle>
+					<DialogDescription>{alertOptions.description}</DialogDescription>
 				</DialogHeader>
 				<DialogFooter>
-					<Button variant="outline" onClick={handleCancel} disabled={isLoading}>
-						{alertOptions?.cancelText ?? "Cancel"}
-					</Button>
-					<Button
-						variant={alertOptions?.variant ?? "default"}
-						onClick={handleConfirm}
-						disabled={isLoading}
-					>
-						{isLoading
-							? "Loading..."
-							: (alertOptions?.confirmText ?? "Confirm")}
-					</Button>
+					{actions.map((action, i) => (
+						<Button
+							key={action.label}
+							variant={action.variant ?? "default"}
+							onClick={() => handleAction(action, i)}
+							disabled={loadingIndex !== null}
+						>
+							{loadingIndex === i ? "Loading..." : action.label}
+						</Button>
+					))}
 				</DialogFooter>
 			</DialogContent>
 		</Dialog>
 	);
 };
 
-const createAlert = (variant: "default" | "destructive") => {
-	return (options: AlertOptions) => {
-		if (!showAlertFn) {
-			console.error(
-				"[alert] Alerter not mounted. Make sure to render <Alerter /> in your app",
-			);
-			return;
-		}
-		const internalOptions: InternalAlertOptions = { ...options, variant };
-		showAlertFn(internalOptions);
-	};
+const alert = (options: AlertOptions) => {
+	if (!showAlertFn) {
+		console.error(
+			"[alert] Alerter not mounted. Make sure to render <Alerter /> in your app",
+		);
+		return;
+	}
+	showAlertFn(options);
 };
 
-const alert = Object.assign(createAlert("default"), {
-	destructive: createAlert("destructive"),
-});
-
 export { Alerter, alert };
+export type { AlertAction, AlertActionVariant, AlertOptions };

--- a/packages/ui/src/atoms/Alert/Alert.tsx
+++ b/packages/ui/src/atoms/Alert/Alert.tsx
@@ -26,6 +26,9 @@ type AlertOptions = {
 	title: string;
 	description: string;
 	actions: AlertAction[];
+	/** Called when the dialog is dismissed via ESC or overlay click
+	 *  (i.e. without clicking any action button). */
+	onDismiss?: () => void;
 };
 
 let showAlertFn: ((options: AlertOptions) => void) | null = null;
@@ -54,11 +57,13 @@ const Alerter = () => {
 	};
 
 	const handleClose = () => {
+		alertOptions?.onDismiss?.();
 		setIsOpen(false);
 	};
 
 	if (!alertOptions) return null;
 
+	// Reverse so callers write [Cancel, Primary] but UI shows [Primary, Cancel]
 	const actions = [...alertOptions.actions].reverse();
 
 	return (

--- a/packages/ui/src/atoms/Alert/index.ts
+++ b/packages/ui/src/atoms/Alert/index.ts
@@ -1,1 +1,2 @@
+export type { AlertAction, AlertActionVariant, AlertOptions } from "./Alert";
 export { Alerter, alert } from "./Alert";

--- a/packages/workspace-client/src/hooks/useFileTree/useFileTree.ts
+++ b/packages/workspace-client/src/hooks/useFileTree/useFileTree.ts
@@ -28,6 +28,7 @@ export interface UseFileTreeResult {
 	toggle: (path: string) => Promise<void>;
 	refreshAll: () => Promise<void>;
 	refreshPath: (path: string) => Promise<void>;
+	reveal: (path: string) => Promise<void>;
 }
 
 interface FileTreeState {
@@ -214,10 +215,10 @@ export function useFileTree({
 			});
 
 			try {
-				const result = await utils.filesystem.listDirectory.fetch({
-					workspaceId,
-					absolutePath,
-				});
+				const result = await utils.filesystem.listDirectory.fetch(
+				{ workspaceId, absolutePath },
+				{ staleTime: 0 },
+			);
 
 				updateState((current) => {
 					const nextEntries = new Map(current.entriesByPath);
@@ -479,6 +480,27 @@ export function useFileTree({
 		state.loadingDirectories,
 	]);
 
+	const reveal = useCallback(
+		async (absolutePath: string): Promise<void> => {
+			if (!rootPath || !absolutePath.startsWith(rootPath)) return;
+
+			// Collect ancestor directories from rootPath down to the parent of the target
+			const ancestors: string[] = [];
+			let current = getParentPath(absolutePath);
+			while (current.length >= rootPath.length && current !== absolutePath) {
+				ancestors.unshift(current);
+				if (current === rootPath) break;
+				current = getParentPath(current);
+			}
+
+			// Expand all ancestors and load their contents
+			for (const dir of ancestors) {
+				await expand(dir);
+			}
+		},
+		[expand, rootPath],
+	);
+
 	return {
 		isLoadingRoot: state.loadingDirectories.has(rootPath),
 		collapseAll,
@@ -488,5 +510,6 @@ export function useFileTree({
 		toggle,
 		refreshAll,
 		refreshPath,
+		reveal,
 	};
 }

--- a/packages/workspace-fs/src/fuzzy-scorer.ts
+++ b/packages/workspace-fs/src/fuzzy-scorer.ts
@@ -1,0 +1,903 @@
+/**
+ * Fuzzy file search scorer — ported from VS Code.
+ *
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ * See https://github.com/microsoft/vscode/blob/main/LICENSE.txt
+ *
+ * Source files:
+ * - https://github.com/microsoft/vscode/blob/main/src/vs/base/common/fuzzyScorer.ts
+ * - https://github.com/microsoft/vscode/blob/main/src/vs/base/common/filters.ts (matchesPrefix)
+ * - https://github.com/microsoft/vscode/blob/main/src/vs/base/common/comparers.ts (compareAnything)
+ *
+ * VS Code-specific imports (CharCode, filters, comparers, platform, etc.) are
+ * inlined below. The scoring algorithm is unchanged.
+ */
+
+// ---------------------------------------------------------------------------
+// Inlined dependencies from VS Code
+// ---------------------------------------------------------------------------
+
+function isUpper(charCode: number): boolean {
+	return charCode >= 65 && charCode <= 90; // A-Z
+}
+
+enum CharCode {
+	Slash = 47,
+	Backslash = 92,
+	Underline = 95,
+	Dash = 45,
+	Period = 46,
+	Space = 32,
+	SingleQuote = 39,
+	DoubleQuote = 34,
+	Colon = 58,
+}
+
+/** Path separator — always `/` for our use case (all paths are normalized to forward slashes). */
+const sep = "/";
+
+interface IMatch {
+	start: number;
+	end: number;
+}
+
+/** Case-insensitive prefix check (inlined from VS Code's strings.ts / filters.ts). */
+function matchesPrefix(
+	word: string,
+	wordToMatchAgainst: string,
+): IMatch[] | null {
+	if (!wordToMatchAgainst || wordToMatchAgainst.length < word.length) {
+		return null;
+	}
+
+	if (!wordToMatchAgainst.toLowerCase().startsWith(word.toLowerCase())) {
+		return null;
+	}
+
+	return word.length > 0 ? [{ start: 0, end: word.length }] : [];
+}
+
+/** Inlined from VS Code's comparers.ts */
+function compareByPrefix(one: string, other: string, lookFor: string): number {
+	const elementAName = one.toLowerCase();
+	const elementBName = other.toLowerCase();
+
+	const elementAPrefixMatch = elementAName.startsWith(lookFor);
+	const elementBPrefixMatch = elementBName.startsWith(lookFor);
+	if (elementAPrefixMatch !== elementBPrefixMatch) {
+		return elementAPrefixMatch ? -1 : 1;
+	}
+
+	if (elementAPrefixMatch && elementBPrefixMatch) {
+		if (elementAName.length < elementBName.length) {
+			return -1;
+		}
+		if (elementAName.length > elementBName.length) {
+			return 1;
+		}
+	}
+
+	return 0;
+}
+
+function compareAnything(one: string, other: string, lookFor: string): number {
+	const elementAName = one.toLowerCase();
+	const elementBName = other.toLowerCase();
+
+	const prefixCompare = compareByPrefix(one, other, lookFor);
+	if (prefixCompare) {
+		return prefixCompare;
+	}
+
+	const elementASuffixMatch = elementAName.endsWith(lookFor);
+	const elementBSuffixMatch = elementBName.endsWith(lookFor);
+	if (elementASuffixMatch !== elementBSuffixMatch) {
+		return elementASuffixMatch ? -1 : 1;
+	}
+
+	return elementAName.localeCompare(elementBName);
+}
+
+// ---------------------------------------------------------------------------
+// #region Fuzzy scorer (from VS Code fuzzyScorer.ts)
+// ---------------------------------------------------------------------------
+
+export type FuzzyScore = [number /* score */, number[] /* match positions */];
+export type FuzzyScorerCache = { [key: string]: IItemScore };
+
+const NO_MATCH = 0;
+const NO_SCORE: FuzzyScore = [NO_MATCH, []];
+
+export function scoreFuzzy(
+	target: string,
+	query: string,
+	queryLower: string,
+	allowNonContiguousMatches: boolean,
+): FuzzyScore {
+	if (!target || !query) {
+		return NO_SCORE;
+	}
+
+	const targetLength = target.length;
+	const queryLength = query.length;
+
+	if (targetLength < queryLength) {
+		return NO_SCORE;
+	}
+
+	const targetLower = target.toLowerCase();
+	return doScoreFuzzy(
+		query,
+		queryLower,
+		queryLength,
+		target,
+		targetLower,
+		targetLength,
+		allowNonContiguousMatches,
+	);
+}
+
+function doScoreFuzzy(
+	query: string,
+	queryLower: string,
+	queryLength: number,
+	target: string,
+	targetLower: string,
+	targetLength: number,
+	allowNonContiguousMatches: boolean,
+): FuzzyScore {
+	const scores: number[] = [];
+	const matches: number[] = [];
+
+	for (let queryIndex = 0; queryIndex < queryLength; queryIndex++) {
+		const queryIndexOffset = queryIndex * targetLength;
+		const queryIndexPreviousOffset = queryIndexOffset - targetLength;
+
+		const queryIndexGtNull = queryIndex > 0;
+
+		// biome-ignore lint/style/noNonNullAssertion: ported from VS Code — index in bounds by loop
+		const queryCharAtIndex = query[queryIndex]!;
+		// biome-ignore lint/style/noNonNullAssertion: ported from VS Code
+		const queryLowerCharAtIndex = queryLower[queryIndex]!;
+
+		for (let targetIndex = 0; targetIndex < targetLength; targetIndex++) {
+			const targetIndexGtNull = targetIndex > 0;
+
+			const currentIndex = queryIndexOffset + targetIndex;
+			const leftIndex = currentIndex - 1;
+			const diagIndex = queryIndexPreviousOffset + targetIndex - 1;
+
+			const leftScore = targetIndexGtNull ? (scores[leftIndex] ?? 0) : 0;
+			const diagScore =
+				queryIndexGtNull && targetIndexGtNull ? (scores[diagIndex] ?? 0) : 0;
+
+			const matchesSequenceLength =
+				queryIndexGtNull && targetIndexGtNull ? (matches[diagIndex] ?? 0) : 0;
+
+			let score: number;
+			if (!diagScore && queryIndexGtNull) {
+				score = 0;
+			} else {
+				score = computeCharScore(
+					queryCharAtIndex,
+					queryLowerCharAtIndex,
+					target,
+					targetLower,
+					targetIndex,
+					matchesSequenceLength,
+				);
+			}
+
+			const isValidScore = score && diagScore + score >= leftScore;
+			if (
+				isValidScore &&
+				(allowNonContiguousMatches ||
+					queryIndexGtNull ||
+					targetLower.startsWith(queryLower, targetIndex))
+			) {
+				matches[currentIndex] = matchesSequenceLength + 1;
+				scores[currentIndex] = diagScore + score;
+			} else {
+				matches[currentIndex] = NO_MATCH;
+				scores[currentIndex] = leftScore;
+			}
+		}
+	}
+
+	const positions: number[] = [];
+	let queryIndex = queryLength - 1;
+	let targetIndex = targetLength - 1;
+	while (queryIndex >= 0 && targetIndex >= 0) {
+		const currentIndex = queryIndex * targetLength + targetIndex;
+		const match = matches[currentIndex];
+		if (match === NO_MATCH) {
+			targetIndex--;
+		} else {
+			positions.push(targetIndex);
+			queryIndex--;
+			targetIndex--;
+		}
+	}
+
+	return [scores[queryLength * targetLength - 1] ?? 0, positions.reverse()];
+}
+
+function computeCharScore(
+	queryCharAtIndex: string,
+	queryLowerCharAtIndex: string,
+	target: string,
+	targetLower: string,
+	targetIndex: number,
+	matchesSequenceLength: number,
+): number {
+	let score = 0;
+
+	// biome-ignore lint/style/noNonNullAssertion: ported from VS Code — index in bounds by loop
+	if (!considerAsEqual(queryLowerCharAtIndex, targetLower[targetIndex]!)) {
+		return score;
+	}
+
+	// Character match bonus
+	score += 1;
+
+	// Consecutive match bonus
+	if (matchesSequenceLength > 0) {
+		score +=
+			Math.min(matchesSequenceLength, 3) * 6 +
+			Math.max(0, matchesSequenceLength - 3) * 3;
+	}
+
+	// Same case bonus
+	if (queryCharAtIndex === target[targetIndex]) {
+		score += 1;
+	}
+
+	// Start of word bonus
+	if (targetIndex === 0) {
+		score += 8;
+	} else {
+		// After separator bonus
+		const separatorBonus = scoreSeparatorAtPos(
+			target.charCodeAt(targetIndex - 1),
+		);
+		if (separatorBonus) {
+			score += separatorBonus;
+		}
+		// Inside word upper case bonus (camelCase), only if not in a contiguous sequence
+		else if (
+			isUpper(target.charCodeAt(targetIndex)) &&
+			matchesSequenceLength === 0
+		) {
+			score += 2;
+		}
+	}
+
+	return score;
+}
+
+function considerAsEqual(a: string, b: string): boolean {
+	if (a === b) {
+		return true;
+	}
+
+	if (a === "/" || a === "\\") {
+		return b === "/" || b === "\\";
+	}
+
+	return false;
+}
+
+function scoreSeparatorAtPos(charCode: number): number {
+	switch (charCode) {
+		case CharCode.Slash:
+		case CharCode.Backslash:
+			return 5;
+		case CharCode.Underline:
+		case CharCode.Dash:
+		case CharCode.Period:
+		case CharCode.Space:
+		case CharCode.SingleQuote:
+		case CharCode.DoubleQuote:
+		case CharCode.Colon:
+			return 4;
+		default:
+			return 0;
+	}
+}
+
+// #endregion
+
+// ---------------------------------------------------------------------------
+// #region Item (label, description, path) scorer
+// ---------------------------------------------------------------------------
+
+export interface IItemScore {
+	score: number;
+	labelMatch?: IMatch[];
+	descriptionMatch?: IMatch[];
+}
+
+const NO_ITEM_SCORE = Object.freeze<IItemScore>({ score: 0 });
+
+export interface IItemAccessor<T> {
+	getItemLabel(item: T): string | undefined;
+	getItemDescription(item: T): string | undefined;
+	getItemPath(file: T): string | undefined;
+}
+
+const PATH_IDENTITY_SCORE = 1 << 18;
+const LABEL_PREFIX_SCORE_THRESHOLD = 1 << 17;
+const LABEL_SCORE_THRESHOLD = 1 << 16;
+
+export function scoreItemFuzzy<T>(
+	item: T,
+	query: IPreparedQuery,
+	allowNonContiguousMatches: boolean,
+	accessor: IItemAccessor<T>,
+	cache: FuzzyScorerCache,
+): IItemScore {
+	if (!item || !query.normalized) {
+		return NO_ITEM_SCORE;
+	}
+
+	const label = accessor.getItemLabel(item);
+	if (!label) {
+		return NO_ITEM_SCORE;
+	}
+
+	const description = accessor.getItemDescription(item);
+
+	const cacheHash = `${label}${description ?? ""}${allowNonContiguousMatches}${query.normalized}`;
+	const cached = cache[cacheHash];
+	if (cached) {
+		return cached;
+	}
+
+	const itemScore = doScoreItemFuzzy(
+		label,
+		description,
+		accessor.getItemPath(item),
+		query,
+		allowNonContiguousMatches,
+	);
+	cache[cacheHash] = itemScore;
+
+	return itemScore;
+}
+
+function doScoreItemFuzzy(
+	label: string,
+	description: string | undefined,
+	path: string | undefined,
+	query: IPreparedQuery,
+	allowNonContiguousMatches: boolean,
+): IItemScore {
+	const preferLabelMatches = !path || !query.containsPathSeparator;
+
+	// Treat identity matches on full path highest
+	if (path && query.pathNormalized === path) {
+		return {
+			score: PATH_IDENTITY_SCORE,
+			labelMatch: [{ start: 0, end: label.length }],
+			descriptionMatch: description
+				? [{ start: 0, end: description.length }]
+				: undefined,
+		};
+	}
+
+	// Score: multiple inputs
+	if (query.values && query.values.length > 1) {
+		return doScoreItemFuzzyMultiple(
+			label,
+			description,
+			path,
+			query.values,
+			preferLabelMatches,
+			allowNonContiguousMatches,
+		);
+	}
+
+	// Score: single input
+	return doScoreItemFuzzySingle(
+		label,
+		description,
+		path,
+		query,
+		preferLabelMatches,
+		allowNonContiguousMatches,
+	);
+}
+
+function doScoreItemFuzzyMultiple(
+	label: string,
+	description: string | undefined,
+	path: string | undefined,
+	query: IPreparedQueryPiece[],
+	preferLabelMatches: boolean,
+	allowNonContiguousMatches: boolean,
+): IItemScore {
+	let totalScore = 0;
+	const totalLabelMatches: IMatch[] = [];
+	const totalDescriptionMatches: IMatch[] = [];
+
+	for (const queryPiece of query) {
+		const { score, labelMatch, descriptionMatch } = doScoreItemFuzzySingle(
+			label,
+			description,
+			path,
+			queryPiece,
+			preferLabelMatches,
+			allowNonContiguousMatches,
+		);
+		if (score === NO_MATCH) {
+			return NO_ITEM_SCORE;
+		}
+
+		totalScore += score;
+		if (labelMatch) {
+			totalLabelMatches.push(...labelMatch);
+		}
+		if (descriptionMatch) {
+			totalDescriptionMatches.push(...descriptionMatch);
+		}
+	}
+
+	return {
+		score: totalScore,
+		labelMatch: normalizeMatches(totalLabelMatches),
+		descriptionMatch: normalizeMatches(totalDescriptionMatches),
+	};
+}
+
+function doScoreItemFuzzySingle(
+	label: string,
+	description: string | undefined,
+	path: string | undefined,
+	query: IPreparedQueryPiece,
+	preferLabelMatches: boolean,
+	allowNonContiguousMatches: boolean,
+): IItemScore {
+	// Prefer label matches if told so or we have no description
+	if (preferLabelMatches || !description) {
+		const [labelScore, labelPositions] = scoreFuzzy(
+			label,
+			query.normalized,
+			query.normalizedLowercase,
+			allowNonContiguousMatches && !query.expectContiguousMatch,
+		);
+		if (labelScore) {
+			const labelPrefixMatch = matchesPrefix(query.normalized, label);
+			let baseScore: number;
+			if (labelPrefixMatch) {
+				baseScore = LABEL_PREFIX_SCORE_THRESHOLD;
+
+				// Boost labels that are short (e.g. "window.ts" > "windowActions.ts" for query "window")
+				const prefixLengthBoost = Math.round(
+					(query.normalized.length / label.length) * 100,
+				);
+				baseScore += prefixLengthBoost;
+			} else {
+				baseScore = LABEL_SCORE_THRESHOLD;
+			}
+
+			return {
+				score: baseScore + labelScore,
+				labelMatch: labelPrefixMatch || createMatches(labelPositions),
+			};
+		}
+	}
+
+	// Finally compute description + label scores if we have a description
+	if (description) {
+		let descriptionPrefix = description;
+		if (path) {
+			descriptionPrefix = `${description}${sep}`;
+		}
+
+		const descriptionPrefixLength = descriptionPrefix.length;
+		const descriptionAndLabel = `${descriptionPrefix}${label}`;
+
+		const [labelDescriptionScore, labelDescriptionPositions] = scoreFuzzy(
+			descriptionAndLabel,
+			query.normalized,
+			query.normalizedLowercase,
+			allowNonContiguousMatches && !query.expectContiguousMatch,
+		);
+		if (labelDescriptionScore) {
+			const labelDescriptionMatches = createMatches(labelDescriptionPositions);
+			const labelMatch: IMatch[] = [];
+			const descriptionMatch: IMatch[] = [];
+
+			for (const h of labelDescriptionMatches) {
+				if (
+					h.start < descriptionPrefixLength &&
+					h.end > descriptionPrefixLength
+				) {
+					labelMatch.push({ start: 0, end: h.end - descriptionPrefixLength });
+					descriptionMatch.push({
+						start: h.start,
+						end: descriptionPrefixLength,
+					});
+				} else if (h.start >= descriptionPrefixLength) {
+					labelMatch.push({
+						start: h.start - descriptionPrefixLength,
+						end: h.end - descriptionPrefixLength,
+					});
+				} else {
+					descriptionMatch.push(h);
+				}
+			}
+
+			return { score: labelDescriptionScore, labelMatch, descriptionMatch };
+		}
+	}
+
+	return NO_ITEM_SCORE;
+}
+
+function createMatches(offsets: number[] | undefined): IMatch[] {
+	const ret: IMatch[] = [];
+	if (!offsets) {
+		return ret;
+	}
+
+	let last: IMatch | undefined;
+	for (const pos of offsets) {
+		if (last && last.end === pos) {
+			last.end += 1;
+		} else {
+			last = { start: pos, end: pos + 1 };
+			ret.push(last);
+		}
+	}
+
+	return ret;
+}
+
+function normalizeMatches(matches: IMatch[]): IMatch[] {
+	const sortedMatches = matches.sort(
+		(matchA, matchB) => matchA.start - matchB.start,
+	);
+
+	const normalizedMatches: IMatch[] = [];
+	let currentMatch: IMatch | undefined;
+	for (const match of sortedMatches) {
+		if (!currentMatch || !matchOverlaps(currentMatch, match)) {
+			currentMatch = match;
+			normalizedMatches.push(match);
+		} else {
+			currentMatch.start = Math.min(currentMatch.start, match.start);
+			currentMatch.end = Math.max(currentMatch.end, match.end);
+		}
+	}
+
+	return normalizedMatches;
+}
+
+function matchOverlaps(matchA: IMatch, matchB: IMatch): boolean {
+	if (matchA.end < matchB.start) {
+		return false;
+	}
+	if (matchB.end < matchA.start) {
+		return false;
+	}
+	return true;
+}
+
+// #endregion
+
+// ---------------------------------------------------------------------------
+// #region Comparers
+// ---------------------------------------------------------------------------
+
+export function compareItemsByFuzzyScore<T>(
+	itemA: T,
+	itemB: T,
+	query: IPreparedQuery,
+	allowNonContiguousMatches: boolean,
+	accessor: IItemAccessor<T>,
+	cache: FuzzyScorerCache,
+): number {
+	const itemScoreA = scoreItemFuzzy(
+		itemA,
+		query,
+		allowNonContiguousMatches,
+		accessor,
+		cache,
+	);
+	const itemScoreB = scoreItemFuzzy(
+		itemB,
+		query,
+		allowNonContiguousMatches,
+		accessor,
+		cache,
+	);
+
+	const scoreA = itemScoreA.score;
+	const scoreB = itemScoreB.score;
+
+	// 1.) identity matches have highest score
+	if (scoreA === PATH_IDENTITY_SCORE || scoreB === PATH_IDENTITY_SCORE) {
+		if (scoreA !== scoreB) {
+			return scoreA === PATH_IDENTITY_SCORE ? -1 : 1;
+		}
+	}
+
+	// 2.) matches on label are considered higher compared to label+description matches
+	if (scoreA > LABEL_SCORE_THRESHOLD || scoreB > LABEL_SCORE_THRESHOLD) {
+		if (scoreA !== scoreB) {
+			return scoreA > scoreB ? -1 : 1;
+		}
+
+		// prefer more compact matches over longer in label
+		if (
+			scoreA < LABEL_PREFIX_SCORE_THRESHOLD &&
+			scoreB < LABEL_PREFIX_SCORE_THRESHOLD
+		) {
+			const comparedByMatchLength = compareByMatchLength(
+				itemScoreA.labelMatch,
+				itemScoreB.labelMatch,
+			);
+			if (comparedByMatchLength !== 0) {
+				return comparedByMatchLength;
+			}
+		}
+
+		// prefer shorter labels over longer labels
+		const labelA = accessor.getItemLabel(itemA) || "";
+		const labelB = accessor.getItemLabel(itemB) || "";
+		if (labelA.length !== labelB.length) {
+			return labelA.length - labelB.length;
+		}
+	}
+
+	// 3.) compare by score in label+description
+	if (scoreA !== scoreB) {
+		return scoreA > scoreB ? -1 : 1;
+	}
+
+	// 4.) scores are identical: prefer matches in label over non-label matches
+	const itemAHasLabelMatches =
+		Array.isArray(itemScoreA.labelMatch) && itemScoreA.labelMatch.length > 0;
+	const itemBHasLabelMatches =
+		Array.isArray(itemScoreB.labelMatch) && itemScoreB.labelMatch.length > 0;
+	if (itemAHasLabelMatches && !itemBHasLabelMatches) {
+		return -1;
+	} else if (itemBHasLabelMatches && !itemAHasLabelMatches) {
+		return 1;
+	}
+
+	// 5.) scores are identical: prefer more compact matches (label and description)
+	const itemAMatchDistance = computeLabelAndDescriptionMatchDistance(
+		itemA,
+		itemScoreA,
+		accessor,
+	);
+	const itemBMatchDistance = computeLabelAndDescriptionMatchDistance(
+		itemB,
+		itemScoreB,
+		accessor,
+	);
+	if (
+		itemAMatchDistance &&
+		itemBMatchDistance &&
+		itemAMatchDistance !== itemBMatchDistance
+	) {
+		return itemBMatchDistance > itemAMatchDistance ? -1 : 1;
+	}
+
+	// 6.) scores are identical: start to use the fallback compare
+	return fallbackCompare(itemA, itemB, query, accessor);
+}
+
+function computeLabelAndDescriptionMatchDistance<T>(
+	item: T,
+	score: IItemScore,
+	accessor: IItemAccessor<T>,
+): number {
+	let matchStart = -1;
+	let matchEnd = -1;
+
+	if (score.descriptionMatch?.length) {
+		// biome-ignore lint/style/noNonNullAssertion: ported from VS Code — length already checked
+		matchStart = score.descriptionMatch[0]!.start;
+	} else if (score.labelMatch?.length) {
+		// biome-ignore lint/style/noNonNullAssertion: ported from VS Code — length already checked
+		matchStart = score.labelMatch[0]!.start;
+	}
+
+	if (score.labelMatch?.length) {
+		// biome-ignore lint/style/noNonNullAssertion: ported from VS Code — length already checked
+		matchEnd = score.labelMatch[score.labelMatch.length - 1]!.end;
+		if (score.descriptionMatch?.length) {
+			const itemDescription = accessor.getItemDescription(item);
+			if (itemDescription) {
+				matchEnd += itemDescription.length;
+			}
+		}
+	} else if (score.descriptionMatch?.length) {
+		// biome-ignore lint/style/noNonNullAssertion: ported from VS Code — length already checked
+		matchEnd = score.descriptionMatch[score.descriptionMatch.length - 1]!.end;
+	}
+
+	return matchEnd - matchStart;
+}
+
+function compareByMatchLength(
+	matchesA?: IMatch[],
+	matchesB?: IMatch[],
+): number {
+	if ((!matchesA && !matchesB) || (!matchesA?.length && !matchesB?.length)) {
+		return 0;
+	}
+
+	if (!matchesB?.length) {
+		return -1;
+	}
+
+	if (!matchesA?.length) {
+		return 1;
+	}
+
+	// biome-ignore lint/style/noNonNullAssertion: ported from VS Code — length already checked above
+	const matchStartA = matchesA[0]!.start;
+	// biome-ignore lint/style/noNonNullAssertion: ported from VS Code
+	const matchEndA = matchesA[matchesA.length - 1]!.end;
+	const matchLengthA = matchEndA - matchStartA;
+
+	// biome-ignore lint/style/noNonNullAssertion: ported from VS Code — length already checked above
+	const matchStartB = matchesB[0]!.start;
+	// biome-ignore lint/style/noNonNullAssertion: ported from VS Code
+	const matchEndB = matchesB[matchesB.length - 1]!.end;
+	const matchLengthB = matchEndB - matchStartB;
+
+	return matchLengthA === matchLengthB
+		? 0
+		: matchLengthB < matchLengthA
+			? 1
+			: -1;
+}
+
+function fallbackCompare<T>(
+	itemA: T,
+	itemB: T,
+	query: IPreparedQuery,
+	accessor: IItemAccessor<T>,
+): number {
+	const labelA = accessor.getItemLabel(itemA) || "";
+	const labelB = accessor.getItemLabel(itemB) || "";
+
+	const descriptionA = accessor.getItemDescription(itemA);
+	const descriptionB = accessor.getItemDescription(itemB);
+
+	const labelDescriptionALength =
+		labelA.length + (descriptionA ? descriptionA.length : 0);
+	const labelDescriptionBLength =
+		labelB.length + (descriptionB ? descriptionB.length : 0);
+
+	if (labelDescriptionALength !== labelDescriptionBLength) {
+		return labelDescriptionALength - labelDescriptionBLength;
+	}
+
+	const pathA = accessor.getItemPath(itemA);
+	const pathB = accessor.getItemPath(itemB);
+
+	if (pathA && pathB && pathA.length !== pathB.length) {
+		return pathA.length - pathB.length;
+	}
+
+	if (labelA !== labelB) {
+		return compareAnything(labelA, labelB, query.normalized);
+	}
+
+	if (descriptionA && descriptionB && descriptionA !== descriptionB) {
+		return compareAnything(descriptionA, descriptionB, query.normalized);
+	}
+
+	if (pathA && pathB && pathA !== pathB) {
+		return compareAnything(pathA, pathB, query.normalized);
+	}
+
+	return 0;
+}
+
+// #endregion
+
+// ---------------------------------------------------------------------------
+// #region Query normalizer
+// ---------------------------------------------------------------------------
+
+export interface IPreparedQueryPiece {
+	original: string;
+	originalLowercase: string;
+	pathNormalized: string;
+	normalized: string;
+	normalizedLowercase: string;
+	expectContiguousMatch: boolean;
+}
+
+export interface IPreparedQuery extends IPreparedQueryPiece {
+	values: IPreparedQueryPiece[] | undefined;
+	containsPathSeparator: boolean;
+}
+
+function queryExpectsExactMatch(query: string) {
+	return query.startsWith('"') && query.endsWith('"');
+}
+
+const MULTIPLE_QUERY_VALUES_SEPARATOR = " ";
+
+export function prepareQuery(original: string): IPreparedQuery {
+	if (typeof original !== "string") {
+		original = "";
+	}
+
+	const originalLowercase = original.toLowerCase();
+	const { pathNormalized, normalized, normalizedLowercase } =
+		normalizeQuery(original);
+	const containsPathSeparator = pathNormalized.indexOf(sep) >= 0;
+	const expectExactMatch = queryExpectsExactMatch(original);
+
+	let values: IPreparedQueryPiece[] | undefined;
+
+	const originalSplit = original.split(MULTIPLE_QUERY_VALUES_SEPARATOR);
+	if (originalSplit.length > 1) {
+		for (const originalPiece of originalSplit) {
+			const expectExactMatchPiece = queryExpectsExactMatch(originalPiece);
+			const {
+				pathNormalized: pathNormalizedPiece,
+				normalized: normalizedPiece,
+				normalizedLowercase: normalizedLowercasePiece,
+			} = normalizeQuery(originalPiece);
+
+			if (normalizedPiece) {
+				if (!values) {
+					values = [];
+				}
+
+				values.push({
+					original: originalPiece,
+					originalLowercase: originalPiece.toLowerCase(),
+					pathNormalized: pathNormalizedPiece,
+					normalized: normalizedPiece,
+					normalizedLowercase: normalizedLowercasePiece,
+					expectContiguousMatch: expectExactMatchPiece,
+				});
+			}
+		}
+	}
+
+	return {
+		original,
+		originalLowercase,
+		pathNormalized,
+		normalized,
+		normalizedLowercase,
+		values,
+		containsPathSeparator,
+		expectContiguousMatch: expectExactMatch,
+	};
+}
+
+function normalizeQuery(original: string): {
+	pathNormalized: string;
+	normalized: string;
+	normalizedLowercase: string;
+} {
+	// Normalize backslashes to forward slashes (we always use forward slashes)
+	const pathNormalized = original.replace(/\\/g, sep);
+
+	// Remove quotes, wildcards, whitespace, ellipsis, trailing hash
+	const normalized = pathNormalized
+		.replace(/[*\u2026\s"]/g, "")
+		.replace(/(?<=.)#$/, "");
+
+	return {
+		pathNormalized,
+		normalized,
+		normalizedLowercase: normalized.toLowerCase(),
+	};
+}
+
+// #endregion

--- a/packages/workspace-fs/src/search.ts
+++ b/packages/workspace-fs/src/search.ts
@@ -1128,22 +1128,6 @@ export async function searchFiles({
 	});
 	const safeLimit = safeSearchLimit(limit);
 
-	const exactMatches = collectExactFileSearchMatches({
-		index,
-		query: trimmedQuery,
-		pathMatcher,
-		limit: safeLimit,
-	});
-	if (exactMatches.length > 0) {
-		return exactMatches.map((result) => ({
-			absolutePath: result.item.absolutePath,
-			relativePath: result.item.relativePath,
-			name: result.item.name,
-			kind: "file" as const,
-			score: result.score,
-		}));
-	}
-
 	const searchableItems = pathMatcher.hasFilters
 		? index.items.filter((item) =>
 				matchesPathFilters(item.relativePath, pathMatcher),
@@ -1154,7 +1138,10 @@ export async function searchFiles({
 		return [];
 	}
 
-	// Use VS Code fuzzy scorer instead of Fuse.js for better path-aware matching
+	// Use VS Code fuzzy scorer for all file search (exact + fuzzy unified).
+	// The scorer naturally ranks exact matches highest, so no separate
+	// exact-match fast path is needed. This ensures consistent scoring
+	// across workspaces for cross-workspace ranking.
 	const prepared = prepareQuery(trimmedQuery);
 	const cache: FuzzyScorerCache = {};
 
@@ -1183,17 +1170,12 @@ export async function searchFiles({
 		),
 	);
 
-	// Normalize fuzzy scores to 0..1 range to be compatible with exact match
-	// scores (0.985-1.0). This ensures cross-workspace score sorting works
-	// correctly when mixing exact and fuzzy results.
-	const maxScore = scored[0]?.score ?? 1;
-
 	return scored.slice(0, safeLimit).map((result) => ({
 		absolutePath: result.item.absolutePath,
 		relativePath: result.item.relativePath,
 		name: result.item.name,
 		kind: "file" as const,
-		score: maxScore > 0 ? (result.score / maxScore) * 0.98 : 0,
+		score: result.score,
 	}));
 }
 

--- a/packages/workspace-fs/src/search.ts
+++ b/packages/workspace-fs/src/search.ts
@@ -4,6 +4,13 @@ import path from "node:path";
 import { promisify } from "node:util";
 import fg from "fast-glob";
 import Fuse from "fuse.js";
+import {
+	compareItemsByFuzzyScore,
+	type FuzzyScorerCache,
+	type IItemAccessor,
+	prepareQuery,
+	scoreItemFuzzy,
+} from "./fuzzy-scorer";
 import { readFile as readFsFile, writeFile as writeFsFile } from "./fs";
 import {
 	isPathWithinRoot,
@@ -43,6 +50,8 @@ interface SearchIndexEntry {
 	absolutePath: string;
 	relativePath: string;
 	name: string;
+	/** Parent directory path (pre-computed for fuzzy scorer). */
+	description: string | undefined;
 	lowerName: string;
 	lowerRelativePath: string;
 	compactName: string;
@@ -176,6 +185,7 @@ function createSearchIndexEntry(
 		path.join(rootPath, normalizedRelativePath),
 	);
 	const name = path.basename(normalizedRelativePath);
+	const dir = normalizedRelativePath.slice(0, -(name.length + 1));
 	const lowerName = name.toLowerCase();
 	const lowerRelativePath = normalizedRelativePath.toLowerCase();
 
@@ -183,6 +193,7 @@ function createSearchIndexEntry(
 		absolutePath,
 		relativePath: normalizedRelativePath,
 		name,
+		description: dir || undefined,
 		lowerName,
 		lowerRelativePath,
 		compactName: normalizeSearchText(name),
@@ -1082,6 +1093,18 @@ export function patchSearchIndexesForRoot(
 	}
 }
 
+const searchEntryAccessor: IItemAccessor<SearchIndexEntry> = {
+	getItemLabel(item) {
+		return item.name;
+	},
+	getItemDescription(item) {
+		return item.description;
+	},
+	getItemPath(item) {
+		return item.relativePath;
+	},
+};
+
 export async function searchFiles({
 	rootPath,
 	query,
@@ -1131,19 +1154,41 @@ export async function searchFiles({
 		return [];
 	}
 
-	const fuse = pathMatcher.hasFilters
-		? createFileSearchFuse(searchableItems)
-		: index.fuse;
-	const results = fuse.search(trimmedQuery, {
-		limit: safeLimit,
-	});
+	// Use VS Code fuzzy scorer instead of Fuse.js for better path-aware matching
+	const prepared = prepareQuery(trimmedQuery);
+	const cache: FuzzyScorerCache = {};
 
-	return results.map((result) => ({
+	const scored: Array<{ item: SearchIndexEntry; score: number }> = [];
+	for (const item of searchableItems) {
+		const itemScore = scoreItemFuzzy(
+			item,
+			prepared,
+			true,
+			searchEntryAccessor,
+			cache,
+		);
+		if (itemScore.score > 0) {
+			scored.push({ item, score: itemScore.score });
+		}
+	}
+
+	scored.sort((a, b) =>
+		compareItemsByFuzzyScore(
+			a.item,
+			b.item,
+			prepared,
+			true,
+			searchEntryAccessor,
+			cache,
+		),
+	);
+
+	return scored.slice(0, safeLimit).map((result) => ({
 		absolutePath: result.item.absolutePath,
 		relativePath: result.item.relativePath,
 		name: result.item.name,
 		kind: "file" as const,
-		score: 1 - (result.score ?? 0),
+		score: result.score,
 	}));
 }
 

--- a/packages/workspace-fs/src/search.ts
+++ b/packages/workspace-fs/src/search.ts
@@ -1186,7 +1186,7 @@ export async function searchFiles({
 	// Normalize fuzzy scores to 0..1 range to be compatible with exact match
 	// scores (0.985-1.0). This ensures cross-workspace score sorting works
 	// correctly when mixing exact and fuzzy results.
-	const maxScore = scored.length > 0 ? scored[0].score : 1;
+	const maxScore = scored[0]?.score ?? 1;
 
 	return scored.slice(0, safeLimit).map((result) => ({
 		absolutePath: result.item.absolutePath,

--- a/packages/workspace-fs/src/search.ts
+++ b/packages/workspace-fs/src/search.ts
@@ -1183,12 +1183,17 @@ export async function searchFiles({
 		),
 	);
 
+	// Normalize fuzzy scores to 0..1 range to be compatible with exact match
+	// scores (0.985-1.0). This ensures cross-workspace score sorting works
+	// correctly when mixing exact and fuzzy results.
+	const maxScore = scored.length > 0 ? scored[0].score : 1;
+
 	return scored.slice(0, safeLimit).map((result) => ({
 		absolutePath: result.item.absolutePath,
 		relativePath: result.item.relativePath,
 		name: result.item.name,
 		kind: "file" as const,
-		score: result.score,
+		score: maxScore > 0 ? (result.score / maxScore) * 0.98 : 0,
 	}));
 }
 


### PR DESCRIPTION
## Summary

upstream (superset-sh/superset) から要検討カテゴリの全コミットを取り込み。
PR #83（安全11件）、PR #84（fuzzy scorer + ターミナル系）の続き。

### このPRに含まれる変更

#### PR #84と同じ内容
- **N6**: VS Code fuzzy scorer完全統一（exact match fast path削除）
- **G2→N8→N10→N14**: ターミナル系チェーン + Host Service分離
- レビュー修正（workspaceName, prepareQuit("stop"), TerminalPaneDataフォールバック, macOS cleanupMainWindowResources）

#### 新規: ファイルツリー系チェーン (G3+N11)
- **Alert API移行**: `onConfirm/onCancel` → `actions[]`配列。全8 call site移行
- **PaneDefinition拡張**: `onHeaderClick`, `onBeforeClose`追加
- **setPanePinned簡素化**: `tabId`引数削除
- **useFileTree.reveal()**: ファイル選択時にツリー内自動スクロール
- **FilePane + 4 Renderers**: Code(Monaco)/Markdown(TipTap)/Image + SpreadsheetViewer(フォーク独自)
- **WorkspaceSidebar**: タブ型UI (Files/Changes/Checks)
- **FilesTab**: 再帰ファイルツリー、inline create/rename/delete、コンテキストメニュー(Reveal in Finder, Copy Path等)
- **page.tsx**: ResizablePanelGroup + sidebar toggle (Cmd+L)

#### フォーク独自機能の維持
- SpreadsheetViewer: FilePane内でisSpreadsheetFile判定→専用Viewerへ振り分け
- SyncService: GitHub APIポーリングのバックエンド集中管理
- IS_FORK: auto-updater独自リリースチェック
- app-commandハンドラ: マウス戻る/進むボタン対応

#### レビュー指摘対応
- SpreadsheetViewerの到達パス修正（useFileDocumentの2MB制限をバイパス）
- Save未実装ボタン→「Discard Changes」に変更（データ消失誤認防止）
- PaneHeader onClickバブリング修正（ボタン内クリックでpinされない）

### 既知の未対応事項（upstream由来）
- terminal_sessions reconciliation未実装
- health.info publicProcedure（localhost限定）
- readManifest()値検証なし
- FilesTab 562行（分割は次回）

## Test plan
- [ ] デスクトップアプリのビルド確認
- [ ] v2ワークスペースでファイルツリーサイドバー表示確認 (Cmd+L toggle)
- [ ] ファイルツリーからのファイル開閉（コード/Markdown/画像/スプレッドシート）
- [ ] ファイルのinline作成/リネーム/削除
- [ ] コンテキストメニュー（Reveal in Finder, Copy Path）
- [ ] 未保存ファイル閉じる時の「Discard Changes」確認ダイアログ
- [ ] ターミナル起動・タブ切替後の出力保持
- [ ] ファイル検索（Cmd+P）の動作・精度確認
- [ ] macOS hide-to-tray→再オープン→ポート競合なし
- [ ] 旧バージョンからのアップグレード（TerminalPaneDataフォールバック）