### PR TITLE
feat: Markdownおよび全言語のシンタックスハイライト強化

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -43,7 +43,7 @@ import {
 	reconcileDaemonSessions,
 } from "./lib/terminal";
 import { disposeTray, initTray } from "./lib/tray";
-import { MainWindow, cleanupMainWindowResources } from "./windows/main";
+import { cleanupMainWindowResources, MainWindow } from "./windows/main";
 
 console.log("[main] Local database ready:", !!localDb);
 const IS_DEV = process.env.NODE_ENV === "development";

--- a/apps/desktop/src/main/lib/language-services/lsp/ExternalLspLanguageProvider.ts
+++ b/apps/desktop/src/main/lib/language-services/lsp/ExternalLspLanguageProvider.ts
@@ -142,7 +142,10 @@ export class ExternalLspLanguageProvider implements LanguageServiceProvider {
 
 	private readonly sessions = new Map<string, WorkspaceSession>();
 
-	private readonly pendingSessions = new Map<string, Promise<WorkspaceSession>>();
+	private readonly pendingSessions = new Map<
+		string,
+		Promise<WorkspaceSession>
+	>();
 
 	private readonly workspaceErrors = new Map<string, string | null>();
 

--- a/apps/desktop/src/main/lib/language-services/lsp/StdioJsonRpcClient.ts
+++ b/apps/desktop/src/main/lib/language-services/lsp/StdioJsonRpcClient.ts
@@ -238,10 +238,9 @@ export class StdioJsonRpcClient {
 			this.buffer = result.rest;
 
 			if (result.kind === "skip") {
-				console.warn(
-					"[language-services/lsp] Skipped invalid header block",
-					{ name: this.options.name },
-				);
+				console.warn("[language-services/lsp] Skipped invalid header block", {
+					name: this.options.name,
+				});
 				continue;
 			}
 

--- a/apps/desktop/src/main/lib/language-services/providers/dart/DartLanguageProvider.ts
+++ b/apps/desktop/src/main/lib/language-services/providers/dart/DartLanguageProvider.ts
@@ -192,7 +192,10 @@ export class DartLanguageProvider implements LanguageServiceProvider {
 
 	private readonly sessions = new Map<string, WorkspaceSession>();
 
-	private readonly pendingSessions = new Map<string, Promise<WorkspaceSession>>();
+	private readonly pendingSessions = new Map<
+		string,
+		Promise<WorkspaceSession>
+	>();
 
 	private readonly workspaceErrors = new Map<string, string | null>();
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/FilePane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/FilePane.tsx
@@ -1,8 +1,12 @@
 import type { RendererContext } from "@superset/panes";
 import { useFileDocument } from "@superset/workspace-client";
 import { useCallback } from "react";
-import { isImageFile, isMarkdownFile, isSpreadsheetFile } from "shared/file-types";
 import { SpreadsheetViewer } from "renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/components/SpreadsheetViewer";
+import {
+	isImageFile,
+	isMarkdownFile,
+	isSpreadsheetFile,
+} from "shared/file-types";
 import type { FilePaneData, PaneViewerData } from "../../../../types";
 import { CodeRenderer } from "./renderers/CodeRenderer";
 import { ImageRenderer } from "./renderers/ImageRenderer";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
@@ -11,8 +11,8 @@ import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { useCallback, useEffect, useMemo } from "react";
 import { HiMiniXMark } from "react-icons/hi2";
 import { TbLayoutColumns, TbLayoutRows } from "react-icons/tb";
-import { addBrowserShortcutListener } from "renderer/lib/browser-shortcut-events";
 import { HotkeyLabel, useHotkey } from "renderer/hotkeys";
+import { addBrowserShortcutListener } from "renderer/lib/browser-shortcut-events";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 import {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/workspace/$workspaceId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/workspace/$workspaceId/page.tsx
@@ -9,8 +9,8 @@ import {
 import { useCallback, useEffect, useMemo } from "react";
 import { useCopyToClipboard } from "renderer/hooks/useCopyToClipboard";
 import { useFileOpenMode } from "renderer/hooks/useFileOpenMode";
-import { addBrowserShortcutListener } from "renderer/lib/browser-shortcut-events";
 import { useHotkey } from "renderer/hotkeys";
+import { addBrowserShortcutListener } from "renderer/lib/browser-shortcut-events";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { getWorkspaceDisplayName } from "renderer/lib/getWorkspaceDisplayName";
 import { electronTrpcClient as trpcClient } from "renderer/lib/trpc-client";
@@ -442,33 +442,51 @@ export function WorkspacePage({
 		{ enabled: isActive },
 	);
 
-	useHotkey("PREV_TAB", () => {
-		if (!activeTabId || tabs.length === 0) return;
-		const index = tabs.findIndex((t) => t.id === activeTabId);
-		const prevIndex = index <= 0 ? tabs.length - 1 : index - 1;
-		setActiveTab(workspaceId, tabs[prevIndex].id);
-	}, { enabled: isActive });
+	useHotkey(
+		"PREV_TAB",
+		() => {
+			if (!activeTabId || tabs.length === 0) return;
+			const index = tabs.findIndex((t) => t.id === activeTabId);
+			const prevIndex = index <= 0 ? tabs.length - 1 : index - 1;
+			setActiveTab(workspaceId, tabs[prevIndex].id);
+		},
+		{ enabled: isActive },
+	);
 
-	useHotkey("NEXT_TAB", () => {
-		if (!activeTabId || tabs.length === 0) return;
-		const index = tabs.findIndex((t) => t.id === activeTabId);
-		const nextIndex = index >= tabs.length - 1 || index === -1 ? 0 : index + 1;
-		setActiveTab(workspaceId, tabs[nextIndex].id);
-	}, { enabled: isActive });
+	useHotkey(
+		"NEXT_TAB",
+		() => {
+			if (!activeTabId || tabs.length === 0) return;
+			const index = tabs.findIndex((t) => t.id === activeTabId);
+			const nextIndex =
+				index >= tabs.length - 1 || index === -1 ? 0 : index + 1;
+			setActiveTab(workspaceId, tabs[nextIndex].id);
+		},
+		{ enabled: isActive },
+	);
 
-	useHotkey("PREV_TAB_ALT", () => {
-		if (!activeTabId || tabs.length === 0) return;
-		const index = tabs.findIndex((t) => t.id === activeTabId);
-		const prevIndex = index <= 0 ? tabs.length - 1 : index - 1;
-		setActiveTab(workspaceId, tabs[prevIndex].id);
-	}, { enabled: isActive });
+	useHotkey(
+		"PREV_TAB_ALT",
+		() => {
+			if (!activeTabId || tabs.length === 0) return;
+			const index = tabs.findIndex((t) => t.id === activeTabId);
+			const prevIndex = index <= 0 ? tabs.length - 1 : index - 1;
+			setActiveTab(workspaceId, tabs[prevIndex].id);
+		},
+		{ enabled: isActive },
+	);
 
-	useHotkey("NEXT_TAB_ALT", () => {
-		if (!activeTabId || tabs.length === 0) return;
-		const index = tabs.findIndex((t) => t.id === activeTabId);
-		const nextIndex = index >= tabs.length - 1 || index === -1 ? 0 : index + 1;
-		setActiveTab(workspaceId, tabs[nextIndex].id);
-	}, { enabled: isActive });
+	useHotkey(
+		"NEXT_TAB_ALT",
+		() => {
+			if (!activeTabId || tabs.length === 0) return;
+			const index = tabs.findIndex((t) => t.id === activeTabId);
+			const nextIndex =
+				index >= tabs.length - 1 || index === -1 ? 0 : index + 1;
+			setActiveTab(workspaceId, tabs[nextIndex].id);
+		},
+		{ enabled: isActive },
+	);
 
 	const switchToTab = useCallback(
 		(index: number) => {
@@ -490,21 +508,29 @@ export function WorkspacePage({
 	useHotkey("JUMP_TO_TAB_8", () => switchToTab(7), { enabled: isActive });
 	useHotkey("JUMP_TO_TAB_9", () => switchToTab(8), { enabled: isActive });
 
-	useHotkey("PREV_PANE", () => {
-		if (!activeTabId || !activeTab?.layout || !focusedPaneId) return;
-		const prevPaneId = getPreviousPaneId(activeTab.layout, focusedPaneId);
-		if (prevPaneId) {
-			setFocusedPane(activeTabId, prevPaneId);
-		}
-	}, { enabled: isActive });
+	useHotkey(
+		"PREV_PANE",
+		() => {
+			if (!activeTabId || !activeTab?.layout || !focusedPaneId) return;
+			const prevPaneId = getPreviousPaneId(activeTab.layout, focusedPaneId);
+			if (prevPaneId) {
+				setFocusedPane(activeTabId, prevPaneId);
+			}
+		},
+		{ enabled: isActive },
+	);
 
-	useHotkey("NEXT_PANE", () => {
-		if (!activeTabId || !activeTab?.layout || !focusedPaneId) return;
-		const nextPaneId = getNextPaneId(activeTab.layout, focusedPaneId);
-		if (nextPaneId) {
-			setFocusedPane(activeTabId, nextPaneId);
-		}
-	}, { enabled: isActive });
+	useHotkey(
+		"NEXT_PANE",
+		() => {
+			if (!activeTabId || !activeTab?.layout || !focusedPaneId) return;
+			const nextPaneId = getNextPaneId(activeTab.layout, focusedPaneId);
+			if (nextPaneId) {
+				setFocusedPane(activeTabId, nextPaneId);
+			}
+		},
+		{ enabled: isActive },
+	);
 
 	// Open in last used app shortcut
 	const projectId = workspace?.projectId;
@@ -645,15 +671,19 @@ export function WorkspacePage({
 	useHotkey("TOGGLE_SIDEBAR", () => toggleSidebar(), { enabled: isActive });
 
 	// Toggle expand/collapse sidebar (⌘⇧L)
-	useHotkey("TOGGLE_EXPAND_SIDEBAR", () => {
-		if (!isSidebarOpen) {
-			setSidebarOpen(true);
-			setSidebarMode(SidebarMode.Changes);
-		} else {
-			const isExpanded = currentSidebarMode === SidebarMode.Changes;
-			setSidebarMode(isExpanded ? SidebarMode.Tabs : SidebarMode.Changes);
-		}
-	}, { enabled: isActive });
+	useHotkey(
+		"TOGGLE_EXPAND_SIDEBAR",
+		() => {
+			if (!isSidebarOpen) {
+				setSidebarOpen(true);
+				setSidebarMode(SidebarMode.Changes);
+			} else {
+				const isExpanded = currentSidebarMode === SidebarMode.Changes;
+				setSidebarMode(isExpanded ? SidebarMode.Tabs : SidebarMode.Changes);
+			}
+		},
+		{ enabled: isActive },
+	);
 
 	// Pane splitting helper - resolves target pane for split operations
 	const resolveSplitTarget = useCallback(
@@ -774,24 +804,32 @@ export function WorkspacePage({
 			{ id: workspaceId },
 			{ enabled: !!workspaceId },
 		);
-	useHotkey("PREV_WORKSPACE", () => {
-		const prevWorkspaceId = getPreviousWorkspace.data;
-		if (prevWorkspaceId) {
-			navigateToWorkspace(prevWorkspaceId, navigate);
-		}
-	}, { enabled: isActive });
+	useHotkey(
+		"PREV_WORKSPACE",
+		() => {
+			const prevWorkspaceId = getPreviousWorkspace.data;
+			if (prevWorkspaceId) {
+				navigateToWorkspace(prevWorkspaceId, navigate);
+			}
+		},
+		{ enabled: isActive },
+	);
 
 	// Navigate to next workspace (⌘↓)
 	const getNextWorkspace = electronTrpc.workspaces.getNextWorkspace.useQuery(
 		{ id: workspaceId },
 		{ enabled: !!workspaceId },
 	);
-	useHotkey("NEXT_WORKSPACE", () => {
-		const nextWorkspaceId = getNextWorkspace.data;
-		if (nextWorkspaceId) {
-			navigateToWorkspace(nextWorkspaceId, navigate);
-		}
-	}, { enabled: isActive });
+	useHotkey(
+		"NEXT_WORKSPACE",
+		() => {
+			const nextWorkspaceId = getNextWorkspace.data;
+			if (nextWorkspaceId) {
+				navigateToWorkspace(nextWorkspaceId, navigate);
+			}
+		},
+		{ enabled: isActive },
+	);
 
 	return (
 		<WorkspaceIdProvider value={workspaceId}>

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/components/CodeEditor/loadLanguageSupport.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/components/CodeEditor/loadLanguageSupport.ts
@@ -1,9 +1,9 @@
 import {
 	LanguageDescription,
+	LanguageSupport,
 	StreamLanguage,
 	type StreamParser,
 } from "@codemirror/language";
-import type { Extension } from "@codemirror/state";
 import {
 	csvStreamLanguage,
 	graphqlStreamLanguage,
@@ -11,205 +11,20 @@ import {
 	tsvStreamLanguage,
 } from "./streamLanguages";
 
-/**
- * Language descriptions for nested code blocks inside Markdown.
- * Each entry lazily loads its parser only when a matching fenced code block is found.
- */
-const markdownCodeLanguages: LanguageDescription[] = [
-	LanguageDescription.of({
-		name: "javascript",
-		alias: ["js", "jsx", "mjs", "cjs"],
-		async load() {
-			const { javascript } = await import("@codemirror/lang-javascript");
-			return new (await import("@codemirror/language")).LanguageSupport(
-				javascript({ jsx: true }).language,
-			);
-		},
-	}),
-	LanguageDescription.of({
-		name: "typescript",
-		alias: ["ts", "tsx"],
-		async load() {
-			const { javascript } = await import("@codemirror/lang-javascript");
-			return new (await import("@codemirror/language")).LanguageSupport(
-				javascript({ typescript: true, jsx: true }).language,
-			);
-		},
-	}),
-	LanguageDescription.of({
-		name: "json",
-		alias: ["jsonc"],
-		async load() {
-			const { json } = await import("@codemirror/lang-json");
-			return new (await import("@codemirror/language")).LanguageSupport(
-				json().language,
-			);
-		},
-	}),
-	LanguageDescription.of({
-		name: "html",
-		alias: ["htm"],
-		async load() {
-			const { html } = await import("@codemirror/lang-html");
-			return new (await import("@codemirror/language")).LanguageSupport(
-				html().language,
-			);
-		},
-	}),
-	LanguageDescription.of({
-		name: "css",
-		alias: ["scss", "less"],
-		async load() {
-			const { css } = await import("@codemirror/lang-css");
-			return new (await import("@codemirror/language")).LanguageSupport(
-				css().language,
-			);
-		},
-	}),
-	LanguageDescription.of({
-		name: "python",
-		alias: ["py"],
-		async load() {
-			const { python } = await import("@codemirror/lang-python");
-			return new (await import("@codemirror/language")).LanguageSupport(
-				python().language,
-			);
-		},
-	}),
-	LanguageDescription.of({
-		name: "yaml",
-		alias: ["yml"],
-		async load() {
-			const { yaml } = await import("@codemirror/lang-yaml");
-			return new (await import("@codemirror/language")).LanguageSupport(
-				yaml().language,
-			);
-		},
-	}),
-	LanguageDescription.of({
-		name: "xml",
-		async load() {
-			const { xml } = await import("@codemirror/lang-xml");
-			return new (await import("@codemirror/language")).LanguageSupport(
-				xml().language,
-			);
-		},
-	}),
-	LanguageDescription.of({
-		name: "sql",
-		async load() {
-			const { sql } = await import("@codemirror/lang-sql");
-			return new (await import("@codemirror/language")).LanguageSupport(
-				sql().language,
-			);
-		},
-	}),
-	LanguageDescription.of({
-		name: "rust",
-		alias: ["rs"],
-		async load() {
-			const { rust } = await import("@codemirror/lang-rust");
-			return new (await import("@codemirror/language")).LanguageSupport(
-				rust().language,
-			);
-		},
-	}),
-	LanguageDescription.of({
-		name: "java",
-		async load() {
-			const { java } = await import("@codemirror/lang-java");
-			return new (await import("@codemirror/language")).LanguageSupport(
-				java().language,
-			);
-		},
-	}),
-	LanguageDescription.of({
-		name: "cpp",
-		alias: ["c", "h", "hpp"],
-		async load() {
-			const { cpp } = await import("@codemirror/lang-cpp");
-			return new (await import("@codemirror/language")).LanguageSupport(
-				cpp().language,
-			);
-		},
-	}),
-	LanguageDescription.of({
-		name: "go",
-		alias: ["golang"],
-		async load() {
-			const { go } = await import("@codemirror/lang-go");
-			return new (await import("@codemirror/language")).LanguageSupport(
-				go().language,
-			);
-		},
-	}),
-	LanguageDescription.of({
-		name: "php",
-		async load() {
-			const { php } = await import("@codemirror/lang-php");
-			return new (await import("@codemirror/language")).LanguageSupport(
-				php().language,
-			);
-		},
-	}),
-	LanguageDescription.of({
-		name: "shell",
-		alias: ["bash", "sh", "zsh"],
-		async load() {
-			const mod = await import("@codemirror/legacy-modes/mode/shell");
-			const lang = StreamLanguage.define(mod.shell as StreamParser<unknown>);
-			return new (await import("@codemirror/language")).LanguageSupport(lang);
-		},
-	}),
-	LanguageDescription.of({
-		name: "dockerfile",
-		alias: ["docker"],
-		async load() {
-			const mod = await import("@codemirror/legacy-modes/mode/dockerfile");
-			const lang = StreamLanguage.define(
-				mod.dockerFile as StreamParser<unknown>,
-			);
-			return new (await import("@codemirror/language")).LanguageSupport(lang);
-		},
-	}),
-	LanguageDescription.of({
-		name: "toml",
-		async load() {
-			const mod = await import("@codemirror/legacy-modes/mode/toml");
-			const lang = StreamLanguage.define(mod.toml as StreamParser<unknown>);
-			return new (await import("@codemirror/language")).LanguageSupport(lang);
-		},
-	}),
-	LanguageDescription.of({
-		name: "ruby",
-		alias: ["rb"],
-		async load() {
-			const mod = await import("@codemirror/legacy-modes/mode/ruby");
-			const lang = StreamLanguage.define(mod.ruby as StreamParser<unknown>);
-			return new (await import("@codemirror/language")).LanguageSupport(lang);
-		},
-	}),
-	LanguageDescription.of({
-		name: "swift",
-		async load() {
-			const mod = await import("@codemirror/legacy-modes/mode/swift");
-			const lang = StreamLanguage.define(mod.swift as StreamParser<unknown>);
-			return new (await import("@codemirror/language")).LanguageSupport(lang);
-		},
-	}),
-];
-
 async function loadLegacyLanguage(
 	loader: () => Promise<Record<string, unknown>>,
 	key: string,
-): Promise<Extension> {
+): Promise<LanguageSupport> {
 	const languageModule = await loader();
-	return StreamLanguage.define(languageModule[key] as StreamParser<unknown>);
+	const lang = StreamLanguage.define(
+		languageModule[key] as StreamParser<unknown>,
+	);
+	return new LanguageSupport(lang);
 }
 
 export async function loadLanguageSupport(
 	language: string,
-): Promise<Extension | null> {
+): Promise<LanguageSupport | null> {
 	switch (language) {
 		case "typescript":
 		case "javascript": {
@@ -219,10 +34,7 @@ export async function loadLanguageSupport(
 				jsx: true,
 			});
 		}
-		case "json": {
-			const { json } = await import("@codemirror/lang-json");
-			return json();
-		}
+		case "json":
 		case "jsonc": {
 			const { json } = await import("@codemirror/lang-json");
 			return json();
@@ -242,7 +54,7 @@ export async function loadLanguageSupport(
 			return markdown({ codeLanguages: markdownCodeLanguages });
 		}
 		case "graphql":
-			return StreamLanguage.define(graphqlStreamLanguage);
+			return new LanguageSupport(StreamLanguage.define(graphqlStreamLanguage));
 		case "plaintext":
 			return null;
 		case "yaml": {
@@ -293,7 +105,7 @@ export async function loadLanguageSupport(
 				"dockerFile",
 			);
 		case "makefile":
-			return StreamLanguage.define(makefileStreamLanguage);
+			return new LanguageSupport(StreamLanguage.define(makefileStreamLanguage));
 		case "toml":
 			return loadLegacyLanguage(
 				() => import("@codemirror/legacy-modes/mode/toml"),
@@ -330,10 +142,58 @@ export async function loadLanguageSupport(
 				"properties",
 			);
 		case "csv":
-			return StreamLanguage.define(csvStreamLanguage);
+			return new LanguageSupport(StreamLanguage.define(csvStreamLanguage));
 		case "tsv":
-			return StreamLanguage.define(tsvStreamLanguage);
+			return new LanguageSupport(StreamLanguage.define(tsvStreamLanguage));
 		default:
 			return null;
 	}
 }
+
+/**
+ * Languages available for nested highlighting inside Markdown fenced code blocks.
+ * Each entry delegates to loadLanguageSupport so there is a single source of truth.
+ */
+const MARKDOWN_NESTED_LANGUAGES: Array<{ name: string; alias?: string[] }> = [
+	{ name: "javascript", alias: ["js", "jsx", "mjs", "cjs"] },
+	{ name: "typescript", alias: ["ts", "tsx"] },
+	{ name: "json", alias: ["jsonc"] },
+	{ name: "html", alias: ["htm"] },
+	{ name: "css", alias: ["scss", "less"] },
+	{ name: "python", alias: ["py"] },
+	{ name: "yaml", alias: ["yml"] },
+	{ name: "xml" },
+	{ name: "sql" },
+	{ name: "rust", alias: ["rs"] },
+	{ name: "java" },
+	{ name: "cpp", alias: ["c", "h", "hpp"] },
+	{ name: "go", alias: ["golang"] },
+	{ name: "php" },
+	{ name: "shell", alias: ["bash", "sh", "zsh"] },
+	{ name: "dockerfile", alias: ["docker"] },
+	{ name: "toml" },
+	{ name: "ruby", alias: ["rb"] },
+	{ name: "swift" },
+];
+
+const markdownCodeLanguages: LanguageDescription[] =
+	MARKDOWN_NESTED_LANGUAGES.map(({ name, alias }) =>
+		LanguageDescription.of({
+			name,
+			alias,
+			async load() {
+				const support = await loadLanguageSupport(name);
+				return (
+					support ??
+					new LanguageSupport(
+						StreamLanguage.define({
+							token: (stream) => {
+								stream.next();
+								return null;
+							},
+						}),
+					)
+				);
+			},
+		}),
+	);

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/components/CodeEditor/loadLanguageSupport.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/components/CodeEditor/loadLanguageSupport.ts
@@ -174,6 +174,14 @@ const MARKDOWN_NESTED_LANGUAGES: Array<{ name: string; alias?: string[] }> = [
 	{ name: "toml" },
 	{ name: "ruby", alias: ["rb"] },
 	{ name: "swift" },
+	{ name: "graphql", alias: ["gql"] },
+	{ name: "dart" },
+	{ name: "csharp", alias: ["cs", "c#"] },
+	{ name: "kotlin", alias: ["kt"] },
+	{ name: "makefile", alias: ["make"] },
+	{ name: "dotenv", alias: ["env"] },
+	{ name: "csv" },
+	{ name: "tsv" },
 ];
 
 const markdownCodeLanguages: LanguageDescription[] =

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/components/CodeEditor/loadLanguageSupport.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/components/CodeEditor/loadLanguageSupport.ts
@@ -1,4 +1,8 @@
-import { StreamLanguage, type StreamParser } from "@codemirror/language";
+import {
+	LanguageDescription,
+	StreamLanguage,
+	type StreamParser,
+} from "@codemirror/language";
 import type { Extension } from "@codemirror/state";
 import {
 	csvStreamLanguage,
@@ -6,6 +10,194 @@ import {
 	makefileStreamLanguage,
 	tsvStreamLanguage,
 } from "./streamLanguages";
+
+/**
+ * Language descriptions for nested code blocks inside Markdown.
+ * Each entry lazily loads its parser only when a matching fenced code block is found.
+ */
+const markdownCodeLanguages: LanguageDescription[] = [
+	LanguageDescription.of({
+		name: "javascript",
+		alias: ["js", "jsx", "mjs", "cjs"],
+		async load() {
+			const { javascript } = await import("@codemirror/lang-javascript");
+			return new (await import("@codemirror/language")).LanguageSupport(
+				javascript({ jsx: true }).language,
+			);
+		},
+	}),
+	LanguageDescription.of({
+		name: "typescript",
+		alias: ["ts", "tsx"],
+		async load() {
+			const { javascript } = await import("@codemirror/lang-javascript");
+			return new (await import("@codemirror/language")).LanguageSupport(
+				javascript({ typescript: true, jsx: true }).language,
+			);
+		},
+	}),
+	LanguageDescription.of({
+		name: "json",
+		alias: ["jsonc"],
+		async load() {
+			const { json } = await import("@codemirror/lang-json");
+			return new (await import("@codemirror/language")).LanguageSupport(
+				json().language,
+			);
+		},
+	}),
+	LanguageDescription.of({
+		name: "html",
+		alias: ["htm"],
+		async load() {
+			const { html } = await import("@codemirror/lang-html");
+			return new (await import("@codemirror/language")).LanguageSupport(
+				html().language,
+			);
+		},
+	}),
+	LanguageDescription.of({
+		name: "css",
+		alias: ["scss", "less"],
+		async load() {
+			const { css } = await import("@codemirror/lang-css");
+			return new (await import("@codemirror/language")).LanguageSupport(
+				css().language,
+			);
+		},
+	}),
+	LanguageDescription.of({
+		name: "python",
+		alias: ["py"],
+		async load() {
+			const { python } = await import("@codemirror/lang-python");
+			return new (await import("@codemirror/language")).LanguageSupport(
+				python().language,
+			);
+		},
+	}),
+	LanguageDescription.of({
+		name: "yaml",
+		alias: ["yml"],
+		async load() {
+			const { yaml } = await import("@codemirror/lang-yaml");
+			return new (await import("@codemirror/language")).LanguageSupport(
+				yaml().language,
+			);
+		},
+	}),
+	LanguageDescription.of({
+		name: "xml",
+		async load() {
+			const { xml } = await import("@codemirror/lang-xml");
+			return new (await import("@codemirror/language")).LanguageSupport(
+				xml().language,
+			);
+		},
+	}),
+	LanguageDescription.of({
+		name: "sql",
+		async load() {
+			const { sql } = await import("@codemirror/lang-sql");
+			return new (await import("@codemirror/language")).LanguageSupport(
+				sql().language,
+			);
+		},
+	}),
+	LanguageDescription.of({
+		name: "rust",
+		alias: ["rs"],
+		async load() {
+			const { rust } = await import("@codemirror/lang-rust");
+			return new (await import("@codemirror/language")).LanguageSupport(
+				rust().language,
+			);
+		},
+	}),
+	LanguageDescription.of({
+		name: "java",
+		async load() {
+			const { java } = await import("@codemirror/lang-java");
+			return new (await import("@codemirror/language")).LanguageSupport(
+				java().language,
+			);
+		},
+	}),
+	LanguageDescription.of({
+		name: "cpp",
+		alias: ["c", "h", "hpp"],
+		async load() {
+			const { cpp } = await import("@codemirror/lang-cpp");
+			return new (await import("@codemirror/language")).LanguageSupport(
+				cpp().language,
+			);
+		},
+	}),
+	LanguageDescription.of({
+		name: "go",
+		alias: ["golang"],
+		async load() {
+			const { go } = await import("@codemirror/lang-go");
+			return new (await import("@codemirror/language")).LanguageSupport(
+				go().language,
+			);
+		},
+	}),
+	LanguageDescription.of({
+		name: "php",
+		async load() {
+			const { php } = await import("@codemirror/lang-php");
+			return new (await import("@codemirror/language")).LanguageSupport(
+				php().language,
+			);
+		},
+	}),
+	LanguageDescription.of({
+		name: "shell",
+		alias: ["bash", "sh", "zsh"],
+		async load() {
+			const mod = await import("@codemirror/legacy-modes/mode/shell");
+			const lang = StreamLanguage.define(mod.shell as StreamParser<unknown>);
+			return new (await import("@codemirror/language")).LanguageSupport(lang);
+		},
+	}),
+	LanguageDescription.of({
+		name: "dockerfile",
+		alias: ["docker"],
+		async load() {
+			const mod = await import("@codemirror/legacy-modes/mode/dockerfile");
+			const lang = StreamLanguage.define(
+				mod.dockerFile as StreamParser<unknown>,
+			);
+			return new (await import("@codemirror/language")).LanguageSupport(lang);
+		},
+	}),
+	LanguageDescription.of({
+		name: "toml",
+		async load() {
+			const mod = await import("@codemirror/legacy-modes/mode/toml");
+			const lang = StreamLanguage.define(mod.toml as StreamParser<unknown>);
+			return new (await import("@codemirror/language")).LanguageSupport(lang);
+		},
+	}),
+	LanguageDescription.of({
+		name: "ruby",
+		alias: ["rb"],
+		async load() {
+			const mod = await import("@codemirror/legacy-modes/mode/ruby");
+			const lang = StreamLanguage.define(mod.ruby as StreamParser<unknown>);
+			return new (await import("@codemirror/language")).LanguageSupport(lang);
+		},
+	}),
+	LanguageDescription.of({
+		name: "swift",
+		async load() {
+			const mod = await import("@codemirror/legacy-modes/mode/swift");
+			const lang = StreamLanguage.define(mod.swift as StreamParser<unknown>);
+			return new (await import("@codemirror/language")).LanguageSupport(lang);
+		},
+	}),
+];
 
 async function loadLegacyLanguage(
 	loader: () => Promise<Record<string, unknown>>,
@@ -47,7 +239,7 @@ export async function loadLanguageSupport(
 		}
 		case "markdown": {
 			const { markdown } = await import("@codemirror/lang-markdown");
-			return markdown();
+			return markdown({ codeLanguages: markdownCodeLanguages });
 		}
 		case "graphql":
 			return StreamLanguage.define(graphqlStreamLanguage);

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/utils/code-theme/shiki-theme.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/utils/code-theme/shiki-theme.ts
@@ -112,6 +112,41 @@ export function createShikiTheme(theme: Theme) {
 				},
 			},
 
+			// Operators
+			{
+				scope: [
+					"keyword.operator",
+					"keyword.operator.assignment",
+					"keyword.operator.arithmetic",
+					"keyword.operator.logical",
+					"keyword.operator.comparison",
+					"keyword.operator.ternary",
+					"keyword.operator.spread",
+					"keyword.operator.rest",
+					"keyword.operator.type",
+				],
+				settings: {
+					foreground: toHex(editorTheme.syntax.operator),
+				},
+			},
+
+			// Punctuation
+			{
+				scope: [
+					"punctuation",
+					"punctuation.definition.block",
+					"punctuation.definition.parameters",
+					"punctuation.definition.array",
+					"punctuation.separator",
+					"punctuation.terminator",
+					"meta.brace",
+					"meta.bracket",
+				],
+				settings: {
+					foreground: toHex(editorTheme.syntax.punctuation),
+				},
+			},
+
 			// Markdown
 			{
 				scope: [

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/utils/code-theme/shiki-theme.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/utils/code-theme/shiki-theme.ts
@@ -111,6 +111,86 @@ export function createShikiTheme(theme: Theme) {
 					foreground: toHex(editorTheme.syntax.invalid),
 				},
 			},
+
+			// Markdown
+			{
+				scope: [
+					"markup.heading",
+					"punctuation.definition.heading",
+					"entity.name.section",
+				],
+				settings: {
+					foreground: toHex(editorTheme.syntax.markdownHeading),
+					fontStyle: "bold",
+				},
+			},
+			{
+				scope: ["markup.italic"],
+				settings: {
+					foreground: toHex(editorTheme.syntax.markdownEmphasis),
+					fontStyle: "italic",
+				},
+			},
+			{
+				scope: ["markup.bold"],
+				settings: {
+					foreground: toHex(editorTheme.syntax.markdownStrong),
+					fontStyle: "bold",
+				},
+			},
+			{
+				scope: ["markup.strikethrough"],
+				settings: {
+					foreground: toHex(editorTheme.syntax.markdownStrikethrough),
+				},
+			},
+			{
+				scope: ["markup.underline.link", "string.other.link"],
+				settings: {
+					foreground: toHex(editorTheme.syntax.markdownLink),
+				},
+			},
+			{
+				scope: ["markup.underline.link.image"],
+				settings: {
+					foreground: toHex(editorTheme.syntax.markdownUrl),
+				},
+			},
+			{
+				scope: [
+					"markup.inline.raw",
+					"markup.fenced_code.block",
+					"markup.raw.block",
+				],
+				settings: {
+					foreground: toHex(editorTheme.syntax.markdownCode),
+				},
+			},
+			{
+				scope: ["markup.quote"],
+				settings: {
+					foreground: toHex(editorTheme.syntax.markdownQuote),
+					fontStyle: "italic",
+				},
+			},
+			{
+				scope: ["markup.list", "punctuation.definition.list"],
+				settings: {
+					foreground: toHex(editorTheme.syntax.markdownList),
+				},
+			},
+			{
+				scope: ["meta.separator"],
+				settings: {
+					foreground: toHex(editorTheme.syntax.markdownSeparator),
+				},
+			},
+			{
+				scope: ["fenced_code.block.language"],
+				settings: {
+					foreground: toHex(editorTheme.syntax.markdownMeta),
+				},
+			},
 		],
 	};
 }

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/utils/code-theme/shiki-theme.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/utils/code-theme/shiki-theme.ts
@@ -101,7 +101,7 @@ export function createShikiTheme(theme: Theme) {
 				},
 			},
 			{
-				scope: ["entity.name.type", "support.type", "storage.type"],
+				scope: ["entity.name.type", "support.type"],
 				settings: {
 					foreground: toHex(editorTheme.syntax.typeName),
 				},

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/utils/code-theme/shiki-theme.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/utils/code-theme/shiki-theme.ts
@@ -25,6 +25,13 @@ export function createShikiTheme(theme: Theme) {
 				},
 			},
 			{
+				scope: ["comment.block.documentation", "comment.line.documentation"],
+				settings: {
+					foreground: toHex(editorTheme.syntax.docComment),
+					fontStyle: "italic",
+				},
+			},
+			{
 				scope: ["comment", "punctuation.definition.comment"],
 				settings: {
 					foreground: toHex(editorTheme.syntax.comment),
@@ -32,13 +39,31 @@ export function createShikiTheme(theme: Theme) {
 				},
 			},
 			{
-				scope: ["keyword", "storage", "storage.type"],
+				scope: ["keyword.control"],
+				settings: {
+					foreground: toHex(editorTheme.syntax.controlKeyword),
+				},
+			},
+			{
+				scope: ["storage", "storage.type", "storage.modifier"],
+				settings: {
+					foreground: toHex(editorTheme.syntax.storageKeyword),
+				},
+			},
+			{
+				scope: ["keyword"],
 				settings: {
 					foreground: toHex(editorTheme.syntax.keyword),
 				},
 			},
 			{
-				scope: ["string", "string.template", "string.regexp"],
+				scope: ["constant.character.escape"],
+				settings: {
+					foreground: toHex(editorTheme.syntax.escape),
+				},
+			},
+			{
+				scope: ["string", "string.template"],
 				settings: {
 					foreground: toHex(editorTheme.syntax.string),
 				},
@@ -57,6 +82,16 @@ export function createShikiTheme(theme: Theme) {
 				],
 				settings: {
 					foreground: toHex(editorTheme.syntax.functionCall),
+				},
+			},
+			{
+				scope: [
+					"variable.other.property",
+					"support.variable.property",
+					"meta.property.object",
+				],
+				settings: {
+					foreground: toHex(editorTheme.syntax.variableProperty),
 				},
 			},
 			{
@@ -109,6 +144,17 @@ export function createShikiTheme(theme: Theme) {
 				scope: ["invalid", "invalid.illegal"],
 				settings: {
 					foreground: toHex(editorTheme.syntax.invalid),
+				},
+			},
+			{
+				scope: [
+					"meta.decorator",
+					"meta.function.decorator",
+					"punctuation.definition.annotation",
+					"storage.type.annotation",
+				],
+				settings: {
+					foreground: toHex(editorTheme.syntax.annotation),
 				},
 			},
 

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/utils/code-theme/shiki-theme.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/utils/code-theme/shiki-theme.ts
@@ -223,7 +223,7 @@ export function createShikiTheme(theme: Theme) {
 			{
 				scope: ["fenced_code.block.language"],
 				settings: {
-					foreground: toHex(editorTheme.syntax.markdownMeta),
+					foreground: toHex(editorTheme.syntax.meta),
 				},
 			},
 		],

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/utils/code-theme/syntax-highlighting.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/utils/code-theme/syntax-highlighting.ts
@@ -153,7 +153,7 @@ export function getCodeSyntaxHighlighting(theme: Theme): Extension {
 					tags.annotation,
 					tags.processingInstruction,
 				],
-				color: editorTheme.syntax.markdownMeta,
+				color: editorTheme.syntax.meta,
 			},
 
 			// ── Diff ──────────────────────────────────────────────────

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/utils/code-theme/syntax-highlighting.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/utils/code-theme/syntax-highlighting.ts
@@ -8,51 +8,104 @@ export function getCodeSyntaxHighlighting(theme: Theme): Extension {
 
 	return syntaxHighlighting(
 		HighlightStyle.define([
+			// ── Keywords ──────────────────────────────────────────────
 			{
-				tag: [tags.keyword, tags.operatorKeyword, tags.modifier],
+				tag: [
+					tags.keyword,
+					tags.operatorKeyword,
+					tags.modifier,
+					tags.controlKeyword,
+					tags.definitionKeyword,
+					tags.moduleKeyword,
+					tags.self,
+					tags.unit,
+				],
 				color: editorTheme.syntax.keyword,
 			},
+
+			// ── Comments ──────────────────────────────────────────────
 			{
 				tag: [tags.comment, tags.lineComment, tags.blockComment],
 				color: editorTheme.syntax.comment,
 				fontStyle: "italic",
 			},
 			{
-				tag: [tags.string, tags.special(tags.string)],
+				tag: [tags.docComment, tags.docString],
+				color: editorTheme.syntax.comment,
+				fontStyle: "italic",
+			},
+
+			// ── Strings & character literals ──────────────────────────
+			{
+				tag: [
+					tags.string,
+					tags.special(tags.string),
+					tags.character,
+					tags.attributeValue,
+				],
 				color: editorTheme.syntax.string,
 			},
+
+			// ── Numbers & atoms ───────────────────────────────────────
 			{
-				tag: [tags.number, tags.integer, tags.float, tags.bool, tags.null],
+				tag: [
+					tags.number,
+					tags.integer,
+					tags.float,
+					tags.bool,
+					tags.null,
+					tags.atom,
+					tags.color,
+				],
 				color: editorTheme.syntax.number,
 			},
+
+			// ── Literals (generic fallback) ───────────────────────────
+			{
+				tag: [tags.literal],
+				color: editorTheme.syntax.number,
+			},
+
+			// ── Functions & macros ────────────────────────────────────
 			{
 				tag: [
 					tags.function(tags.variableName),
 					tags.function(tags.propertyName),
 					tags.labelName,
+					tags.macroName,
 				],
 				color: editorTheme.syntax.functionCall,
 			},
+
+			// ── Variables & properties ────────────────────────────────
 			{
 				tag: [tags.variableName, tags.name, tags.propertyName],
 				color: editorTheme.syntax.variableName,
 			},
+
+			// ── Types & namespaces ────────────────────────────────────
 			{
-				tag: [tags.typeName, tags.definition(tags.typeName)],
+				tag: [tags.typeName, tags.definition(tags.typeName), tags.namespace],
 				color: editorTheme.syntax.typeName,
 			},
 			{
 				tag: [tags.className],
 				color: editorTheme.syntax.className,
 			},
+
+			// ── Constants ─────────────────────────────────────────────
 			{
 				tag: [tags.constant(tags.name), tags.standard(tags.name)],
 				color: editorTheme.syntax.constant,
 			},
+
+			// ── Regex & escape ────────────────────────────────────────
 			{
 				tag: [tags.regexp, tags.escape, tags.special(tags.regexp)],
 				color: editorTheme.syntax.regexp,
 			},
+
+			// ── Tags & attributes (HTML/XML/JSX) ──────────────────────
 			{
 				tag: [tags.tagName, tags.angleBracket],
 				color: editorTheme.syntax.tagName,
@@ -61,12 +114,69 @@ export function getCodeSyntaxHighlighting(theme: Theme): Extension {
 				tag: [tags.attributeName],
 				color: editorTheme.syntax.attributeName,
 			},
+
+			// ── Operators ─────────────────────────────────────────────
+			{
+				tag: [
+					tags.operator,
+					tags.derefOperator,
+					tags.arithmeticOperator,
+					tags.logicOperator,
+					tags.bitwiseOperator,
+					tags.compareOperator,
+					tags.updateOperator,
+					tags.definitionOperator,
+					tags.typeOperator,
+					tags.controlOperator,
+				],
+				color: editorTheme.syntax.operator,
+			},
+
+			// ── Punctuation & brackets ────────────────────────────────
+			{
+				tag: [
+					tags.punctuation,
+					tags.separator,
+					tags.bracket,
+					tags.squareBracket,
+					tags.paren,
+					tags.brace,
+				],
+				color: editorTheme.syntax.punctuation,
+			},
+
+			// ── Meta & annotations ────────────────────────────────────
+			{
+				tag: [
+					tags.meta,
+					tags.documentMeta,
+					tags.annotation,
+					tags.processingInstruction,
+				],
+				color: editorTheme.syntax.markdownMeta,
+			},
+
+			// ── Diff ──────────────────────────────────────────────────
+			{
+				tag: [tags.inserted],
+				color: editorTheme.syntax.string,
+			},
+			{
+				tag: [tags.deleted],
+				color: editorTheme.syntax.invalid,
+			},
+			{
+				tag: [tags.changed],
+				color: editorTheme.syntax.keyword,
+			},
+
+			// ── Invalid ───────────────────────────────────────────────
 			{
 				tag: [tags.invalid],
 				color: editorTheme.syntax.invalid,
 			},
 
-			// Markdown
+			// ── Markdown ──────────────────────────────────────────────
 			{
 				tag: [tags.heading],
 				color: editorTheme.syntax.markdownHeading,
@@ -130,14 +240,6 @@ export function getCodeSyntaxHighlighting(theme: Theme): Extension {
 			{
 				tag: [tags.contentSeparator],
 				color: editorTheme.syntax.markdownSeparator,
-			},
-			{
-				tag: [tags.processingInstruction],
-				color: editorTheme.syntax.markdownMeta,
-			},
-			{
-				tag: [tags.meta],
-				color: editorTheme.syntax.markdownMeta,
 			},
 		]),
 	);

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/utils/code-theme/syntax-highlighting.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/utils/code-theme/syntax-highlighting.ts
@@ -65,6 +65,80 @@ export function getCodeSyntaxHighlighting(theme: Theme): Extension {
 				tag: [tags.invalid],
 				color: editorTheme.syntax.invalid,
 			},
+
+			// Markdown
+			{
+				tag: [tags.heading],
+				color: editorTheme.syntax.markdownHeading,
+				fontWeight: "bold",
+			},
+			{
+				tag: [tags.heading1],
+				color: editorTheme.syntax.markdownHeading,
+				fontWeight: "bold",
+				fontSize: "1.4em",
+			},
+			{
+				tag: [tags.heading2],
+				color: editorTheme.syntax.markdownHeading,
+				fontWeight: "bold",
+				fontSize: "1.2em",
+			},
+			{
+				tag: [tags.heading3],
+				color: editorTheme.syntax.markdownHeading,
+				fontWeight: "bold",
+				fontSize: "1.1em",
+			},
+			{
+				tag: [tags.emphasis],
+				color: editorTheme.syntax.markdownEmphasis,
+				fontStyle: "italic",
+			},
+			{
+				tag: [tags.strong],
+				color: editorTheme.syntax.markdownStrong,
+				fontWeight: "bold",
+			},
+			{
+				tag: [tags.strikethrough],
+				color: editorTheme.syntax.markdownStrikethrough,
+				textDecoration: "line-through",
+			},
+			{
+				tag: [tags.link],
+				color: editorTheme.syntax.markdownLink,
+				textDecoration: "underline",
+			},
+			{
+				tag: [tags.url],
+				color: editorTheme.syntax.markdownUrl,
+			},
+			{
+				tag: [tags.monospace],
+				color: editorTheme.syntax.markdownCode,
+			},
+			{
+				tag: [tags.quote],
+				color: editorTheme.syntax.markdownQuote,
+				fontStyle: "italic",
+			},
+			{
+				tag: [tags.list],
+				color: editorTheme.syntax.markdownList,
+			},
+			{
+				tag: [tags.contentSeparator],
+				color: editorTheme.syntax.markdownSeparator,
+			},
+			{
+				tag: [tags.processingInstruction],
+				color: editorTheme.syntax.markdownMeta,
+			},
+			{
+				tag: [tags.meta],
+				color: editorTheme.syntax.markdownMeta,
+			},
 		]),
 	);
 }

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/utils/code-theme/syntax-highlighting.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/utils/code-theme/syntax-highlighting.ts
@@ -8,15 +8,20 @@ export function getCodeSyntaxHighlighting(theme: Theme): Extension {
 
 	return syntaxHighlighting(
 		HighlightStyle.define([
-			// ── Keywords ──────────────────────────────────────────────
+			// ── Keywords (split by sub-category) ──────────────────────
+			{
+				tag: [tags.controlKeyword],
+				color: editorTheme.syntax.controlKeyword,
+			},
+			{
+				tag: [tags.definitionKeyword, tags.moduleKeyword],
+				color: editorTheme.syntax.storageKeyword,
+			},
 			{
 				tag: [
 					tags.keyword,
 					tags.operatorKeyword,
 					tags.modifier,
-					tags.controlKeyword,
-					tags.definitionKeyword,
-					tags.moduleKeyword,
 					tags.self,
 					tags.unit,
 				],
@@ -25,17 +30,21 @@ export function getCodeSyntaxHighlighting(theme: Theme): Extension {
 
 			// ── Comments ──────────────────────────────────────────────
 			{
-				tag: [tags.comment, tags.lineComment, tags.blockComment],
-				color: editorTheme.syntax.comment,
+				tag: [tags.docComment, tags.docString],
+				color: editorTheme.syntax.docComment,
 				fontStyle: "italic",
 			},
 			{
-				tag: [tags.docComment, tags.docString],
+				tag: [tags.comment, tags.lineComment, tags.blockComment],
 				color: editorTheme.syntax.comment,
 				fontStyle: "italic",
 			},
 
 			// ── Strings & character literals ──────────────────────────
+			{
+				tag: [tags.escape],
+				color: editorTheme.syntax.escape,
+			},
 			{
 				tag: [
 					tags.string,
@@ -79,7 +88,11 @@ export function getCodeSyntaxHighlighting(theme: Theme): Extension {
 
 			// ── Variables & properties ────────────────────────────────
 			{
-				tag: [tags.variableName, tags.name, tags.propertyName],
+				tag: [tags.propertyName],
+				color: editorTheme.syntax.variableProperty,
+			},
+			{
+				tag: [tags.variableName, tags.name],
 				color: editorTheme.syntax.variableName,
 			},
 
@@ -99,9 +112,9 @@ export function getCodeSyntaxHighlighting(theme: Theme): Extension {
 				color: editorTheme.syntax.constant,
 			},
 
-			// ── Regex & escape ────────────────────────────────────────
+			// ── Regex ─────────────────────────────────────────────────
 			{
-				tag: [tags.regexp, tags.escape, tags.special(tags.regexp)],
+				tag: [tags.regexp, tags.special(tags.regexp)],
 				color: editorTheme.syntax.regexp,
 			},
 
@@ -145,14 +158,15 @@ export function getCodeSyntaxHighlighting(theme: Theme): Extension {
 				color: editorTheme.syntax.punctuation,
 			},
 
-			// ── Meta & annotations ────────────────────────────────────
+			// ── Annotations & decorators ──────────────────────────────
 			{
-				tag: [
-					tags.meta,
-					tags.documentMeta,
-					tags.annotation,
-					tags.processingInstruction,
-				],
+				tag: [tags.annotation],
+				color: editorTheme.syntax.annotation,
+			},
+
+			// ── Meta ──────────────────────────────────────────────────
+			{
+				tag: [tags.meta, tags.documentMeta, tags.processingInstruction],
 				color: editorTheme.syntax.meta,
 			},
 
@@ -199,6 +213,17 @@ export function getCodeSyntaxHighlighting(theme: Theme): Extension {
 				color: editorTheme.syntax.markdownHeading,
 				fontWeight: "bold",
 				fontSize: "1.1em",
+			},
+			{
+				tag: [tags.heading4],
+				color: editorTheme.syntax.markdownHeading,
+				fontWeight: "bold",
+				fontSize: "1.05em",
+			},
+			{
+				tag: [tags.heading5, tags.heading6],
+				color: editorTheme.syntax.markdownHeading,
+				fontWeight: "bold",
 			},
 			{
 				tag: [tags.emphasis],

--- a/apps/desktop/src/shared/themes/editor-theme.ts
+++ b/apps/desktop/src/shared/themes/editor-theme.ts
@@ -70,6 +70,10 @@ export function getEditorTheme(theme: Theme): EditorTheme {
 			attributeName: terminal?.yellow ?? theme.ui.chart4,
 			invalid: terminal?.brightRed ?? theme.ui.destructive,
 
+			// Operators and punctuation
+			operator: theme.ui.foreground,
+			punctuation: theme.ui.mutedForeground,
+
 			// Markdown-specific
 			markdownHeading: terminal?.red ?? theme.ui.chart1,
 			markdownEmphasis: terminal?.magenta ?? theme.ui.primary,

--- a/apps/desktop/src/shared/themes/editor-theme.ts
+++ b/apps/desktop/src/shared/themes/editor-theme.ts
@@ -57,11 +57,16 @@ export function getEditorTheme(theme: Theme): EditorTheme {
 		syntax: {
 			plainText: theme.ui.foreground,
 			comment: terminal?.brightBlack ?? theme.ui.mutedForeground,
+			docComment: terminal?.brightBlack ?? theme.ui.mutedForeground,
 			keyword: terminal?.magenta ?? theme.ui.primary,
+			controlKeyword: terminal?.magenta ?? theme.ui.primary,
+			storageKeyword: terminal?.magenta ?? theme.ui.primary,
 			string: terminal?.green ?? theme.ui.chart2,
+			escape: terminal?.red ?? theme.ui.destructive,
 			number: terminal?.yellow ?? theme.ui.chart4,
 			functionCall: terminal?.blue ?? theme.ui.chart3,
 			variableName: theme.ui.foreground,
+			variableProperty: theme.ui.foreground,
 			typeName: terminal?.cyan ?? theme.ui.chart3,
 			className: terminal?.yellow ?? theme.ui.chart4,
 			constant: terminal?.cyan ?? theme.ui.chart5,
@@ -69,6 +74,7 @@ export function getEditorTheme(theme: Theme): EditorTheme {
 			tagName: terminal?.red ?? theme.ui.chart1,
 			attributeName: terminal?.yellow ?? theme.ui.chart4,
 			invalid: terminal?.brightRed ?? theme.ui.destructive,
+			annotation: terminal?.yellow ?? theme.ui.chart4,
 
 			// Operators and punctuation
 			operator: theme.ui.foreground,

--- a/apps/desktop/src/shared/themes/editor-theme.ts
+++ b/apps/desktop/src/shared/themes/editor-theme.ts
@@ -85,7 +85,7 @@ export function getEditorTheme(theme: Theme): EditorTheme {
 			markdownQuote: terminal?.brightBlack ?? theme.ui.mutedForeground,
 			markdownList: terminal?.yellow ?? theme.ui.chart4,
 			markdownSeparator: theme.ui.mutedForeground,
-			markdownMeta: terminal?.blue ?? theme.ui.chart3,
+			meta: terminal?.blue ?? theme.ui.chart3,
 		},
 	};
 

--- a/apps/desktop/src/shared/themes/editor-theme.ts
+++ b/apps/desktop/src/shared/themes/editor-theme.ts
@@ -69,6 +69,19 @@ export function getEditorTheme(theme: Theme): EditorTheme {
 			tagName: terminal?.red ?? theme.ui.chart1,
 			attributeName: terminal?.yellow ?? theme.ui.chart4,
 			invalid: terminal?.brightRed ?? theme.ui.destructive,
+
+			// Markdown-specific
+			markdownHeading: terminal?.red ?? theme.ui.chart1,
+			markdownEmphasis: terminal?.magenta ?? theme.ui.primary,
+			markdownStrong: terminal?.magenta ?? theme.ui.primary,
+			markdownStrikethrough: theme.ui.mutedForeground,
+			markdownLink: terminal?.blue ?? theme.ui.chart3,
+			markdownUrl: terminal?.cyan ?? theme.ui.chart5,
+			markdownCode: terminal?.green ?? theme.ui.chart2,
+			markdownQuote: terminal?.brightBlack ?? theme.ui.mutedForeground,
+			markdownList: terminal?.yellow ?? theme.ui.chart4,
+			markdownSeparator: theme.ui.mutedForeground,
+			markdownMeta: terminal?.blue ?? theme.ui.chart3,
 		},
 	};
 

--- a/apps/desktop/src/shared/themes/import.ts
+++ b/apps/desktop/src/shared/themes/import.ts
@@ -116,6 +116,8 @@ const editorSyntaxSchema = z
 		tagName: z.string().optional(),
 		attributeName: z.string().optional(),
 		invalid: z.string().optional(),
+		operator: z.string().optional(),
+		punctuation: z.string().optional(),
 		markdownHeading: z.string().optional(),
 		markdownEmphasis: z.string().optional(),
 		markdownStrong: z.string().optional(),

--- a/apps/desktop/src/shared/themes/import.ts
+++ b/apps/desktop/src/shared/themes/import.ts
@@ -178,6 +178,304 @@ function isThemePack(value: unknown): value is {
 	);
 }
 
+// ── VS Code theme format detection & conversion ──────────────
+
+interface VsCodeTokenColor {
+	scope?: string | string[];
+	settings?: { foreground?: string; fontStyle?: string };
+}
+
+function isVsCodeTheme(value: unknown): value is {
+	name?: string;
+	type?: string;
+	tokenColors?: VsCodeTokenColor[];
+	colors?: Record<string, string>;
+	semanticHighlighting?: boolean;
+	semanticTokenColors?: Record<string, unknown>;
+} {
+	if (typeof value !== "object" || value === null) return false;
+	const obj = value as Record<string, unknown>;
+	return Array.isArray(obj.tokenColors);
+}
+
+/**
+ * Scope-to-EditorSyntaxColors mapping.
+ * Order matters: more specific scopes should come first.
+ * The first matching scope wins for each syntax key.
+ */
+const SCOPE_TO_SYNTAX: Array<{
+	key: string;
+	scopes: string[];
+}> = [
+	// Markdown (specific scopes first)
+	{
+		key: "markdownHeading",
+		scopes: [
+			"markup.heading",
+			"entity.name.section",
+			"punctuation.definition.heading",
+		],
+	},
+	{
+		key: "markdownStrong",
+		scopes: ["markup.bold", "punctuation.definition.bold"],
+	},
+	{
+		key: "markdownEmphasis",
+		scopes: ["markup.italic", "punctuation.definition.italic"],
+	},
+	{ key: "markdownStrikethrough", scopes: ["markup.strikethrough"] },
+	{
+		key: "markdownLink",
+		scopes: [
+			"markup.underline.link",
+			"string.other.link.title",
+			"string.other.link.description",
+		],
+	},
+	{
+		key: "markdownUrl",
+		scopes: ["markup.underline.link.image"],
+	},
+	{
+		key: "markdownCode",
+		scopes: ["markup.inline.raw", "markup.fenced_code", "markup.raw"],
+	},
+	{ key: "markdownQuote", scopes: ["markup.quote"] },
+	{
+		key: "markdownList",
+		scopes: [
+			"punctuation.definition.list",
+			"beginning.punctuation.definition.list",
+		],
+	},
+	// Code tokens
+	{
+		key: "comment",
+		scopes: ["comment", "punctuation.definition.comment"],
+	},
+	{
+		key: "keyword",
+		scopes: ["keyword", "keyword.control", "storage", "storage.type"],
+	},
+	{ key: "string", scopes: ["string"] },
+	{
+		key: "number",
+		scopes: ["constant.numeric", "constant.language"],
+	},
+	{
+		key: "functionCall",
+		scopes: [
+			"entity.name.function",
+			"support.function",
+			"meta.function-call",
+			"variable.function",
+		],
+	},
+	{ key: "variableName", scopes: ["variable"] },
+	{
+		key: "typeName",
+		scopes: ["entity.name.type", "support.type", "support.class"],
+	},
+	{
+		key: "className",
+		scopes: ["entity.name.class", "entity.other.inherited-class"],
+	},
+	{ key: "constant", scopes: ["constant", "support.constant"] },
+	{ key: "regexp", scopes: ["string.regexp"] },
+	{
+		key: "tagName",
+		scopes: ["entity.name.tag", "punctuation.definition.tag"],
+	},
+	{
+		key: "attributeName",
+		scopes: ["entity.other.attribute-name"],
+	},
+	{ key: "invalid", scopes: ["invalid"] },
+	{
+		key: "operator",
+		scopes: ["keyword.operator"],
+	},
+	{
+		key: "punctuation",
+		scopes: ["punctuation", "meta.brace", "meta.bracket"],
+	},
+	{ key: "meta", scopes: ["meta.tag", "meta.selector"] },
+];
+
+/**
+ * VS Code `colors` key → Superset UIColors key.
+ */
+const VSCODE_COLORS_TO_UI: Record<string, string> = {
+	"editor.background": "background",
+	"editor.foreground": "foreground",
+	"editorWidget.background": "card",
+	"editorWidget.foreground": "cardForeground",
+	"editorHoverWidget.background": "popover",
+	"editorHoverWidget.foreground": "popoverForeground",
+	"button.background": "primary",
+	"button.foreground": "primaryForeground",
+	"button.secondaryBackground": "secondary",
+	"button.secondaryForeground": "secondaryForeground",
+	"tab.inactiveBackground": "muted",
+	"editorLineNumber.foreground": "mutedForeground",
+	"list.hoverBackground": "accent",
+	"list.activeSelectionForeground": "accentForeground",
+	"editorGroup.border": "border",
+	"input.background": "input",
+	focusBorder: "ring",
+	"sideBar.background": "sidebar",
+	"sideBar.foreground": "sidebarForeground",
+	"sideBarTitle.foreground": "sidebarForeground",
+	"activityBar.foreground": "sidebarPrimary",
+	"activityBarBadge.foreground": "sidebarPrimaryForeground",
+	"sideBarSectionHeader.background": "sidebarAccent",
+	"sideBarSectionHeader.foreground": "sidebarAccentForeground",
+	"sideBar.border": "sidebarBorder",
+	"editorError.foreground": "destructive",
+};
+
+/**
+ * VS Code `colors` key → Superset TerminalColors key.
+ */
+const VSCODE_COLORS_TO_TERMINAL: Record<string, string> = {
+	"terminal.background": "background",
+	"terminal.foreground": "foreground",
+	"terminalCursor.foreground": "cursor",
+	"terminalCursor.background": "cursorAccent",
+	"terminal.selectionBackground": "selectionBackground",
+	"terminal.ansiBlack": "black",
+	"terminal.ansiRed": "red",
+	"terminal.ansiGreen": "green",
+	"terminal.ansiYellow": "yellow",
+	"terminal.ansiBlue": "blue",
+	"terminal.ansiMagenta": "magenta",
+	"terminal.ansiCyan": "cyan",
+	"terminal.ansiWhite": "white",
+	"terminal.ansiBrightBlack": "brightBlack",
+	"terminal.ansiBrightRed": "brightRed",
+	"terminal.ansiBrightGreen": "brightGreen",
+	"terminal.ansiBrightYellow": "brightYellow",
+	"terminal.ansiBrightBlue": "brightBlue",
+	"terminal.ansiBrightMagenta": "brightMagenta",
+	"terminal.ansiBrightCyan": "brightCyan",
+	"terminal.ansiBrightWhite": "brightWhite",
+};
+
+/**
+ * VS Code `colors` key → Superset EditorColors key.
+ */
+const VSCODE_COLORS_TO_EDITOR: Record<string, string> = {
+	"editor.background": "background",
+	"editor.foreground": "foreground",
+	"editorGroup.border": "border",
+	"editorCursor.foreground": "cursor",
+	"editorGutter.background": "gutterBackground",
+	"editorLineNumber.foreground": "gutterForeground",
+	"editor.lineHighlightBackground": "activeLine",
+	"editor.selectionBackground": "selection",
+	"editor.findMatchHighlightBackground": "search",
+	"editor.findMatchBackground": "searchActive",
+	"diffEditor.insertedTextBackground": "addition",
+	"diffEditor.removedTextBackground": "deletion",
+};
+
+/**
+ * Extract the foreground color for a given scope from VS Code tokenColors.
+ * Uses prefix matching: scope "keyword.control" matches pattern "keyword".
+ */
+function findColorForScope(
+	tokenColors: VsCodeTokenColor[],
+	pattern: string,
+): string | undefined {
+	// Search in reverse so later (more specific) entries win
+	for (let i = tokenColors.length - 1; i >= 0; i--) {
+		const entry = tokenColors[i];
+		if (!entry.settings?.foreground) continue;
+
+		const scopes = Array.isArray(entry.scope)
+			? entry.scope
+			: typeof entry.scope === "string"
+				? entry.scope.split(",").map((s) => s.trim())
+				: [];
+
+		for (const scope of scopes) {
+			if (scope === pattern || scope.startsWith(`${pattern}.`)) {
+				return entry.settings.foreground;
+			}
+		}
+	}
+	return undefined;
+}
+
+/**
+ * Convert a VS Code theme (with tokenColors/colors) to Superset format.
+ */
+function convertVsCodeTheme(vscode: {
+	name?: string;
+	type?: string;
+	tokenColors?: VsCodeTokenColor[];
+	colors?: Record<string, string>;
+}): Record<string, unknown> {
+	const result: Record<string, unknown> = {};
+
+	if (vscode.name) result.name = vscode.name;
+	result.type = vscode.type === "light" ? "light" : "dark";
+
+	const tokenColors = vscode.tokenColors ?? [];
+	const vsColors = vscode.colors ?? {};
+
+	// ── Extract UI colors from VS Code colors ──
+	const ui: Record<string, string> = {};
+	for (const [vsKey, supersetKey] of Object.entries(VSCODE_COLORS_TO_UI)) {
+		const value = vsColors[vsKey];
+		if (value) ui[supersetKey] = value;
+	}
+	if (Object.keys(ui).length > 0) result.ui = ui;
+
+	// ── Extract terminal colors ──
+	const terminal: Record<string, string> = {};
+	for (const [vsKey, supersetKey] of Object.entries(
+		VSCODE_COLORS_TO_TERMINAL,
+	)) {
+		const value = vsColors[vsKey];
+		if (value) terminal[supersetKey] = value;
+	}
+	if (Object.keys(terminal).length > 0) result.terminal = terminal;
+
+	// ── Extract editor colors ──
+	const editorColors: Record<string, string> = {};
+	for (const [vsKey, supersetKey] of Object.entries(VSCODE_COLORS_TO_EDITOR)) {
+		const value = vsColors[vsKey];
+		if (value) editorColors[supersetKey] = value;
+	}
+
+	// ── Extract syntax colors from tokenColors ──
+	const syntax: Record<string, string> = {};
+	for (const { key, scopes } of SCOPE_TO_SYNTAX) {
+		if (syntax[key]) continue; // already found by a more specific rule
+		for (const scope of scopes) {
+			const color = findColorForScope(tokenColors, scope);
+			if (color) {
+				syntax[key] = color;
+				break;
+			}
+		}
+	}
+
+	// ── Build editor override ──
+	const hasEditorColors = Object.keys(editorColors).length > 0;
+	const hasSyntax = Object.keys(syntax).length > 0;
+	if (hasEditorColors || hasSyntax) {
+		result.editor = {
+			...(hasEditorColors ? { colors: editorColors } : {}),
+			...(hasSyntax ? { syntax } : {}),
+		};
+	}
+
+	return result;
+}
+
 function parseThemeEntry(
 	entry: unknown,
 	index: number,
@@ -280,6 +578,11 @@ export function parseThemeConfigFile(content: string): ThemeConfigParseResult {
 		parsedJson = JSON.parse(content);
 	} catch {
 		return { ok: false, error: "Invalid JSON file" };
+	}
+
+	// VS Code theme format: convert tokenColors/colors to Superset format
+	if (isVsCodeTheme(parsedJson)) {
+		parsedJson = convertVsCodeTheme(parsedJson);
 	}
 
 	const entries = Array.isArray(parsedJson)

--- a/apps/desktop/src/shared/themes/import.ts
+++ b/apps/desktop/src/shared/themes/import.ts
@@ -116,6 +116,17 @@ const editorSyntaxSchema = z
 		tagName: z.string().optional(),
 		attributeName: z.string().optional(),
 		invalid: z.string().optional(),
+		markdownHeading: z.string().optional(),
+		markdownEmphasis: z.string().optional(),
+		markdownStrong: z.string().optional(),
+		markdownStrikethrough: z.string().optional(),
+		markdownLink: z.string().optional(),
+		markdownUrl: z.string().optional(),
+		markdownCode: z.string().optional(),
+		markdownQuote: z.string().optional(),
+		markdownList: z.string().optional(),
+		markdownSeparator: z.string().optional(),
+		markdownMeta: z.string().optional(),
 	})
 	.passthrough();
 

--- a/apps/desktop/src/shared/themes/import.ts
+++ b/apps/desktop/src/shared/themes/import.ts
@@ -128,7 +128,7 @@ const editorSyntaxSchema = z
 		markdownQuote: z.string().optional(),
 		markdownList: z.string().optional(),
 		markdownSeparator: z.string().optional(),
-		markdownMeta: z.string().optional(),
+		meta: z.string().optional(),
 	})
 	.passthrough();
 

--- a/apps/desktop/src/shared/themes/import.ts
+++ b/apps/desktop/src/shared/themes/import.ts
@@ -104,11 +104,16 @@ const editorSyntaxSchema = z
 	.object({
 		plainText: z.string().optional(),
 		comment: z.string().optional(),
+		docComment: z.string().optional(),
 		keyword: z.string().optional(),
+		controlKeyword: z.string().optional(),
+		storageKeyword: z.string().optional(),
 		string: z.string().optional(),
+		escape: z.string().optional(),
 		number: z.string().optional(),
 		functionCall: z.string().optional(),
 		variableName: z.string().optional(),
+		variableProperty: z.string().optional(),
 		typeName: z.string().optional(),
 		className: z.string().optional(),
 		constant: z.string().optional(),
@@ -116,6 +121,7 @@ const editorSyntaxSchema = z
 		tagName: z.string().optional(),
 		attributeName: z.string().optional(),
 		invalid: z.string().optional(),
+		annotation: z.string().optional(),
 		operator: z.string().optional(),
 		punctuation: z.string().optional(),
 		markdownHeading: z.string().optional(),
@@ -249,15 +255,28 @@ const SCOPE_TO_SYNTAX: Array<{
 			"beginning.punctuation.definition.list",
 		],
 	},
-	// Code tokens
+	// Code tokens (specific scopes first, then generic fallbacks)
+	{
+		key: "docComment",
+		scopes: ["comment.block.documentation", "comment.line.documentation"],
+	},
 	{
 		key: "comment",
 		scopes: ["comment", "punctuation.definition.comment"],
 	},
 	{
-		key: "keyword",
-		scopes: ["keyword", "keyword.control", "storage", "storage.type"],
+		key: "controlKeyword",
+		scopes: ["keyword.control"],
 	},
+	{
+		key: "storageKeyword",
+		scopes: ["storage", "storage.type", "storage.modifier"],
+	},
+	{
+		key: "keyword",
+		scopes: ["keyword"],
+	},
+	{ key: "escape", scopes: ["constant.character.escape"] },
 	{ key: "string", scopes: ["string"] },
 	{
 		key: "number",
@@ -270,6 +289,14 @@ const SCOPE_TO_SYNTAX: Array<{
 			"support.function",
 			"meta.function-call",
 			"variable.function",
+		],
+	},
+	{
+		key: "variableProperty",
+		scopes: [
+			"variable.other.property",
+			"support.variable.property",
+			"meta.property.object",
 		],
 	},
 	{ key: "variableName", scopes: ["variable"] },
@@ -292,6 +319,15 @@ const SCOPE_TO_SYNTAX: Array<{
 		scopes: ["entity.other.attribute-name"],
 	},
 	{ key: "invalid", scopes: ["invalid"] },
+	{
+		key: "annotation",
+		scopes: [
+			"meta.decorator",
+			"meta.function.decorator",
+			"punctuation.definition.annotation",
+			"storage.type.annotation",
+		],
+	},
 	{
 		key: "operator",
 		scopes: ["keyword.operator"],

--- a/apps/desktop/src/shared/themes/import.ts
+++ b/apps/desktop/src/shared/themes/import.ts
@@ -232,16 +232,16 @@ const SCOPE_TO_SYNTAX: Array<{
 	},
 	{ key: "markdownStrikethrough", scopes: ["markup.strikethrough"] },
 	{
+		key: "markdownUrl",
+		scopes: ["markup.underline.link.image"],
+	},
+	{
 		key: "markdownLink",
 		scopes: [
 			"markup.underline.link",
 			"string.other.link.title",
 			"string.other.link.description",
 		],
-	},
-	{
-		key: "markdownUrl",
-		scopes: ["markup.underline.link.image"],
 	},
 	{
 		key: "markdownCode",
@@ -424,7 +424,10 @@ function findColorForScope(
 	tokenColors: VsCodeTokenColor[],
 	pattern: string,
 ): string | undefined {
-	// Search in reverse so later (more specific) entries win
+	// Two-pass search: exact match first, then prefix match.
+	// Within each pass, later entries win (VS Code convention).
+	let prefixMatch: string | undefined;
+
 	for (let i = tokenColors.length - 1; i >= 0; i--) {
 		const entry = tokenColors[i];
 		if (!entry.settings?.foreground) continue;
@@ -436,12 +439,15 @@ function findColorForScope(
 				: [];
 
 		for (const scope of scopes) {
-			if (scope === pattern || scope.startsWith(`${pattern}.`)) {
+			if (scope === pattern) {
 				return entry.settings.foreground;
+			}
+			if (!prefixMatch && scope.startsWith(`${pattern}.`)) {
+				prefixMatch = entry.settings.foreground;
 			}
 		}
 	}
-	return undefined;
+	return prefixMatch;
 }
 
 /**

--- a/apps/desktop/src/shared/themes/types.ts
+++ b/apps/desktop/src/shared/themes/types.ts
@@ -250,7 +250,7 @@ export interface EditorSyntaxColors {
 	markdownQuote: string;
 	markdownList: string;
 	markdownSeparator: string;
-	markdownMeta: string;
+	meta: string;
 }
 
 /**

--- a/apps/desktop/src/shared/themes/types.ts
+++ b/apps/desktop/src/shared/themes/types.ts
@@ -222,11 +222,16 @@ export interface EditorColors {
 export interface EditorSyntaxColors {
 	plainText: string;
 	comment: string;
+	docComment: string;
 	keyword: string;
+	controlKeyword: string;
+	storageKeyword: string;
 	string: string;
+	escape: string;
 	number: string;
 	functionCall: string;
 	variableName: string;
+	variableProperty: string;
 	typeName: string;
 	className: string;
 	constant: string;
@@ -234,6 +239,7 @@ export interface EditorSyntaxColors {
 	tagName: string;
 	attributeName: string;
 	invalid: string;
+	annotation: string;
 
 	// Operators and punctuation
 	operator: string;

--- a/apps/desktop/src/shared/themes/types.ts
+++ b/apps/desktop/src/shared/themes/types.ts
@@ -235,6 +235,10 @@ export interface EditorSyntaxColors {
 	attributeName: string;
 	invalid: string;
 
+	// Operators and punctuation
+	operator: string;
+	punctuation: string;
+
 	// Markdown-specific
 	markdownHeading: string;
 	markdownEmphasis: string;

--- a/apps/desktop/src/shared/themes/types.ts
+++ b/apps/desktop/src/shared/themes/types.ts
@@ -234,6 +234,19 @@ export interface EditorSyntaxColors {
 	tagName: string;
 	attributeName: string;
 	invalid: string;
+
+	// Markdown-specific
+	markdownHeading: string;
+	markdownEmphasis: string;
+	markdownStrong: string;
+	markdownStrikethrough: string;
+	markdownLink: string;
+	markdownUrl: string;
+	markdownCode: string;
+	markdownQuote: string;
+	markdownList: string;
+	markdownSeparator: string;
+	markdownMeta: string;
 }
 
 /**

--- a/packages/panes/src/react/components/Workspace/components/Tab/components/Pane/components/PaneHeader/PaneHeader.tsx
+++ b/packages/panes/src/react/components/Workspace/components/Tab/components/Pane/components/PaneHeader/PaneHeader.tsx
@@ -63,7 +63,8 @@ export function PaneHeader({
 			)}
 			onClick={(e) => {
 				// Don't trigger pin when clicking action buttons inside the header
-				if (e.target instanceof HTMLElement && e.target.closest("button")) return;
+				if (e.target instanceof HTMLElement && e.target.closest("button"))
+					return;
 				onClick?.();
 			}}
 			onAuxClick={(e) => {

--- a/packages/workspace-client/src/hooks/useFileTree/useFileTree.ts
+++ b/packages/workspace-client/src/hooks/useFileTree/useFileTree.ts
@@ -216,9 +216,9 @@ export function useFileTree({
 
 			try {
 				const result = await utils.filesystem.listDirectory.fetch(
-				{ workspaceId, absolutePath },
-				{ staleTime: 0 },
-			);
+					{ workspaceId, absolutePath },
+					{ staleTime: 0 },
+				);
 
 				updateState((current) => {
 					const nextEntries = new Map(current.entriesByPath);

--- a/packages/workspace-fs/src/search.ts
+++ b/packages/workspace-fs/src/search.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { promisify } from "node:util";
 import fg from "fast-glob";
 import Fuse from "fuse.js";
+import { readFile as readFsFile, writeFile as writeFsFile } from "./fs";
 import {
 	compareItemsByFuzzyScore,
 	type FuzzyScorerCache,
@@ -11,7 +12,6 @@ import {
 	prepareQuery,
 	scoreItemFuzzy,
 } from "./fuzzy-scorer";
-import { readFile as readFsFile, writeFile as writeFsFile } from "./fs";
 import {
 	isPathWithinRoot,
 	normalizeAbsolutePath,
@@ -586,7 +586,7 @@ function compareFileSearchMatches(
 	return left.item.relativePath.localeCompare(right.item.relativePath);
 }
 
-function collectExactFileSearchMatches({
+function _collectExactFileSearchMatches({
 	index,
 	query,
 	pathMatcher,


### PR DESCRIPTION
## Summary

- CodeMirrorエディタでMarkdown固有の要素（見出し、太字、斜体、リンク、コードブロック、引用、リスト等）のシンタックスハイライトを追加
- Lezerの全タグ（operator、punctuation、brackets、controlKeyword、namespace、docComment等）をカバーし、VS Code並のハイライト品質を実現
- Markdownのfenced code blocks内で19言語のネスト言語ハイライトを有効化（遅延ロード対応）
- テーマシステムに `operator`、`punctuation`、Markdown系11色のカスタマイズプロパティを追加。ユーザーがテーマJSONで個別に色指定可能
- Shikiテーマにも対応するスコープを追加し、プレビュー側との一貫性を確保

## 変更ファイル

| ファイル | 変更内容 |
|---------|---------|
| `types.ts` | `EditorSyntaxColors` に13個のプロパティ追加 |
| `editor-theme.ts` | ターミナル/UIカラーからのデフォルト導出 |
| `import.ts` | Zodスキーマに新プロパティ追加 |
| `syntax-highlighting.ts` | 全Lezerタグのスタイル定義 |
| `shiki-theme.ts` | TextMateスコープ追加 |
| `loadLanguageSupport.ts` | Markdown内ネスト言語ハイライト |

## Test plan

- [ ] .mdファイルを開いて見出し・太字・斜体・リンク・引用・リスト・コードブロックfenceが色分けされることを確認
- [ ] Markdown内の ```js ```python 等のコードブロックが各言語としてハイライトされることを確認
- [ ] .ts/.js/.py/.yaml/.env 等のファイルで演算子・括弧が適切に色分けされることを確認
- [ ] Settings > Appearance からテーマを切り替えてハイライト色が追従することを確認
- [ ] カスタムテーマをインポートし、新プロパティ（markdownHeading等）が反映されることを確認
- [ ] 新プロパティなしの既存カスタムテーマが問題なく動作することを確認（後方互換性）