### PR TITLE
fix: LSP language services の安定性不具合5件を修正

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/github/repo-context.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/github/repo-context.ts
@@ -21,15 +21,21 @@ async function refreshRepoContext(
 		}
 
 		const data = result.data;
-		let context: RepoContext;
+		let context: RepoContext | undefined;
 
 		if (data.isFork && data.parent) {
-			context = {
-				repoUrl: data.url,
-				upstreamUrl: data.parent.url,
-				isFork: true,
-			};
-		} else {
+			const upstreamUrl =
+				data.parent.url ??
+				(data.parent.owner?.login && data.parent.name
+					? `https://github.com/${data.parent.owner.login}/${data.parent.name}`
+					: null);
+
+			if (upstreamUrl) {
+				context = { repoUrl: data.url, upstreamUrl, isFork: true };
+			}
+		}
+
+		if (!context) {
 			const originUrl = await getOriginUrl(worktreePath);
 			const ghUrl = normalizeGitHubUrl(data.url);
 

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/github/repo-context.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/github/repo-context.ts
@@ -45,11 +45,19 @@ async function refreshRepoContext(
 					upstreamUrl: ghUrl,
 					isFork: true,
 				};
+			} else if (data.isFork) {
+				// Fork but upstream URL could not be determined — surface as error
+				// rather than silently treating as non-fork (which would misdirect PRs)
+				console.warn(
+					"[GitHub] Fork detected but upstream URL could not be resolved",
+					{ url: data.url },
+				);
+				return null;
 			} else {
 				context = {
 					repoUrl: data.url,
 					upstreamUrl: data.url,
-					isFork: data.isFork,
+					isFork: false,
 				};
 			}
 		}

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/github/types.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/github/types.ts
@@ -185,7 +185,14 @@ export const GHPRResponseSchema = z.object({
 export const GHRepoResponseSchema = z.object({
 	url: z.string(),
 	isFork: z.boolean().optional().default(false),
-	parent: z.object({ url: z.string() }).nullable().optional(),
+	parent: z
+		.object({
+			url: z.string().optional(),
+			name: z.string().optional(),
+			owner: z.object({ login: z.string() }).optional(),
+		})
+		.nullable()
+		.optional(),
 });
 
 export interface RepoContext {

--- a/apps/desktop/src/main/lib/language-services/lsp/ExternalLspLanguageProvider.ts
+++ b/apps/desktop/src/main/lib/language-services/lsp/ExternalLspLanguageProvider.ts
@@ -142,6 +142,8 @@ export class ExternalLspLanguageProvider implements LanguageServiceProvider {
 
 	private readonly sessions = new Map<string, WorkspaceSession>();
 
+	private readonly pendingSessions = new Map<string, Promise<WorkspaceSession>>();
+
 	private readonly workspaceErrors = new Map<string, string | null>();
 
 	constructor(private readonly options: ExternalLspProviderOptions) {
@@ -339,6 +341,24 @@ export class ExternalLspLanguageProvider implements LanguageServiceProvider {
 			return existing;
 		}
 
+		const pending = this.pendingSessions.get(workspaceId);
+		if (pending) {
+			return pending;
+		}
+
+		const promise = this.initSession(workspaceId, workspacePath);
+		this.pendingSessions.set(workspaceId, promise);
+		try {
+			return await promise;
+		} finally {
+			this.pendingSessions.delete(workspaceId);
+		}
+	}
+
+	private async initSession(
+		workspaceId: string,
+		workspacePath: string,
+	): Promise<WorkspaceSession> {
 		const resolvedCommand = await this.options.resolveServerCommand({
 			workspaceId,
 			workspacePath,

--- a/apps/desktop/src/main/lib/language-services/lsp/StdioJsonRpcClient.ts
+++ b/apps/desktop/src/main/lib/language-services/lsp/StdioJsonRpcClient.ts
@@ -105,6 +105,8 @@ export class StdioJsonRpcClient {
 
 	private readonly pendingRequests = new Map<number, PendingRequest>();
 
+	private stopping = false;
+
 	constructor(private readonly options: StdioJsonRpcClientOptions) {}
 
 	async start(): Promise<void> {
@@ -197,39 +199,23 @@ export class StdioJsonRpcClient {
 	}
 
 	async stop(): Promise<void> {
-		if (!this.process) {
+		if (!this.process || this.stopping) {
 			return;
 		}
 
+		this.stopping = true;
 		const child = this.process;
 
 		// Attempt graceful LSP shutdown → exit before killing
 		try {
-			// Use a short dedicated timeout; writeMessage checks this.process,
-			// so keep it alive until after we send exit.
-			await Promise.race([
-				this.writeMessage({
-					jsonrpc: "2.0",
-					id: ++this.nextId,
-					method: "shutdown",
-					params: null,
-				}),
-				new Promise((_, reject) =>
-					setTimeout(
-						() => reject(new Error("shutdown write timed out")),
-						5_000,
-					),
-				),
-			]);
-			await this.writeMessage({
-				jsonrpc: "2.0",
-				method: "exit",
-			});
+			await this.request("shutdown", null, 5_000);
+			await this.notify("exit");
 		} catch {
 			// Graceful path failed — fall through to kill
 		}
 
 		this.process = null;
+		this.stopping = false;
 		child.removeAllListeners();
 		if (!child.killed) {
 			child.kill();

--- a/apps/desktop/src/main/lib/language-services/lsp/StdioJsonRpcClient.ts
+++ b/apps/desktop/src/main/lib/language-services/lsp/StdioJsonRpcClient.ts
@@ -64,9 +64,12 @@ function isJsonRpcRequestMessage(
 	return "id" in message && "method" in message;
 }
 
-function consumeMessage(
-	buffer: Buffer<ArrayBufferLike>,
-): { body: string; rest: Buffer<ArrayBufferLike> } | null {
+type ConsumeResult =
+	| { kind: "message"; body: string; rest: Buffer<ArrayBufferLike> }
+	| { kind: "skip"; rest: Buffer<ArrayBufferLike> }
+	| null;
+
+function consumeMessage(buffer: Buffer<ArrayBufferLike>): ConsumeResult {
 	const separatorIndex = buffer.indexOf("\r\n\r\n");
 	if (separatorIndex === -1) {
 		return null;
@@ -75,7 +78,8 @@ function consumeMessage(
 	const header = buffer.subarray(0, separatorIndex).toString("utf8");
 	const contentLengthMatch = /Content-Length:\s*(\d+)/i.exec(header);
 	if (!contentLengthMatch) {
-		return null;
+		// Invalid header — skip past the separator so the buffer can recover
+		return { kind: "skip", rest: buffer.subarray(separatorIndex + 4) };
 	}
 
 	const contentLength = Number(contentLengthMatch[1]);
@@ -86,6 +90,7 @@ function consumeMessage(
 	}
 
 	return {
+		kind: "message",
 		body: buffer.subarray(bodyStart, bodyEnd).toString("utf8"),
 		rest: buffer.subarray(bodyEnd),
 	};
@@ -143,16 +148,40 @@ export class StdioJsonRpcClient {
 		});
 	}
 
-	async request(method: string, params?: unknown): Promise<unknown> {
+	async request(
+		method: string,
+		params?: unknown,
+		timeoutMs = 30_000,
+	): Promise<unknown> {
 		const id = ++this.nextId;
 		return await new Promise<unknown>((resolve, reject) => {
-			this.pendingRequests.set(id, { resolve, reject });
+			const timer = setTimeout(() => {
+				this.pendingRequests.delete(id);
+				reject(
+					new Error(
+						`${this.options.name} request "${method}" timed out after ${timeoutMs}ms`,
+					),
+				);
+			}, timeoutMs);
+
+			this.pendingRequests.set(id, {
+				resolve: (value) => {
+					clearTimeout(timer);
+					resolve(value);
+				},
+				reject: (error) => {
+					clearTimeout(timer);
+					reject(error);
+				},
+			});
+
 			void this.writeMessage({
 				jsonrpc: "2.0",
 				id,
 				method,
 				params,
 			}).catch((error) => {
+				clearTimeout(timer);
 				this.pendingRequests.delete(id);
 				reject(error);
 			});
@@ -173,6 +202,33 @@ export class StdioJsonRpcClient {
 		}
 
 		const child = this.process;
+
+		// Attempt graceful LSP shutdown → exit before killing
+		try {
+			// Use a short dedicated timeout; writeMessage checks this.process,
+			// so keep it alive until after we send exit.
+			await Promise.race([
+				this.writeMessage({
+					jsonrpc: "2.0",
+					id: ++this.nextId,
+					method: "shutdown",
+					params: null,
+				}),
+				new Promise((_, reject) =>
+					setTimeout(
+						() => reject(new Error("shutdown write timed out")),
+						5_000,
+					),
+				),
+			]);
+			await this.writeMessage({
+				jsonrpc: "2.0",
+				method: "exit",
+			});
+		} catch {
+			// Graceful path failed — fall through to kill
+		}
+
 		this.process = null;
 		child.removeAllListeners();
 		if (!child.killed) {
@@ -188,18 +244,27 @@ export class StdioJsonRpcClient {
 	private handleStdout(chunk: Buffer<ArrayBufferLike>): void {
 		this.buffer = Buffer.concat([this.buffer, chunk]);
 		while (true) {
-			const message = consumeMessage(this.buffer);
-			if (!message) {
+			const result = consumeMessage(this.buffer);
+			if (!result) {
 				return;
 			}
 
-			this.buffer = message.rest;
-			if (!message.body.trim()) {
+			this.buffer = result.rest;
+
+			if (result.kind === "skip") {
+				console.warn(
+					"[language-services/lsp] Skipped invalid header block",
+					{ name: this.options.name },
+				);
+				continue;
+			}
+
+			if (!result.body.trim()) {
 				continue;
 			}
 
 			try {
-				const parsed = JSON.parse(message.body) as JsonRpcMessage;
+				const parsed = JSON.parse(result.body) as JsonRpcMessage;
 				this.handleMessage(parsed);
 			} catch (error) {
 				console.error(
@@ -207,7 +272,7 @@ export class StdioJsonRpcClient {
 					{
 						name: this.options.name,
 						error,
-						body: message.body,
+						body: result.body,
 					},
 				);
 			}

--- a/apps/desktop/src/main/lib/language-services/lsp/command-resolvers.ts
+++ b/apps/desktop/src/main/lib/language-services/lsp/command-resolvers.ts
@@ -84,6 +84,7 @@ export function resolveAvailableExecutable(
 				},
 				shell: candidate.shell,
 				stdio: "ignore",
+				timeout: 10_000,
 			},
 		);
 		if (probeResult.status !== 0) {

--- a/apps/desktop/src/main/lib/language-services/providers/dart/DartLanguageProvider.ts
+++ b/apps/desktop/src/main/lib/language-services/providers/dart/DartLanguageProvider.ts
@@ -60,10 +60,13 @@ type ResolvedDartCommand = {
 	shell: boolean;
 };
 
+const SPAWN_TIMEOUT_MS = 10_000;
+
 function canExecute(command: string, shell: boolean): boolean {
 	const probe = spawnSync(command, ["--version"], {
 		stdio: "ignore",
 		shell,
+		timeout: SPAWN_TIMEOUT_MS,
 	});
 	return probe.status === 0;
 }
@@ -98,6 +101,7 @@ function resolveFlutterSdkCommands(): string[] {
 	const locateResult = spawnSync(locateCommand, [flutterCommand], {
 		encoding: "utf8",
 		shell: process.platform === "win32",
+		timeout: SPAWN_TIMEOUT_MS,
 	});
 	if (locateResult.status !== 0 || !locateResult.stdout) {
 		return [];
@@ -187,6 +191,8 @@ export class DartLanguageProvider implements LanguageServiceProvider {
 	readonly languageIds = ["dart"];
 
 	private readonly sessions = new Map<string, WorkspaceSession>();
+
+	private readonly pendingSessions = new Map<string, Promise<WorkspaceSession>>();
 
 	private readonly workspaceErrors = new Map<string, string | null>();
 
@@ -371,6 +377,24 @@ export class DartLanguageProvider implements LanguageServiceProvider {
 			return existing;
 		}
 
+		const pending = this.pendingSessions.get(workspaceId);
+		if (pending) {
+			return pending;
+		}
+
+		const promise = this.initSession(workspaceId, workspacePath);
+		this.pendingSessions.set(workspaceId, promise);
+		try {
+			return await promise;
+		} finally {
+			this.pendingSessions.delete(workspaceId);
+		}
+	}
+
+	private async initSession(
+		workspaceId: string,
+		workspacePath: string,
+	): Promise<WorkspaceSession> {
 		const resolvedDartCommand = resolveDartCommand();
 		if (!resolvedDartCommand) {
 			const error =


### PR DESCRIPTION
## Summary
Closes #82
Closes #86

### repo-context ポーリング無限ループ修正 (#86)
フォークリポジトリで `gh repo view` の `parent.url` が欠落している場合に、repo-context のGitHub APIポーリングが無限ループする問題を修正。

### LSP language services 安定性不具合5件修正 (#82)
コード読解ベースの調査で発見されたdesktop LSP実装の高優先度不具合5件を修正。

- **ensureSession 二重起動競合**: `pendingSessions` Mapで初期化中のPromiseを共有し、同一workspaceIdへの並行呼び出しによるセッション重複起動を防止（ExternalLspLanguageProvider / DartLanguageProvider 両方）
- **stop() shutdown/exit 欠落**: LSP仕様に準拠した `shutdown` → `exit` → `kill` の正規終了シーケンスを追加（5秒タイムアウト付き）
- **request() タイムアウトなし**: 30秒デフォルトタイムアウトを追加し、応答なしrequestによるPromise無期限待機・pendingRequests蓄積を防止
- **consumeMessage() バッファ復帰不能**: 不正ヘッダ（Content-Length欠落等）時にセパレータ以降へバッファを進める `skip` 機構を追加し、受信処理の永久停止を防止
- **spawnSync 無タイムアウト**: `command-resolvers.ts` / `DartLanguageProvider.ts` の全 `spawnSync` 呼び出しに `timeout: 10_000` を追加し、Electronメインスレッドのフリーズを防止

## Test plan
- [ ] フォークリポジトリでGitタブのポーリングが安定していることを確認
- [ ] デスクトップアプリでLSP対応言語（TypeScript, Go, Dart等）のファイルを開き、diagnosticsが正常に表示されることを確認
- [ ] 複数ファイルを同時に開いた際にセッションが重複起動しないことを確認
- [ ] ワークスペースを閉じた際にLSPプロセスが正常終了することを確認
- [ ] LSPサーバーが未インストールの言語でエラーが適切に表示されることを確認