### PR TITLE
feat: VS Code Extension Host Shim (Claude Code / ChatGPT対応)

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/index.ts
@@ -32,6 +32,7 @@ import { createTabTearoffRouter } from "./tab-tearoff";
 import { createTerminalRouter } from "./terminal";
 import { createUiStateRouter } from "./ui-state";
 import { createWindowRouter } from "./window";
+import { createVscodeExtensionsRouter } from "./vscode-extensions";
 import { createWorkspacesRouter } from "./workspaces";
 
 export const createAppRouter = (
@@ -71,6 +72,7 @@ export const createAppRouter = (
 		hostServiceManager: createHostServiceManagerRouter(),
 		tabTearoff: createTabTearoffRouter(wm),
 		extensions: createExtensionsRouter(getWindow),
+		vscodeExtensions: createVscodeExtensionsRouter(),
 	});
 };
 

--- a/apps/desktop/src/lib/trpc/routers/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/index.ts
@@ -31,8 +31,8 @@ import { createSettingsRouter } from "./settings";
 import { createTabTearoffRouter } from "./tab-tearoff";
 import { createTerminalRouter } from "./terminal";
 import { createUiStateRouter } from "./ui-state";
-import { createWindowRouter } from "./window";
 import { createVscodeExtensionsRouter } from "./vscode-extensions";
+import { createWindowRouter } from "./window";
 import { createWorkspacesRouter } from "./workspaces";
 
 export const createAppRouter = (

--- a/apps/desktop/src/lib/trpc/routers/ui-state/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/ui-state/index.ts
@@ -45,6 +45,7 @@ const paneSchema = z.object({
 		"git-graph",
 		"database-explorer",
 		"action-logs",
+		"vscode-extension",
 	]),
 	name: z.string(),
 	isNew: z.boolean().optional(),
@@ -109,6 +110,12 @@ const paneSchema = z.object({
 				}),
 			),
 			initialJobIndex: z.number().optional(),
+		})
+		.optional(),
+	vscodeExtension: z
+		.object({
+			viewType: z.string(),
+			extensionId: z.string(),
 		})
 		.optional(),
 	workspaceRun: z

--- a/apps/desktop/src/lib/trpc/routers/vscode-extensions/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/vscode-extensions/index.ts
@@ -55,6 +55,16 @@ export const createVscodeExtensionsRouter = () => {
 				return { success: true };
 			}),
 
+		/** Restart a specific extension */
+		restartExtension: publicProcedure
+			.input(z.object({ extensionId: z.string() }))
+			.mutation(async ({ input }) => {
+				const { restartExtension } =
+					require("main/lib/vscode-shim/extension-host") as typeof import("main/lib/vscode-shim/extension-host");
+				const success = await restartExtension(input.extensionId);
+				return { success };
+			}),
+
 		/** Subscribe to webview events (HTML changes, messages from extension) */
 		subscribeWebview: publicProcedure.subscription(() => {
 			return observable<WebviewBridgeEvent>((emit) => {

--- a/apps/desktop/src/lib/trpc/routers/vscode-extensions/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/vscode-extensions/index.ts
@@ -4,6 +4,10 @@ import os from "node:os";
 import path from "node:path";
 import { pipeline } from "node:stream/promises";
 import { observable } from "@trpc/server/observable";
+import {
+	getWebviewUrl,
+	setWebviewHtml,
+} from "main/lib/vscode-shim/api/webview-server";
 import { setActiveTextEditor } from "main/lib/vscode-shim/api/window";
 import {
 	getActiveExtensions,
@@ -238,13 +242,18 @@ export const createVscodeExtensionsRouter = () => {
 					input.extensionPath,
 				);
 				if (!viewId) {
-					return { viewId: null, html: null };
+					return { viewId: null, url: null };
 				}
-				const html = webviewBridge.getHtml(viewId) ?? null;
+				// Store HTML in webview server and return HTTP URL
+				const html = webviewBridge.getHtml(viewId);
+				if (html) {
+					setWebviewHtml(viewId, html);
+				}
+				const url = getWebviewUrl(viewId);
 				console.log(
-					`[vscode-shim] resolveWebview: viewId=${viewId}, hasHtml=${!!html}, htmlLen=${html?.length ?? 0}`,
+					`[vscode-shim] resolveWebview: viewId=${viewId}, hasHtml=${!!html}, url=${url}`,
 				);
-				return { viewId, html };
+				return { viewId, url };
 			}),
 
 		/** Get current webview HTML */

--- a/apps/desktop/src/lib/trpc/routers/vscode-extensions/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/vscode-extensions/index.ts
@@ -1,0 +1,71 @@
+import { observable } from "@trpc/server/observable";
+import { z } from "zod";
+import { publicProcedure, router } from "../..";
+import { webviewBridge } from "main/lib/vscode-shim/webview-bridge";
+import type { WebviewBridgeEvent } from "main/lib/vscode-shim/webview-bridge";
+
+export const createVscodeExtensionsRouter = () => {
+	return router({
+		/** Get list of loaded extensions */
+		getExtensions: publicProcedure.query(() => {
+			const { getActiveExtensions } =
+				require("main/lib/vscode-shim") as typeof import("main/lib/vscode-shim");
+			return getActiveExtensions();
+		}),
+
+		/** Resolve a webview view for a given viewType, returns initial HTML */
+		resolveWebview: publicProcedure
+			.input(
+				z.object({
+					viewType: z.string(),
+					extensionPath: z.string(),
+				}),
+			)
+			.mutation(({ input }) => {
+				const viewId = webviewBridge.resolveView(
+					input.viewType,
+					input.extensionPath,
+				);
+				if (!viewId) {
+					return { viewId: null, html: null };
+				}
+				const html = webviewBridge.getHtml(viewId) ?? null;
+				return { viewId, html };
+			}),
+
+		/** Get current webview HTML */
+		getWebviewHtml: publicProcedure
+			.input(z.object({ viewType: z.string() }))
+			.query(({ input }) => {
+				const viewId = webviewBridge.getViewId(input.viewType);
+				if (!viewId) return null;
+				return webviewBridge.getHtml(viewId) ?? null;
+			}),
+
+		/** Send a message from renderer to extension webview */
+		postMessageToExtension: publicProcedure
+			.input(
+				z.object({
+					viewId: z.string(),
+					message: z.unknown(),
+				}),
+			)
+			.mutation(({ input }) => {
+				webviewBridge.postMessageToExtension(input.viewId, input.message);
+				return { success: true };
+			}),
+
+		/** Subscribe to webview events (HTML changes, messages from extension) */
+		subscribeWebview: publicProcedure.subscription(() => {
+			return observable<WebviewBridgeEvent>((emit) => {
+				const handler = (event: WebviewBridgeEvent) => {
+					emit.next(event);
+				};
+				webviewBridge.on("webview-event", handler);
+				return () => {
+					webviewBridge.off("webview-event", handler);
+				};
+			});
+		}),
+	});
+};

--- a/apps/desktop/src/lib/trpc/routers/vscode-extensions/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/vscode-extensions/index.ts
@@ -55,6 +55,21 @@ export const createVscodeExtensionsRouter = () => {
 				return { success: true };
 			}),
 
+		/** Notify main process of active file change (for activeTextEditor) */
+		setActiveEditor: publicProcedure
+			.input(
+				z.object({
+					filePath: z.string().nullable(),
+					languageId: z.string().optional(),
+				}),
+			)
+			.mutation(({ input }) => {
+				const { setActiveTextEditor } =
+					require("main/lib/vscode-shim") as typeof import("main/lib/vscode-shim");
+				setActiveTextEditor(input.filePath, input.languageId);
+				return { success: true };
+			}),
+
 		/** Restart a specific extension */
 		restartExtension: publicProcedure
 			.input(z.object({ extensionId: z.string() }))

--- a/apps/desktop/src/lib/trpc/routers/vscode-extensions/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/vscode-extensions/index.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { pipeline } from "node:stream/promises";
+import { TRPCError } from "@trpc/server";
 import { observable } from "@trpc/server/observable";
 import {
 	getWebviewUrl,
@@ -366,6 +367,12 @@ export const createVscodeExtensionsRouter = () => {
 				}),
 			)
 			.mutation(async ({ input }) => {
+				if (!KNOWN_EXTENSIONS.some((e) => e.id === input.extensionId)) {
+					throw new TRPCError({
+						code: "BAD_REQUEST",
+						message: "Unknown extension",
+					});
+				}
 				const config = readEnabledConfig();
 				config[input.extensionId] = input.enabled;
 				writeEnabledConfig(config);

--- a/apps/desktop/src/lib/trpc/routers/vscode-extensions/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/vscode-extensions/index.ts
@@ -1,6 +1,8 @@
+import { execSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { pipeline } from "node:stream/promises";
 import { observable } from "@trpc/server/observable";
 import type { WebviewBridgeEvent } from "main/lib/vscode-shim/webview-bridge";
 import { webviewBridge } from "main/lib/vscode-shim/webview-bridge";
@@ -40,6 +42,136 @@ function isExtensionInstalled(extensionId: string): boolean {
 	return entries.some((entry) =>
 		entry.toLowerCase().startsWith(extensionId.toLowerCase()),
 	);
+}
+
+/**
+ * Download a VS Code extension from the marketplace and extract to extensions dir.
+ * Uses the VS Code Marketplace Gallery API to fetch the .vsix package.
+ */
+async function downloadAndInstallExtension(extensionId: string): Promise<void> {
+	const [publisher, name] = extensionId.split(".");
+	if (!publisher || !name) {
+		throw new Error(`Invalid extension ID: ${extensionId}`);
+	}
+
+	const extensionsDir = getExtensionsDir();
+	fs.mkdirSync(extensionsDir, { recursive: true });
+
+	// Step 1: Query marketplace for latest version + download URL
+	const queryBody = JSON.stringify({
+		filters: [
+			{
+				criteria: [{ filterType: 7, value: `${publisher}.${name}` }],
+			},
+		],
+		flags: 0x200 | 0x1, // IncludeFiles | IncludeVersions
+	});
+
+	const queryResponse = await fetch(
+		"https://marketplace.visualstudio.com/_apis/public/gallery/extensionquery",
+		{
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Accept: "application/json;api-version=6.0-preview.1",
+			},
+			body: queryBody,
+		},
+	);
+
+	if (!queryResponse.ok) {
+		throw new Error(`Marketplace query failed: ${queryResponse.status}`);
+	}
+
+	const queryData = (await queryResponse.json()) as {
+		results: Array<{
+			extensions: Array<{
+				versions: Array<{
+					version: string;
+					targetPlatform?: string;
+					files: Array<{ assetType: string; source: string }>;
+				}>;
+			}>;
+		}>;
+	};
+
+	const ext = queryData.results?.[0]?.extensions?.[0];
+	if (!ext) {
+		throw new Error(`Extension not found: ${extensionId}`);
+	}
+
+	// Find the best matching version (prefer platform-specific)
+	const platform = `${process.platform}-${process.arch}`;
+	const platformVersion = ext.versions.find(
+		(v) => v.targetPlatform === platform,
+	);
+	const universalVersion = ext.versions.find(
+		(v) => !v.targetPlatform || v.targetPlatform === "universal",
+	);
+	const version = platformVersion ?? universalVersion ?? ext.versions[0];
+	if (!version) {
+		throw new Error(`No version found for ${extensionId}`);
+	}
+
+	// Find VSIX download URL
+	const vsixAsset = version.files.find(
+		(f) => f.assetType === "Microsoft.VisualStudio.Services.VSIXPackage",
+	);
+	if (!vsixAsset) {
+		throw new Error(`No VSIX package found for ${extensionId}`);
+	}
+
+	console.log(
+		`[vscode-shim] Downloading ${extensionId}@${version.version} (${version.targetPlatform ?? "universal"})`,
+	);
+
+	// Step 2: Download .vsix
+	const vsixResponse = await fetch(vsixAsset.source);
+	if (!vsixResponse.ok || !vsixResponse.body) {
+		throw new Error(`VSIX download failed: ${vsixResponse.status}`);
+	}
+
+	const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "vscode-ext-"));
+	const vsixPath = path.join(tmpDir, `${extensionId}.vsix`);
+
+	const fileStream = fs.createWriteStream(vsixPath);
+	// @ts-expect-error - Node fetch body is a ReadableStream
+	await pipeline(vsixResponse.body, fileStream);
+
+	// Step 3: Extract .vsix (it's a zip file)
+	const targetSuffix = version.targetPlatform
+		? `-${version.targetPlatform}`
+		: "";
+	const extDir = path.join(
+		extensionsDir,
+		`${publisher}.${name}-${version.version}${targetSuffix}`,
+	);
+
+	if (fs.existsSync(extDir)) {
+		fs.rmSync(extDir, { recursive: true });
+	}
+	fs.mkdirSync(extDir, { recursive: true });
+
+	// Use unzip command (available on macOS/Linux)
+	execSync(`unzip -q -o "${vsixPath}" -d "${tmpDir}/extracted"`);
+
+	// The extension content is in the "extension/" subdirectory of the vsix
+	const extractedExtDir = path.join(tmpDir, "extracted", "extension");
+	if (fs.existsSync(extractedExtDir)) {
+		// Move contents to target directory
+		execSync(`cp -R "${extractedExtDir}/"* "${extDir}/"`);
+	}
+
+	// Copy [Content_Types].xml and extension.vsixmanifest if needed
+	const vsixManifest = path.join(tmpDir, "extracted", "extension.vsixmanifest");
+	if (fs.existsSync(vsixManifest)) {
+		fs.copyFileSync(vsixManifest, path.join(extDir, ".vsixmanifest"));
+	}
+
+	// Cleanup
+	fs.rmSync(tmpDir, { recursive: true });
+
+	console.log(`[vscode-shim] Installed ${extensionId} to ${extDir}`);
 }
 
 export const createVscodeExtensionsRouter = () => {
@@ -124,6 +256,14 @@ export const createVscodeExtensionsRouter = () => {
 				const { setActiveTextEditor } =
 					require("main/lib/vscode-shim") as typeof import("main/lib/vscode-shim");
 				setActiveTextEditor(input.filePath, input.languageId);
+				return { success: true };
+			}),
+
+		/** Download and install an extension from the VS Code Marketplace */
+		installExtension: publicProcedure
+			.input(z.object({ extensionId: z.string() }))
+			.mutation(async ({ input }) => {
+				await downloadAndInstallExtension(input.extensionId);
 				return { success: true };
 			}),
 

--- a/apps/desktop/src/lib/trpc/routers/vscode-extensions/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/vscode-extensions/index.ts
@@ -97,14 +97,12 @@ function waitForHtml(
 	timeoutMs: number,
 ): Promise<string | null> {
 	return new Promise((resolve) => {
-		const check = () => {
-			const html = webviewBridge.getHtml(viewId);
-			if (html) return resolve(html);
-			return null;
-		};
-		// Check immediately
-		const immediate = check();
-		if (immediate) return;
+		// Check immediately before starting poll
+		const html = webviewBridge.getHtml(viewId);
+		if (html) {
+			resolve(html);
+			return;
+		}
 
 		// Poll every 200ms
 		const interval = setInterval(() => {

--- a/apps/desktop/src/lib/trpc/routers/vscode-extensions/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/vscode-extensions/index.ts
@@ -12,6 +12,7 @@ import { setActiveTextEditor } from "main/lib/vscode-shim/api/window";
 import {
 	getActiveExtensions,
 	restartExtension,
+	updateWorkspacePath,
 } from "main/lib/vscode-shim/extension-host";
 import type { WebviewBridgeEvent } from "main/lib/vscode-shim/webview-bridge";
 import { webviewBridge } from "main/lib/vscode-shim/webview-bridge";
@@ -316,6 +317,14 @@ export const createVscodeExtensionsRouter = () => {
 			)
 			.mutation(({ input }) => {
 				webviewBridge.postMessageToExtension(input.viewId, input.message);
+				return { success: true };
+			}),
+
+		/** Set the workspace folder path for extensions */
+		setWorkspacePath: publicProcedure
+			.input(z.object({ workspacePath: z.string() }))
+			.mutation(({ input }) => {
+				updateWorkspacePath(input.workspacePath);
 				return { success: true };
 			}),
 

--- a/apps/desktop/src/lib/trpc/routers/vscode-extensions/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/vscode-extensions/index.ts
@@ -223,7 +223,7 @@ export const createVscodeExtensionsRouter = () => {
 			});
 		}),
 
-		/** Resolve a webview view for a given viewType, returns initial HTML */
+		/** Resolve a webview view for a given viewType, returns viewId + protocol URL */
 		resolveWebview: publicProcedure
 			.input(
 				z.object({
@@ -237,10 +237,17 @@ export const createVscodeExtensionsRouter = () => {
 					input.extensionPath,
 				);
 				if (!viewId) {
-					return { viewId: null, html: null };
+					return { viewId: null, url: null };
 				}
-				const html = webviewBridge.getHtml(viewId) ?? null;
-				return { viewId, html };
+				// Store HTML in protocol handler and return URL
+				const html = webviewBridge.getHtml(viewId);
+				if (html) {
+					const { setWebviewHtml } =
+						require("main/lib/vscode-shim") as typeof import("main/lib/vscode-shim");
+					setWebviewHtml(viewId, html);
+				}
+				const url = `vscode-webview://${viewId}`;
+				return { viewId, url };
 			}),
 
 		/** Get current webview HTML */

--- a/apps/desktop/src/lib/trpc/routers/vscode-extensions/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/vscode-extensions/index.ts
@@ -9,7 +9,10 @@ import {
 	getWebviewUrl,
 	setWebviewHtml,
 } from "main/lib/vscode-shim/api/webview-server";
-import { setActiveTextEditor } from "main/lib/vscode-shim/api/window";
+import {
+	onOpenFile,
+	setActiveTextEditor,
+} from "main/lib/vscode-shim/api/window";
 import {
 	getActiveExtensions,
 	restartExtension,
@@ -424,6 +427,16 @@ export const createVscodeExtensionsRouter = () => {
 				const success = await restartExtension(input.extensionId);
 				return { success };
 			}),
+
+		/** Subscribe to file open requests from extensions (showTextDocument) */
+		subscribeOpenFile: publicProcedure.subscription(() => {
+			return observable<{ filePath: string; line?: number }>((emit) => {
+				const disposable = onOpenFile((data) => {
+					emit.next(data);
+				});
+				return () => disposable.dispose();
+			});
+		}),
 
 		/** Subscribe to webview events (HTML changes, messages from extension) */
 		subscribeWebview: publicProcedure.subscription(() => {

--- a/apps/desktop/src/lib/trpc/routers/vscode-extensions/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/vscode-extensions/index.ts
@@ -1,4 +1,4 @@
-import { execSync } from "node:child_process";
+import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -49,6 +49,16 @@ function isExtensionInstalled(extensionId: string): boolean {
  * Uses the VS Code Marketplace Gallery API to fetch the .vsix package.
  */
 async function downloadAndInstallExtension(extensionId: string): Promise<void> {
+	// Validate against known extensions whitelist
+	if (!KNOWN_EXTENSIONS.some((e) => e.id === extensionId)) {
+		throw new Error(`Unknown extension: ${extensionId}`);
+	}
+
+	// Strict format validation
+	if (!/^[a-zA-Z0-9_-]+\.[a-zA-Z0-9_-]+$/.test(extensionId)) {
+		throw new Error(`Invalid extension ID format: ${extensionId}`);
+	}
+
 	const [publisher, name] = extensionId.split(".");
 	if (!publisher || !name) {
 		throw new Error(`Invalid extension ID: ${extensionId}`);
@@ -147,31 +157,42 @@ async function downloadAndInstallExtension(extensionId: string): Promise<void> {
 		`${publisher}.${name}-${version.version}${targetSuffix}`,
 	);
 
-	if (fs.existsSync(extDir)) {
-		fs.rmSync(extDir, { recursive: true });
+	try {
+		if (fs.existsSync(extDir)) {
+			fs.rmSync(extDir, { recursive: true });
+		}
+		fs.mkdirSync(extDir, { recursive: true });
+
+		// Extract .vsix using spawnSync (no shell injection risk)
+		const extractDir = path.join(tmpDir, "extracted");
+		const unzipResult = spawnSync(
+			"unzip",
+			["-q", "-o", vsixPath, "-d", extractDir],
+			{
+				stdio: "pipe",
+			},
+		);
+		if (unzipResult.status !== 0) {
+			throw new Error(`unzip failed: ${unzipResult.stderr?.toString()}`);
+		}
+
+		// Copy extension content using Node.js fs (no shell commands)
+		const extractedExtDir = path.join(extractDir, "extension");
+		if (fs.existsSync(extractedExtDir)) {
+			fs.cpSync(extractedExtDir, extDir, { recursive: true });
+		}
+
+		// Copy vsixmanifest if present
+		const vsixManifest = path.join(extractDir, "extension.vsixmanifest");
+		if (fs.existsSync(vsixManifest)) {
+			fs.copyFileSync(vsixManifest, path.join(extDir, ".vsixmanifest"));
+		}
+
+		console.log(`[vscode-shim] Installed ${extensionId} to ${extDir}`);
+	} finally {
+		// Always cleanup temp directory
+		fs.rmSync(tmpDir, { recursive: true, force: true });
 	}
-	fs.mkdirSync(extDir, { recursive: true });
-
-	// Use unzip command (available on macOS/Linux)
-	execSync(`unzip -q -o "${vsixPath}" -d "${tmpDir}/extracted"`);
-
-	// The extension content is in the "extension/" subdirectory of the vsix
-	const extractedExtDir = path.join(tmpDir, "extracted", "extension");
-	if (fs.existsSync(extractedExtDir)) {
-		// Move contents to target directory
-		execSync(`cp -R "${extractedExtDir}/"* "${extDir}/"`);
-	}
-
-	// Copy [Content_Types].xml and extension.vsixmanifest if needed
-	const vsixManifest = path.join(tmpDir, "extracted", "extension.vsixmanifest");
-	if (fs.existsSync(vsixManifest)) {
-		fs.copyFileSync(vsixManifest, path.join(extDir, ".vsixmanifest"));
-	}
-
-	// Cleanup
-	fs.rmSync(tmpDir, { recursive: true });
-
-	console.log(`[vscode-shim] Installed ${extensionId} to ${extDir}`);
 }
 
 export const createVscodeExtensionsRouter = () => {

--- a/apps/desktop/src/lib/trpc/routers/vscode-extensions/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/vscode-extensions/index.ts
@@ -243,10 +243,14 @@ export const createVscodeExtensionsRouter = () => {
 				}
 				// Store HTML in protocol handler and return URL
 				const html = webviewBridge.getHtml(viewId);
+				console.log(
+					`[vscode-shim] resolveWebview: viewId=${viewId}, hasHtml=${!!html}, htmlLen=${html?.length ?? 0}`,
+				);
 				if (html) {
 					setWebviewHtml(viewId, html);
 				}
-				const url = `vscode-webview://${viewId}`;
+				// Use proper URL with hostname to avoid colon parsing issues
+				const url = `vscode-webview://webview/${encodeURIComponent(viewId)}`;
 				return { viewId, url };
 			}),
 

--- a/apps/desktop/src/lib/trpc/routers/vscode-extensions/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/vscode-extensions/index.ts
@@ -4,7 +4,6 @@ import os from "node:os";
 import path from "node:path";
 import { pipeline } from "node:stream/promises";
 import { observable } from "@trpc/server/observable";
-import { setWebviewHtml } from "main/lib/vscode-shim/api/protocol-handler";
 import { setActiveTextEditor } from "main/lib/vscode-shim/api/window";
 import {
 	getActiveExtensions,
@@ -225,7 +224,7 @@ export const createVscodeExtensionsRouter = () => {
 			});
 		}),
 
-		/** Resolve a webview view for a given viewType, returns viewId + protocol URL */
+		/** Resolve a webview view for a given viewType, returns viewId + HTML */
 		resolveWebview: publicProcedure
 			.input(
 				z.object({
@@ -239,19 +238,13 @@ export const createVscodeExtensionsRouter = () => {
 					input.extensionPath,
 				);
 				if (!viewId) {
-					return { viewId: null, url: null };
+					return { viewId: null, html: null };
 				}
-				// Store HTML in protocol handler and return URL
-				const html = webviewBridge.getHtml(viewId);
+				const html = webviewBridge.getHtml(viewId) ?? null;
 				console.log(
 					`[vscode-shim] resolveWebview: viewId=${viewId}, hasHtml=${!!html}, htmlLen=${html?.length ?? 0}`,
 				);
-				if (html) {
-					setWebviewHtml(viewId, html);
-				}
-				// Use proper URL with hostname to avoid colon parsing issues
-				const url = `vscode-webview://webview/${encodeURIComponent(viewId)}`;
-				return { viewId, url };
+				return { viewId, html };
 			}),
 
 		/** Get current webview HTML */

--- a/apps/desktop/src/lib/trpc/routers/vscode-extensions/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/vscode-extensions/index.ts
@@ -1,8 +1,8 @@
 import { observable } from "@trpc/server/observable";
+import type { WebviewBridgeEvent } from "main/lib/vscode-shim/webview-bridge";
+import { webviewBridge } from "main/lib/vscode-shim/webview-bridge";
 import { z } from "zod";
 import { publicProcedure, router } from "../..";
-import { webviewBridge } from "main/lib/vscode-shim/webview-bridge";
-import type { WebviewBridgeEvent } from "main/lib/vscode-shim/webview-bridge";
 
 export const createVscodeExtensionsRouter = () => {
 	return router({

--- a/apps/desktop/src/lib/trpc/routers/vscode-extensions/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/vscode-extensions/index.ts
@@ -1,16 +1,73 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { observable } from "@trpc/server/observable";
 import type { WebviewBridgeEvent } from "main/lib/vscode-shim/webview-bridge";
 import { webviewBridge } from "main/lib/vscode-shim/webview-bridge";
 import { z } from "zod";
 import { publicProcedure, router } from "../..";
 
+/** Known VS Code extensions that can be managed */
+const KNOWN_EXTENSIONS = [
+	{
+		id: "anthropic.claude-code",
+		name: "Claude Code",
+		publisher: "Anthropic",
+		description: "AI coding assistant by Anthropic",
+		marketplaceUrl:
+			"https://marketplace.visualstudio.com/items?itemName=anthropic.claude-code",
+		viewType: "claudeVSCodeSidebar",
+	},
+	{
+		id: "openai.chatgpt",
+		name: "ChatGPT / Codex",
+		publisher: "OpenAI",
+		description: "AI coding assistant by OpenAI",
+		marketplaceUrl:
+			"https://marketplace.visualstudio.com/items?itemName=openai.chatgpt",
+		viewType: "chatgpt.sidebarView",
+	},
+] as const;
+
+function getExtensionsDir(): string {
+	return path.join(os.homedir(), ".vscode", "extensions");
+}
+
+function isExtensionInstalled(extensionId: string): boolean {
+	const dir = getExtensionsDir();
+	if (!fs.existsSync(dir)) return false;
+	const entries = fs.readdirSync(dir);
+	return entries.some((entry) =>
+		entry.toLowerCase().startsWith(extensionId.toLowerCase()),
+	);
+}
+
 export const createVscodeExtensionsRouter = () => {
 	return router({
-		/** Get list of loaded extensions */
+		/** Get list of loaded (active) extensions */
 		getExtensions: publicProcedure.query(() => {
 			const { getActiveExtensions } =
 				require("main/lib/vscode-shim") as typeof import("main/lib/vscode-shim");
 			return getActiveExtensions();
+		}),
+
+		/** Get all known extensions with their install/active status */
+		getKnownExtensions: publicProcedure.query(() => {
+			let activeExtensions: Array<{ id: string; isActive: boolean }> = [];
+			try {
+				const { getActiveExtensions } =
+					require("main/lib/vscode-shim") as typeof import("main/lib/vscode-shim");
+				activeExtensions = getActiveExtensions();
+			} catch {}
+
+			return KNOWN_EXTENSIONS.map((ext) => {
+				const active = activeExtensions.find((a) => a.id === ext.id);
+				return {
+					...ext,
+					installed: isExtensionInstalled(ext.id),
+					active: active?.isActive ?? false,
+				};
+			});
 		}),
 
 		/** Resolve a webview view for a given viewType, returns initial HTML */

--- a/apps/desktop/src/lib/trpc/routers/vscode-extensions/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/vscode-extensions/index.ts
@@ -45,6 +45,42 @@ function getExtensionsDir(): string {
 	return path.join(os.homedir(), ".vscode", "extensions");
 }
 
+/** Persistent enabled/disabled state for extensions */
+function getEnabledConfigPath(): string {
+	const userDataPath = (() => {
+		try {
+			return require("electron").app.getPath("userData");
+		} catch {
+			return path.join(os.homedir(), ".superset-desktop");
+		}
+	})();
+	return path.join(userDataPath, "vscode-extensions-enabled.json");
+}
+
+function readEnabledConfig(): Record<string, boolean> {
+	try {
+		const p = getEnabledConfigPath();
+		if (fs.existsSync(p)) {
+			return JSON.parse(fs.readFileSync(p, "utf-8"));
+		}
+	} catch {}
+	// All enabled by default
+	return {};
+}
+
+function writeEnabledConfig(config: Record<string, boolean>): void {
+	try {
+		const p = getEnabledConfigPath();
+		fs.mkdirSync(path.dirname(p), { recursive: true });
+		fs.writeFileSync(p, JSON.stringify(config, null, 2));
+	} catch {}
+}
+
+function isExtensionEnabled(extensionId: string): boolean {
+	const config = readEnabledConfig();
+	return config[extensionId] !== false; // enabled by default
+}
+
 function isExtensionInstalled(extensionId: string): boolean {
 	const dir = getExtensionsDir();
 	if (!fs.existsSync(dir)) return false;
@@ -259,6 +295,7 @@ export const createVscodeExtensionsRouter = () => {
 				return {
 					...ext,
 					installed: isExtensionInstalled(ext.id),
+					enabled: isExtensionEnabled(ext.id),
 					active: active?.isActive ?? false,
 				};
 			});
@@ -318,6 +355,32 @@ export const createVscodeExtensionsRouter = () => {
 			.mutation(({ input }) => {
 				webviewBridge.postMessageToExtension(input.viewId, input.message);
 				return { success: true };
+			}),
+
+		/** Enable or disable an extension (persisted, requires restart for full effect) */
+		setExtensionEnabled: publicProcedure
+			.input(
+				z.object({
+					extensionId: z.string(),
+					enabled: z.boolean(),
+				}),
+			)
+			.mutation(async ({ input }) => {
+				const config = readEnabledConfig();
+				config[input.extensionId] = input.enabled;
+				writeEnabledConfig(config);
+
+				// If disabling, deactivate immediately
+				if (!input.enabled) {
+					try {
+						const { deactivateExtension } = await import(
+							"main/lib/vscode-shim/loader"
+						);
+						await deactivateExtension(input.extensionId);
+					} catch {}
+				}
+
+				return { success: true, needsRestart: true };
 			}),
 
 		/** Set the workspace folder path for extensions */

--- a/apps/desktop/src/lib/trpc/routers/vscode-extensions/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/vscode-extensions/index.ts
@@ -4,6 +4,12 @@ import os from "node:os";
 import path from "node:path";
 import { pipeline } from "node:stream/promises";
 import { observable } from "@trpc/server/observable";
+import { setWebviewHtml } from "main/lib/vscode-shim/api/protocol-handler";
+import { setActiveTextEditor } from "main/lib/vscode-shim/api/window";
+import {
+	getActiveExtensions,
+	restartExtension,
+} from "main/lib/vscode-shim/extension-host";
 import type { WebviewBridgeEvent } from "main/lib/vscode-shim/webview-bridge";
 import { webviewBridge } from "main/lib/vscode-shim/webview-bridge";
 import { z } from "zod";
@@ -199,8 +205,6 @@ export const createVscodeExtensionsRouter = () => {
 	return router({
 		/** Get list of loaded (active) extensions */
 		getExtensions: publicProcedure.query(() => {
-			const { getActiveExtensions } =
-				require("main/lib/vscode-shim") as typeof import("main/lib/vscode-shim");
 			return getActiveExtensions();
 		}),
 
@@ -208,8 +212,6 @@ export const createVscodeExtensionsRouter = () => {
 		getKnownExtensions: publicProcedure.query(() => {
 			let activeExtensions: Array<{ id: string; isActive: boolean }> = [];
 			try {
-				const { getActiveExtensions } =
-					require("main/lib/vscode-shim") as typeof import("main/lib/vscode-shim");
 				activeExtensions = getActiveExtensions();
 			} catch {}
 
@@ -242,8 +244,6 @@ export const createVscodeExtensionsRouter = () => {
 				// Store HTML in protocol handler and return URL
 				const html = webviewBridge.getHtml(viewId);
 				if (html) {
-					const { setWebviewHtml } =
-						require("main/lib/vscode-shim") as typeof import("main/lib/vscode-shim");
 					setWebviewHtml(viewId, html);
 				}
 				const url = `vscode-webview://${viewId}`;
@@ -281,8 +281,6 @@ export const createVscodeExtensionsRouter = () => {
 				}),
 			)
 			.mutation(({ input }) => {
-				const { setActiveTextEditor } =
-					require("main/lib/vscode-shim") as typeof import("main/lib/vscode-shim");
 				setActiveTextEditor(input.filePath, input.languageId);
 				return { success: true };
 			}),
@@ -299,8 +297,6 @@ export const createVscodeExtensionsRouter = () => {
 		restartExtension: publicProcedure
 			.input(z.object({ extensionId: z.string() }))
 			.mutation(async ({ input }) => {
-				const { restartExtension } =
-					require("main/lib/vscode-shim/extension-host") as typeof import("main/lib/vscode-shim/extension-host");
 				const success = await restartExtension(input.extensionId);
 				return { success };
 			}),

--- a/apps/desktop/src/lib/trpc/routers/vscode-extensions/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/vscode-extensions/index.ts
@@ -53,6 +53,41 @@ function isExtensionInstalled(extensionId: string): boolean {
 	);
 }
 
+/** Wait for HTML to be set on a webview (for async providers) */
+function waitForHtml(
+	viewId: string,
+	timeoutMs: number,
+): Promise<string | null> {
+	return new Promise((resolve) => {
+		const check = () => {
+			const html = webviewBridge.getHtml(viewId);
+			if (html) return resolve(html);
+			return null;
+		};
+		// Check immediately
+		const immediate = check();
+		if (immediate) return;
+
+		// Poll every 200ms
+		const interval = setInterval(() => {
+			const html = webviewBridge.getHtml(viewId);
+			if (html) {
+				clearInterval(interval);
+				resolve(html);
+			}
+		}, 200);
+
+		// Timeout
+		setTimeout(() => {
+			clearInterval(interval);
+			console.warn(
+				`[vscode-shim] waitForHtml timed out after ${timeoutMs}ms for ${viewId}`,
+			);
+			resolve(null);
+		}, timeoutMs);
+	});
+}
+
 /**
  * Download a VS Code extension from the marketplace and extract to extensions dir.
  * Uses the VS Code Marketplace Gallery API to fetch the .vsix package.
@@ -236,7 +271,7 @@ export const createVscodeExtensionsRouter = () => {
 					extensionPath: z.string(),
 				}),
 			)
-			.mutation(({ input }) => {
+			.mutation(async ({ input }) => {
 				const viewId = webviewBridge.resolveView(
 					input.viewType,
 					input.extensionPath,
@@ -244,8 +279,14 @@ export const createVscodeExtensionsRouter = () => {
 				if (!viewId) {
 					return { viewId: null, url: null };
 				}
-				// Store HTML in webview server and return HTTP URL
-				const html = webviewBridge.getHtml(viewId);
+				// Wait for HTML if provider sets it asynchronously
+				let html = webviewBridge.getHtml(viewId);
+				if (!html) {
+					console.log(
+						`[vscode-shim] resolveWebview: waiting for async HTML on ${viewId}`,
+					);
+					html = (await waitForHtml(viewId, 5000)) ?? undefined;
+				}
 				if (html) {
 					setWebviewHtml(viewId, html);
 				}

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -43,6 +43,7 @@ import {
 	reconcileDaemonSessions,
 } from "./lib/terminal";
 import { disposeTray, initTray } from "./lib/tray";
+import { initExtensionHost, shutdownExtensionHost } from "./lib/vscode-shim";
 import { cleanupMainWindowResources, MainWindow } from "./windows/main";
 
 console.log("[main] Local database ready:", !!localDb);
@@ -408,6 +409,7 @@ app.on("before-quit", async (event) => {
 	}
 
 	isQuitting = true;
+	shutdownExtensionHost().catch(() => {});
 	closeLocalDb();
 	if (quitMode === "stop") {
 		manager.stopAll();
@@ -587,6 +589,11 @@ if (!gotTheLock) {
 		await makeAppSetup(() => MainWindow());
 		setupAutoUpdater();
 		initTray();
+
+		// Initialize VS Code extension host (loads Claude Code, ChatGPT etc.)
+		initExtensionHost().catch((err) => {
+			console.error("[main] Failed to initialize VS Code extension host:", err);
+		});
 
 		const coldStartUrl = findDeepLinkInArgv(process.argv);
 		if (coldStartUrl) {

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -43,7 +43,11 @@ import {
 	reconcileDaemonSessions,
 } from "./lib/terminal";
 import { disposeTray, initTray } from "./lib/tray";
-import { initExtensionHost, shutdownExtensionHost } from "./lib/vscode-shim";
+// Lazy import to avoid module resolution issues during Vite build
+const loadVscodeShim = () =>
+	import("./lib/vscode-shim") as Promise<
+		typeof import("./lib/vscode-shim")
+	>;
 import { cleanupMainWindowResources, MainWindow } from "./windows/main";
 
 console.log("[main] Local database ready:", !!localDb);
@@ -409,7 +413,9 @@ app.on("before-quit", async (event) => {
 	}
 
 	isQuitting = true;
-	shutdownExtensionHost().catch(() => {});
+	loadVscodeShim()
+		.then((mod) => mod.shutdownExtensionHost())
+		.catch(() => {});
 	closeLocalDb();
 	if (quitMode === "stop") {
 		manager.stopAll();
@@ -591,9 +597,11 @@ if (!gotTheLock) {
 		initTray();
 
 		// Initialize VS Code extension host (loads Claude Code, ChatGPT etc.)
-		initExtensionHost().catch((err) => {
-			console.error("[main] Failed to initialize VS Code extension host:", err);
-		});
+		loadVscodeShim()
+			.then((mod) => mod.initExtensionHost())
+			.catch((err) => {
+				console.error("[main] Failed to initialize VS Code extension host:", err);
+			});
 
 		const coldStartUrl = findDeepLinkInArgv(process.argv);
 		if (coldStartUrl) {

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -43,11 +43,11 @@ import {
 	reconcileDaemonSessions,
 } from "./lib/terminal";
 import { disposeTray, initTray } from "./lib/tray";
+
 // Lazy import to avoid module resolution issues during Vite build
 const loadVscodeShim = () =>
-	import("./lib/vscode-shim") as Promise<
-		typeof import("./lib/vscode-shim")
-	>;
+	import("./lib/vscode-shim") as Promise<typeof import("./lib/vscode-shim")>;
+
 import { cleanupMainWindowResources, MainWindow } from "./windows/main";
 
 console.log("[main] Local database ready:", !!localDb);
@@ -495,6 +495,24 @@ protocol.registerSchemesAsPrivileged([
 			supportFetchAPI: true,
 		},
 	},
+	{
+		scheme: "vscode-webview-resource",
+		privileges: {
+			standard: true,
+			secure: true,
+			bypassCSP: true,
+			supportFetchAPI: true,
+		},
+	},
+	{
+		scheme: "vscode-webview",
+		privileges: {
+			standard: true,
+			secure: true,
+			bypassCSP: true,
+			supportFetchAPI: true,
+		},
+	},
 ]);
 
 const gotTheLock = app.requestSingleInstanceLock();
@@ -600,7 +618,10 @@ if (!gotTheLock) {
 		loadVscodeShim()
 			.then((mod) => mod.initExtensionHost())
 			.catch((err) => {
-				console.error("[main] Failed to initialize VS Code extension host:", err);
+				console.error(
+					"[main] Failed to initialize VS Code extension host:",
+					err,
+				);
 			});
 
 		const coldStartUrl = findDeepLinkInArgv(process.argv);

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -429,9 +429,10 @@ app.on("before-quit", async (event) => {
 	}
 
 	isQuitting = true;
-	loadVscodeShim()
-		.then((mod) => mod.shutdownExtensionHost())
-		.catch(() => {});
+	try {
+		const mod = await loadVscodeShim();
+		await mod.shutdownExtensionHost();
+	} catch {}
 	closeLocalDb();
 	if (quitMode === "stop") {
 		manager.stopAll();

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -1,6 +1,6 @@
 import path from "node:path";
 import { pathToFileURL } from "node:url";
-import { projects, settings, workspaces } from "@superset/local-db";
+import { projects, settings, workspaces, worktrees } from "@superset/local-db";
 import { desc, eq, isNull } from "drizzle-orm";
 import {
 	app,
@@ -74,6 +74,22 @@ if (process.defaultApp) {
 	}
 } else {
 	app.setAsDefaultProtocolClient(PROTOCOL_SCHEME);
+}
+
+function getLastOpenedWorkspacePath(): string | null {
+	try {
+		const row = localDb
+			.select({ worktreePath: worktrees.path })
+			.from(workspaces)
+			.innerJoin(worktrees, eq(workspaces.worktreeId, worktrees.id))
+			.where(isNull(workspaces.deletingAt))
+			.orderBy(desc(workspaces.lastOpenedAt))
+			.limit(1)
+			.get();
+		return row?.worktreePath ?? null;
+	} catch {
+		return null;
+	}
 }
 
 function normalizeRepoValue(
@@ -615,8 +631,14 @@ if (!gotTheLock) {
 		initTray();
 
 		// Initialize VS Code extension host (loads Claude Code, ChatGPT etc.)
+		// Get the last opened workspace path so extensions start with correct cwd
 		loadVscodeShim()
-			.then((mod) => mod.initExtensionHost())
+			.then((mod) => {
+				const lastWorkspacePath = getLastOpenedWorkspacePath();
+				return mod.initExtensionHost({
+					workspacePath: lastWorkspacePath ?? undefined,
+				});
+			})
 			.catch((err) => {
 				console.error(
 					"[main] Failed to initialize VS Code extension host:",

--- a/apps/desktop/src/main/lib/vscode-shim/api/commands.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/api/commands.ts
@@ -2,7 +2,7 @@
  * VS Code commands API shim.
  */
 
-import { Disposable } from "./event-emitter.js";
+import { Disposable } from "./event-emitter";
 
 type CommandHandler = (...args: unknown[]) => unknown;
 

--- a/apps/desktop/src/main/lib/vscode-shim/api/commands.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/api/commands.ts
@@ -2,8 +2,91 @@
  * VS Code commands API shim.
  */
 
-import { shimWarn } from "./debug-log";
+import { shimLog, shimWarn } from "./debug-log";
 import { Disposable } from "./event-emitter";
+
+const UNHANDLED = Symbol("unhandled");
+
+/**
+ * Handle VS Code built-in commands that extensions expect to work.
+ * Returns UNHANDLED if the command is not a known built-in.
+ */
+function handleBuiltinCommand(
+	command: string,
+	args: unknown[],
+): unknown | typeof UNHANDLED {
+	switch (command) {
+		// Diff view (Claude Code uses this for file diffs)
+		case "vscode.diff": {
+			shimLog(
+				`[vscode-shim] vscode.diff called with`,
+				args[0],
+				args[1],
+				args[2],
+			);
+			// TODO: could open diff in Superset's file viewer
+			return undefined;
+		}
+
+		// Open file
+		case "vscode.open": {
+			shimLog(`[vscode-shim] vscode.open called with`, args[0]);
+			return undefined;
+		}
+
+		// Reveal file in OS file manager
+		case "revealFileInOS":
+		case "revealInExplorer": {
+			try {
+				const uri = args[0] as { fsPath?: string };
+				if (uri?.fsPath) {
+					const { shell } = require("electron");
+					shell.showItemInFolder(uri.fsPath);
+				}
+			} catch {}
+			return undefined;
+		}
+
+		// Focus editor
+		case "workbench.action.focusFirstEditorGroup":
+		case "workbench.action.lockEditorGroup":
+			return undefined;
+
+		// Reload window (Codex uses this)
+		case "workbench.action.reloadWindow": {
+			try {
+				const { BrowserWindow } = require("electron");
+				const win = BrowserWindow.getFocusedWindow();
+				win?.reload();
+			} catch {}
+			return undefined;
+		}
+
+		// Open settings
+		case "workbench.action.openSettings":
+		case "workbench.action.openGlobalKeybindings":
+		case "workbench.action.showCommands":
+			// These don't have direct Superset equivalents
+			return undefined;
+
+		// Close active editor
+		case "workbench.action.revertAndCloseActiveEditor":
+		case "workbench.action.moveEditorToNewWindow":
+			return undefined;
+
+		// Speech/dictation (Claude Code)
+		case "workbench.action.editorDictation.start":
+		case "workbench.action.editorDictation.stop":
+			return undefined;
+
+		// Notebook (Claude Code)
+		case "notebook.cell.execute":
+			return undefined;
+
+		default:
+			return UNHANDLED;
+	}
+}
 
 type CommandHandler = (...args: unknown[]) => unknown;
 
@@ -34,6 +117,12 @@ export const commands = {
 			const [key, value] = args;
 			contextState.set(key as string, value);
 			return undefined as T;
+		}
+
+		// Handle VS Code built-in commands
+		const builtinResult = handleBuiltinCommand(command, args);
+		if (builtinResult !== UNHANDLED) {
+			return builtinResult as T;
 		}
 
 		const handler = registry.get(command);

--- a/apps/desktop/src/main/lib/vscode-shim/api/commands.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/api/commands.ts
@@ -1,0 +1,42 @@
+/**
+ * VS Code commands API shim.
+ */
+
+import { Disposable } from "./event-emitter.js";
+
+type CommandHandler = (...args: unknown[]) => unknown;
+
+const registry = new Map<string, CommandHandler>();
+const contextState = new Map<string, unknown>();
+
+export function getContextValue(key: string): unknown {
+	return contextState.get(key);
+}
+
+export const commands = {
+	registerCommand(command: string, callback: CommandHandler, _thisArg?: unknown): Disposable {
+		registry.set(command, callback);
+		return new Disposable(() => {
+			registry.delete(command);
+		});
+	},
+
+	async executeCommand<T = unknown>(command: string, ...args: unknown[]): Promise<T> {
+		if (command === "setContext") {
+			const [key, value] = args;
+			contextState.set(key as string, value);
+			return undefined as T;
+		}
+
+		const handler = registry.get(command);
+		if (!handler) {
+			console.warn(`[vscode-shim] Command not found: ${command}`);
+			return undefined as T;
+		}
+		return (await handler(...args)) as T;
+	},
+
+	getCommands(_filterInternal?: boolean): Promise<string[]> {
+		return Promise.resolve([...registry.keys()]);
+	},
+};

--- a/apps/desktop/src/main/lib/vscode-shim/api/commands.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/api/commands.ts
@@ -2,6 +2,7 @@
  * VS Code commands API shim.
  */
 
+import { shimWarn } from "./debug-log";
 import { Disposable } from "./event-emitter";
 
 type CommandHandler = (...args: unknown[]) => unknown;
@@ -37,7 +38,7 @@ export const commands = {
 
 		const handler = registry.get(command);
 		if (!handler) {
-			console.warn(`[vscode-shim] Command not found: ${command}`);
+			shimWarn(`[vscode-shim] Command not found: ${command}`);
 			return undefined as T;
 		}
 		return (await handler(...args)) as T;

--- a/apps/desktop/src/main/lib/vscode-shim/api/commands.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/api/commands.ts
@@ -14,14 +14,21 @@ export function getContextValue(key: string): unknown {
 }
 
 export const commands = {
-	registerCommand(command: string, callback: CommandHandler, _thisArg?: unknown): Disposable {
+	registerCommand(
+		command: string,
+		callback: CommandHandler,
+		_thisArg?: unknown,
+	): Disposable {
 		registry.set(command, callback);
 		return new Disposable(() => {
 			registry.delete(command);
 		});
 	},
 
-	async executeCommand<T = unknown>(command: string, ...args: unknown[]): Promise<T> {
+	async executeCommand<T = unknown>(
+		command: string,
+		...args: unknown[]
+	): Promise<T> {
 		if (command === "setContext") {
 			const [key, value] = args;
 			contextState.set(key as string, value);

--- a/apps/desktop/src/main/lib/vscode-shim/api/configuration.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/api/configuration.ts
@@ -1,0 +1,106 @@
+/**
+ * VS Code workspace configuration shim.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { Disposable, EventEmitter } from "./event-emitter.js";
+import type { ExtensionManifest } from "../types.js";
+
+interface ConfigurationChangeEvent {
+	affectsConfiguration(section: string, _scope?: unknown): boolean;
+}
+
+const _onDidChangeConfiguration = new EventEmitter<ConfigurationChangeEvent>();
+export const onDidChangeConfiguration = _onDidChangeConfiguration.event;
+
+function getUserDataPath(): string {
+	try {
+		const { app } = require("electron");
+		return app.getPath("userData");
+	} catch {
+		return path.join(require("node:os").homedir(), ".superset-desktop");
+	}
+}
+
+const configFilePath = path.join(getUserDataPath(), "vscode-extension-settings.json");
+
+let configData: Record<string, unknown> = {};
+
+function loadConfig(): void {
+	try {
+		if (fs.existsSync(configFilePath)) {
+			configData = JSON.parse(fs.readFileSync(configFilePath, "utf-8"));
+		}
+	} catch {
+		configData = {};
+	}
+}
+
+function saveConfig(): void {
+	try {
+		fs.mkdirSync(path.dirname(configFilePath), { recursive: true });
+		fs.writeFileSync(configFilePath, JSON.stringify(configData, null, 2));
+	} catch (err) {
+		console.error("[vscode-shim] Failed to save config:", err);
+	}
+}
+
+loadConfig();
+
+/** Merge defaults from extension contributes.configuration into config */
+export function registerExtensionDefaults(manifest: ExtensionManifest): void {
+	const configs = manifest.contributes?.configuration;
+	if (!configs) return;
+	const schemas = Array.isArray(configs) ? configs : [configs];
+	for (const schema of schemas) {
+		if (!schema.properties) continue;
+		for (const [key, prop] of Object.entries(schema.properties)) {
+			if (prop.default !== undefined && configData[key] === undefined) {
+				configData[key] = prop.default;
+			}
+		}
+	}
+}
+
+class WorkspaceConfiguration {
+	private _section: string;
+
+	constructor(section: string) {
+		this._section = section;
+	}
+
+	get<T>(key: string, defaultValue?: T): T {
+		const fullKey = this._section ? `${this._section}.${key}` : key;
+		const value = configData[fullKey];
+		return (value !== undefined ? value : defaultValue) as T;
+	}
+
+	has(key: string): boolean {
+		const fullKey = this._section ? `${this._section}.${key}` : key;
+		return fullKey in configData;
+	}
+
+	inspect<T>(key: string): { key: string; defaultValue?: T; globalValue?: T } | undefined {
+		const fullKey = this._section ? `${this._section}.${key}` : key;
+		return {
+			key: fullKey,
+			globalValue: configData[fullKey] as T | undefined,
+		};
+	}
+
+	async update(key: string, value: unknown, _configurationTarget?: unknown, _overrideInLanguage?: boolean): Promise<void> {
+		const fullKey = this._section ? `${this._section}.${key}` : key;
+		configData[fullKey] = value;
+		saveConfig();
+		_onDidChangeConfiguration.fire({
+			affectsConfiguration(section: string) {
+				return fullKey.startsWith(section);
+			},
+		});
+	}
+}
+
+export function getConfiguration(section?: string, _scope?: unknown): WorkspaceConfiguration {
+	return new WorkspaceConfiguration(section ?? "");
+}

--- a/apps/desktop/src/main/lib/vscode-shim/api/configuration.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/api/configuration.ts
@@ -4,8 +4,8 @@
 
 import fs from "node:fs";
 import path from "node:path";
-import { Disposable, EventEmitter } from "./event-emitter.js";
 import type { ExtensionManifest } from "../types.js";
+import { EventEmitter } from "./event-emitter.js";
 
 interface ConfigurationChangeEvent {
 	affectsConfiguration(section: string, _scope?: unknown): boolean;
@@ -23,7 +23,10 @@ function getUserDataPath(): string {
 	}
 }
 
-const configFilePath = path.join(getUserDataPath(), "vscode-extension-settings.json");
+const configFilePath = path.join(
+	getUserDataPath(),
+	"vscode-extension-settings.json",
+);
 
 let configData: Record<string, unknown> = {};
 
@@ -81,7 +84,9 @@ class WorkspaceConfiguration {
 		return fullKey in configData;
 	}
 
-	inspect<T>(key: string): { key: string; defaultValue?: T; globalValue?: T } | undefined {
+	inspect<T>(
+		key: string,
+	): { key: string; defaultValue?: T; globalValue?: T } | undefined {
 		const fullKey = this._section ? `${this._section}.${key}` : key;
 		return {
 			key: fullKey,
@@ -89,7 +94,12 @@ class WorkspaceConfiguration {
 		};
 	}
 
-	async update(key: string, value: unknown, _configurationTarget?: unknown, _overrideInLanguage?: boolean): Promise<void> {
+	async update(
+		key: string,
+		value: unknown,
+		_configurationTarget?: unknown,
+		_overrideInLanguage?: boolean,
+	): Promise<void> {
 		const fullKey = this._section ? `${this._section}.${key}` : key;
 		configData[fullKey] = value;
 		saveConfig();
@@ -101,6 +111,9 @@ class WorkspaceConfiguration {
 	}
 }
 
-export function getConfiguration(section?: string, _scope?: unknown): WorkspaceConfiguration {
+export function getConfiguration(
+	section?: string,
+	_scope?: unknown,
+): WorkspaceConfiguration {
 	return new WorkspaceConfiguration(section ?? "");
 }

--- a/apps/desktop/src/main/lib/vscode-shim/api/configuration.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/api/configuration.ts
@@ -4,8 +4,8 @@
 
 import fs from "node:fs";
 import path from "node:path";
-import type { ExtensionManifest } from "../types.js";
-import { EventEmitter } from "./event-emitter.js";
+import type { ExtensionManifest } from "../types";
+import { EventEmitter } from "./event-emitter";
 
 interface ConfigurationChangeEvent {
 	affectsConfiguration(section: string, _scope?: unknown): boolean;

--- a/apps/desktop/src/main/lib/vscode-shim/api/debug-log.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/api/debug-log.ts
@@ -1,0 +1,21 @@
+/**
+ * Conditional debug logger for vscode-shim.
+ * Logs are shown in development mode (bun dev) but suppressed in production builds.
+ */
+
+const IS_DEV =
+	process.env.NODE_ENV === "development" ||
+	process.env.DEBUG_VSCODE_SHIM === "1";
+
+export function shimLog(...args: unknown[]): void {
+	if (IS_DEV) console.log(...args);
+}
+
+export function shimWarn(...args: unknown[]): void {
+	if (IS_DEV) console.warn(...args);
+}
+
+export function shimError(...args: unknown[]): void {
+	// Always log errors
+	console.error(...args);
+}

--- a/apps/desktop/src/main/lib/vscode-shim/api/event-emitter.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/api/event-emitter.ts
@@ -1,0 +1,89 @@
+/**
+ * VS Code EventEmitter and Disposable shim.
+ */
+
+export type Event<T> = (
+	listener: (e: T) => unknown,
+	thisArgs?: unknown,
+	disposables?: Disposable[],
+) => Disposable;
+
+export class Disposable {
+	private _callOnDispose: (() => void) | undefined;
+
+	constructor(callOnDispose: () => void) {
+		this._callOnDispose = callOnDispose;
+	}
+
+	static from(...disposables: { dispose(): unknown }[]): Disposable {
+		return new Disposable(() => {
+			for (const d of disposables) {
+				d.dispose();
+			}
+		});
+	}
+
+	dispose(): void {
+		this._callOnDispose?.();
+		this._callOnDispose = undefined;
+	}
+}
+
+export class EventEmitter<T> {
+	private _listeners: Array<{ fn: (e: T) => unknown; thisArgs?: unknown }> = [];
+	private _disposed = false;
+
+	readonly event: Event<T> = (
+		listener: (e: T) => unknown,
+		thisArgs?: unknown,
+		disposables?: Disposable[],
+	): Disposable => {
+		const entry = { fn: listener, thisArgs };
+		this._listeners.push(entry);
+		const disposable = new Disposable(() => {
+			const idx = this._listeners.indexOf(entry);
+			if (idx >= 0) this._listeners.splice(idx, 1);
+		});
+		if (disposables) disposables.push(disposable);
+		return disposable;
+	};
+
+	fire(data: T): void {
+		if (this._disposed) return;
+		for (const { fn, thisArgs } of [...this._listeners]) {
+			fn.call(thisArgs, data);
+		}
+	}
+
+	dispose(): void {
+		this._disposed = true;
+		this._listeners.length = 0;
+	}
+}
+
+export class CancellationTokenSource {
+	private _emitter = new EventEmitter<void>();
+	private _isCancelled = false;
+
+	readonly token: CancellationToken = {
+		isCancellationRequested: false,
+		onCancellationRequested: this._emitter.event,
+	};
+
+	cancel(): void {
+		if (!this._isCancelled) {
+			this._isCancelled = true;
+			(this.token as { isCancellationRequested: boolean }).isCancellationRequested = true;
+			this._emitter.fire(undefined as void);
+		}
+	}
+
+	dispose(): void {
+		this._emitter.dispose();
+	}
+}
+
+export interface CancellationToken {
+	readonly isCancellationRequested: boolean;
+	readonly onCancellationRequested: Event<void>;
+}

--- a/apps/desktop/src/main/lib/vscode-shim/api/event-emitter.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/api/event-emitter.ts
@@ -73,8 +73,10 @@ export class CancellationTokenSource {
 	cancel(): void {
 		if (!this._isCancelled) {
 			this._isCancelled = true;
-			(this.token as { isCancellationRequested: boolean }).isCancellationRequested = true;
-			this._emitter.fire(undefined as void);
+			(
+				this.token as { isCancellationRequested: boolean }
+			).isCancellationRequested = true;
+			this._emitter.fire(undefined as undefined);
 		}
 	}
 

--- a/apps/desktop/src/main/lib/vscode-shim/api/extension-context.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/api/extension-context.ts
@@ -58,7 +58,30 @@ class Memento {
 class SecretStorage {
 	private _data = new Map<string, string>();
 	private _onDidChange = new EventEmitter<{ key: string }>();
+	private _filePath: string;
 	readonly onDidChange: Event<{ key: string }> = this._onDidChange.event;
+
+	constructor(filePath: string) {
+		this._filePath = filePath;
+		try {
+			if (fs.existsSync(filePath)) {
+				const raw = fs.readFileSync(filePath, "utf-8");
+				const parsed = JSON.parse(raw) as Record<string, string>;
+				for (const [k, v] of Object.entries(parsed)) {
+					this._data.set(k, v);
+				}
+			}
+		} catch {}
+	}
+
+	private _persist(): void {
+		try {
+			const obj: Record<string, string> = {};
+			for (const [k, v] of this._data) obj[k] = v;
+			fs.mkdirSync(path.dirname(this._filePath), { recursive: true });
+			fs.writeFileSync(this._filePath, JSON.stringify(obj, null, 2));
+		} catch {}
+	}
 
 	async get(key: string): Promise<string | undefined> {
 		return this._data.get(key);
@@ -66,11 +89,13 @@ class SecretStorage {
 
 	async store(key: string, value: string): Promise<void> {
 		this._data.set(key, value);
+		this._persist();
 		this._onDidChange.fire({ key });
 	}
 
 	async delete(key: string): Promise<void> {
 		this._data.delete(key);
+		this._persist();
 		this._onDidChange.fire({ key });
 	}
 }
@@ -165,7 +190,7 @@ export function createExtensionContext(
 		extensionUri: Uri.file(extensionPath),
 		globalState: new Memento(path.join(globalStoragePath, "state.json")),
 		workspaceState: new Memento(path.join(storagePath, "state.json")),
-		secrets: new SecretStorage(),
+		secrets: new SecretStorage(path.join(globalStoragePath, "secrets.json")),
 		storagePath,
 		globalStoragePath,
 		logPath,

--- a/apps/desktop/src/main/lib/vscode-shim/api/extension-context.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/api/extension-context.ts
@@ -4,16 +4,21 @@
 
 import fs from "node:fs";
 import path from "node:path";
+
 function getUserDataPath(): string {
 	try {
 		return require("electron").app.getPath("userData");
 	} catch {
-		return require("node:path").join(require("node:os").homedir(), ".superset-desktop");
+		return require("node:path").join(
+			require("node:os").homedir(),
+			".superset-desktop",
+		);
 	}
 }
-import { Disposable, EventEmitter, type Event } from "./event-emitter.js";
-import { Uri } from "./uri.js";
+
 import type { ExtensionManifest } from "../types.js";
+import { type Disposable, type Event, EventEmitter } from "./event-emitter.js";
+import { Uri } from "./uri.js";
 
 class Memento {
 	private _data: Record<string, unknown>;
@@ -79,7 +84,9 @@ interface EnvironmentVariableCollection {
 	get(variable: string): unknown;
 	delete(variable: string): void;
 	clear(): void;
-	forEach(callback: (variable: string, mutator: unknown, collection: unknown) => void): void;
+	forEach(
+		callback: (variable: string, mutator: unknown, collection: unknown) => void,
+	): void;
 	[Symbol.iterator](): Iterator<[string, unknown]>;
 }
 
@@ -100,11 +107,21 @@ function createEnvironmentVariableCollection(): EnvironmentVariableCollection {
 			vars.set(variable, { type: 3, value });
 			process.env[variable] = value + (process.env[variable] ?? "");
 		},
-		get(variable: string) { return vars.get(variable); },
-		delete(variable: string) { vars.delete(variable); },
-		clear() { vars.clear(); },
-		forEach(callback) { for (const [k, v] of vars) callback(k, v, this); },
-		*[Symbol.iterator]() { yield* vars.entries(); },
+		get(variable: string) {
+			return vars.get(variable);
+		},
+		delete(variable: string) {
+			vars.delete(variable);
+		},
+		clear() {
+			vars.clear();
+		},
+		forEach(callback) {
+			for (const [k, v] of vars) callback(k, v, this);
+		},
+		*[Symbol.iterator]() {
+			yield* vars.entries();
+		},
 	};
 }
 

--- a/apps/desktop/src/main/lib/vscode-shim/api/extension-context.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/api/extension-context.ts
@@ -16,9 +16,9 @@ function getUserDataPath(): string {
 	}
 }
 
-import type { ExtensionManifest } from "../types.js";
-import { type Disposable, type Event, EventEmitter } from "./event-emitter.js";
-import { Uri } from "./uri.js";
+import type { ExtensionManifest } from "../types";
+import { type Disposable, type Event, EventEmitter } from "./event-emitter";
+import { Uri } from "./uri";
 
 class Memento {
 	private _data: Record<string, unknown>;

--- a/apps/desktop/src/main/lib/vscode-shim/api/extension-context.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/api/extension-context.ts
@@ -1,0 +1,166 @@
+/**
+ * VS Code ExtensionContext shim.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+function getUserDataPath(): string {
+	try {
+		return require("electron").app.getPath("userData");
+	} catch {
+		return require("node:path").join(require("node:os").homedir(), ".superset-desktop");
+	}
+}
+import { Disposable, EventEmitter, type Event } from "./event-emitter.js";
+import { Uri } from "./uri.js";
+import type { ExtensionManifest } from "../types.js";
+
+class Memento {
+	private _data: Record<string, unknown>;
+	private _filePath: string;
+
+	constructor(filePath: string) {
+		this._filePath = filePath;
+		try {
+			this._data = fs.existsSync(filePath)
+				? JSON.parse(fs.readFileSync(filePath, "utf-8"))
+				: {};
+		} catch {
+			this._data = {};
+		}
+	}
+
+	get<T>(key: string, defaultValue?: T): T {
+		const val = this._data[key];
+		return (val !== undefined ? val : defaultValue) as T;
+	}
+
+	async update(key: string, value: unknown): Promise<void> {
+		if (value === undefined) {
+			delete this._data[key];
+		} else {
+			this._data[key] = value;
+		}
+		fs.mkdirSync(path.dirname(this._filePath), { recursive: true });
+		fs.writeFileSync(this._filePath, JSON.stringify(this._data, null, 2));
+	}
+
+	keys(): readonly string[] {
+		return Object.keys(this._data);
+	}
+}
+
+class SecretStorage {
+	private _data = new Map<string, string>();
+	private _onDidChange = new EventEmitter<{ key: string }>();
+	readonly onDidChange: Event<{ key: string }> = this._onDidChange.event;
+
+	async get(key: string): Promise<string | undefined> {
+		return this._data.get(key);
+	}
+
+	async store(key: string, value: string): Promise<void> {
+		this._data.set(key, value);
+		this._onDidChange.fire({ key });
+	}
+
+	async delete(key: string): Promise<void> {
+		this._data.delete(key);
+		this._onDidChange.fire({ key });
+	}
+}
+
+interface EnvironmentVariableCollection {
+	persistent: boolean;
+	description: string | undefined;
+	replace(variable: string, value: string, options?: unknown): void;
+	append(variable: string, value: string, options?: unknown): void;
+	prepend(variable: string, value: string, options?: unknown): void;
+	get(variable: string): unknown;
+	delete(variable: string): void;
+	clear(): void;
+	forEach(callback: (variable: string, mutator: unknown, collection: unknown) => void): void;
+	[Symbol.iterator](): Iterator<[string, unknown]>;
+}
+
+function createEnvironmentVariableCollection(): EnvironmentVariableCollection {
+	const vars = new Map<string, { type: number; value: string }>();
+	return {
+		persistent: true,
+		description: undefined,
+		replace(variable: string, value: string) {
+			vars.set(variable, { type: 1, value });
+			process.env[variable] = value;
+		},
+		append(variable: string, value: string) {
+			vars.set(variable, { type: 2, value });
+			process.env[variable] = (process.env[variable] ?? "") + value;
+		},
+		prepend(variable: string, value: string) {
+			vars.set(variable, { type: 3, value });
+			process.env[variable] = value + (process.env[variable] ?? "");
+		},
+		get(variable: string) { return vars.get(variable); },
+		delete(variable: string) { vars.delete(variable); },
+		clear() { vars.clear(); },
+		forEach(callback) { for (const [k, v] of vars) callback(k, v, this); },
+		*[Symbol.iterator]() { yield* vars.entries(); },
+	};
+}
+
+export interface VscodeExtensionContext {
+	subscriptions: Disposable[];
+	extensionPath: string;
+	extensionUri: Uri;
+	globalState: Memento;
+	workspaceState: Memento;
+	secrets: SecretStorage;
+	storagePath: string | undefined;
+	globalStoragePath: string;
+	logPath: string;
+	extensionMode: number;
+	environmentVariableCollection: EnvironmentVariableCollection;
+	extension: {
+		id: string;
+		extensionPath: string;
+		packageJSON: ExtensionManifest;
+	};
+	asAbsolutePath(relativePath: string): string;
+}
+
+export function createExtensionContext(
+	extensionId: string,
+	extensionPath: string,
+	manifest: ExtensionManifest,
+): VscodeExtensionContext {
+	const storageBase = path.join(getUserDataPath(), "vscode-extensions");
+	const globalStoragePath = path.join(storageBase, extensionId, "global");
+	const storagePath = path.join(storageBase, extensionId, "workspace");
+	const logPath = path.join(storageBase, extensionId, "logs");
+
+	fs.mkdirSync(globalStoragePath, { recursive: true });
+	fs.mkdirSync(storagePath, { recursive: true });
+	fs.mkdirSync(logPath, { recursive: true });
+
+	return {
+		subscriptions: [],
+		extensionPath,
+		extensionUri: Uri.file(extensionPath),
+		globalState: new Memento(path.join(globalStoragePath, "state.json")),
+		workspaceState: new Memento(path.join(storagePath, "state.json")),
+		secrets: new SecretStorage(),
+		storagePath,
+		globalStoragePath,
+		logPath,
+		extensionMode: 1,
+		environmentVariableCollection: createEnvironmentVariableCollection(),
+		extension: {
+			id: extensionId,
+			extensionPath,
+			packageJSON: manifest,
+		},
+		asAbsolutePath(relativePath: string): string {
+			return path.join(extensionPath, relativePath);
+		},
+	};
+}

--- a/apps/desktop/src/main/lib/vscode-shim/api/extension-context.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/api/extension-context.ts
@@ -55,6 +55,23 @@ class Memento {
 	}
 }
 
+function getSafeStorage(): {
+	encryptString(plainText: string): Buffer;
+	decryptString(encrypted: Buffer): string;
+	isEncryptionAvailable(): boolean;
+} | null {
+	try {
+		// eslint-disable-next-line @typescript-eslint/no-require-imports
+		return require("electron").safeStorage as {
+			encryptString(plainText: string): Buffer;
+			decryptString(encrypted: Buffer): string;
+			isEncryptionAvailable(): boolean;
+		};
+	} catch {
+		return null;
+	}
+}
+
 class SecretStorage {
 	private _data = new Map<string, string>();
 	private _onDidChange = new EventEmitter<{ key: string }>();
@@ -67,8 +84,19 @@ class SecretStorage {
 			if (fs.existsSync(filePath)) {
 				const raw = fs.readFileSync(filePath, "utf-8");
 				const parsed = JSON.parse(raw) as Record<string, string>;
+				const safeStorage = getSafeStorage();
 				for (const [k, v] of Object.entries(parsed)) {
-					this._data.set(k, v);
+					try {
+						if (safeStorage?.isEncryptionAvailable()) {
+							const buf = Buffer.from(v, "base64");
+							this._data.set(k, safeStorage.decryptString(buf));
+						} else {
+							this._data.set(k, v);
+						}
+					} catch {
+						// If decryption fails (e.g. key changed), store as-is
+						this._data.set(k, v);
+					}
 				}
 			}
 		} catch {}
@@ -76,8 +104,15 @@ class SecretStorage {
 
 	private _persist(): void {
 		try {
+			const safeStorage = getSafeStorage();
 			const obj: Record<string, string> = {};
-			for (const [k, v] of this._data) obj[k] = v;
+			for (const [k, v] of this._data) {
+				if (safeStorage?.isEncryptionAvailable()) {
+					obj[k] = safeStorage.encryptString(v).toString("base64");
+				} else {
+					obj[k] = v;
+				}
+			}
 			fs.mkdirSync(path.dirname(this._filePath), { recursive: true });
 			fs.writeFileSync(this._filePath, JSON.stringify(obj, null, 2));
 		} catch {}
@@ -122,15 +157,12 @@ function createEnvironmentVariableCollection(): EnvironmentVariableCollection {
 		description: undefined,
 		replace(variable: string, value: string) {
 			vars.set(variable, { type: 1, value });
-			process.env[variable] = value;
 		},
 		append(variable: string, value: string) {
 			vars.set(variable, { type: 2, value });
-			process.env[variable] = (process.env[variable] ?? "") + value;
 		},
 		prepend(variable: string, value: string) {
 			vars.set(variable, { type: 3, value });
-			process.env[variable] = value + (process.env[variable] ?? "");
 		},
 		get(variable: string) {
 			return vars.get(variable);

--- a/apps/desktop/src/main/lib/vscode-shim/api/output-channel.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/api/output-channel.ts
@@ -1,0 +1,96 @@
+/**
+ * VS Code OutputChannel shim.
+ */
+
+import { Disposable } from "./event-emitter.js";
+
+export class OutputChannel {
+	readonly name: string;
+	private _lines: string[] = [];
+	private _disposed = false;
+
+	constructor(name: string) {
+		this.name = name;
+	}
+
+	append(value: string): void {
+		if (this._disposed) return;
+		const last = this._lines.length - 1;
+		if (last >= 0) {
+			this._lines[last] += value;
+		} else {
+			this._lines.push(value);
+		}
+	}
+
+	appendLine(value: string): void {
+		if (this._disposed) return;
+		console.log(`[${this.name}] ${value}`);
+		this._lines.push(value);
+	}
+
+	clear(): void {
+		this._lines.length = 0;
+	}
+
+	show(_preserveFocus?: boolean): void {
+		// In future, could switch to an output tab in the UI
+	}
+
+	hide(): void {
+		// noop
+	}
+
+	replace(value: string): void {
+		this._lines = [value];
+	}
+
+	dispose(): void {
+		this._disposed = true;
+		this._lines.length = 0;
+	}
+}
+
+export class LogOutputChannel extends OutputChannel {
+	trace(message: string, ..._args: unknown[]): void {
+		this.appendLine(`[TRACE] ${message}`);
+	}
+
+	debug(message: string, ..._args: unknown[]): void {
+		this.appendLine(`[DEBUG] ${message}`);
+	}
+
+	info(message: string, ..._args: unknown[]): void {
+		this.appendLine(`[INFO] ${message}`);
+	}
+
+	warn(message: string, ..._args: unknown[]): void {
+		this.appendLine(`[WARN] ${message}`);
+	}
+
+	error(error: string | Error, ..._args: unknown[]): void {
+		const msg = error instanceof Error ? error.message : error;
+		this.appendLine(`[ERROR] ${msg}`);
+	}
+}
+
+const channels = new Map<string, OutputChannel>();
+
+export function createOutputChannel(name: string, options?: { log: true } | string): OutputChannel {
+	const existing = channels.get(name);
+	if (existing) return existing;
+
+	const channel =
+		options && typeof options === "object" && options.log
+			? new LogOutputChannel(name)
+			: new OutputChannel(name);
+	channels.set(name, channel);
+	return channel;
+}
+
+export function getOutputChannelDisposable(): Disposable {
+	return new Disposable(() => {
+		for (const ch of channels.values()) ch.dispose();
+		channels.clear();
+	});
+}

--- a/apps/desktop/src/main/lib/vscode-shim/api/output-channel.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/api/output-channel.ts
@@ -76,7 +76,10 @@ export class LogOutputChannel extends OutputChannel {
 
 const channels = new Map<string, OutputChannel>();
 
-export function createOutputChannel(name: string, options?: { log: true } | string): OutputChannel {
+export function createOutputChannel(
+	name: string,
+	options?: { log: true } | string,
+): OutputChannel {
 	const existing = channels.get(name);
 	if (existing) return existing;
 

--- a/apps/desktop/src/main/lib/vscode-shim/api/output-channel.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/api/output-channel.ts
@@ -2,6 +2,7 @@
  * VS Code OutputChannel shim.
  */
 
+import { shimLog } from "./debug-log";
 import { Disposable } from "./event-emitter";
 
 export class OutputChannel {
@@ -25,7 +26,7 @@ export class OutputChannel {
 
 	appendLine(value: string): void {
 		if (this._disposed) return;
-		console.log(`[${this.name}] ${value}`);
+		shimLog(`[${this.name}] ${value}`);
 		this._lines.push(value);
 	}
 

--- a/apps/desktop/src/main/lib/vscode-shim/api/output-channel.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/api/output-channel.ts
@@ -2,7 +2,7 @@
  * VS Code OutputChannel shim.
  */
 
-import { Disposable } from "./event-emitter.js";
+import { Disposable } from "./event-emitter";
 
 export class OutputChannel {
 	readonly name: string;

--- a/apps/desktop/src/main/lib/vscode-shim/api/protocol-handler.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/api/protocol-handler.ts
@@ -6,7 +6,19 @@
  */
 
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
+
+/** Allowed base directories for serving extension resources */
+const ALLOWED_ROOTS: string[] = [
+	path.join(os.homedir(), ".vscode", "extensions"),
+	path.join(os.homedir(), ".vscode-insiders", "extensions"),
+];
+
+function isPathAllowed(filePath: string): boolean {
+	const resolved = path.resolve(filePath);
+	return ALLOWED_ROOTS.some((root) => resolved.startsWith(root + path.sep));
+}
 
 const MIME_TYPES: Record<string, string> = {
 	".html": "text/html",
@@ -44,6 +56,11 @@ export function registerWebviewProtocol(): void {
 				filePath = filePath.slice(1);
 			}
 
+			// Prevent path traversal — only serve files from extension directories
+			if (!isPathAllowed(filePath)) {
+				return new Response("Forbidden", { status: 403 });
+			}
+
 			if (!fs.existsSync(filePath)) {
 				return new Response("Not found", { status: 404 });
 			}
@@ -54,7 +71,6 @@ export function registerWebviewProtocol(): void {
 			return new Response(content, {
 				headers: {
 					"Content-Type": mimeType,
-					"Access-Control-Allow-Origin": "*",
 				},
 			});
 		});

--- a/apps/desktop/src/main/lib/vscode-shim/api/protocol-handler.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/api/protocol-handler.ts
@@ -2,13 +2,14 @@
  * Electron protocol handler for serving VS Code extension webview resources.
  *
  * Registers `vscode-webview-resource://` protocol to serve local files
- * from extension directories, enabling webview HTML to load CSS/JS/images.
+ * from extension directories. The main webview HTML is served by
+ * webview-server.ts instead (HTTP on localhost).
  */
 
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { shimLog, shimWarn } from "./debug-log";
+import { shimLog } from "./debug-log";
 
 /** Allowed base directories for serving extension resources */
 const ALLOWED_ROOTS: string[] = [
@@ -18,7 +19,9 @@ const ALLOWED_ROOTS: string[] = [
 
 function isPathAllowed(filePath: string): boolean {
 	const resolved = path.resolve(filePath);
-	return ALLOWED_ROOTS.some((root) => resolved.startsWith(root + path.sep));
+	return ALLOWED_ROOTS.some(
+		(root) => resolved === root || resolved.startsWith(root + path.sep),
+	);
 }
 
 const MIME_TYPES: Record<string, string> = {
@@ -49,15 +52,12 @@ export function registerWebviewProtocol(): void {
 
 		protocol.handle("vscode-webview-resource", (request: Request) => {
 			const url = new URL(request.url);
-			// The path contains the local file path
 			let filePath = decodeURIComponent(url.pathname);
 
-			// On macOS, pathname might start with extra slash
 			if (process.platform === "darwin" && filePath.startsWith("//")) {
 				filePath = filePath.slice(1);
 			}
 
-			// Prevent path traversal — only serve files from extension directories
 			if (!isPathAllowed(filePath)) {
 				return new Response("Forbidden", { status: 403 });
 			}
@@ -70,86 +70,12 @@ export function registerWebviewProtocol(): void {
 			const mimeType = getMimeType(filePath);
 
 			return new Response(content, {
-				headers: {
-					"Content-Type": mimeType,
-				},
+				headers: { "Content-Type": mimeType },
 			});
 		});
 
 		shimLog("[vscode-shim] Registered vscode-webview-resource:// protocol");
-
-		// Serve webview HTML pages with their own CSP (bypasses parent CSP)
-		protocol.handle("vscode-webview", (request: Request) => {
-			// URL format: vscode-webview://webview/{encodedViewId}
-			const url = new URL(request.url);
-			const viewId = decodeURIComponent(url.pathname.replace(/^\/+/, ""));
-			shimLog(
-				`[vscode-webview] Request for viewId: "${viewId}", stored keys: [${[...webviewHtmlStore.keys()].join(", ")}]`,
-			);
-			let html =
-				webviewHtmlStore.get(viewId) ??
-				`<html><body style="color:#ccc;background:#1e1e1e;font-family:sans-serif;padding:20px"><p>Webview content not available. viewId: ${viewId}</p></body></html>`;
-
-			// Inject acquireVsCodeApi bridge script
-			html = injectBridgeScript(html);
-
-			return new Response(html, {
-				headers: {
-					"Content-Type": "text/html; charset=utf-8",
-					"Content-Security-Policy": [
-						"default-src 'none'",
-						"script-src 'unsafe-inline' vscode-webview-resource:",
-						"style-src 'unsafe-inline' vscode-webview-resource:",
-						"img-src vscode-webview-resource: https: data:",
-						"font-src vscode-webview-resource: https: data:",
-						"connect-src https: wss: ws:",
-					].join("; "),
-				},
-			});
-		});
-
-		shimLog("[vscode-shim] Registered vscode-webview:// protocol");
 	} catch (err) {
-		shimWarn("[vscode-shim] Failed to register protocol handler:", err);
+		console.error("[vscode-shim] Failed to register protocol handler:", err);
 	}
-}
-
-const BRIDGE_SCRIPT = `<script>
-(function() {
-	let _state = null;
-	const vscodeApi = {
-		postMessage(message) {
-			window.parent.postMessage({ type: 'vscode-api', data: message }, '*');
-		},
-		getState() { return _state; },
-		setState(state) { _state = state; return state; }
-	};
-	window.acquireVsCodeApi = function() { return vscodeApi; };
-	window.addEventListener('message', function(event) {
-		if (event.data && event.data.type === 'vscode-message') {
-			window.dispatchEvent(new MessageEvent('message', { data: event.data.data }));
-		}
-	});
-})();
-</script>`;
-
-function injectBridgeScript(html: string): string {
-	if (html.includes("</head>")) {
-		return html.replace("</head>", `${BRIDGE_SCRIPT}</head>`);
-	}
-	if (html.includes("<body")) {
-		return html.replace(/<body([^>]*)>/, `<body$1>${BRIDGE_SCRIPT}`);
-	}
-	return `${BRIDGE_SCRIPT}${html}`;
-}
-
-/** Store for webview HTML content, keyed by viewId */
-const webviewHtmlStore = new Map<string, string>();
-
-export function setWebviewHtml(viewId: string, html: string): void {
-	webviewHtmlStore.set(viewId, html);
-}
-
-export function clearWebviewHtml(viewId: string): void {
-	webviewHtmlStore.delete(viewId);
 }

--- a/apps/desktop/src/main/lib/vscode-shim/api/protocol-handler.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/api/protocol-handler.ts
@@ -79,10 +79,15 @@ export function registerWebviewProtocol(): void {
 
 		// Serve webview HTML pages with their own CSP (bypasses parent CSP)
 		protocol.handle("vscode-webview", (request: Request) => {
+			// URL format: vscode-webview://webview/{encodedViewId}
 			const url = new URL(request.url);
-			const viewId = url.pathname.replace(/^\/+/, "");
+			const viewId = decodeURIComponent(url.pathname.replace(/^\/+/, ""));
+			console.log(
+				`[vscode-webview] Request for viewId: "${viewId}", stored keys: [${[...webviewHtmlStore.keys()].join(", ")}]`,
+			);
 			let html =
-				webviewHtmlStore.get(viewId) ?? "<html><body>No content</body></html>";
+				webviewHtmlStore.get(viewId) ??
+				`<html><body style="color:#ccc;background:#1e1e1e;font-family:sans-serif;padding:20px"><p>Webview content not available. viewId: ${viewId}</p></body></html>`;
 
 			// Inject acquireVsCodeApi bridge script
 			html = injectBridgeScript(html);

--- a/apps/desktop/src/main/lib/vscode-shim/api/protocol-handler.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/api/protocol-handler.ts
@@ -76,7 +76,74 @@ export function registerWebviewProtocol(): void {
 		});
 
 		console.log("[vscode-shim] Registered vscode-webview-resource:// protocol");
+
+		// Serve webview HTML pages with their own CSP (bypasses parent CSP)
+		protocol.handle("vscode-webview", (request: Request) => {
+			const url = new URL(request.url);
+			const viewId = url.pathname.replace(/^\/+/, "");
+			let html =
+				webviewHtmlStore.get(viewId) ?? "<html><body>No content</body></html>";
+
+			// Inject acquireVsCodeApi bridge script
+			html = injectBridgeScript(html);
+
+			return new Response(html, {
+				headers: {
+					"Content-Type": "text/html; charset=utf-8",
+					"Content-Security-Policy": [
+						"default-src 'none'",
+						"script-src 'unsafe-inline' vscode-webview-resource:",
+						"style-src 'unsafe-inline' vscode-webview-resource:",
+						"img-src vscode-webview-resource: https: data:",
+						"font-src vscode-webview-resource: https: data:",
+						"connect-src https: wss: ws:",
+					].join("; "),
+				},
+			});
+		});
+
+		console.log("[vscode-shim] Registered vscode-webview:// protocol");
 	} catch (err) {
 		console.warn("[vscode-shim] Failed to register protocol handler:", err);
 	}
+}
+
+const BRIDGE_SCRIPT = `<script>
+(function() {
+	let _state = null;
+	const vscodeApi = {
+		postMessage(message) {
+			window.parent.postMessage({ type: 'vscode-api', data: message }, '*');
+		},
+		getState() { return _state; },
+		setState(state) { _state = state; return state; }
+	};
+	window.acquireVsCodeApi = function() { return vscodeApi; };
+	window.addEventListener('message', function(event) {
+		if (event.data && event.data.type === 'vscode-message') {
+			window.dispatchEvent(new MessageEvent('message', { data: event.data.data }));
+		}
+	});
+})();
+</script>`;
+
+function injectBridgeScript(html: string): string {
+	if (html.includes("</head>")) {
+		return html.replace("</head>", `${BRIDGE_SCRIPT}</head>`);
+	}
+	if (html.includes("<body")) {
+		return html.replace(/<body([^>]*)>/, `<body$1>${BRIDGE_SCRIPT}`);
+	}
+	return `${BRIDGE_SCRIPT}${html}`;
+}
+
+/** Store for webview HTML content, keyed by viewId */
+const webviewHtmlStore = new Map<string, string>();
+
+export function setWebviewHtml(viewId: string, html: string): void {
+	webviewHtmlStore.set(viewId, html);
+}
+
+export function clearWebviewHtml(viewId: string): void {
+	webviewHtmlStore.delete(viewId);
 }

--- a/apps/desktop/src/main/lib/vscode-shim/api/protocol-handler.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/api/protocol-handler.ts
@@ -8,6 +8,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { shimLog, shimWarn } from "./debug-log";
 
 /** Allowed base directories for serving extension resources */
 const ALLOWED_ROOTS: string[] = [
@@ -75,14 +76,14 @@ export function registerWebviewProtocol(): void {
 			});
 		});
 
-		console.log("[vscode-shim] Registered vscode-webview-resource:// protocol");
+		shimLog("[vscode-shim] Registered vscode-webview-resource:// protocol");
 
 		// Serve webview HTML pages with their own CSP (bypasses parent CSP)
 		protocol.handle("vscode-webview", (request: Request) => {
 			// URL format: vscode-webview://webview/{encodedViewId}
 			const url = new URL(request.url);
 			const viewId = decodeURIComponent(url.pathname.replace(/^\/+/, ""));
-			console.log(
+			shimLog(
 				`[vscode-webview] Request for viewId: "${viewId}", stored keys: [${[...webviewHtmlStore.keys()].join(", ")}]`,
 			);
 			let html =
@@ -107,9 +108,9 @@ export function registerWebviewProtocol(): void {
 			});
 		});
 
-		console.log("[vscode-shim] Registered vscode-webview:// protocol");
+		shimLog("[vscode-shim] Registered vscode-webview:// protocol");
 	} catch (err) {
-		console.warn("[vscode-shim] Failed to register protocol handler:", err);
+		shimWarn("[vscode-shim] Failed to register protocol handler:", err);
 	}
 }
 

--- a/apps/desktop/src/main/lib/vscode-shim/api/protocol-handler.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/api/protocol-handler.ts
@@ -1,0 +1,66 @@
+/**
+ * Electron protocol handler for serving VS Code extension webview resources.
+ *
+ * Registers `vscode-webview-resource://` protocol to serve local files
+ * from extension directories, enabling webview HTML to load CSS/JS/images.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+
+const MIME_TYPES: Record<string, string> = {
+	".html": "text/html",
+	".css": "text/css",
+	".js": "application/javascript",
+	".mjs": "application/javascript",
+	".json": "application/json",
+	".svg": "image/svg+xml",
+	".png": "image/png",
+	".jpg": "image/jpeg",
+	".jpeg": "image/jpeg",
+	".gif": "image/gif",
+	".woff": "font/woff",
+	".woff2": "font/woff2",
+	".ttf": "font/ttf",
+	".ico": "image/x-icon",
+};
+
+function getMimeType(filePath: string): string {
+	const ext = path.extname(filePath).toLowerCase();
+	return MIME_TYPES[ext] ?? "application/octet-stream";
+}
+
+export function registerWebviewProtocol(): void {
+	try {
+		const { protocol } = require("electron");
+
+		protocol.handle("vscode-webview-resource", (request: Request) => {
+			const url = new URL(request.url);
+			// The path contains the local file path
+			let filePath = decodeURIComponent(url.pathname);
+
+			// On macOS, pathname might start with extra slash
+			if (process.platform === "darwin" && filePath.startsWith("//")) {
+				filePath = filePath.slice(1);
+			}
+
+			if (!fs.existsSync(filePath)) {
+				return new Response("Not found", { status: 404 });
+			}
+
+			const content = fs.readFileSync(filePath);
+			const mimeType = getMimeType(filePath);
+
+			return new Response(content, {
+				headers: {
+					"Content-Type": mimeType,
+					"Access-Control-Allow-Origin": "*",
+				},
+			});
+		});
+
+		console.log("[vscode-shim] Registered vscode-webview-resource:// protocol");
+	} catch (err) {
+		console.warn("[vscode-shim] Failed to register protocol handler:", err);
+	}
+}

--- a/apps/desktop/src/main/lib/vscode-shim/api/terminal-shim.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/api/terminal-shim.ts
@@ -76,7 +76,7 @@ export function createTerminal(
 	const processIdPromise = (async () => {
 		if (!manager) return undefined;
 		try {
-			const _result = await manager.createOrAttach({
+			const result = await manager.createOrAttach({
 				paneId,
 				tabId: `vscode-ext-tab-${paneId}`,
 				workspaceId: "vscode-extension-host",
@@ -84,6 +84,7 @@ export function createTerminal(
 				cols: 120,
 				rows: 30,
 			});
+			pid = result?.snapshot?.pid;
 			// Listen for exit
 			manager.on(`exit:${paneId}`, (exitCode: number) => {
 				exitStatus = { code: exitCode };

--- a/apps/desktop/src/main/lib/vscode-shim/api/terminal-shim.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/api/terminal-shim.ts
@@ -92,8 +92,8 @@ export function createTerminal(
 				rows: 30,
 			});
 			pid = result?.snapshot?.pid;
-			// Listen for exit
-			manager.on(`exit:${paneId}`, (exitCode: number) => {
+			// Listen for exit (store handler ref for cleanup in dispose)
+			const exitHandler = (exitCode: number) => {
 				exitStatus = { code: exitCode };
 				_onDidCloseTerminal.fire(terminal);
 				const idx = activeTerminals.indexOf(terminal);
@@ -103,7 +103,10 @@ export function createTerminal(
 					exitCode,
 					execution: { commandLine: { value: "" } },
 				});
-			});
+				// Self-cleanup
+				manager.off(`exit:${paneId}`, exitHandler);
+			};
+			manager.on(`exit:${paneId}`, exitHandler);
 			return pid;
 		} catch (err) {
 			console.error(`[vscode-shim] Failed to create terminal "${name}":`, err);
@@ -181,6 +184,7 @@ export function createTerminal(
 		},
 		dispose() {
 			if (manager) {
+				manager.off(`exit:${paneId}`, () => {});
 				manager.kill(paneId).catch(() => {});
 			}
 			const idx = activeTerminals.indexOf(terminal);

--- a/apps/desktop/src/main/lib/vscode-shim/api/terminal-shim.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/api/terminal-shim.ts
@@ -125,16 +125,39 @@ export function createTerminal(
 					return {
 						execution: { commandLine: command },
 						async *read() {
-							// Collect output from the terminal
+							// Collect output using idle-timeout: yield when output
+							// stops for 200ms, or after max 30s total
 							const chunks: string[] = [];
-							const handler = (data: string) => {
-								chunks.push(data);
-							};
-							manager.on(`data:${paneId}`, handler);
-							// Wait briefly for output
-							await new Promise((r) => setTimeout(r, 500));
-							manager.off(`data:${paneId}`, handler);
-							yield chunks.join("");
+							const output: string = await new Promise((resolve) => {
+								let idleTimer: ReturnType<typeof setTimeout>;
+								const maxTimer = setTimeout(() => {
+									cleanup();
+									resolve(chunks.join(""));
+								}, 30000);
+
+								const handler = (data: string) => {
+									chunks.push(data);
+									clearTimeout(idleTimer);
+									idleTimer = setTimeout(() => {
+										cleanup();
+										resolve(chunks.join(""));
+									}, 200);
+								};
+
+								const cleanup = () => {
+									clearTimeout(idleTimer);
+									clearTimeout(maxTimer);
+									manager.off(`data:${paneId}`, handler);
+								};
+
+								manager.on(`data:${paneId}`, handler);
+								// Initial timeout if no output at all
+								idleTimer = setTimeout(() => {
+									cleanup();
+									resolve(chunks.join(""));
+								}, 2000);
+							});
+							yield output;
 						},
 					};
 				},

--- a/apps/desktop/src/main/lib/vscode-shim/api/terminal-shim.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/api/terminal-shim.ts
@@ -3,7 +3,7 @@
  */
 
 import { randomUUID } from "node:crypto";
-import { EventEmitter } from "./event-emitter.js";
+import { EventEmitter } from "./event-emitter";
 
 interface TerminalOptions {
 	name?: string;

--- a/apps/desktop/src/main/lib/vscode-shim/api/terminal-shim.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/api/terminal-shim.ts
@@ -3,6 +3,7 @@
  */
 
 import { randomUUID } from "node:crypto";
+import { shimLog } from "./debug-log";
 import { EventEmitter } from "./event-emitter";
 
 interface TerminalOptions {
@@ -135,7 +136,7 @@ export function createTerminal(
 		},
 		sendText(text: string, addNewLine = true) {
 			if (!manager) {
-				console.log(`[vscode-shim] Terminal "${name}" sendText: ${text}`);
+				shimLog(`[vscode-shim] Terminal "${name}" sendText: ${text}`);
 				return;
 			}
 			manager.write({

--- a/apps/desktop/src/main/lib/vscode-shim/api/terminal-shim.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/api/terminal-shim.ts
@@ -51,8 +51,12 @@ const activeTerminals: ShimTerminal[] = [];
 
 function getTerminalManager() {
 	try {
-		const { getDaemonTerminalManager } = require("main/lib/terminal");
-		return getDaemonTerminalManager();
+		// Use dynamic import path that the bundler can resolve
+		// eslint-disable-next-line @typescript-eslint/no-var-requires
+		const mod = require("../../terminal") as {
+			getDaemonTerminalManager: () => unknown;
+		};
+		return mod.getDaemonTerminalManager();
 	} catch {
 		return null;
 	}

--- a/apps/desktop/src/main/lib/vscode-shim/api/terminal-shim.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/api/terminal-shim.ts
@@ -1,0 +1,173 @@
+/**
+ * VS Code Terminal API shim backed by DaemonTerminalManager.
+ */
+
+import { randomUUID } from "node:crypto";
+import { Disposable, EventEmitter } from "./event-emitter.js";
+
+interface TerminalOptions {
+	name?: string;
+	cwd?: string;
+	env?: Record<string, string | null>;
+	shellPath?: string;
+	shellArgs?: string[];
+}
+
+interface ShimTerminal {
+	readonly name: string;
+	readonly processId: Promise<number | undefined>;
+	readonly exitStatus: { code: number | undefined } | undefined;
+	readonly shellIntegration?: ShellIntegration;
+	sendText(text: string, addNewLine?: boolean): void;
+	show(preserveFocus?: boolean): void;
+	hide(): void;
+	dispose(): void;
+}
+
+interface ShellIntegration {
+	executeCommand(command: string): {
+		execution: { commandLine: string };
+		read(): AsyncIterable<string>;
+	};
+}
+
+const _onDidOpenTerminal = new EventEmitter<ShimTerminal>();
+const _onDidCloseTerminal = new EventEmitter<ShimTerminal>();
+const _onDidChangeActiveTerminal = new EventEmitter<ShimTerminal | undefined>();
+const _onDidEndTerminalShellExecution = new EventEmitter<unknown>();
+const _onDidChangeTerminalShellIntegration = new EventEmitter<unknown>();
+
+export const terminalEvents = {
+	onDidOpenTerminal: _onDidOpenTerminal.event,
+	onDidCloseTerminal: _onDidCloseTerminal.event,
+	onDidChangeActiveTerminal: _onDidChangeActiveTerminal.event,
+	onDidEndTerminalShellExecution: _onDidEndTerminalShellExecution.event,
+	onDidChangeTerminalShellIntegration: _onDidChangeTerminalShellIntegration.event,
+};
+
+const activeTerminals: ShimTerminal[] = [];
+
+function getTerminalManager() {
+	try {
+		const { getDaemonTerminalManager } = require("main/lib/terminal");
+		return getDaemonTerminalManager();
+	} catch {
+		return null;
+	}
+}
+
+export function createTerminal(
+	nameOrOptions?: string | TerminalOptions,
+): ShimTerminal {
+	const opts: TerminalOptions =
+		typeof nameOrOptions === "string"
+			? { name: nameOrOptions }
+			: nameOrOptions ?? {};
+
+	const name = opts.name ?? "Extension Terminal";
+	const paneId = `vscode-ext-terminal-${randomUUID()}`;
+	let exitStatus: { code: number | undefined } | undefined;
+	let pid: number | undefined;
+
+	const manager = getTerminalManager();
+
+	// Create session asynchronously
+	const processIdPromise = (async () => {
+		if (!manager) return undefined;
+		try {
+			const result = await manager.createOrAttach({
+				paneId,
+				tabId: `vscode-ext-tab-${paneId}`,
+				workspaceId: "vscode-extension-host",
+				cwd: opts.cwd,
+				cols: 120,
+				rows: 30,
+			});
+			// Listen for exit
+			manager.on(`exit:${paneId}`, (exitCode: number) => {
+				exitStatus = { code: exitCode };
+				_onDidCloseTerminal.fire(terminal);
+				const idx = activeTerminals.indexOf(terminal);
+				if (idx >= 0) activeTerminals.splice(idx, 1);
+				_onDidEndTerminalShellExecution.fire({
+					terminal,
+					exitCode,
+					execution: { commandLine: { value: "" } },
+				});
+			});
+			return pid;
+		} catch (err) {
+			console.error(`[vscode-shim] Failed to create terminal "${name}":`, err);
+			return undefined;
+		}
+	})();
+
+	const terminal: ShimTerminal = {
+		name,
+		processId: processIdPromise,
+		get exitStatus() {
+			return exitStatus;
+		},
+		get shellIntegration(): ShellIntegration | undefined {
+			if (!manager) return undefined;
+			return {
+				executeCommand(command: string) {
+					manager.write({ paneId, data: `${command}\n` });
+					return {
+						execution: { commandLine: command },
+						async *read() {
+							// Collect output from the terminal
+							const chunks: string[] = [];
+							const handler = (data: string) => {
+								chunks.push(data);
+							};
+							manager.on(`data:${paneId}`, handler);
+							// Wait briefly for output
+							await new Promise((r) => setTimeout(r, 500));
+							manager.off(`data:${paneId}`, handler);
+							yield chunks.join("");
+						},
+					};
+				},
+			};
+		},
+		sendText(text: string, addNewLine = true) {
+			if (!manager) {
+				console.log(`[vscode-shim] Terminal "${name}" sendText: ${text}`);
+				return;
+			}
+			manager.write({
+				paneId,
+				data: addNewLine ? `${text}\n` : text,
+			});
+		},
+		show(_preserveFocus?: boolean) {
+			// Could focus the terminal in the UI
+		},
+		hide() {
+			// noop
+		},
+		dispose() {
+			if (manager) {
+				manager.kill(paneId).catch(() => {});
+			}
+			const idx = activeTerminals.indexOf(terminal);
+			if (idx >= 0) activeTerminals.splice(idx, 1);
+			_onDidCloseTerminal.fire(terminal);
+		},
+	};
+
+	activeTerminals.push(terminal);
+	_onDidOpenTerminal.fire(terminal);
+	_onDidChangeActiveTerminal.fire(terminal);
+
+	return terminal;
+}
+
+export function getTerminals(): ShimTerminal[] {
+	return [...activeTerminals];
+}
+
+export function getActiveTerminal(): ShimTerminal | undefined {
+	return activeTerminals[activeTerminals.length - 1];
+}

--- a/apps/desktop/src/main/lib/vscode-shim/api/terminal-shim.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/api/terminal-shim.ts
@@ -53,10 +53,11 @@ function getTerminalManager() {
 	try {
 		// Use dynamic import path that the bundler can resolve
 		// eslint-disable-next-line @typescript-eslint/no-var-requires
+		// biome-ignore lint: dynamic require for bundler compat
 		const mod = require("../../terminal") as {
-			getDaemonTerminalManager: () => unknown;
+			getDaemonTerminalManager: () => any;
 		};
-		return mod.getDaemonTerminalManager();
+		return mod.getDaemonTerminalManager() as any;
 	} catch {
 		return null;
 	}

--- a/apps/desktop/src/main/lib/vscode-shim/api/terminal-shim.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/api/terminal-shim.ts
@@ -5,6 +5,7 @@
 import { randomUUID } from "node:crypto";
 import { shimLog } from "./debug-log";
 import { EventEmitter } from "./event-emitter";
+import { workspace } from "./workspace";
 
 interface TerminalOptions {
 	name?: string;
@@ -86,7 +87,7 @@ export function createTerminal(
 				paneId,
 				tabId: `vscode-ext-tab-${paneId}`,
 				workspaceId: "vscode-extension-host",
-				cwd: opts.cwd,
+				cwd: opts.cwd ?? workspace.rootPath,
 				cols: 120,
 				rows: 30,
 			});

--- a/apps/desktop/src/main/lib/vscode-shim/api/terminal-shim.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/api/terminal-shim.ts
@@ -3,7 +3,7 @@
  */
 
 import { randomUUID } from "node:crypto";
-import { Disposable, EventEmitter } from "./event-emitter.js";
+import { EventEmitter } from "./event-emitter.js";
 
 interface TerminalOptions {
 	name?: string;
@@ -42,7 +42,8 @@ export const terminalEvents = {
 	onDidCloseTerminal: _onDidCloseTerminal.event,
 	onDidChangeActiveTerminal: _onDidChangeActiveTerminal.event,
 	onDidEndTerminalShellExecution: _onDidEndTerminalShellExecution.event,
-	onDidChangeTerminalShellIntegration: _onDidChangeTerminalShellIntegration.event,
+	onDidChangeTerminalShellIntegration:
+		_onDidChangeTerminalShellIntegration.event,
 };
 
 const activeTerminals: ShimTerminal[] = [];
@@ -62,7 +63,7 @@ export function createTerminal(
 	const opts: TerminalOptions =
 		typeof nameOrOptions === "string"
 			? { name: nameOrOptions }
-			: nameOrOptions ?? {};
+			: (nameOrOptions ?? {});
 
 	const name = opts.name ?? "Extension Terminal";
 	const paneId = `vscode-ext-terminal-${randomUUID()}`;
@@ -75,7 +76,7 @@ export function createTerminal(
 	const processIdPromise = (async () => {
 		if (!manager) return undefined;
 		try {
-			const result = await manager.createOrAttach({
+			const _result = await manager.createOrAttach({
 				paneId,
 				tabId: `vscode-ext-tab-${paneId}`,
 				workspaceId: "vscode-extension-host",

--- a/apps/desktop/src/main/lib/vscode-shim/api/uri.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/api/uri.ts
@@ -61,7 +61,13 @@ export class Uri {
 		return result;
 	}
 
-	toJSON(): { scheme: string; authority: string; path: string; query: string; fragment: string } {
+	toJSON(): {
+		scheme: string;
+		authority: string;
+		path: string;
+		query: string;
+		fragment: string;
+	} {
 		return {
 			scheme: this.scheme,
 			authority: this.authority,

--- a/apps/desktop/src/main/lib/vscode-shim/api/uri.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/api/uri.ts
@@ -1,0 +1,114 @@
+/**
+ * VS Code Uri shim.
+ */
+
+import path from "node:path";
+import { URL } from "node:url";
+
+export class Uri {
+	readonly scheme: string;
+	readonly authority: string;
+	readonly path: string;
+	readonly query: string;
+	readonly fragment: string;
+
+	private constructor(
+		scheme: string,
+		authority: string,
+		uriPath: string,
+		query: string,
+		fragment: string,
+	) {
+		this.scheme = scheme;
+		this.authority = authority;
+		this.path = uriPath;
+		this.query = query;
+		this.fragment = fragment;
+	}
+
+	get fsPath(): string {
+		if (this.scheme === "file") {
+			return this.path.startsWith("/") ? this.path : `/${this.path}`;
+		}
+		return this.path;
+	}
+
+	with(change: {
+		scheme?: string;
+		authority?: string;
+		path?: string;
+		query?: string;
+		fragment?: string;
+	}): Uri {
+		return new Uri(
+			change.scheme ?? this.scheme,
+			change.authority ?? this.authority,
+			change.path ?? this.path,
+			change.query ?? this.query,
+			change.fragment ?? this.fragment,
+		);
+	}
+
+	toString(): string {
+		if (this.scheme === "file") {
+			return `file://${this.path}`;
+		}
+		let result = `${this.scheme}://`;
+		if (this.authority) result += this.authority;
+		result += this.path;
+		if (this.query) result += `?${this.query}`;
+		if (this.fragment) result += `#${this.fragment}`;
+		return result;
+	}
+
+	toJSON(): { scheme: string; authority: string; path: string; query: string; fragment: string } {
+		return {
+			scheme: this.scheme,
+			authority: this.authority,
+			path: this.path,
+			query: this.query,
+			fragment: this.fragment,
+		};
+	}
+
+	static file(filePath: string): Uri {
+		const normalized = filePath.replace(/\\/g, "/");
+		return new Uri("file", "", normalized, "", "");
+	}
+
+	static parse(value: string): Uri {
+		try {
+			const url = new URL(value);
+			return new Uri(
+				url.protocol.replace(":", ""),
+				url.hostname + (url.port ? `:${url.port}` : ""),
+				decodeURIComponent(url.pathname),
+				url.search.replace("?", ""),
+				url.hash.replace("#", ""),
+			);
+		} catch {
+			return Uri.file(value);
+		}
+	}
+
+	static from(components: {
+		scheme: string;
+		authority?: string;
+		path?: string;
+		query?: string;
+		fragment?: string;
+	}): Uri {
+		return new Uri(
+			components.scheme,
+			components.authority ?? "",
+			components.path ?? "",
+			components.query ?? "",
+			components.fragment ?? "",
+		);
+	}
+
+	static joinPath(base: Uri, ...pathSegments: string[]): Uri {
+		const joined = path.posix.join(base.path, ...pathSegments);
+		return base.with({ path: joined });
+	}
+}

--- a/apps/desktop/src/main/lib/vscode-shim/api/webview-server.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/api/webview-server.ts
@@ -10,6 +10,7 @@ import fs from "node:fs";
 import http from "node:http";
 import os from "node:os";
 import path from "node:path";
+import { shimLog, shimWarn } from "./debug-log";
 
 const MIME_TYPES: Record<string, string> = {
 	".html": "text/html; charset=utf-8",
@@ -226,20 +227,20 @@ export async function startWebviewServer(): Promise<number> {
 	return new Promise((resolve, reject) => {
 		server = http.createServer((req, res) => {
 			const url = new URL(req.url ?? "/", `http://127.0.0.1`);
-			console.log(`[webview-server] ${req.method} ${url.pathname}`);
+			shimLog(`[webview-server] ${req.method} ${url.pathname}`);
 
 			// Serve webview HTML pages: /webview/{viewId}
 			if (url.pathname.startsWith("/webview/")) {
 				const viewId = decodeURIComponent(
 					url.pathname.slice("/webview/".length),
 				);
-				console.log(
+				shimLog(
 					`[webview-server] Serving webview: viewId="${viewId}", htmlStore has ${htmlStore.size} entries: [${[...htmlStore.keys()].join(", ")}]`,
 				);
 				let html = htmlStore.get(viewId);
 
 				if (!html) {
-					console.warn(`[webview-server] HTML not found for viewId: ${viewId}`);
+					shimWarn(`[webview-server] HTML not found for viewId: ${viewId}`);
 					res.writeHead(404, { "Content-Type": "text/html; charset=utf-8" });
 					res.end(
 						`<html><body style="color:#ccc;background:#1e1e1e;font-family:sans-serif;padding:20px"><h3>Webview loading...</h3><p>viewId: ${viewId}</p><p>Available: ${[...htmlStore.keys()].join(", ") || "none"}</p><script>setTimeout(()=>location.reload(),2000)</script></body></html>`,
@@ -247,26 +248,24 @@ export async function startWebviewServer(): Promise<number> {
 					return;
 				}
 
-				console.log(`[webview-server] Raw HTML length: ${html.length}`);
-				console.log(
+				shimLog(`[webview-server] Raw HTML length: ${html.length}`);
+				shimLog(
 					`[webview-server] HTML preview (first 300): ${html.substring(0, 300)}`,
 				);
 
 				// Strip extension's CSP (we provide our own via headers), rewrite URLs, inject bridge
 				const beforeCsp = html.length;
 				html = stripExtensionCsp(html);
-				console.log(
+				shimLog(
 					`[webview-server] After CSP strip: ${beforeCsp} -> ${html.length} (removed ${beforeCsp - html.length} chars)`,
 				);
 
 				html = rewriteResourceUrls(html);
-				console.log(`[webview-server] After URL rewrite: ${html.length} chars`);
+				shimLog(`[webview-server] After URL rewrite: ${html.length} chars`);
 
 				html = injectBridge(html);
-				console.log(
-					`[webview-server] After bridge inject: ${html.length} chars`,
-				);
-				console.log(
+				shimLog(`[webview-server] After bridge inject: ${html.length} chars`);
+				shimLog(
 					`[webview-server] Final HTML preview (first 500): ${html.substring(0, 500)}`,
 				);
 
@@ -299,7 +298,7 @@ export async function startWebviewServer(): Promise<number> {
 					filePath = filePath.slice(1);
 				}
 
-				console.log(
+				shimLog(
 					`[webview-server] Resource request: ${filePath}, allowed: ${isPathAllowed(filePath)}, exists: ${fs.existsSync(filePath)}`,
 				);
 
@@ -335,7 +334,7 @@ export async function startWebviewServer(): Promise<number> {
 			const addr = server?.address();
 			if (addr && typeof addr === "object") {
 				serverPort = addr.port;
-				console.log(
+				shimLog(
 					`[vscode-shim] Webview server listening on http://127.0.0.1:${serverPort}`,
 				);
 				resolve(serverPort);

--- a/apps/desktop/src/main/lib/vscode-shim/api/webview-server.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/api/webview-server.ts
@@ -145,7 +145,13 @@ const BRIDGE_SCRIPT = `${VSCODE_THEME_CSS}<script>
 	window.acquireVsCodeApi = function() { return vscodeApi; };
 	window.addEventListener('message', function(event) {
 		if (event.data && event.data.type === 'vscode-message') {
-			window.dispatchEvent(new MessageEvent('message', { data: event.data.data }));
+			// Re-dispatch with origin matching window.location.origin
+			// (required by Codex message-bus origin validation)
+			window.dispatchEvent(new MessageEvent('message', {
+				data: event.data.data,
+				origin: window.location.origin,
+				source: window
+			}));
 		}
 	});
 })();

--- a/apps/desktop/src/main/lib/vscode-shim/api/webview-server.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/api/webview-server.ts
@@ -243,7 +243,7 @@ export async function startWebviewServer(): Promise<number> {
 					shimWarn(`[webview-server] HTML not found for viewId: ${viewId}`);
 					res.writeHead(404, { "Content-Type": "text/html; charset=utf-8" });
 					res.end(
-						`<html><body style="color:#ccc;background:#1e1e1e;font-family:sans-serif;padding:20px"><h3>Webview loading...</h3><p>viewId: ${viewId}</p><p>Available: ${[...htmlStore.keys()].join(", ") || "none"}</p><script>setTimeout(()=>location.reload(),2000)</script></body></html>`,
+						`<html><body style="color:#ccc;background:#1e1e1e;font-family:sans-serif;padding:20px"><h3>Webview content not available</h3><script>setTimeout(()=>location.reload(),2000)</script></body></html>`,
 					);
 					return;
 				}
@@ -281,7 +281,6 @@ export async function startWebviewServer(): Promise<number> {
 						`frame-src http://127.0.0.1:${serverPort} https:`,
 						"worker-src blob:",
 					].join("; "),
-					"Access-Control-Allow-Origin": "*",
 				});
 				res.end(html);
 				return;

--- a/apps/desktop/src/main/lib/vscode-shim/api/webview-server.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/api/webview-server.ts
@@ -96,6 +96,22 @@ function rewriteResourceUrls(html: string): string {
 	);
 }
 
+/**
+ * Strip the extension's own CSP meta tag and nonce attributes.
+ * Our HTTP server provides its own CSP via response headers.
+ * Extensions set restrictive CSPs with nonces that block our bridge script.
+ */
+function stripExtensionCsp(html: string): string {
+	// Remove CSP meta tags
+	let result = html.replace(
+		/<meta\s+http-equiv=["']Content-Security-Policy["'][^>]*>/gi,
+		"",
+	);
+	// Remove nonce attributes from script/style tags
+	result = result.replace(/\s+nonce=["'][^"']*["']/g, "");
+	return result;
+}
+
 function injectBridge(html: string): string {
 	if (html.includes("</head>")) {
 		return html.replace("</head>", `${BRIDGE_SCRIPT}</head>`);
@@ -123,7 +139,8 @@ export async function startWebviewServer(): Promise<number> {
 					return;
 				}
 
-				// Rewrite resource URLs and inject bridge
+				// Strip extension's CSP (we provide our own via headers), rewrite URLs, inject bridge
+				html = stripExtensionCsp(html);
 				html = rewriteResourceUrls(html);
 				html = injectBridge(html);
 

--- a/apps/desktop/src/main/lib/vscode-shim/api/webview-server.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/api/webview-server.ts
@@ -125,24 +125,37 @@ export async function startWebviewServer(): Promise<number> {
 	return new Promise((resolve, reject) => {
 		server = http.createServer((req, res) => {
 			const url = new URL(req.url ?? "/", `http://127.0.0.1`);
+			console.log(`[webview-server] ${req.method} ${url.pathname}`);
 
 			// Serve webview HTML pages: /webview/{viewId}
 			if (url.pathname.startsWith("/webview/")) {
 				const viewId = decodeURIComponent(
 					url.pathname.slice("/webview/".length),
 				);
+				console.log(`[webview-server] Serving webview: viewId="${viewId}", htmlStore has ${htmlStore.size} entries: [${[...htmlStore.keys()].join(", ")}]`);
 				let html = htmlStore.get(viewId);
 
 				if (!html) {
-					res.writeHead(404, { "Content-Type": "text/plain" });
-					res.end(`View not found: ${viewId}`);
+					console.warn(`[webview-server] HTML not found for viewId: ${viewId}`);
+					res.writeHead(404, { "Content-Type": "text/html; charset=utf-8" });
+					res.end(`<html><body style="color:#ccc;background:#1e1e1e;font-family:sans-serif;padding:20px"><h3>Webview loading...</h3><p>viewId: ${viewId}</p><p>Available: ${[...htmlStore.keys()].join(", ") || "none"}</p><script>setTimeout(()=>location.reload(),2000)</script></body></html>`);
 					return;
 				}
 
+				console.log(`[webview-server] Raw HTML length: ${html.length}`);
+				console.log(`[webview-server] HTML preview (first 300): ${html.substring(0, 300)}`);
+
 				// Strip extension's CSP (we provide our own via headers), rewrite URLs, inject bridge
+				const beforeCsp = html.length;
 				html = stripExtensionCsp(html);
+				console.log(`[webview-server] After CSP strip: ${beforeCsp} -> ${html.length} (removed ${beforeCsp - html.length} chars)`);
+
 				html = rewriteResourceUrls(html);
+				console.log(`[webview-server] After URL rewrite: ${html.length} chars`);
+
 				html = injectBridge(html);
+				console.log(`[webview-server] After bridge inject: ${html.length} chars`);
+				console.log(`[webview-server] Final HTML preview (first 500): ${html.substring(0, 500)}`);
 
 				res.writeHead(200, {
 					"Content-Type": "text/html; charset=utf-8",
@@ -171,6 +184,8 @@ export async function startWebviewServer(): Promise<number> {
 				if (process.platform === "darwin" && filePath.startsWith("//")) {
 					filePath = filePath.slice(1);
 				}
+
+				console.log(`[webview-server] Resource request: ${filePath}, allowed: ${isPathAllowed(filePath)}, exists: ${fs.existsSync(filePath)}`);
 
 				if (!isPathAllowed(filePath)) {
 					res.writeHead(403, { "Content-Type": "text/plain" });

--- a/apps/desktop/src/main/lib/vscode-shim/api/webview-server.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/api/webview-server.ts
@@ -268,12 +268,13 @@ export async function startWebviewServer(): Promise<number> {
 					"Content-Type": "text/html; charset=utf-8",
 					"Content-Security-Policy": [
 						"default-src 'none'",
-						`script-src 'unsafe-inline' http://127.0.0.1:${serverPort}`,
-						`style-src 'unsafe-inline' http://127.0.0.1:${serverPort}`,
-						`img-src http://127.0.0.1:${serverPort} https: data:`,
+						`script-src 'unsafe-inline' 'unsafe-eval' http://127.0.0.1:${serverPort} https:`,
+						`style-src 'unsafe-inline' http://127.0.0.1:${serverPort} https:`,
+						`img-src http://127.0.0.1:${serverPort} https: data: blob:`,
 						`font-src http://127.0.0.1:${serverPort} https: data:`,
-						"connect-src https: wss: ws: http://127.0.0.1:*",
-						`frame-src http://127.0.0.1:${serverPort}`,
+						"connect-src https: wss: ws: http://127.0.0.1:* http://localhost:*",
+						`frame-src http://127.0.0.1:${serverPort} https:`,
+						"worker-src blob:",
 					].join("; "),
 					"Access-Control-Allow-Origin": "*",
 				});

--- a/apps/desktop/src/main/lib/vscode-shim/api/webview-server.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/api/webview-server.ts
@@ -44,8 +44,95 @@ function isPathAllowed(filePath: string): boolean {
 /** Store for webview HTML content, keyed by viewId */
 const htmlStore = new Map<string, string>();
 
+/** VS Code dark theme CSS variables - required for extension webviews to render */
+const VSCODE_THEME_CSS = `<style>
+:root {
+  --vscode-font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  --vscode-font-size: 13px;
+  --vscode-font-weight: normal;
+  --vscode-editor-font-family: 'SF Mono', Monaco, Menlo, Consolas, monospace;
+  --vscode-editor-font-size: 13px;
+  --vscode-editor-background: #1e1e1e;
+  --vscode-editor-foreground: #d4d4d4;
+  --vscode-foreground: #cccccc;
+  --vscode-disabledForeground: #cccccc80;
+  --vscode-descriptionForeground: #acacac;
+  --vscode-errorForeground: #f48771;
+  --vscode-focusBorder: #007fd4;
+  --vscode-sideBar-background: #252526;
+  --vscode-sideBar-foreground: #cccccc;
+  --vscode-sideBar-border: #2d2d2d;
+  --vscode-sideBarTitle-foreground: #bbbbbb;
+  --vscode-sideBarSectionHeader-background: #80808033;
+  --vscode-sideBarSectionHeader-foreground: #cccccc;
+  --vscode-panel-background: #1e1e1e;
+  --vscode-panel-foreground: #cccccc;
+  --vscode-panel-border: #80808059;
+  --vscode-panelTitle-activeForeground: #e7e7e7;
+  --vscode-panelTitle-inactiveForeground: #e7e7e780;
+  --vscode-input-background: #3c3c3c;
+  --vscode-input-foreground: #cccccc;
+  --vscode-input-border: #3c3c3c;
+  --vscode-input-placeholderForeground: #a6a6a6;
+  --vscode-inputOption-activeBorder: #007acc;
+  --vscode-inputOption-activeBackground: #007fd466;
+  --vscode-inputOption-activeForeground: #ffffff;
+  --vscode-button-background: #0e639c;
+  --vscode-button-foreground: #ffffff;
+  --vscode-button-hoverBackground: #1177bb;
+  --vscode-button-secondaryBackground: #3a3d41;
+  --vscode-button-secondaryForeground: #ffffff;
+  --vscode-button-secondaryHoverBackground: #45494e;
+  --vscode-badge-background: #4d4d4d;
+  --vscode-badge-foreground: #ffffff;
+  --vscode-scrollbarSlider-background: #79797966;
+  --vscode-scrollbarSlider-hoverBackground: #646464b3;
+  --vscode-scrollbarSlider-activeBackground: #bfbfbf66;
+  --vscode-list-hoverBackground: #2a2d2e;
+  --vscode-list-hoverForeground: #cccccc;
+  --vscode-list-activeSelectionBackground: #04395e;
+  --vscode-list-activeSelectionForeground: #ffffff;
+  --vscode-list-inactiveSelectionBackground: #37373d;
+  --vscode-list-inactiveSelectionForeground: #cccccc;
+  --vscode-dropdown-background: #3c3c3c;
+  --vscode-dropdown-foreground: #f0f0f0;
+  --vscode-dropdown-border: #3c3c3c;
+  --vscode-checkbox-background: #3c3c3c;
+  --vscode-checkbox-border: #3c3c3c;
+  --vscode-checkbox-foreground: #f0f0f0;
+  --vscode-textLink-foreground: #3794ff;
+  --vscode-textLink-activeForeground: #3794ff;
+  --vscode-widget-shadow: #0000005c;
+  --vscode-widget-border: #303031;
+  --vscode-toolbar-hoverBackground: #5a5d5e50;
+  --vscode-tab-activeBackground: #1e1e1e;
+  --vscode-tab-activeForeground: #ffffff;
+  --vscode-tab-inactiveBackground: #2d2d2d;
+  --vscode-tab-inactiveForeground: #ffffff80;
+  --vscode-tab-border: #252526;
+  --vscode-notifications-background: #252526;
+  --vscode-notifications-foreground: #cccccc;
+  --vscode-notifications-border: #303031;
+  --vscode-commandCenter-background: #ffffff0d;
+  --vscode-commandCenter-foreground: #cccccc;
+  --vscode-icon-foreground: #c5c5c5;
+  --vscode-keybindingLabel-foreground: #cccccc;
+  color-scheme: dark;
+}
+body {
+  background: var(--vscode-editor-background);
+  color: var(--vscode-foreground);
+  font-family: var(--vscode-font-family);
+  font-size: var(--vscode-font-size);
+  margin: 0;
+  padding: 0;
+}
+body.vscode-dark { color-scheme: dark; }
+body.vscode-light { color-scheme: light; }
+</style>`;
+
 /** Bridge script injected into every webview page */
-const BRIDGE_SCRIPT = `<script>
+const BRIDGE_SCRIPT = `${VSCODE_THEME_CSS}<script>
 (function() {
 	let _state = null;
 	const vscodeApi = {
@@ -113,10 +200,18 @@ function stripExtensionCsp(html: string): string {
 }
 
 function injectBridge(html: string): string {
-	if (html.includes("</head>")) {
-		return html.replace("</head>", `${BRIDGE_SCRIPT}</head>`);
+	// Inject bridge script + theme CSS into head
+	let result = html;
+	if (result.includes("</head>")) {
+		result = result.replace("</head>", `${BRIDGE_SCRIPT}</head>`);
+	} else {
+		result = `${BRIDGE_SCRIPT}${result}`;
 	}
-	return `${BRIDGE_SCRIPT}${html}`;
+	// Add vscode-dark class to body for theme detection
+	if (result.includes("<body")) {
+		result = result.replace(/<body([^>]*)>/, '<body$1 class="vscode-dark">');
+	}
+	return result;
 }
 
 export async function startWebviewServer(): Promise<number> {

--- a/apps/desktop/src/main/lib/vscode-shim/api/webview-server.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/api/webview-server.ts
@@ -1,0 +1,207 @@
+/**
+ * Local HTTP server for serving VS Code extension webview content.
+ *
+ * Serves both webview HTML pages and extension resources (JS/CSS/images)
+ * on localhost with appropriate CSP headers. This bypasses all iframe
+ * CSP/protocol restrictions since HTTP is universally supported.
+ */
+
+import fs from "node:fs";
+import http from "node:http";
+import os from "node:os";
+import path from "node:path";
+
+const MIME_TYPES: Record<string, string> = {
+	".html": "text/html; charset=utf-8",
+	".css": "text/css",
+	".js": "application/javascript",
+	".mjs": "application/javascript",
+	".json": "application/json",
+	".svg": "image/svg+xml",
+	".png": "image/png",
+	".jpg": "image/jpeg",
+	".jpeg": "image/jpeg",
+	".gif": "image/gif",
+	".woff": "font/woff",
+	".woff2": "font/woff2",
+	".ttf": "font/ttf",
+	".ico": "image/x-icon",
+	".wasm": "application/wasm",
+};
+
+const ALLOWED_ROOTS = [
+	path.join(os.homedir(), ".vscode", "extensions"),
+	path.join(os.homedir(), ".vscode-insiders", "extensions"),
+];
+
+function isPathAllowed(filePath: string): boolean {
+	const resolved = path.resolve(filePath);
+	return ALLOWED_ROOTS.some(
+		(root) => resolved === root || resolved.startsWith(root + path.sep),
+	);
+}
+
+/** Store for webview HTML content, keyed by viewId */
+const htmlStore = new Map<string, string>();
+
+/** Bridge script injected into every webview page */
+const BRIDGE_SCRIPT = `<script>
+(function() {
+	let _state = null;
+	const vscodeApi = {
+		postMessage(message) {
+			window.parent.postMessage({ type: 'vscode-api', data: message }, '*');
+		},
+		getState() { return _state; },
+		setState(state) { _state = state; return state; }
+	};
+	window.acquireVsCodeApi = function() { return vscodeApi; };
+	window.addEventListener('message', function(event) {
+		if (event.data && event.data.type === 'vscode-message') {
+			window.dispatchEvent(new MessageEvent('message', { data: event.data.data }));
+		}
+	});
+})();
+</script>`;
+
+let server: http.Server | null = null;
+let serverPort = 0;
+
+export function getWebviewServerPort(): number {
+	return serverPort;
+}
+
+export function setWebviewHtml(viewId: string, html: string): void {
+	htmlStore.set(viewId, html);
+}
+
+export function clearWebviewHtml(viewId: string): void {
+	htmlStore.delete(viewId);
+}
+
+export function getWebviewUrl(viewId: string): string {
+	return `http://127.0.0.1:${serverPort}/webview/${encodeURIComponent(viewId)}`;
+}
+
+/**
+ * Rewrite vscode-webview-resource:// URLs in HTML to use our HTTP server.
+ */
+function rewriteResourceUrls(html: string): string {
+	return html.replace(
+		/vscode-webview-resource:\/\/([^"'\s)]+)/g,
+		(_, resourcePath) => {
+			const decoded = decodeURIComponent(resourcePath);
+			return `http://127.0.0.1:${serverPort}/resource${decoded}`;
+		},
+	);
+}
+
+function injectBridge(html: string): string {
+	if (html.includes("</head>")) {
+		return html.replace("</head>", `${BRIDGE_SCRIPT}</head>`);
+	}
+	return `${BRIDGE_SCRIPT}${html}`;
+}
+
+export async function startWebviewServer(): Promise<number> {
+	if (server) return serverPort;
+
+	return new Promise((resolve, reject) => {
+		server = http.createServer((req, res) => {
+			const url = new URL(req.url ?? "/", `http://127.0.0.1`);
+
+			// Serve webview HTML pages: /webview/{viewId}
+			if (url.pathname.startsWith("/webview/")) {
+				const viewId = decodeURIComponent(
+					url.pathname.slice("/webview/".length),
+				);
+				let html = htmlStore.get(viewId);
+
+				if (!html) {
+					res.writeHead(404, { "Content-Type": "text/plain" });
+					res.end(`View not found: ${viewId}`);
+					return;
+				}
+
+				// Rewrite resource URLs and inject bridge
+				html = rewriteResourceUrls(html);
+				html = injectBridge(html);
+
+				res.writeHead(200, {
+					"Content-Type": "text/html; charset=utf-8",
+					"Content-Security-Policy": [
+						"default-src 'none'",
+						`script-src 'unsafe-inline' http://127.0.0.1:${serverPort}`,
+						`style-src 'unsafe-inline' http://127.0.0.1:${serverPort}`,
+						`img-src http://127.0.0.1:${serverPort} https: data:`,
+						`font-src http://127.0.0.1:${serverPort} https: data:`,
+						"connect-src https: wss: ws: http://127.0.0.1:*",
+						`frame-src http://127.0.0.1:${serverPort}`,
+					].join("; "),
+					"Access-Control-Allow-Origin": "*",
+				});
+				res.end(html);
+				return;
+			}
+
+			// Serve extension resources: /resource/{filepath}
+			if (url.pathname.startsWith("/resource/")) {
+				let filePath = decodeURIComponent(
+					url.pathname.slice("/resource".length),
+				);
+
+				// Normalize path
+				if (process.platform === "darwin" && filePath.startsWith("//")) {
+					filePath = filePath.slice(1);
+				}
+
+				if (!isPathAllowed(filePath)) {
+					res.writeHead(403, { "Content-Type": "text/plain" });
+					res.end("Forbidden");
+					return;
+				}
+
+				if (!fs.existsSync(filePath)) {
+					res.writeHead(404, { "Content-Type": "text/plain" });
+					res.end("Not found");
+					return;
+				}
+
+				const ext = path.extname(filePath).toLowerCase();
+				const mimeType = MIME_TYPES[ext] ?? "application/octet-stream";
+
+				const content = fs.readFileSync(filePath);
+				res.writeHead(200, {
+					"Content-Type": mimeType,
+					"Cache-Control": "public, max-age=3600",
+				});
+				res.end(content);
+				return;
+			}
+
+			res.writeHead(404);
+			res.end("Not found");
+		});
+
+		server.listen(0, "127.0.0.1", () => {
+			const addr = server?.address();
+			if (addr && typeof addr === "object") {
+				serverPort = addr.port;
+				console.log(
+					`[vscode-shim] Webview server listening on http://127.0.0.1:${serverPort}`,
+				);
+				resolve(serverPort);
+			} else {
+				reject(new Error("Failed to get server address"));
+			}
+		});
+
+		server.on("error", reject);
+	});
+}
+
+export function stopWebviewServer(): void {
+	server?.close();
+	server = null;
+	serverPort = 0;
+}

--- a/apps/desktop/src/main/lib/vscode-shim/api/webview-server.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/api/webview-server.ts
@@ -132,30 +132,42 @@ export async function startWebviewServer(): Promise<number> {
 				const viewId = decodeURIComponent(
 					url.pathname.slice("/webview/".length),
 				);
-				console.log(`[webview-server] Serving webview: viewId="${viewId}", htmlStore has ${htmlStore.size} entries: [${[...htmlStore.keys()].join(", ")}]`);
+				console.log(
+					`[webview-server] Serving webview: viewId="${viewId}", htmlStore has ${htmlStore.size} entries: [${[...htmlStore.keys()].join(", ")}]`,
+				);
 				let html = htmlStore.get(viewId);
 
 				if (!html) {
 					console.warn(`[webview-server] HTML not found for viewId: ${viewId}`);
 					res.writeHead(404, { "Content-Type": "text/html; charset=utf-8" });
-					res.end(`<html><body style="color:#ccc;background:#1e1e1e;font-family:sans-serif;padding:20px"><h3>Webview loading...</h3><p>viewId: ${viewId}</p><p>Available: ${[...htmlStore.keys()].join(", ") || "none"}</p><script>setTimeout(()=>location.reload(),2000)</script></body></html>`);
+					res.end(
+						`<html><body style="color:#ccc;background:#1e1e1e;font-family:sans-serif;padding:20px"><h3>Webview loading...</h3><p>viewId: ${viewId}</p><p>Available: ${[...htmlStore.keys()].join(", ") || "none"}</p><script>setTimeout(()=>location.reload(),2000)</script></body></html>`,
+					);
 					return;
 				}
 
 				console.log(`[webview-server] Raw HTML length: ${html.length}`);
-				console.log(`[webview-server] HTML preview (first 300): ${html.substring(0, 300)}`);
+				console.log(
+					`[webview-server] HTML preview (first 300): ${html.substring(0, 300)}`,
+				);
 
 				// Strip extension's CSP (we provide our own via headers), rewrite URLs, inject bridge
 				const beforeCsp = html.length;
 				html = stripExtensionCsp(html);
-				console.log(`[webview-server] After CSP strip: ${beforeCsp} -> ${html.length} (removed ${beforeCsp - html.length} chars)`);
+				console.log(
+					`[webview-server] After CSP strip: ${beforeCsp} -> ${html.length} (removed ${beforeCsp - html.length} chars)`,
+				);
 
 				html = rewriteResourceUrls(html);
 				console.log(`[webview-server] After URL rewrite: ${html.length} chars`);
 
 				html = injectBridge(html);
-				console.log(`[webview-server] After bridge inject: ${html.length} chars`);
-				console.log(`[webview-server] Final HTML preview (first 500): ${html.substring(0, 500)}`);
+				console.log(
+					`[webview-server] After bridge inject: ${html.length} chars`,
+				);
+				console.log(
+					`[webview-server] Final HTML preview (first 500): ${html.substring(0, 500)}`,
+				);
 
 				res.writeHead(200, {
 					"Content-Type": "text/html; charset=utf-8",
@@ -185,7 +197,9 @@ export async function startWebviewServer(): Promise<number> {
 					filePath = filePath.slice(1);
 				}
 
-				console.log(`[webview-server] Resource request: ${filePath}, allowed: ${isPathAllowed(filePath)}, exists: ${fs.existsSync(filePath)}`);
+				console.log(
+					`[webview-server] Resource request: ${filePath}, allowed: ${isPathAllowed(filePath)}, exists: ${fs.existsSync(filePath)}`,
+				);
 
 				if (!isPathAllowed(filePath)) {
 					res.writeHead(403, { "Content-Type": "text/plain" });

--- a/apps/desktop/src/main/lib/vscode-shim/api/webview.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/api/webview.ts
@@ -179,10 +179,15 @@ export function resolveWebviewView(
 	const proxiedWebview = new Proxy(rawWebview, {
 		set(target, prop, value) {
 			if (prop === "html") {
+				const htmlStr = typeof value === "string" ? value : String(value);
+				console.log(
+					`[webview:${viewId}] HTML set, length=${htmlStr.length}, preview="${htmlStr.substring(0, 100)}..."`,
+				);
 				(target as { html: string }).html = value;
 				_onWebviewEvent.fire({ viewId, type: "html", data: value });
 				return true;
 			}
+			console.log(`[webview:${viewId}] Property set: ${String(prop)}`);
 			(target as unknown as Record<string | symbol, unknown>)[prop] = value;
 			return true;
 		},
@@ -214,7 +219,31 @@ export function resolveWebviewView(
 		onCancellationRequested: new EventEmitter<void>().event,
 	};
 
-	provider.resolveWebviewView(view, { state: undefined }, cancellationToken);
+	console.log(`[webview:${viewId}] Calling provider.resolveWebviewView...`);
+	try {
+		const result = provider.resolveWebviewView(
+			view,
+			{ state: undefined },
+			cancellationToken,
+		);
+		if (result && typeof (result as Promise<void>).then === "function") {
+			(result as Promise<void>)
+				.then(() => {
+					console.log(
+						`[webview:${viewId}] Provider resolved (async). HTML set: ${!!rawWebview.html}, len=${rawWebview.html?.length ?? 0}`,
+					);
+				})
+				.catch((err: unknown) => {
+					console.error(`[webview:${viewId}] Provider rejected:`, err);
+				});
+		} else {
+			console.log(
+				`[webview:${viewId}] Provider resolved (sync). HTML set: ${!!rawWebview.html}, len=${rawWebview.html?.length ?? 0}`,
+			);
+		}
+	} catch (err) {
+		console.error(`[webview:${viewId}] Provider threw:`, err);
+	}
 
 	return { view, viewId };
 }

--- a/apps/desktop/src/main/lib/vscode-shim/api/webview.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/api/webview.ts
@@ -158,7 +158,7 @@ function createWebview(
 export function resolveWebviewView(
 	viewType: string,
 	extensionPath: string,
-): WebviewView | undefined {
+): { view: WebviewView; viewId: string } | undefined {
 	const provider = viewProviders.get(viewType);
 	if (!provider) return undefined;
 
@@ -209,7 +209,7 @@ export function resolveWebviewView(
 
 	provider.resolveWebviewView(view, { state: undefined }, cancellationToken);
 
-	return view;
+	return { view, viewId };
 }
 
 export function createWebviewPanel(

--- a/apps/desktop/src/main/lib/vscode-shim/api/webview.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/api/webview.ts
@@ -2,8 +2,8 @@
  * VS Code Webview API shim.
  */
 
-import { Disposable, type Event, EventEmitter } from "./event-emitter.js";
-import { Uri } from "./uri.js";
+import { Disposable, type Event, EventEmitter } from "./event-emitter";
+import { Uri } from "./uri";
 
 export interface WebviewOptions {
 	enableScripts?: boolean;

--- a/apps/desktop/src/main/lib/vscode-shim/api/webview.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/api/webview.ts
@@ -70,7 +70,7 @@ export interface WebviewPanelSerializer {
 // Emits when webview html/messages change — consumed by tRPC router
 export interface WebviewEvent {
 	viewId: string;
-	type: "html" | "message" | "title" | "dispose";
+	type: "html" | "message" | "title" | "dispose" | "panel-created";
 	data: unknown;
 }
 
@@ -273,15 +273,20 @@ export function createWebviewPanel(
 	const viewColumn =
 		typeof showOptions === "number" ? showOptions : showOptions.viewColumn;
 
+	// Relay extension→panel postMessage as events
+	webview._onDidPostMessage.event((message) => {
+		_onWebviewEvent.fire({ viewId: panelId, type: "message", data: message });
+	});
+
 	const proxiedWebview = new Proxy(webview, {
 		set(target, prop, value) {
 			if (prop === "html") {
+				const htmlStr = typeof value === "string" ? value : String(value);
+				shimLog(
+					`[webview:${panelId}] Panel HTML set, length=${htmlStr.length}`,
+				);
 				(target as { html: string }).html = value;
-				_onWebviewEvent.fire({
-					panelId,
-					type: "html",
-					data: value,
-				} as unknown as WebviewEvent);
+				_onWebviewEvent.fire({ viewId: panelId, type: "html", data: value });
 				return true;
 			}
 			(target as unknown as Record<string | symbol, unknown>)[prop] = value;
@@ -300,14 +305,23 @@ export function createWebviewPanel(
 		onDidChangeViewState: _onDidChangeViewState.event,
 		iconPath: undefined,
 		reveal(_viewColumn?: number, _preserveFocus?: boolean) {
-			// noop
+			// noop for now
 		},
 		dispose() {
 			_onDidDispose.fire();
+			_onWebviewEvent.fire({ viewId: panelId, type: "dispose", data: null });
 			activePanels.delete(panelId);
 		},
 	};
 
 	activePanels.set(panelId, panel);
+
+	// Notify renderer to create a UI tab for this panel
+	_onWebviewEvent.fire({
+		viewId: panelId,
+		type: "panel-created" as WebviewEvent["type"],
+		data: { viewType, title, panelId },
+	});
+
 	return panel;
 }

--- a/apps/desktop/src/main/lib/vscode-shim/api/webview.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/api/webview.ts
@@ -320,7 +320,7 @@ export function createWebviewPanel(
 	_onWebviewEvent.fire({
 		viewId: panelId,
 		type: "panel-created" as WebviewEvent["type"],
-		data: { viewType, title, panelId },
+		data: { viewType, title, panelId, extensionPath },
 	});
 
 	return panel;

--- a/apps/desktop/src/main/lib/vscode-shim/api/webview.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/api/webview.ts
@@ -1,0 +1,243 @@
+/**
+ * VS Code Webview API shim.
+ */
+
+import { Disposable, EventEmitter, type Event } from "./event-emitter.js";
+import { Uri } from "./uri.js";
+
+export interface WebviewOptions {
+	enableScripts?: boolean;
+	enableCommandUris?: boolean;
+	localResourceRoots?: Uri[];
+	portMapping?: Array<{ webviewPort: number; extensionHostPort: number }>;
+}
+
+export interface Webview {
+	options: WebviewOptions;
+	html: string;
+	readonly onDidReceiveMessage: Event<unknown>;
+	postMessage(message: unknown): Promise<boolean>;
+	asWebviewUri(localResource: Uri): Uri;
+	readonly cspSource: string;
+}
+
+export interface WebviewView {
+	readonly viewType: string;
+	readonly webview: Webview;
+	title?: string;
+	description?: string;
+	badge?: { tooltip: string; value: number };
+	readonly visible: boolean;
+	readonly onDidDispose: Event<void>;
+	readonly onDidChangeVisibility: Event<void>;
+	show(preserveFocus?: boolean): void;
+	dispose(): void;
+}
+
+export interface WebviewPanel {
+	readonly viewType: string;
+	title: string;
+	readonly webview: Webview;
+	readonly active: boolean;
+	readonly visible: boolean;
+	readonly viewColumn: number | undefined;
+	readonly onDidDispose: Event<void>;
+	readonly onDidChangeViewState: Event<{ webviewPanel: WebviewPanel }>;
+	iconPath?: Uri | { light: Uri; dark: Uri };
+	reveal(viewColumn?: number, preserveFocus?: boolean): void;
+	dispose(): void;
+}
+
+export interface WebviewViewProvider {
+	resolveWebviewView(
+		webviewView: WebviewView,
+		context: { state?: unknown },
+		token: { isCancellationRequested: boolean; onCancellationRequested: Event<void> },
+	): void | Promise<void>;
+}
+
+export interface WebviewPanelSerializer {
+	deserializeWebviewPanel(webviewPanel: WebviewPanel, state: unknown): Promise<void>;
+}
+
+// Emits when webview html/messages change — consumed by tRPC router
+export interface WebviewEvent {
+	viewId: string;
+	type: "html" | "message" | "title" | "dispose";
+	data: unknown;
+}
+
+const _onWebviewEvent = new EventEmitter<WebviewEvent>();
+export const onWebviewEvent = _onWebviewEvent.event;
+
+const viewProviders = new Map<string, WebviewViewProvider>();
+const panelSerializers = new Map<string, WebviewPanelSerializer>();
+const activeViews = new Map<string, WebviewView>();
+const activePanels = new Map<string, WebviewPanel>();
+
+export function getViewProvider(viewType: string): WebviewViewProvider | undefined {
+	return viewProviders.get(viewType);
+}
+
+export function getActiveView(viewId: string): WebviewView | undefined {
+	return activeViews.get(viewId);
+}
+
+export function getActivePanel(panelId: string): WebviewPanel | undefined {
+	return activePanels.get(panelId);
+}
+
+export function registerWebviewViewProvider(
+	viewType: string,
+	provider: WebviewViewProvider,
+	_options?: { webviewOptions?: { retainContextWhenHidden?: boolean } },
+): Disposable {
+	viewProviders.set(viewType, provider);
+	return new Disposable(() => {
+		viewProviders.delete(viewType);
+	});
+}
+
+export function registerWebviewPanelSerializer(
+	viewType: string,
+	serializer: WebviewPanelSerializer,
+): Disposable {
+	panelSerializers.set(viewType, serializer);
+	return new Disposable(() => {
+		panelSerializers.delete(viewType);
+	});
+}
+
+function createWebview(extensionPath: string, options?: WebviewOptions): Webview {
+	const _onDidReceiveMessage = new EventEmitter<unknown>();
+	let _html = "";
+
+	return {
+		options: options ?? {},
+		get html() {
+			return _html;
+		},
+		set html(value: string) {
+			_html = value;
+			// Notification happens via the WebviewView/Panel wrapper
+		},
+		onDidReceiveMessage: _onDidReceiveMessage.event,
+		async postMessage(message: unknown): Promise<boolean> {
+			// Will be bridged to renderer via tRPC
+			return true;
+		},
+		asWebviewUri(localResource: Uri): Uri {
+			return Uri.from({
+				scheme: "vscode-webview-resource",
+				path: localResource.path,
+			});
+		},
+		cspSource: "vscode-webview-resource:",
+	};
+}
+
+/** Called from renderer when a sidebar view becomes visible */
+export function resolveWebviewView(
+	viewType: string,
+	extensionPath: string,
+): WebviewView | undefined {
+	const provider = viewProviders.get(viewType);
+	if (!provider) return undefined;
+
+	const _onDidDispose = new EventEmitter<void>();
+	const _onDidChangeVisibility = new EventEmitter<void>();
+	const webview = createWebview(extensionPath, { enableScripts: true });
+	const viewId = `view:${viewType}:${Date.now()}`;
+
+	// Intercept html setter to emit events
+	const rawWebview = webview;
+	const proxiedWebview = new Proxy(rawWebview, {
+		set(target, prop, value) {
+			if (prop === "html") {
+				(target as { html: string }).html = value;
+				_onWebviewEvent.fire({ viewId, type: "html", data: value });
+				return true;
+			}
+			(target as Record<string | symbol, unknown>)[prop] = value;
+			return true;
+		},
+	});
+
+	const view: WebviewView = {
+		viewType,
+		webview: proxiedWebview,
+		title: undefined,
+		description: undefined,
+		badge: undefined,
+		visible: true,
+		onDidDispose: _onDidDispose.event,
+		onDidChangeVisibility: _onDidChangeVisibility.event,
+		show(_preserveFocus?: boolean) {
+			// noop for now
+		},
+		dispose() {
+			_onDidDispose.fire();
+			_onWebviewEvent.fire({ viewId, type: "dispose", data: null });
+			activeViews.delete(viewId);
+		},
+	};
+
+	activeViews.set(viewId, view);
+
+	const cancellationToken = {
+		isCancellationRequested: false,
+		onCancellationRequested: new EventEmitter<void>().event,
+	};
+
+	provider.resolveWebviewView(view, { state: undefined }, cancellationToken);
+
+	return view;
+}
+
+export function createWebviewPanel(
+	viewType: string,
+	title: string,
+	showOptions: number | { viewColumn: number; preserveFocus?: boolean },
+	extensionPath: string,
+	options?: WebviewOptions,
+): WebviewPanel {
+	const _onDidDispose = new EventEmitter<void>();
+	const _onDidChangeViewState = new EventEmitter<{ webviewPanel: WebviewPanel }>();
+	const webview = createWebview(extensionPath, options);
+	const panelId = `panel:${viewType}:${Date.now()}`;
+	const viewColumn = typeof showOptions === "number" ? showOptions : showOptions.viewColumn;
+
+	const proxiedWebview = new Proxy(webview, {
+		set(target, prop, value) {
+			if (prop === "html") {
+				(target as { html: string }).html = value;
+				_onWebviewEvent.fire({ panelId, type: "html", data: value } as unknown as WebviewEvent);
+				return true;
+			}
+			(target as Record<string | symbol, unknown>)[prop] = value;
+			return true;
+		},
+	});
+
+	const panel: WebviewPanel = {
+		viewType,
+		title,
+		webview: proxiedWebview,
+		active: true,
+		visible: true,
+		viewColumn,
+		onDidDispose: _onDidDispose.event,
+		onDidChangeViewState: _onDidChangeViewState.event,
+		iconPath: undefined,
+		reveal(_viewColumn?: number, _preserveFocus?: boolean) {
+			// noop
+		},
+		dispose() {
+			_onDidDispose.fire();
+			activePanels.delete(panelId);
+		},
+	};
+
+	activePanels.set(panelId, panel);
+	return panel;
+}

--- a/apps/desktop/src/main/lib/vscode-shim/api/webview.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/api/webview.ts
@@ -160,7 +160,9 @@ export function resolveWebviewView(
 	viewType: string,
 	extensionPath: string,
 ): { view: WebviewView; viewId: string } | undefined {
-	console.log(`[vscode-shim] resolveWebviewView: ${viewType}, registered providers: [${[...viewProviders.keys()].join(", ")}]`);
+	console.log(
+		`[vscode-shim] resolveWebviewView: ${viewType}, registered providers: [${[...viewProviders.keys()].join(", ")}]`,
+	);
 	const provider = viewProviders.get(viewType);
 	if (!provider) {
 		console.warn(`[vscode-shim] No provider found for viewType: ${viewType}`);

--- a/apps/desktop/src/main/lib/vscode-shim/api/webview.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/api/webview.ts
@@ -2,6 +2,7 @@
  * VS Code Webview API shim.
  */
 
+import { shimLog, shimWarn } from "./debug-log";
 import { Disposable, type Event, EventEmitter } from "./event-emitter";
 import { Uri } from "./uri";
 
@@ -100,7 +101,7 @@ export function registerWebviewViewProvider(
 	provider: WebviewViewProvider,
 	_options?: { webviewOptions?: { retainContextWhenHidden?: boolean } },
 ): Disposable {
-	console.log(`[vscode-shim] registerWebviewViewProvider: ${viewType}`);
+	shimLog(`[vscode-shim] registerWebviewViewProvider: ${viewType}`);
 	viewProviders.set(viewType, provider);
 	return new Disposable(() => {
 		viewProviders.delete(viewType);
@@ -160,12 +161,12 @@ export function resolveWebviewView(
 	viewType: string,
 	extensionPath: string,
 ): { view: WebviewView; viewId: string } | undefined {
-	console.log(
+	shimLog(
 		`[vscode-shim] resolveWebviewView: ${viewType}, registered providers: [${[...viewProviders.keys()].join(", ")}]`,
 	);
 	const provider = viewProviders.get(viewType);
 	if (!provider) {
-		console.warn(`[vscode-shim] No provider found for viewType: ${viewType}`);
+		shimWarn(`[vscode-shim] No provider found for viewType: ${viewType}`);
 		return undefined;
 	}
 
@@ -176,7 +177,7 @@ export function resolveWebviewView(
 
 	// Relay extension→webview postMessage as events (so tRPC subscription can forward to iframe)
 	webview._onDidPostMessage.event((message) => {
-		console.log(
+		shimLog(
 			`[webview:${viewId}] postMessage from extension to webview, type=${typeof message === "object" && message !== null && "type" in message ? (message as { type: string }).type : "unknown"}`,
 		);
 		_onWebviewEvent.fire({ viewId, type: "message", data: message });
@@ -188,14 +189,14 @@ export function resolveWebviewView(
 		set(target, prop, value) {
 			if (prop === "html") {
 				const htmlStr = typeof value === "string" ? value : String(value);
-				console.log(
+				shimLog(
 					`[webview:${viewId}] HTML set, length=${htmlStr.length}, preview="${htmlStr.substring(0, 100)}..."`,
 				);
 				(target as { html: string }).html = value;
 				_onWebviewEvent.fire({ viewId, type: "html", data: value });
 				return true;
 			}
-			console.log(`[webview:${viewId}] Property set: ${String(prop)}`);
+			shimLog(`[webview:${viewId}] Property set: ${String(prop)}`);
 			(target as unknown as Record<string | symbol, unknown>)[prop] = value;
 			return true;
 		},
@@ -227,7 +228,7 @@ export function resolveWebviewView(
 		onCancellationRequested: new EventEmitter<void>().event,
 	};
 
-	console.log(`[webview:${viewId}] Calling provider.resolveWebviewView...`);
+	shimLog(`[webview:${viewId}] Calling provider.resolveWebviewView...`);
 	try {
 		const result = provider.resolveWebviewView(
 			view,
@@ -237,7 +238,7 @@ export function resolveWebviewView(
 		if (result && typeof (result as Promise<void>).then === "function") {
 			(result as Promise<void>)
 				.then(() => {
-					console.log(
+					shimLog(
 						`[webview:${viewId}] Provider resolved (async). HTML set: ${!!rawWebview.html}, len=${rawWebview.html?.length ?? 0}`,
 					);
 				})
@@ -245,7 +246,7 @@ export function resolveWebviewView(
 					console.error(`[webview:${viewId}] Provider rejected:`, err);
 				});
 		} else {
-			console.log(
+			shimLog(
 				`[webview:${viewId}] Provider resolved (sync). HTML set: ${!!rawWebview.html}, len=${rawWebview.html?.length ?? 0}`,
 			);
 		}

--- a/apps/desktop/src/main/lib/vscode-shim/api/webview.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/api/webview.ts
@@ -2,7 +2,7 @@
  * VS Code Webview API shim.
  */
 
-import { Disposable, EventEmitter, type Event } from "./event-emitter.js";
+import { Disposable, type Event, EventEmitter } from "./event-emitter.js";
 import { Uri } from "./uri.js";
 
 export interface WebviewOptions {
@@ -52,12 +52,18 @@ export interface WebviewViewProvider {
 	resolveWebviewView(
 		webviewView: WebviewView,
 		context: { state?: unknown },
-		token: { isCancellationRequested: boolean; onCancellationRequested: Event<void> },
+		token: {
+			isCancellationRequested: boolean;
+			onCancellationRequested: Event<void>;
+		},
 	): void | Promise<void>;
 }
 
 export interface WebviewPanelSerializer {
-	deserializeWebviewPanel(webviewPanel: WebviewPanel, state: unknown): Promise<void>;
+	deserializeWebviewPanel(
+		webviewPanel: WebviewPanel,
+		state: unknown,
+	): Promise<void>;
 }
 
 // Emits when webview html/messages change — consumed by tRPC router
@@ -75,7 +81,9 @@ const panelSerializers = new Map<string, WebviewPanelSerializer>();
 const activeViews = new Map<string, WebviewView>();
 const activePanels = new Map<string, WebviewPanel>();
 
-export function getViewProvider(viewType: string): WebviewViewProvider | undefined {
+export function getViewProvider(
+	viewType: string,
+): WebviewViewProvider | undefined {
 	return viewProviders.get(viewType);
 }
 
@@ -113,7 +121,10 @@ export interface WebviewInternal extends Webview {
 	_onDidPostMessage: EventEmitter<unknown>;
 }
 
-function createWebview(extensionPath: string, options?: WebviewOptions): WebviewInternal {
+function createWebview(
+	_extensionPath: string,
+	options?: WebviewOptions,
+): WebviewInternal {
 	const _onDidReceiveMessage = new EventEmitter<unknown>();
 	const _onDidPostMessage = new EventEmitter<unknown>();
 	let _html = "";
@@ -165,7 +176,7 @@ export function resolveWebviewView(
 				_onWebviewEvent.fire({ viewId, type: "html", data: value });
 				return true;
 			}
-			(target as Record<string | symbol, unknown>)[prop] = value;
+			(target as unknown as Record<string | symbol, unknown>)[prop] = value;
 			return true;
 		},
 	});
@@ -209,19 +220,26 @@ export function createWebviewPanel(
 	options?: WebviewOptions,
 ): WebviewPanel {
 	const _onDidDispose = new EventEmitter<void>();
-	const _onDidChangeViewState = new EventEmitter<{ webviewPanel: WebviewPanel }>();
+	const _onDidChangeViewState = new EventEmitter<{
+		webviewPanel: WebviewPanel;
+	}>();
 	const webview = createWebview(extensionPath, options);
 	const panelId = `panel:${viewType}:${Date.now()}`;
-	const viewColumn = typeof showOptions === "number" ? showOptions : showOptions.viewColumn;
+	const viewColumn =
+		typeof showOptions === "number" ? showOptions : showOptions.viewColumn;
 
 	const proxiedWebview = new Proxy(webview, {
 		set(target, prop, value) {
 			if (prop === "html") {
 				(target as { html: string }).html = value;
-				_onWebviewEvent.fire({ panelId, type: "html", data: value } as unknown as WebviewEvent);
+				_onWebviewEvent.fire({
+					panelId,
+					type: "html",
+					data: value,
+				} as unknown as WebviewEvent);
 				return true;
 			}
-			(target as Record<string | symbol, unknown>)[prop] = value;
+			(target as unknown as Record<string | symbol, unknown>)[prop] = value;
 			return true;
 		},
 	});

--- a/apps/desktop/src/main/lib/vscode-shim/api/webview.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/api/webview.ts
@@ -108,8 +108,14 @@ export function registerWebviewPanelSerializer(
 	});
 }
 
-function createWebview(extensionPath: string, options?: WebviewOptions): Webview {
+export interface WebviewInternal extends Webview {
+	_onDidReceiveMessage: EventEmitter<unknown>;
+	_onDidPostMessage: EventEmitter<unknown>;
+}
+
+function createWebview(extensionPath: string, options?: WebviewOptions): WebviewInternal {
 	const _onDidReceiveMessage = new EventEmitter<unknown>();
+	const _onDidPostMessage = new EventEmitter<unknown>();
 	let _html = "";
 
 	return {
@@ -119,11 +125,12 @@ function createWebview(extensionPath: string, options?: WebviewOptions): Webview
 		},
 		set html(value: string) {
 			_html = value;
-			// Notification happens via the WebviewView/Panel wrapper
 		},
 		onDidReceiveMessage: _onDidReceiveMessage.event,
+		_onDidReceiveMessage,
+		_onDidPostMessage,
 		async postMessage(message: unknown): Promise<boolean> {
-			// Will be bridged to renderer via tRPC
+			_onDidPostMessage.fire(message);
 			return true;
 		},
 		asWebviewUri(localResource: Uri): Uri {

--- a/apps/desktop/src/main/lib/vscode-shim/api/webview.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/api/webview.ts
@@ -100,6 +100,7 @@ export function registerWebviewViewProvider(
 	provider: WebviewViewProvider,
 	_options?: { webviewOptions?: { retainContextWhenHidden?: boolean } },
 ): Disposable {
+	console.log(`[vscode-shim] registerWebviewViewProvider: ${viewType}`);
 	viewProviders.set(viewType, provider);
 	return new Disposable(() => {
 		viewProviders.delete(viewType);
@@ -159,8 +160,12 @@ export function resolveWebviewView(
 	viewType: string,
 	extensionPath: string,
 ): { view: WebviewView; viewId: string } | undefined {
+	console.log(`[vscode-shim] resolveWebviewView: ${viewType}, registered providers: [${[...viewProviders.keys()].join(", ")}]`);
 	const provider = viewProviders.get(viewType);
-	if (!provider) return undefined;
+	if (!provider) {
+		console.warn(`[vscode-shim] No provider found for viewType: ${viewType}`);
+		return undefined;
+	}
 
 	const _onDidDispose = new EventEmitter<void>();
 	const _onDidChangeVisibility = new EventEmitter<void>();

--- a/apps/desktop/src/main/lib/vscode-shim/api/webview.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/api/webview.ts
@@ -174,6 +174,14 @@ export function resolveWebviewView(
 	const webview = createWebview(extensionPath, { enableScripts: true });
 	const viewId = `view:${viewType}:${Date.now()}`;
 
+	// Relay extension→webview postMessage as events (so tRPC subscription can forward to iframe)
+	webview._onDidPostMessage.event((message) => {
+		console.log(
+			`[webview:${viewId}] postMessage from extension to webview, type=${typeof message === "object" && message !== null && "type" in message ? (message as { type: string }).type : "unknown"}`,
+		);
+		_onWebviewEvent.fire({ viewId, type: "message", data: message });
+	});
+
 	// Intercept html setter to emit events
 	const rawWebview = webview;
 	const proxiedWebview = new Proxy(rawWebview, {

--- a/apps/desktop/src/main/lib/vscode-shim/api/window.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/api/window.ts
@@ -12,6 +12,7 @@ function getDialog(): typeof import("electron").dialog {
 	}
 }
 
+import { shimLog, shimWarn } from "./debug-log";
 import { Disposable, type Event, EventEmitter } from "./event-emitter";
 import { createOutputChannel, type OutputChannel } from "./output-channel";
 import {
@@ -183,7 +184,7 @@ export const window = {
 		...items: string[]
 	): Promise<string | undefined> {
 		if (items.length === 0) {
-			console.log(`[vscode-shim] INFO: ${message}`);
+			shimLog(`[vscode-shim] INFO: ${message}`);
 			return undefined;
 		}
 		const result = await getDialog().showMessageBox({
@@ -199,7 +200,7 @@ export const window = {
 		...items: string[]
 	): Promise<string | undefined> {
 		if (items.length === 0) {
-			console.warn(`[vscode-shim] WARN: ${message}`);
+			shimWarn(`[vscode-shim] WARN: ${message}`);
 			return undefined;
 		}
 		const result = await getDialog().showMessageBox({
@@ -232,7 +233,7 @@ export const window = {
 	): Promise<string | undefined> {
 		const resolved = await items;
 		// For MVP, return first item. In Phase 3, render a proper picker in renderer
-		console.warn("[vscode-shim] showQuickPick stub, returning first item");
+		shimWarn("[vscode-shim] showQuickPick stub, returning first item");
 		return resolved[0];
 	},
 
@@ -241,12 +242,12 @@ export const window = {
 		value?: string;
 		placeHolder?: string;
 	}): Promise<string | undefined> {
-		console.warn("[vscode-shim] showInputBox stub");
+		shimWarn("[vscode-shim] showInputBox stub");
 		return undefined;
 	},
 
 	async showOpenDialog(_options?: unknown): Promise<Uri[] | undefined> {
-		console.warn("[vscode-shim] showOpenDialog stub");
+		shimWarn("[vscode-shim] showOpenDialog stub");
 		return undefined;
 	},
 
@@ -258,7 +259,7 @@ export const window = {
 			"uri" in (document as object)
 				? (document as { uri: Uri }).uri
 				: (document as Uri);
-		console.log(`[vscode-shim] showTextDocument: ${uri.toString()}`);
+		shimLog(`[vscode-shim] showTextDocument: ${uri.toString()}`);
 		// Return a minimal editor stub
 		return {
 			document: {
@@ -341,7 +342,7 @@ export const window = {
 			supportsMultipleEditorsPerDocument?: boolean;
 		},
 	): Disposable {
-		console.log(`[vscode-shim] registerCustomEditorProvider: ${viewType}`);
+		shimLog(`[vscode-shim] registerCustomEditorProvider: ${viewType}`);
 		return new Disposable(() => {});
 	},
 

--- a/apps/desktop/src/main/lib/vscode-shim/api/window.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/api/window.ts
@@ -11,21 +11,20 @@ function getDialog(): typeof import("electron").dialog {
 		} as unknown as typeof import("electron").dialog;
 	}
 }
-import { Disposable, EventEmitter, type Event } from "./event-emitter.js";
-import { Uri } from "./uri.js";
+
+import { Disposable, type Event, EventEmitter } from "./event-emitter.js";
 import { createOutputChannel, type OutputChannel } from "./output-channel.js";
 import {
 	createTerminal as createTerminalImpl,
-	getTerminals,
 	getActiveTerminal,
+	getTerminals,
 	terminalEvents,
 } from "./terminal-shim.js";
+import type { Uri } from "./uri.js";
 import {
-	registerWebviewViewProvider,
-	registerWebviewPanelSerializer,
 	createWebviewPanel,
-	type WebviewViewProvider,
-	type WebviewPanelSerializer,
+	registerWebviewPanelSerializer,
+	registerWebviewViewProvider,
 	type WebviewOptions,
 	type WebviewPanel,
 } from "./webview.js";
@@ -108,13 +107,18 @@ export const window = {
 	onDidCloseTerminal: terminalEvents.onDidCloseTerminal,
 	onDidChangeActiveTerminal: terminalEvents.onDidChangeActiveTerminal,
 	onDidEndTerminalShellExecution: terminalEvents.onDidEndTerminalShellExecution,
-	onDidChangeTerminalShellIntegration: terminalEvents.onDidChangeTerminalShellIntegration,
+	onDidChangeTerminalShellIntegration:
+		terminalEvents.onDidChangeTerminalShellIntegration,
 	onDidChangeWindowState: new EventEmitter<{ focused: boolean }>().event,
 	state: { focused: true, active: true },
 
 	// Tab groups
 	tabGroups: {
-		all: [] as Array<{ tabs: unknown[]; isActive: boolean; viewColumn: number }>,
+		all: [] as Array<{
+			tabs: unknown[];
+			isActive: boolean;
+			viewColumn: number;
+		}>,
 		get activeTabGroup() {
 			return { tabs: [], isActive: true, viewColumn: 1 };
 		},
@@ -126,7 +130,10 @@ export const window = {
 	},
 
 	// Messages
-	async showInformationMessage(message: string, ...items: string[]): Promise<string | undefined> {
+	async showInformationMessage(
+		message: string,
+		...items: string[]
+	): Promise<string | undefined> {
 		if (items.length === 0) {
 			console.log(`[vscode-shim] INFO: ${message}`);
 			return undefined;
@@ -139,7 +146,10 @@ export const window = {
 		return items[result.response];
 	},
 
-	async showWarningMessage(message: string, ...items: string[]): Promise<string | undefined> {
+	async showWarningMessage(
+		message: string,
+		...items: string[]
+	): Promise<string | undefined> {
 		if (items.length === 0) {
 			console.warn(`[vscode-shim] WARN: ${message}`);
 			return undefined;
@@ -152,7 +162,10 @@ export const window = {
 		return items[result.response];
 	},
 
-	async showErrorMessage(message: string, ...items: string[]): Promise<string | undefined> {
+	async showErrorMessage(
+		message: string,
+		...items: string[]
+	): Promise<string | undefined> {
 		if (items.length === 0) {
 			console.error(`[vscode-shim] ERROR: ${message}`);
 			return undefined;
@@ -175,16 +188,16 @@ export const window = {
 		return resolved[0];
 	},
 
-	async showInputBox(
-		_options?: { prompt?: string; value?: string; placeHolder?: string },
-	): Promise<string | undefined> {
+	async showInputBox(_options?: {
+		prompt?: string;
+		value?: string;
+		placeHolder?: string;
+	}): Promise<string | undefined> {
 		console.warn("[vscode-shim] showInputBox stub");
 		return undefined;
 	},
 
-	async showOpenDialog(
-		_options?: unknown,
-	): Promise<Uri[] | undefined> {
+	async showOpenDialog(_options?: unknown): Promise<Uri[] | undefined> {
 		console.warn("[vscode-shim] showOpenDialog stub");
 		return undefined;
 	},
@@ -193,14 +206,19 @@ export const window = {
 		document: { uri: Uri } | Uri,
 		_options?: unknown,
 	): Promise<TextEditor | undefined> {
-		const uri = "uri" in (document as object) ? (document as { uri: Uri }).uri : (document as Uri);
+		const uri =
+			"uri" in (document as object)
+				? (document as { uri: Uri }).uri
+				: (document as Uri);
 		console.log(`[vscode-shim] showTextDocument: ${uri.toString()}`);
 		// Return a minimal editor stub
 		return {
 			document: {
 				uri,
 				fileName: uri.fsPath,
-				getText() { return ""; },
+				getText() {
+					return "";
+				},
 				languageId: "plaintext",
 			},
 			selection: {
@@ -217,8 +235,13 @@ export const window = {
 	withProgress<T>(
 		_options: { location: number; title?: string; cancellable?: boolean },
 		task: (
-			progress: { report(value: { message?: string; increment?: number }): void },
-			token: { isCancellationRequested: boolean; onCancellationRequested: Event<void> },
+			progress: {
+				report(value: { message?: string; increment?: number }): void;
+			},
+			token: {
+				isCancellationRequested: boolean;
+				onCancellationRequested: Event<void>;
+			},
 		) => Promise<T>,
 	): Promise<T> {
 		const progress = {
@@ -233,12 +256,23 @@ export const window = {
 		return task(progress, token);
 	},
 
-	createOutputChannel(name: string, options?: { log: true } | string): OutputChannel {
+	createOutputChannel(
+		name: string,
+		options?: { log: true } | string,
+	): OutputChannel {
 		return createOutputChannel(name, options);
 	},
 
 	createTerminal(
-		nameOrOptions?: string | { name?: string; cwd?: string; env?: Record<string, string | null>; shellPath?: string; shellArgs?: string[] },
+		nameOrOptions?:
+			| string
+			| {
+					name?: string;
+					cwd?: string;
+					env?: Record<string, string | null>;
+					shellPath?: string;
+					shellArgs?: string[];
+			  },
 	): Terminal {
 		return createTerminalImpl(nameOrOptions) as Terminal;
 	},
@@ -253,8 +287,11 @@ export const window = {
 
 	registerCustomEditorProvider(
 		viewType: string,
-		provider: unknown,
-		options?: { webviewOptions?: { retainContextWhenHidden?: boolean }; supportsMultipleEditorsPerDocument?: boolean },
+		_provider: unknown,
+		_options?: {
+			webviewOptions?: { retainContextWhenHidden?: boolean };
+			supportsMultipleEditorsPerDocument?: boolean;
+		},
 	): Disposable {
 		console.log(`[vscode-shim] registerCustomEditorProvider: ${viewType}`);
 		return new Disposable(() => {});

--- a/apps/desktop/src/main/lib/vscode-shim/api/window.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/api/window.ts
@@ -67,6 +67,13 @@ interface Terminal {
 const _onDidChangeActiveTextEditor = new EventEmitter<TextEditor | undefined>();
 const _onDidChangeVisibleTextEditors = new EventEmitter<TextEditor[]>();
 const _onDidChangeTextEditorSelection = new EventEmitter<unknown>();
+
+// Emits when showTextDocument is called - renderer listens to open file viewer
+const _openFileEmitter = new EventEmitter<{
+	filePath: string;
+	line?: number;
+}>();
+export const onOpenFile = _openFileEmitter.event;
 // Active text editor state — updated from renderer via tRPC
 let _activeTextEditor: TextEditor | undefined;
 const _visibleTextEditors: TextEditor[] = [];
@@ -267,6 +274,16 @@ export const window = {
 				? (document as { uri: Uri }).uri
 				: (document as Uri);
 		shimLog(`[vscode-shim] showTextDocument: ${uri.toString()}`);
+
+		// Notify renderer to open the file in file viewer
+		if (uri.scheme === "file" && uri.fsPath) {
+			_openFileEmitter.fire({
+				filePath: uri.fsPath,
+				line: (_options as { selection?: { start?: { line?: number } } })
+					?.selection?.start?.line,
+			});
+		}
+
 		// Return a minimal editor stub
 		return {
 			document: {

--- a/apps/desktop/src/main/lib/vscode-shim/api/window.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/api/window.ts
@@ -15,6 +15,12 @@ import { Disposable, EventEmitter, type Event } from "./event-emitter.js";
 import { Uri } from "./uri.js";
 import { createOutputChannel, type OutputChannel } from "./output-channel.js";
 import {
+	createTerminal as createTerminalImpl,
+	getTerminals,
+	getActiveTerminal,
+	terminalEvents,
+} from "./terminal-shim.js";
+import {
 	registerWebviewViewProvider,
 	registerWebviewPanelSerializer,
 	createWebviewPanel,
@@ -61,13 +67,7 @@ interface Terminal {
 const _onDidChangeActiveTextEditor = new EventEmitter<TextEditor | undefined>();
 const _onDidChangeVisibleTextEditors = new EventEmitter<TextEditor[]>();
 const _onDidChangeTextEditorSelection = new EventEmitter<unknown>();
-const _onDidOpenTerminal = new EventEmitter<Terminal>();
-const _onDidCloseTerminal = new EventEmitter<Terminal>();
-const _onDidChangeActiveTerminal = new EventEmitter<Terminal | undefined>();
-const _onDidEndTerminalShellExecution = new EventEmitter<unknown>();
-const _onDidChangeTerminalShellIntegration = new EventEmitter<unknown>();
-
-const terminals: Terminal[] = [];
+// Terminal events are delegated to terminal-shim.ts
 
 export const window = {
 	// Text editor
@@ -80,22 +80,23 @@ export const window = {
 	},
 
 	get activeTerminal(): Terminal | undefined {
-		return terminals[terminals.length - 1];
+		return getActiveTerminal() as Terminal | undefined;
 	},
 
 	get terminals(): Terminal[] {
-		return [...terminals];
+		return getTerminals() as Terminal[];
 	},
 
 	onDidChangeActiveTextEditor: _onDidChangeActiveTextEditor.event,
 	onDidChangeVisibleTextEditors: _onDidChangeVisibleTextEditors.event,
 	onDidChangeTextEditorSelection: _onDidChangeTextEditorSelection.event,
-	onDidOpenTerminal: _onDidOpenTerminal.event,
-	onDidCloseTerminal: _onDidCloseTerminal.event,
-	onDidChangeActiveTerminal: _onDidChangeActiveTerminal.event,
-	onDidEndTerminalShellExecution: _onDidEndTerminalShellExecution.event,
-	onDidChangeTerminalShellIntegration: _onDidChangeTerminalShellIntegration.event,
+	onDidOpenTerminal: terminalEvents.onDidOpenTerminal,
+	onDidCloseTerminal: terminalEvents.onDidCloseTerminal,
+	onDidChangeActiveTerminal: terminalEvents.onDidChangeActiveTerminal,
+	onDidEndTerminalShellExecution: terminalEvents.onDidEndTerminalShellExecution,
+	onDidChangeTerminalShellIntegration: terminalEvents.onDidChangeTerminalShellIntegration,
 	onDidChangeWindowState: new EventEmitter<{ focused: boolean }>().event,
+	state: { focused: true, active: true },
 
 	// Tab groups
 	tabGroups: {
@@ -178,8 +179,25 @@ export const window = {
 		document: { uri: Uri } | Uri,
 		_options?: unknown,
 	): Promise<TextEditor | undefined> {
-		console.warn("[vscode-shim] showTextDocument stub");
-		return undefined;
+		const uri = "uri" in (document as object) ? (document as { uri: Uri }).uri : (document as Uri);
+		console.log(`[vscode-shim] showTextDocument: ${uri.toString()}`);
+		// Return a minimal editor stub
+		return {
+			document: {
+				uri,
+				fileName: uri.fsPath,
+				getText() { return ""; },
+				languageId: "plaintext",
+			},
+			selection: {
+				start: { line: 0, character: 0 },
+				end: { line: 0, character: 0 },
+				isEmpty: true,
+				active: { line: 0, character: 0 },
+			},
+			selections: [],
+			viewColumn: 1,
+		};
 	},
 
 	withProgress<T>(
@@ -208,30 +226,7 @@ export const window = {
 	createTerminal(
 		nameOrOptions?: string | { name?: string; cwd?: string; env?: Record<string, string | null>; shellPath?: string; shellArgs?: string[] },
 	): Terminal {
-		const name = typeof nameOrOptions === "string"
-			? nameOrOptions
-			: nameOrOptions?.name ?? "Terminal";
-
-		// For MVP, create a stub terminal. Phase 3 will wire to DaemonTerminalManager
-		const terminal: Terminal = {
-			name,
-			processId: Promise.resolve(undefined),
-			sendText(text: string, _addNewLine?: boolean) {
-				console.log(`[vscode-shim] Terminal "${name}" sendText: ${text}`);
-			},
-			show(_preserveFocus?: boolean) {},
-			hide() {},
-			dispose() {
-				const idx = terminals.indexOf(terminal);
-				if (idx >= 0) terminals.splice(idx, 1);
-				_onDidCloseTerminal.fire(terminal);
-			},
-			exitStatus: undefined,
-		};
-
-		terminals.push(terminal);
-		_onDidOpenTerminal.fire(terminal);
-		return terminal;
+		return createTerminalImpl(nameOrOptions) as Terminal;
 	},
 
 	registerUriHandler(handler: { handleUri(uri: Uri): void }): Disposable {
@@ -245,6 +240,27 @@ export const window = {
 	): Disposable {
 		console.log(`[vscode-shim] registerCustomEditorProvider: ${viewType}`);
 		return new Disposable(() => {});
+	},
+
+	createStatusBarItem(
+		_alignmentOrId?: unknown,
+		_priority?: number,
+	): {
+		text: string;
+		tooltip: string;
+		command: string | undefined;
+		show(): void;
+		hide(): void;
+		dispose(): void;
+	} {
+		return {
+			text: "",
+			tooltip: "",
+			command: undefined,
+			show() {},
+			hide() {},
+			dispose() {},
+		};
 	},
 
 	// Webview delegation

--- a/apps/desktop/src/main/lib/vscode-shim/api/window.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/api/window.ts
@@ -1,0 +1,262 @@
+/**
+ * VS Code window API shim.
+ */
+
+function getDialog(): typeof import("electron").dialog {
+	try {
+		return require("electron").dialog;
+	} catch {
+		return {
+			showMessageBox: async () => ({ response: 0, checkboxChecked: false }),
+		} as unknown as typeof import("electron").dialog;
+	}
+}
+import { Disposable, EventEmitter, type Event } from "./event-emitter.js";
+import { Uri } from "./uri.js";
+import { createOutputChannel, type OutputChannel } from "./output-channel.js";
+import {
+	registerWebviewViewProvider,
+	registerWebviewPanelSerializer,
+	createWebviewPanel,
+	type WebviewViewProvider,
+	type WebviewPanelSerializer,
+	type WebviewOptions,
+	type WebviewPanel,
+} from "./webview.js";
+
+interface TextEditor {
+	readonly document: {
+		uri: Uri;
+		fileName: string;
+		getText(range?: unknown): string;
+		languageId: string;
+	};
+	readonly selection: {
+		readonly start: { line: number; character: number };
+		readonly end: { line: number; character: number };
+		readonly isEmpty: boolean;
+		readonly active: { line: number; character: number };
+	};
+	readonly selections: Array<unknown>;
+	readonly viewColumn: number | undefined;
+}
+
+interface Terminal {
+	readonly name: string;
+	readonly processId: Promise<number | undefined>;
+	sendText(text: string, addNewLine?: boolean): void;
+	show(preserveFocus?: boolean): void;
+	hide(): void;
+	dispose(): void;
+	readonly exitStatus: { code: number | undefined } | undefined;
+	readonly shellIntegration?: {
+		executeCommand(command: string): {
+			execution: { commandLine: string };
+			read(): AsyncIterable<string>;
+		};
+	};
+}
+
+// Minimal stubs for activeTextEditor and visible editors
+const _onDidChangeActiveTextEditor = new EventEmitter<TextEditor | undefined>();
+const _onDidChangeVisibleTextEditors = new EventEmitter<TextEditor[]>();
+const _onDidChangeTextEditorSelection = new EventEmitter<unknown>();
+const _onDidOpenTerminal = new EventEmitter<Terminal>();
+const _onDidCloseTerminal = new EventEmitter<Terminal>();
+const _onDidChangeActiveTerminal = new EventEmitter<Terminal | undefined>();
+const _onDidEndTerminalShellExecution = new EventEmitter<unknown>();
+const _onDidChangeTerminalShellIntegration = new EventEmitter<unknown>();
+
+const terminals: Terminal[] = [];
+
+export const window = {
+	// Text editor
+	get activeTextEditor(): TextEditor | undefined {
+		return undefined; // Will be connected to file-viewer state in Phase 4
+	},
+
+	get visibleTextEditors(): TextEditor[] {
+		return [];
+	},
+
+	get activeTerminal(): Terminal | undefined {
+		return terminals[terminals.length - 1];
+	},
+
+	get terminals(): Terminal[] {
+		return [...terminals];
+	},
+
+	onDidChangeActiveTextEditor: _onDidChangeActiveTextEditor.event,
+	onDidChangeVisibleTextEditors: _onDidChangeVisibleTextEditors.event,
+	onDidChangeTextEditorSelection: _onDidChangeTextEditorSelection.event,
+	onDidOpenTerminal: _onDidOpenTerminal.event,
+	onDidCloseTerminal: _onDidCloseTerminal.event,
+	onDidChangeActiveTerminal: _onDidChangeActiveTerminal.event,
+	onDidEndTerminalShellExecution: _onDidEndTerminalShellExecution.event,
+	onDidChangeTerminalShellIntegration: _onDidChangeTerminalShellIntegration.event,
+	onDidChangeWindowState: new EventEmitter<{ focused: boolean }>().event,
+
+	// Tab groups
+	tabGroups: {
+		all: [] as Array<{ tabs: unknown[]; isActive: boolean; viewColumn: number }>,
+		get activeTabGroup() {
+			return { tabs: [], isActive: true, viewColumn: 1 };
+		},
+		onDidChangeTabGroups: new EventEmitter<unknown>().event,
+		onDidChangeTabs: new EventEmitter<unknown>().event,
+		close(_tab: unknown): Promise<boolean> {
+			return Promise.resolve(true);
+		},
+	},
+
+	// Messages
+	async showInformationMessage(message: string, ...items: string[]): Promise<string | undefined> {
+		if (items.length === 0) {
+			console.log(`[vscode-shim] INFO: ${message}`);
+			return undefined;
+		}
+		const result = await getDialog().showMessageBox({
+			type: "info",
+			message,
+			buttons: items,
+		});
+		return items[result.response];
+	},
+
+	async showWarningMessage(message: string, ...items: string[]): Promise<string | undefined> {
+		if (items.length === 0) {
+			console.warn(`[vscode-shim] WARN: ${message}`);
+			return undefined;
+		}
+		const result = await getDialog().showMessageBox({
+			type: "warning",
+			message,
+			buttons: items,
+		});
+		return items[result.response];
+	},
+
+	async showErrorMessage(message: string, ...items: string[]): Promise<string | undefined> {
+		if (items.length === 0) {
+			console.error(`[vscode-shim] ERROR: ${message}`);
+			return undefined;
+		}
+		const result = await getDialog().showMessageBox({
+			type: "error",
+			message,
+			buttons: items,
+		});
+		return items[result.response];
+	},
+
+	async showQuickPick(
+		items: string[] | Promise<string[]>,
+		_options?: { placeHolder?: string; canPickMany?: boolean },
+	): Promise<string | undefined> {
+		const resolved = await items;
+		// For MVP, return first item. In Phase 3, render a proper picker in renderer
+		console.warn("[vscode-shim] showQuickPick stub, returning first item");
+		return resolved[0];
+	},
+
+	async showInputBox(
+		_options?: { prompt?: string; value?: string; placeHolder?: string },
+	): Promise<string | undefined> {
+		console.warn("[vscode-shim] showInputBox stub");
+		return undefined;
+	},
+
+	async showOpenDialog(
+		_options?: unknown,
+	): Promise<Uri[] | undefined> {
+		console.warn("[vscode-shim] showOpenDialog stub");
+		return undefined;
+	},
+
+	async showTextDocument(
+		document: { uri: Uri } | Uri,
+		_options?: unknown,
+	): Promise<TextEditor | undefined> {
+		console.warn("[vscode-shim] showTextDocument stub");
+		return undefined;
+	},
+
+	withProgress<T>(
+		_options: { location: number; title?: string; cancellable?: boolean },
+		task: (
+			progress: { report(value: { message?: string; increment?: number }): void },
+			token: { isCancellationRequested: boolean; onCancellationRequested: Event<void> },
+		) => Promise<T>,
+	): Promise<T> {
+		const progress = {
+			report(_value: { message?: string; increment?: number }) {
+				// noop for now
+			},
+		};
+		const token = {
+			isCancellationRequested: false,
+			onCancellationRequested: new EventEmitter<void>().event,
+		};
+		return task(progress, token);
+	},
+
+	createOutputChannel(name: string, options?: { log: true } | string): OutputChannel {
+		return createOutputChannel(name, options);
+	},
+
+	createTerminal(
+		nameOrOptions?: string | { name?: string; cwd?: string; env?: Record<string, string | null>; shellPath?: string; shellArgs?: string[] },
+	): Terminal {
+		const name = typeof nameOrOptions === "string"
+			? nameOrOptions
+			: nameOrOptions?.name ?? "Terminal";
+
+		// For MVP, create a stub terminal. Phase 3 will wire to DaemonTerminalManager
+		const terminal: Terminal = {
+			name,
+			processId: Promise.resolve(undefined),
+			sendText(text: string, _addNewLine?: boolean) {
+				console.log(`[vscode-shim] Terminal "${name}" sendText: ${text}`);
+			},
+			show(_preserveFocus?: boolean) {},
+			hide() {},
+			dispose() {
+				const idx = terminals.indexOf(terminal);
+				if (idx >= 0) terminals.splice(idx, 1);
+				_onDidCloseTerminal.fire(terminal);
+			},
+			exitStatus: undefined,
+		};
+
+		terminals.push(terminal);
+		_onDidOpenTerminal.fire(terminal);
+		return terminal;
+	},
+
+	registerUriHandler(handler: { handleUri(uri: Uri): void }): Disposable {
+		return new Disposable(() => {});
+	},
+
+	registerCustomEditorProvider(
+		viewType: string,
+		provider: unknown,
+		options?: { webviewOptions?: { retainContextWhenHidden?: boolean }; supportsMultipleEditorsPerDocument?: boolean },
+	): Disposable {
+		console.log(`[vscode-shim] registerCustomEditorProvider: ${viewType}`);
+		return new Disposable(() => {});
+	},
+
+	// Webview delegation
+	registerWebviewViewProvider,
+	registerWebviewPanelSerializer,
+
+	createWebviewPanel(
+		viewType: string,
+		title: string,
+		showOptions: number | { viewColumn: number; preserveFocus?: boolean },
+		options?: WebviewOptions,
+	): WebviewPanel {
+		return createWebviewPanel(viewType, title, showOptions, "", options);
+	},
+};

--- a/apps/desktop/src/main/lib/vscode-shim/api/window.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/api/window.ts
@@ -112,6 +112,13 @@ export function setActiveTextEditor(
 	if (previous !== _activeTextEditor) {
 		_onDidChangeActiveTextEditor.fire(_activeTextEditor);
 		_onDidChangeVisibleTextEditors.fire([..._visibleTextEditors]);
+		if (_activeTextEditor) {
+			_onDidChangeTextEditorSelection.fire({
+				textEditor: _activeTextEditor,
+				selections: [_activeTextEditor.selection],
+				kind: 1,
+			});
+		}
 	}
 }
 

--- a/apps/desktop/src/main/lib/vscode-shim/api/window.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/api/window.ts
@@ -67,6 +67,20 @@ interface Terminal {
 const _onDidChangeActiveTextEditor = new EventEmitter<TextEditor | undefined>();
 const _onDidChangeVisibleTextEditors = new EventEmitter<TextEditor[]>();
 const _onDidChangeTextEditorSelection = new EventEmitter<unknown>();
+// URI handlers for deep-link activation (e.g., ChatGPT OAuth)
+const uriHandlers: Array<{ handleUri(uri: Uri): void }> = [];
+
+/** Called from Electron's open-url handler to dispatch URIs to extensions */
+export function handleUri(uri: Uri): void {
+	for (const handler of uriHandlers) {
+		try {
+			handler.handleUri(uri);
+		} catch (err) {
+			console.error("[vscode-shim] URI handler error:", err);
+		}
+	}
+}
+
 // Terminal events are delegated to terminal-shim.ts
 
 export const window = {
@@ -230,7 +244,11 @@ export const window = {
 	},
 
 	registerUriHandler(handler: { handleUri(uri: Uri): void }): Disposable {
-		return new Disposable(() => {});
+		uriHandlers.push(handler);
+		return new Disposable(() => {
+			const idx = uriHandlers.indexOf(handler);
+			if (idx >= 0) uriHandlers.splice(idx, 1);
+		});
 	},
 
 	registerCustomEditorProvider(

--- a/apps/desktop/src/main/lib/vscode-shim/api/window.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/api/window.ts
@@ -20,7 +20,7 @@ import {
 	getTerminals,
 	terminalEvents,
 } from "./terminal-shim.js";
-import type { Uri } from "./uri.js";
+import { Uri } from "./uri.js";
 import {
 	createWebviewPanel,
 	registerWebviewPanelSerializer,
@@ -66,6 +66,54 @@ interface Terminal {
 const _onDidChangeActiveTextEditor = new EventEmitter<TextEditor | undefined>();
 const _onDidChangeVisibleTextEditors = new EventEmitter<TextEditor[]>();
 const _onDidChangeTextEditorSelection = new EventEmitter<unknown>();
+// Active text editor state — updated from renderer via tRPC
+let _activeTextEditor: TextEditor | undefined;
+const _visibleTextEditors: TextEditor[] = [];
+
+/** Called from tRPC when the focused file-viewer pane changes */
+export function setActiveTextEditor(
+	filePath: string | null,
+	languageId?: string,
+): void {
+	const previous = _activeTextEditor;
+
+	if (!filePath) {
+		_activeTextEditor = undefined;
+	} else {
+		const uri = Uri.file(filePath);
+		_activeTextEditor = {
+			document: {
+				uri,
+				fileName: filePath,
+				getText() {
+					try {
+						return require("node:fs").readFileSync(filePath, "utf-8");
+					} catch {
+						return "";
+					}
+				},
+				languageId: languageId ?? "plaintext",
+			},
+			selection: {
+				start: { line: 0, character: 0 },
+				end: { line: 0, character: 0 },
+				isEmpty: true,
+				active: { line: 0, character: 0 },
+			},
+			selections: [],
+			viewColumn: 1,
+		};
+		// Update visible editors
+		_visibleTextEditors.length = 0;
+		_visibleTextEditors.push(_activeTextEditor);
+	}
+
+	if (previous !== _activeTextEditor) {
+		_onDidChangeActiveTextEditor.fire(_activeTextEditor);
+		_onDidChangeVisibleTextEditors.fire([..._visibleTextEditors]);
+	}
+}
+
 // URI handlers for deep-link activation (e.g., ChatGPT OAuth)
 const uriHandlers: Array<{ handleUri(uri: Uri): void }> = [];
 
@@ -85,11 +133,11 @@ export function handleUri(uri: Uri): void {
 export const window = {
 	// Text editor
 	get activeTextEditor(): TextEditor | undefined {
-		return undefined; // Will be connected to file-viewer state in Phase 4
+		return _activeTextEditor;
 	},
 
 	get visibleTextEditors(): TextEditor[] {
-		return [];
+		return [..._visibleTextEditors];
 	},
 
 	get activeTerminal(): Terminal | undefined {

--- a/apps/desktop/src/main/lib/vscode-shim/api/window.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/api/window.ts
@@ -12,22 +12,22 @@ function getDialog(): typeof import("electron").dialog {
 	}
 }
 
-import { Disposable, type Event, EventEmitter } from "./event-emitter.js";
-import { createOutputChannel, type OutputChannel } from "./output-channel.js";
+import { Disposable, type Event, EventEmitter } from "./event-emitter";
+import { createOutputChannel, type OutputChannel } from "./output-channel";
 import {
 	createTerminal as createTerminalImpl,
 	getActiveTerminal,
 	getTerminals,
 	terminalEvents,
-} from "./terminal-shim.js";
-import { Uri } from "./uri.js";
+} from "./terminal-shim";
+import { Uri } from "./uri";
 import {
 	createWebviewPanel,
 	registerWebviewPanelSerializer,
 	registerWebviewViewProvider,
 	type WebviewOptions,
 	type WebviewPanel,
-} from "./webview.js";
+} from "./webview";
 
 interface TextEditor {
 	readonly document: {

--- a/apps/desktop/src/main/lib/vscode-shim/api/workspace.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/api/workspace.ts
@@ -164,9 +164,7 @@ export const workspace = {
 		if (!workspaceFolderPath) return [];
 		try {
 			const results: string[] = [];
-			const ignorePatterns = exclude
-				? [exclude]
-				: ["node_modules", ".git"];
+			const ignorePatterns = exclude ? [exclude] : ["node_modules", ".git"];
 
 			function walkDir(dir: string, depth: number): void {
 				if (depth > 15 || (maxResults && results.length >= maxResults)) return;
@@ -195,9 +193,7 @@ export const workspace = {
 			walkDir(workspaceFolderPath, 0);
 			return results.map((r) => Uri.file(r));
 		} catch {
-			shimWarn(
-				"[vscode-shim] workspace.findFiles failed, returning empty",
-			);
+			shimWarn("[vscode-shim] workspace.findFiles failed, returning empty");
 			return [];
 		}
 	},

--- a/apps/desktop/src/main/lib/vscode-shim/api/workspace.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/api/workspace.ts
@@ -53,6 +53,15 @@ const textDocumentContentProviders = new Map<string, unknown>();
 export function setWorkspacePath(folderPath: string): void {
 	const oldPath = workspaceFolderPath;
 	workspaceFolderPath = folderPath;
+
+	// Also set process.cwd so spawned subprocesses (claude CLI, codex CLI)
+	// inherit the correct working directory for finding CLAUDE.md, etc.
+	if (folderPath && fs.existsSync(folderPath)) {
+		try {
+			process.chdir(folderPath);
+		} catch {}
+	}
+
 	if (oldPath !== folderPath) {
 		_onDidChangeWorkspaceFolders.fire({
 			added: folderPath

--- a/apps/desktop/src/main/lib/vscode-shim/api/workspace.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/api/workspace.ts
@@ -156,16 +156,30 @@ export const workspace = {
 	},
 
 	async findFiles(
-		_include: string,
-		_exclude?: string | null,
-		_maxResults?: number,
+		include: string,
+		exclude?: string | null,
+		maxResults?: number,
 		_token?: unknown,
 	): Promise<Uri[]> {
-		// Simple glob-based file search using workspace root
 		if (!workspaceFolderPath) return [];
-		// For MVP, return empty array. In Phase 2+, wire to FsHostService.searchFiles
-		shimWarn("[vscode-shim] workspace.findFiles is a stub, returning empty");
-		return [];
+		try {
+			const { globSync } = require("glob") as typeof import("glob");
+			const results = globSync(include, {
+				cwd: workspaceFolderPath,
+				ignore: exclude ? [exclude] : ["**/node_modules/**"],
+				maxDepth: 20,
+				nodir: true,
+			});
+			const limited = maxResults ? results.slice(0, maxResults) : results;
+			return limited.map((r: string) =>
+				Uri.file(path.join(workspaceFolderPath!, r)),
+			);
+		} catch {
+			shimWarn(
+				"[vscode-shim] workspace.findFiles: glob failed, returning empty",
+			);
+			return [];
+		}
 	},
 
 	async applyEdit(_edit: WorkspaceEdit): Promise<boolean> {

--- a/apps/desktop/src/main/lib/vscode-shim/api/workspace.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/api/workspace.ts
@@ -163,20 +163,40 @@ export const workspace = {
 	): Promise<Uri[]> {
 		if (!workspaceFolderPath) return [];
 		try {
-			const { globSync } = require("glob") as typeof import("glob");
-			const results = globSync(include, {
-				cwd: workspaceFolderPath,
-				ignore: exclude ? [exclude] : ["**/node_modules/**"],
-				maxDepth: 20,
-				nodir: true,
-			});
-			const limited = maxResults ? results.slice(0, maxResults) : results;
-			return limited.map((r: string) =>
-				Uri.file(path.join(workspaceFolderPath!, r)),
-			);
+			const results: string[] = [];
+			const ignorePatterns = exclude
+				? [exclude]
+				: ["node_modules", ".git"];
+
+			function walkDir(dir: string, depth: number): void {
+				if (depth > 15 || (maxResults && results.length >= maxResults)) return;
+				let entries: fs.Dirent[];
+				try {
+					entries = fs.readdirSync(dir, { withFileTypes: true });
+				} catch {
+					return;
+				}
+				for (const entry of entries) {
+					if (ignorePatterns.some((p) => entry.name.includes(p))) continue;
+					const fullPath = path.join(dir, entry.name);
+					if (entry.isDirectory()) {
+						walkDir(fullPath, depth + 1);
+					} else if (entry.isFile()) {
+						// Simple extension matching from include pattern (e.g., "**/*.ts")
+						const ext = include.match(/\*(\.\w+)$/)?.[1];
+						if (!ext || entry.name.endsWith(ext)) {
+							results.push(fullPath);
+						}
+					}
+					if (maxResults && results.length >= maxResults) return;
+				}
+			}
+
+			walkDir(workspaceFolderPath, 0);
+			return results.map((r) => Uri.file(r));
 		} catch {
 			shimWarn(
-				"[vscode-shim] workspace.findFiles: glob failed, returning empty",
+				"[vscode-shim] workspace.findFiles failed, returning empty",
 			);
 			return [];
 		}

--- a/apps/desktop/src/main/lib/vscode-shim/api/workspace.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/api/workspace.ts
@@ -4,9 +4,9 @@
 
 import fs from "node:fs";
 import path from "node:path";
-import { getConfiguration, onDidChangeConfiguration } from "./configuration.js";
-import { Disposable, type Event, EventEmitter } from "./event-emitter.js";
-import { Uri } from "./uri.js";
+import { getConfiguration, onDidChangeConfiguration } from "./configuration";
+import { Disposable, type Event, EventEmitter } from "./event-emitter";
+import { Uri } from "./uri";
 
 interface WorkspaceFolder {
 	readonly uri: Uri;

--- a/apps/desktop/src/main/lib/vscode-shim/api/workspace.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/api/workspace.ts
@@ -54,14 +54,6 @@ export function setWorkspacePath(folderPath: string): void {
 	const oldPath = workspaceFolderPath;
 	workspaceFolderPath = folderPath;
 
-	// Also set process.cwd so spawned subprocesses (claude CLI, codex CLI)
-	// inherit the correct working directory for finding CLAUDE.md, etc.
-	if (folderPath && fs.existsSync(folderPath)) {
-		try {
-			process.chdir(folderPath);
-		} catch {}
-	}
-
 	if (oldPath !== folderPath) {
 		_onDidChangeWorkspaceFolders.fire({
 			added: folderPath

--- a/apps/desktop/src/main/lib/vscode-shim/api/workspace.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/api/workspace.ts
@@ -1,0 +1,226 @@
+/**
+ * VS Code workspace API shim.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { Disposable, EventEmitter, type Event } from "./event-emitter.js";
+import { Uri } from "./uri.js";
+import { getConfiguration, onDidChangeConfiguration } from "./configuration.js";
+
+interface WorkspaceFolder {
+	readonly uri: Uri;
+	readonly name: string;
+	readonly index: number;
+}
+
+interface TextDocument {
+	readonly uri: Uri;
+	readonly fileName: string;
+	readonly languageId: string;
+	readonly version: number;
+	readonly lineCount: number;
+	getText(range?: unknown): string;
+	save(): Promise<boolean>;
+}
+
+interface WorkspaceEdit {
+	entries(): Array<[Uri, Array<{ range: unknown; newText: string }>]>;
+}
+
+interface FileSystemWatcher {
+	readonly onDidCreate: Event<Uri>;
+	readonly onDidChange: Event<Uri>;
+	readonly onDidDelete: Event<Uri>;
+	dispose(): void;
+}
+
+// Current workspace path — set via setWorkspacePath()
+let workspaceFolderPath: string | undefined;
+const _onDidChangeWorkspaceFolders = new EventEmitter<unknown>();
+const _onDidChangeTextDocument = new EventEmitter<unknown>();
+const _onDidOpenTextDocument = new EventEmitter<TextDocument>();
+const _onDidCloseTextDocument = new EventEmitter<TextDocument>();
+const _onWillSaveTextDocument = new EventEmitter<unknown>();
+
+const fileSystemProviders = new Map<string, unknown>();
+const textDocumentContentProviders = new Map<string, unknown>();
+
+export function setWorkspacePath(folderPath: string): void {
+	workspaceFolderPath = folderPath;
+}
+
+export const workspace = {
+	get workspaceFolders(): WorkspaceFolder[] | undefined {
+		if (!workspaceFolderPath) return undefined;
+		return [
+			{
+				uri: Uri.file(workspaceFolderPath),
+				name: path.basename(workspaceFolderPath),
+				index: 0,
+			},
+		];
+	},
+
+	get rootPath(): string | undefined {
+		return workspaceFolderPath;
+	},
+
+	get workspaceFile(): Uri | undefined {
+		return undefined;
+	},
+
+	get textDocuments(): TextDocument[] {
+		return [];
+	},
+
+	get name(): string | undefined {
+		return workspaceFolderPath ? path.basename(workspaceFolderPath) : undefined;
+	},
+
+	onDidChangeWorkspaceFolders: _onDidChangeWorkspaceFolders.event,
+	onDidChangeTextDocument: _onDidChangeTextDocument.event,
+	onDidOpenTextDocument: _onDidOpenTextDocument.event,
+	onDidCloseTextDocument: _onDidCloseTextDocument.event,
+	onWillSaveTextDocument: _onWillSaveTextDocument.event,
+	onDidChangeConfiguration,
+
+	getConfiguration,
+
+	getWorkspaceFolder(uri: Uri): WorkspaceFolder | undefined {
+		if (!workspaceFolderPath) return undefined;
+		if (uri.fsPath.startsWith(workspaceFolderPath)) {
+			return {
+				uri: Uri.file(workspaceFolderPath),
+				name: path.basename(workspaceFolderPath),
+				index: 0,
+			};
+		}
+		return undefined;
+	},
+
+	asRelativePath(pathOrUri: string | Uri, includeWorkspaceFolder?: boolean): string {
+		const p = typeof pathOrUri === "string" ? pathOrUri : pathOrUri.fsPath;
+		if (!workspaceFolderPath) return p;
+		const rel = path.relative(workspaceFolderPath, p);
+		if (rel.startsWith("..")) return p;
+		return rel;
+	},
+
+	async openTextDocument(uriOrPath: Uri | string): Promise<TextDocument> {
+		const filePath =
+			typeof uriOrPath === "string" ? uriOrPath : uriOrPath.fsPath;
+		const content = fs.existsSync(filePath) ? fs.readFileSync(filePath, "utf-8") : "";
+		const lines = content.split("\n");
+		const ext = path.extname(filePath).slice(1);
+
+		return {
+			uri: Uri.file(filePath),
+			fileName: filePath,
+			languageId: ext || "plaintext",
+			version: 1,
+			lineCount: lines.length,
+			getText(_range?: unknown) {
+				return content;
+			},
+			async save() {
+				return true;
+			},
+		};
+	},
+
+	async findFiles(
+		include: string,
+		exclude?: string | null,
+		maxResults?: number,
+		_token?: unknown,
+	): Promise<Uri[]> {
+		// Simple glob-based file search using workspace root
+		if (!workspaceFolderPath) return [];
+		// For MVP, return empty array. In Phase 2+, wire to FsHostService.searchFiles
+		console.warn("[vscode-shim] workspace.findFiles is a stub, returning empty");
+		return [];
+	},
+
+	async applyEdit(_edit: WorkspaceEdit): Promise<boolean> {
+		console.warn("[vscode-shim] workspace.applyEdit is a stub");
+		return true;
+	},
+
+	createFileSystemWatcher(
+		_globPattern: string,
+		_ignoreCreateEvents?: boolean,
+		_ignoreChangeEvents?: boolean,
+		_ignoreDeleteEvents?: boolean,
+	): FileSystemWatcher {
+		const _onCreate = new EventEmitter<Uri>();
+		const _onChange = new EventEmitter<Uri>();
+		const _onDelete = new EventEmitter<Uri>();
+		return {
+			onDidCreate: _onCreate.event,
+			onDidChange: _onChange.event,
+			onDidDelete: _onDelete.event,
+			dispose() {
+				_onCreate.dispose();
+				_onChange.dispose();
+				_onDelete.dispose();
+			},
+		};
+	},
+
+	registerFileSystemProvider(
+		scheme: string,
+		provider: unknown,
+		_options?: { isCaseSensitive?: boolean; isReadonly?: boolean },
+	): Disposable {
+		fileSystemProviders.set(scheme, provider);
+		return new Disposable(() => {
+			fileSystemProviders.delete(scheme);
+		});
+	},
+
+	registerTextDocumentContentProvider(scheme: string, provider: unknown): Disposable {
+		textDocumentContentProviders.set(scheme, provider);
+		return new Disposable(() => {
+			textDocumentContentProviders.delete(scheme);
+		});
+	},
+
+	fs: {
+		async readFile(uri: Uri): Promise<Uint8Array> {
+			return fs.promises.readFile(uri.fsPath);
+		},
+		async writeFile(uri: Uri, content: Uint8Array): Promise<void> {
+			await fs.promises.writeFile(uri.fsPath, content);
+		},
+		async stat(uri: Uri): Promise<{
+			type: number;
+			ctime: number;
+			mtime: number;
+			size: number;
+		}> {
+			const s = await fs.promises.stat(uri.fsPath);
+			return {
+				type: s.isDirectory() ? 2 : 1, // FileType.File=1, Directory=2
+				ctime: s.ctimeMs,
+				mtime: s.mtimeMs,
+				size: s.size,
+			};
+		},
+		async delete(uri: Uri, _options?: { recursive?: boolean; useTrash?: boolean }): Promise<void> {
+			await fs.promises.rm(uri.fsPath, { recursive: _options?.recursive });
+		},
+		async rename(source: Uri, target: Uri, _options?: { overwrite?: boolean }): Promise<void> {
+			await fs.promises.rename(source.fsPath, target.fsPath);
+		},
+		async createDirectory(uri: Uri): Promise<void> {
+			await fs.promises.mkdir(uri.fsPath, { recursive: true });
+		},
+		async copy(source: Uri, target: Uri, _options?: { overwrite?: boolean }): Promise<void> {
+			await fs.promises.copyFile(source.fsPath, target.fsPath);
+		},
+		isWritableFileSystem(scheme: string): boolean | undefined {
+			return scheme === "file" ? true : undefined;
+		},
+	},
+};

--- a/apps/desktop/src/main/lib/vscode-shim/api/workspace.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/api/workspace.ts
@@ -174,9 +174,15 @@ export const workspace = {
 		_options?: { isCaseSensitive?: boolean; isReadonly?: boolean },
 	): Disposable {
 		fileSystemProviders.set(scheme, provider);
+		console.log(`[vscode-shim] Registered FileSystemProvider for scheme: ${scheme}`);
 		return new Disposable(() => {
 			fileSystemProviders.delete(scheme);
 		});
+	},
+
+	/** Get a registered file system provider (used by workspace.fs for custom schemes) */
+	_getFileSystemProvider(scheme: string): unknown {
+		return fileSystemProviders.get(scheme);
 	},
 
 	registerTextDocumentContentProvider(scheme: string, provider: unknown): Disposable {
@@ -188,6 +194,16 @@ export const workspace = {
 
 	fs: {
 		async readFile(uri: Uri): Promise<Uint8Array> {
+			// Check custom FS providers for non-file schemes
+			if (uri.scheme !== "file") {
+				const provider = fileSystemProviders.get(uri.scheme) as
+					| { readFile?(uri: Uri): Promise<Uint8Array> }
+					| undefined;
+				if (provider?.readFile) {
+					return provider.readFile(uri);
+				}
+				throw new Error(`No file system provider for scheme: ${uri.scheme}`);
+			}
 			return fs.promises.readFile(uri.fsPath);
 		},
 		async writeFile(uri: Uri, content: Uint8Array): Promise<void> {
@@ -199,9 +215,18 @@ export const workspace = {
 			mtime: number;
 			size: number;
 		}> {
+			if (uri.scheme !== "file") {
+				const provider = fileSystemProviders.get(uri.scheme) as
+					| { stat?(uri: Uri): Promise<{ type: number; ctime: number; mtime: number; size: number }> }
+					| undefined;
+				if (provider?.stat) {
+					return provider.stat(uri);
+				}
+				return { type: 1, ctime: 0, mtime: 0, size: 0 };
+			}
 			const s = await fs.promises.stat(uri.fsPath);
 			return {
-				type: s.isDirectory() ? 2 : 1, // FileType.File=1, Directory=2
+				type: s.isDirectory() ? 2 : 1,
 				ctime: s.ctimeMs,
 				mtime: s.mtimeMs,
 				size: s.size,

--- a/apps/desktop/src/main/lib/vscode-shim/api/workspace.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/api/workspace.ts
@@ -5,6 +5,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { getConfiguration, onDidChangeConfiguration } from "./configuration";
+import { shimLog, shimWarn } from "./debug-log";
 import { Disposable, type Event, EventEmitter } from "./event-emitter";
 import { Uri } from "./uri";
 
@@ -163,14 +164,12 @@ export const workspace = {
 		// Simple glob-based file search using workspace root
 		if (!workspaceFolderPath) return [];
 		// For MVP, return empty array. In Phase 2+, wire to FsHostService.searchFiles
-		console.warn(
-			"[vscode-shim] workspace.findFiles is a stub, returning empty",
-		);
+		shimWarn("[vscode-shim] workspace.findFiles is a stub, returning empty");
 		return [];
 	},
 
 	async applyEdit(_edit: WorkspaceEdit): Promise<boolean> {
-		console.warn("[vscode-shim] workspace.applyEdit is a stub");
+		shimWarn("[vscode-shim] workspace.applyEdit is a stub");
 		return true;
 	},
 
@@ -201,7 +200,7 @@ export const workspace = {
 		_options?: { isCaseSensitive?: boolean; isReadonly?: boolean },
 	): Disposable {
 		fileSystemProviders.set(scheme, provider);
-		console.log(
+		shimLog(
 			`[vscode-shim] Registered FileSystemProvider for scheme: ${scheme}`,
 		);
 		return new Disposable(() => {

--- a/apps/desktop/src/main/lib/vscode-shim/api/workspace.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/api/workspace.ts
@@ -37,7 +37,10 @@ interface FileSystemWatcher {
 
 // Current workspace path — set via setWorkspacePath()
 let workspaceFolderPath: string | undefined;
-const _onDidChangeWorkspaceFolders = new EventEmitter<unknown>();
+const _onDidChangeWorkspaceFolders = new EventEmitter<{
+	added: Array<{ uri: Uri; name: string; index: number }>;
+	removed: Array<{ uri: Uri; name: string; index: number }>;
+}>();
 const _onDidChangeTextDocument = new EventEmitter<unknown>();
 const _onDidOpenTextDocument = new EventEmitter<TextDocument>();
 const _onDidCloseTextDocument = new EventEmitter<TextDocument>();
@@ -47,7 +50,24 @@ const fileSystemProviders = new Map<string, unknown>();
 const textDocumentContentProviders = new Map<string, unknown>();
 
 export function setWorkspacePath(folderPath: string): void {
+	const oldPath = workspaceFolderPath;
 	workspaceFolderPath = folderPath;
+	if (oldPath !== folderPath) {
+		_onDidChangeWorkspaceFolders.fire({
+			added: folderPath
+				? [
+						{
+							uri: Uri.file(folderPath),
+							name: path.basename(folderPath),
+							index: 0,
+						},
+					]
+				: [],
+			removed: oldPath
+				? [{ uri: Uri.file(oldPath), name: path.basename(oldPath), index: 0 }]
+				: [],
+		});
+	}
 }
 
 export const workspace = {

--- a/apps/desktop/src/main/lib/vscode-shim/api/workspace.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/api/workspace.ts
@@ -4,9 +4,9 @@
 
 import fs from "node:fs";
 import path from "node:path";
-import { Disposable, EventEmitter, type Event } from "./event-emitter.js";
-import { Uri } from "./uri.js";
 import { getConfiguration, onDidChangeConfiguration } from "./configuration.js";
+import { Disposable, type Event, EventEmitter } from "./event-emitter.js";
+import { Uri } from "./uri.js";
 
 interface WorkspaceFolder {
 	readonly uri: Uri;
@@ -99,7 +99,10 @@ export const workspace = {
 		return undefined;
 	},
 
-	asRelativePath(pathOrUri: string | Uri, includeWorkspaceFolder?: boolean): string {
+	asRelativePath(
+		pathOrUri: string | Uri,
+		_includeWorkspaceFolder?: boolean,
+	): string {
 		const p = typeof pathOrUri === "string" ? pathOrUri : pathOrUri.fsPath;
 		if (!workspaceFolderPath) return p;
 		const rel = path.relative(workspaceFolderPath, p);
@@ -110,7 +113,9 @@ export const workspace = {
 	async openTextDocument(uriOrPath: Uri | string): Promise<TextDocument> {
 		const filePath =
 			typeof uriOrPath === "string" ? uriOrPath : uriOrPath.fsPath;
-		const content = fs.existsSync(filePath) ? fs.readFileSync(filePath, "utf-8") : "";
+		const content = fs.existsSync(filePath)
+			? fs.readFileSync(filePath, "utf-8")
+			: "";
 		const lines = content.split("\n");
 		const ext = path.extname(filePath).slice(1);
 
@@ -130,15 +135,17 @@ export const workspace = {
 	},
 
 	async findFiles(
-		include: string,
-		exclude?: string | null,
-		maxResults?: number,
+		_include: string,
+		_exclude?: string | null,
+		_maxResults?: number,
 		_token?: unknown,
 	): Promise<Uri[]> {
 		// Simple glob-based file search using workspace root
 		if (!workspaceFolderPath) return [];
 		// For MVP, return empty array. In Phase 2+, wire to FsHostService.searchFiles
-		console.warn("[vscode-shim] workspace.findFiles is a stub, returning empty");
+		console.warn(
+			"[vscode-shim] workspace.findFiles is a stub, returning empty",
+		);
 		return [];
 	},
 
@@ -174,7 +181,9 @@ export const workspace = {
 		_options?: { isCaseSensitive?: boolean; isReadonly?: boolean },
 	): Disposable {
 		fileSystemProviders.set(scheme, provider);
-		console.log(`[vscode-shim] Registered FileSystemProvider for scheme: ${scheme}`);
+		console.log(
+			`[vscode-shim] Registered FileSystemProvider for scheme: ${scheme}`,
+		);
 		return new Disposable(() => {
 			fileSystemProviders.delete(scheme);
 		});
@@ -185,7 +194,10 @@ export const workspace = {
 		return fileSystemProviders.get(scheme);
 	},
 
-	registerTextDocumentContentProvider(scheme: string, provider: unknown): Disposable {
+	registerTextDocumentContentProvider(
+		scheme: string,
+		provider: unknown,
+	): Disposable {
 		textDocumentContentProviders.set(scheme, provider);
 		return new Disposable(() => {
 			textDocumentContentProviders.delete(scheme);
@@ -217,7 +229,14 @@ export const workspace = {
 		}> {
 			if (uri.scheme !== "file") {
 				const provider = fileSystemProviders.get(uri.scheme) as
-					| { stat?(uri: Uri): Promise<{ type: number; ctime: number; mtime: number; size: number }> }
+					| {
+							stat?(uri: Uri): Promise<{
+								type: number;
+								ctime: number;
+								mtime: number;
+								size: number;
+							}>;
+					  }
 					| undefined;
 				if (provider?.stat) {
 					return provider.stat(uri);
@@ -232,16 +251,27 @@ export const workspace = {
 				size: s.size,
 			};
 		},
-		async delete(uri: Uri, _options?: { recursive?: boolean; useTrash?: boolean }): Promise<void> {
+		async delete(
+			uri: Uri,
+			_options?: { recursive?: boolean; useTrash?: boolean },
+		): Promise<void> {
 			await fs.promises.rm(uri.fsPath, { recursive: _options?.recursive });
 		},
-		async rename(source: Uri, target: Uri, _options?: { overwrite?: boolean }): Promise<void> {
+		async rename(
+			source: Uri,
+			target: Uri,
+			_options?: { overwrite?: boolean },
+		): Promise<void> {
 			await fs.promises.rename(source.fsPath, target.fsPath);
 		},
 		async createDirectory(uri: Uri): Promise<void> {
 			await fs.promises.mkdir(uri.fsPath, { recursive: true });
 		},
-		async copy(source: Uri, target: Uri, _options?: { overwrite?: boolean }): Promise<void> {
+		async copy(
+			source: Uri,
+			target: Uri,
+			_options?: { overwrite?: boolean },
+		): Promise<void> {
 			await fs.promises.copyFile(source.fsPath, target.fsPath);
 		},
 		isWritableFileSystem(scheme: string): boolean | undefined {

--- a/apps/desktop/src/main/lib/vscode-shim/extension-host.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/extension-host.ts
@@ -4,6 +4,7 @@
 
 import os from "node:os";
 import path from "node:path";
+import { commands } from "./api/commands";
 import { shimLog, shimWarn } from "./api/debug-log";
 import { registerWebviewProtocol } from "./api/protocol-handler";
 import { startWebviewServer, stopWebviewServer } from "./api/webview-server";
@@ -56,8 +57,6 @@ export async function initExtensionHost(
 	await startWebviewServer();
 
 	// Set platform context keys (Codex checks these)
-	const { commands } =
-		require("./api/commands") as typeof import("./api/commands");
 	const platform =
 		process.platform === "darwin"
 			? "darwin"

--- a/apps/desktop/src/main/lib/vscode-shim/extension-host.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/extension-host.ts
@@ -72,6 +72,19 @@ export async function initExtensionHost(
 	isInitialized = true;
 }
 
+/** Compare semver-like version strings. Returns positive if a > b. */
+function compareVersions(a: string, b: string): number {
+	const pa = a.split(".").map(Number);
+	const pb = b.split(".").map(Number);
+	const len = Math.max(pa.length, pb.length);
+	for (let i = 0; i < len; i++) {
+		const va = pa[i] ?? 0;
+		const vb = pb[i] ?? 0;
+		if (va !== vb) return va - vb;
+	}
+	return 0;
+}
+
 /** Pick the latest version of each target extension */
 function selectExtensions(
 	all: ExtensionInfo[],
@@ -86,8 +99,9 @@ function selectExtensions(
 		if (!existing) {
 			byId.set(ext.id, ext);
 		} else {
-			// Simple version comparison: prefer later directory (higher version)
-			if (ext.extensionPath > existing.extensionPath) {
+			if (
+				compareVersions(ext.manifest.version, existing.manifest.version) > 0
+			) {
 				byId.set(ext.id, ext);
 			}
 		}

--- a/apps/desktop/src/main/lib/vscode-shim/extension-host.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/extension-host.ts
@@ -2,6 +2,7 @@
  * Extension Host: high-level API to manage VS Code extensions in Superset Desktop.
  */
 
+import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { commands } from "./api/commands";
@@ -75,12 +76,18 @@ export async function initExtensionHost(
 		`[vscode-shim] Loading ${toLoad.length} extensions: ${toLoad.map((e) => e.id).join(", ")}`,
 	);
 
+	// Read enabled config to skip disabled extensions
+	const enabledConfig = readExtensionEnabledConfig();
+
 	for (const ext of toLoad) {
+		if (enabledConfig[ext.id] === false) {
+			shimLog(`[vscode-shim] Skipping disabled extension: ${ext.id}`);
+			continue;
+		}
 		try {
 			await loadExtension(ext);
 		} catch (err) {
 			console.error(`[vscode-shim] Failed to load ${ext.id}:`, err);
-			// Continue loading other extensions
 		}
 	}
 
@@ -166,3 +173,23 @@ export async function restartExtension(extensionId: string): Promise<boolean> {
 }
 
 export { isInitialized as isExtensionHostInitialized };
+
+/** Read extension enabled/disabled config (shared with tRPC router) */
+function readExtensionEnabledConfig(): Record<string, boolean> {
+	try {
+		let userDataPath: string;
+		try {
+			userDataPath = require("electron").app.getPath("userData");
+		} catch {
+			userDataPath = path.join(os.homedir(), ".superset-desktop");
+		}
+		const configPath = path.join(
+			userDataPath,
+			"vscode-extensions-enabled.json",
+		);
+		if (fs.existsSync(configPath)) {
+			return JSON.parse(fs.readFileSync(configPath, "utf-8"));
+		}
+	} catch {}
+	return {};
+}

--- a/apps/desktop/src/main/lib/vscode-shim/extension-host.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/extension-host.ts
@@ -11,6 +11,7 @@ import {
 	getLoadedExtensions,
 } from "./loader.js";
 import { setWorkspacePath } from "./api/workspace.js";
+import { registerWebviewProtocol } from "./api/protocol-handler.js";
 import type { ExtensionInfo } from "./types.js";
 
 // Known extension IDs we support
@@ -43,6 +44,9 @@ export async function initExtensionHost(options: ExtensionHostOptions = {}): Pro
 	if (options.workspacePath) {
 		setWorkspacePath(options.workspacePath);
 	}
+
+	// Register protocol handler for webview resources
+	registerWebviewProtocol();
 
 	console.log(`[vscode-shim] Discovering extensions in ${extensionsDir}`);
 	const discovered = discoverExtensions(extensionsDir);
@@ -103,6 +107,25 @@ export function getActiveExtensions(): Array<{ id: string; isActive: boolean }> 
 		id: ext.info.id,
 		isActive: ext.info.isActive,
 	}));
+}
+
+/** Restart a specific extension (deactivate + re-activate) */
+export async function restartExtension(extensionId: string): Promise<boolean> {
+	const { deactivateExtension, getLoadedExtension } = await import("./loader.js");
+	const loaded = getLoadedExtension(extensionId);
+	if (!loaded) return false;
+
+	const info = { ...loaded.info, isActive: false };
+	await deactivateExtension(extensionId);
+
+	try {
+		await loadExtension(info);
+		console.log(`[vscode-shim] Restarted extension: ${extensionId}`);
+		return true;
+	} catch (err) {
+		console.error(`[vscode-shim] Failed to restart ${extensionId}:`, err);
+		return false;
+	}
 }
 
 export { isInitialized as isExtensionHostInitialized };

--- a/apps/desktop/src/main/lib/vscode-shim/extension-host.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/extension-host.ts
@@ -55,6 +55,17 @@ export async function initExtensionHost(
 	// Start HTTP server for webview content
 	await startWebviewServer();
 
+	// Set platform context keys (Codex checks these)
+	const { commands } =
+		require("./api/commands") as typeof import("./api/commands");
+	const platform =
+		process.platform === "darwin"
+			? "darwin"
+			: process.platform === "win32"
+				? "windows"
+				: "linux";
+	commands.executeCommand("setContext", "os", platform);
+
 	shimLog(`[vscode-shim] Discovering extensions in ${extensionsDir}`);
 	const discovered = discoverExtensions(extensionsDir);
 	shimLog(`[vscode-shim] Found ${discovered.length} extensions total`);

--- a/apps/desktop/src/main/lib/vscode-shim/extension-host.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/extension-host.ts
@@ -1,0 +1,108 @@
+/**
+ * Extension Host: high-level API to manage VS Code extensions in Superset Desktop.
+ */
+
+import os from "node:os";
+import path from "node:path";
+import {
+	discoverExtensions,
+	loadExtension,
+	deactivateAll,
+	getLoadedExtensions,
+} from "./loader.js";
+import { setWorkspacePath } from "./api/workspace.js";
+import type { ExtensionInfo } from "./types.js";
+
+// Known extension IDs we support
+const SUPPORTED_EXTENSIONS = new Set([
+	"anthropic.claude-code",
+	"openai.chatgpt",
+]);
+
+interface ExtensionHostOptions {
+	/** Path to VS Code extensions directory. Defaults to ~/.vscode/extensions */
+	extensionsDir?: string;
+	/** Current workspace folder path */
+	workspacePath?: string;
+	/** Specific extension IDs to load. Defaults to SUPPORTED_EXTENSIONS */
+	extensionIds?: string[];
+}
+
+let isInitialized = false;
+
+export async function initExtensionHost(options: ExtensionHostOptions = {}): Promise<void> {
+	if (isInitialized) {
+		console.warn("[vscode-shim] Extension host already initialized");
+		return;
+	}
+
+	const extensionsDir =
+		options.extensionsDir ?? path.join(os.homedir(), ".vscode", "extensions");
+	const targetIds = new Set(options.extensionIds ?? SUPPORTED_EXTENSIONS);
+
+	if (options.workspacePath) {
+		setWorkspacePath(options.workspacePath);
+	}
+
+	console.log(`[vscode-shim] Discovering extensions in ${extensionsDir}`);
+	const discovered = discoverExtensions(extensionsDir);
+	console.log(`[vscode-shim] Found ${discovered.length} extensions total`);
+
+	// Filter to supported extensions, pick latest version for each
+	const toLoad = selectExtensions(discovered, targetIds);
+	console.log(`[vscode-shim] Loading ${toLoad.length} extensions: ${toLoad.map((e) => e.id).join(", ")}`);
+
+	for (const ext of toLoad) {
+		try {
+			await loadExtension(ext);
+		} catch (err) {
+			console.error(`[vscode-shim] Failed to load ${ext.id}:`, err);
+			// Continue loading other extensions
+		}
+	}
+
+	isInitialized = true;
+}
+
+/** Pick the latest version of each target extension */
+function selectExtensions(
+	all: ExtensionInfo[],
+	targetIds: Set<string>,
+): ExtensionInfo[] {
+	const byId = new Map<string, ExtensionInfo>();
+
+	for (const ext of all) {
+		if (!targetIds.has(ext.id)) continue;
+
+		const existing = byId.get(ext.id);
+		if (!existing) {
+			byId.set(ext.id, ext);
+		} else {
+			// Simple version comparison: prefer later directory (higher version)
+			if (ext.extensionPath > existing.extensionPath) {
+				byId.set(ext.id, ext);
+			}
+		}
+	}
+
+	return [...byId.values()];
+}
+
+export async function shutdownExtensionHost(): Promise<void> {
+	console.log("[vscode-shim] Shutting down extension host");
+	await deactivateAll();
+	isInitialized = false;
+}
+
+export function updateWorkspacePath(workspacePath: string): void {
+	setWorkspacePath(workspacePath);
+}
+
+export function getActiveExtensions(): Array<{ id: string; isActive: boolean }> {
+	return getLoadedExtensions().map((ext) => ({
+		id: ext.info.id,
+		isActive: ext.info.isActive,
+	}));
+}
+
+export { isInitialized as isExtensionHostInitialized };

--- a/apps/desktop/src/main/lib/vscode-shim/extension-host.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/extension-host.ts
@@ -4,6 +4,7 @@
 
 import os from "node:os";
 import path from "node:path";
+import { shimLog, shimWarn } from "./api/debug-log";
 import { registerWebviewProtocol } from "./api/protocol-handler";
 import { startWebviewServer, stopWebviewServer } from "./api/webview-server";
 import { setWorkspacePath } from "./api/workspace";
@@ -36,7 +37,7 @@ export async function initExtensionHost(
 	options: ExtensionHostOptions = {},
 ): Promise<void> {
 	if (isInitialized) {
-		console.warn("[vscode-shim] Extension host already initialized");
+		shimWarn("[vscode-shim] Extension host already initialized");
 		return;
 	}
 
@@ -54,13 +55,13 @@ export async function initExtensionHost(
 	// Start HTTP server for webview content
 	await startWebviewServer();
 
-	console.log(`[vscode-shim] Discovering extensions in ${extensionsDir}`);
+	shimLog(`[vscode-shim] Discovering extensions in ${extensionsDir}`);
 	const discovered = discoverExtensions(extensionsDir);
-	console.log(`[vscode-shim] Found ${discovered.length} extensions total`);
+	shimLog(`[vscode-shim] Found ${discovered.length} extensions total`);
 
 	// Filter to supported extensions, pick latest version for each
 	const toLoad = selectExtensions(discovered, targetIds);
-	console.log(
+	shimLog(
 		`[vscode-shim] Loading ${toLoad.length} extensions: ${toLoad.map((e) => e.id).join(", ")}`,
 	);
 
@@ -115,7 +116,7 @@ function selectExtensions(
 }
 
 export async function shutdownExtensionHost(): Promise<void> {
-	console.log("[vscode-shim] Shutting down extension host");
+	shimLog("[vscode-shim] Shutting down extension host");
 	await deactivateAll();
 	stopWebviewServer();
 	isInitialized = false;
@@ -146,7 +147,7 @@ export async function restartExtension(extensionId: string): Promise<boolean> {
 
 	try {
 		await loadExtension(info);
-		console.log(`[vscode-shim] Restarted extension: ${extensionId}`);
+		shimLog(`[vscode-shim] Restarted extension: ${extensionId}`);
 		return true;
 	} catch (err) {
 		console.error(`[vscode-shim] Failed to restart ${extensionId}:`, err);

--- a/apps/desktop/src/main/lib/vscode-shim/extension-host.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/extension-host.ts
@@ -132,9 +132,7 @@ export function getActiveExtensions(): Array<{
 
 /** Restart a specific extension (deactivate + re-activate) */
 export async function restartExtension(extensionId: string): Promise<boolean> {
-	const { deactivateExtension, getLoadedExtension } = await import(
-		"./loader"
-	);
+	const { deactivateExtension, getLoadedExtension } = await import("./loader");
 	const loaded = getLoadedExtension(extensionId);
 	if (!loaded) return false;
 

--- a/apps/desktop/src/main/lib/vscode-shim/extension-host.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/extension-host.ts
@@ -4,15 +4,15 @@
 
 import os from "node:os";
 import path from "node:path";
-import { registerWebviewProtocol } from "./api/protocol-handler.js";
-import { setWorkspacePath } from "./api/workspace.js";
+import { registerWebviewProtocol } from "./api/protocol-handler";
+import { setWorkspacePath } from "./api/workspace";
 import {
 	deactivateAll,
 	discoverExtensions,
 	getLoadedExtensions,
 	loadExtension,
-} from "./loader.js";
-import type { ExtensionInfo } from "./types.js";
+} from "./loader";
+import type { ExtensionInfo } from "./types";
 
 // Known extension IDs we support
 const SUPPORTED_EXTENSIONS = new Set([
@@ -133,7 +133,7 @@ export function getActiveExtensions(): Array<{
 /** Restart a specific extension (deactivate + re-activate) */
 export async function restartExtension(extensionId: string): Promise<boolean> {
 	const { deactivateExtension, getLoadedExtension } = await import(
-		"./loader.js"
+		"./loader"
 	);
 	const loaded = getLoadedExtension(extensionId);
 	if (!loaded) return false;

--- a/apps/desktop/src/main/lib/vscode-shim/extension-host.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/extension-host.ts
@@ -4,14 +4,14 @@
 
 import os from "node:os";
 import path from "node:path";
-import {
-	discoverExtensions,
-	loadExtension,
-	deactivateAll,
-	getLoadedExtensions,
-} from "./loader.js";
-import { setWorkspacePath } from "./api/workspace.js";
 import { registerWebviewProtocol } from "./api/protocol-handler.js";
+import { setWorkspacePath } from "./api/workspace.js";
+import {
+	deactivateAll,
+	discoverExtensions,
+	getLoadedExtensions,
+	loadExtension,
+} from "./loader.js";
 import type { ExtensionInfo } from "./types.js";
 
 // Known extension IDs we support
@@ -31,7 +31,9 @@ interface ExtensionHostOptions {
 
 let isInitialized = false;
 
-export async function initExtensionHost(options: ExtensionHostOptions = {}): Promise<void> {
+export async function initExtensionHost(
+	options: ExtensionHostOptions = {},
+): Promise<void> {
 	if (isInitialized) {
 		console.warn("[vscode-shim] Extension host already initialized");
 		return;
@@ -54,7 +56,9 @@ export async function initExtensionHost(options: ExtensionHostOptions = {}): Pro
 
 	// Filter to supported extensions, pick latest version for each
 	const toLoad = selectExtensions(discovered, targetIds);
-	console.log(`[vscode-shim] Loading ${toLoad.length} extensions: ${toLoad.map((e) => e.id).join(", ")}`);
+	console.log(
+		`[vscode-shim] Loading ${toLoad.length} extensions: ${toLoad.map((e) => e.id).join(", ")}`,
+	);
 
 	for (const ext of toLoad) {
 		try {
@@ -102,7 +106,10 @@ export function updateWorkspacePath(workspacePath: string): void {
 	setWorkspacePath(workspacePath);
 }
 
-export function getActiveExtensions(): Array<{ id: string; isActive: boolean }> {
+export function getActiveExtensions(): Array<{
+	id: string;
+	isActive: boolean;
+}> {
 	return getLoadedExtensions().map((ext) => ({
 		id: ext.info.id,
 		isActive: ext.info.isActive,
@@ -111,7 +118,9 @@ export function getActiveExtensions(): Array<{ id: string; isActive: boolean }> 
 
 /** Restart a specific extension (deactivate + re-activate) */
 export async function restartExtension(extensionId: string): Promise<boolean> {
-	const { deactivateExtension, getLoadedExtension } = await import("./loader.js");
+	const { deactivateExtension, getLoadedExtension } = await import(
+		"./loader.js"
+	);
 	const loaded = getLoadedExtension(extensionId);
 	if (!loaded) return false;
 

--- a/apps/desktop/src/main/lib/vscode-shim/extension-host.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/extension-host.ts
@@ -5,6 +5,7 @@
 import os from "node:os";
 import path from "node:path";
 import { registerWebviewProtocol } from "./api/protocol-handler";
+import { startWebviewServer, stopWebviewServer } from "./api/webview-server";
 import { setWorkspacePath } from "./api/workspace";
 import {
 	deactivateAll,
@@ -49,6 +50,9 @@ export async function initExtensionHost(
 
 	// Register protocol handler for webview resources
 	registerWebviewProtocol();
+
+	// Start HTTP server for webview content
+	await startWebviewServer();
 
 	console.log(`[vscode-shim] Discovering extensions in ${extensionsDir}`);
 	const discovered = discoverExtensions(extensionsDir);
@@ -113,6 +117,7 @@ function selectExtensions(
 export async function shutdownExtensionHost(): Promise<void> {
 	console.log("[vscode-shim] Shutting down extension host");
 	await deactivateAll();
+	stopWebviewServer();
 	isInitialized = false;
 }
 

--- a/apps/desktop/src/main/lib/vscode-shim/index.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/index.ts
@@ -5,7 +5,6 @@
  * (Claude Code, ChatGPT/Codex) inside the Electron app.
  */
 
-export { clearWebviewHtml, setWebviewHtml } from "./api/protocol-handler";
 export {
 	getActivePanel,
 	getActiveView,
@@ -13,6 +12,7 @@ export {
 	onWebviewEvent,
 	resolveWebviewView,
 } from "./api/webview";
+export { clearWebviewHtml, setWebviewHtml } from "./api/webview-server";
 export { handleUri, setActiveTextEditor } from "./api/window";
 export {
 	getActiveExtensions,

--- a/apps/desktop/src/main/lib/vscode-shim/index.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/index.ts
@@ -11,24 +11,24 @@ export {
 	getViewProvider,
 	onWebviewEvent,
 	resolveWebviewView,
-} from "./api/webview.js";
-export { handleUri, setActiveTextEditor } from "./api/window.js";
+} from "./api/webview";
+export { handleUri, setActiveTextEditor } from "./api/window";
 export {
 	getActiveExtensions,
 	initExtensionHost,
 	shutdownExtensionHost,
 	updateWorkspacePath,
-} from "./extension-host.js";
+} from "./extension-host";
 export {
 	deactivateExtension,
 	discoverExtensions,
 	getLoadedExtension,
 	getLoadedExtensions,
 	loadExtension,
-} from "./loader.js";
+} from "./loader";
 export type {
 	ExtensionInfo,
 	ExtensionManifest,
 	WebviewMessage,
-} from "./types.js";
-export { webviewBridge } from "./webview-bridge.js";
+} from "./types";
+export { webviewBridge } from "./webview-bridge";

--- a/apps/desktop/src/main/lib/vscode-shim/index.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/index.ts
@@ -6,29 +6,29 @@
  */
 
 export {
+	getActivePanel,
+	getActiveView,
+	getViewProvider,
+	onWebviewEvent,
+	resolveWebviewView,
+} from "./api/webview.js";
+export { handleUri } from "./api/window.js";
+export {
+	getActiveExtensions,
 	initExtensionHost,
 	shutdownExtensionHost,
 	updateWorkspacePath,
-	getActiveExtensions,
 } from "./extension-host.js";
-
 export {
-	loadExtension,
 	deactivateExtension,
+	discoverExtensions,
 	getLoadedExtension,
 	getLoadedExtensions,
-	discoverExtensions,
+	loadExtension,
 } from "./loader.js";
-
-export {
-	resolveWebviewView,
-	onWebviewEvent,
-	getViewProvider,
-	getActiveView,
-	getActivePanel,
-} from "./api/webview.js";
-
+export type {
+	ExtensionInfo,
+	ExtensionManifest,
+	WebviewMessage,
+} from "./types.js";
 export { webviewBridge } from "./webview-bridge.js";
-export { handleUri } from "./api/window.js";
-
-export type { ExtensionManifest, ExtensionInfo, WebviewMessage } from "./types.js";

--- a/apps/desktop/src/main/lib/vscode-shim/index.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/index.ts
@@ -1,0 +1,31 @@
+/**
+ * VS Code Extension Host Shim for Superset Desktop.
+ *
+ * Provides a minimal VS Code API surface to run official VS Code extensions
+ * (Claude Code, ChatGPT/Codex) inside the Electron app.
+ */
+
+export {
+	initExtensionHost,
+	shutdownExtensionHost,
+	updateWorkspacePath,
+	getActiveExtensions,
+} from "./extension-host.js";
+
+export {
+	loadExtension,
+	deactivateExtension,
+	getLoadedExtension,
+	getLoadedExtensions,
+	discoverExtensions,
+} from "./loader.js";
+
+export {
+	resolveWebviewView,
+	onWebviewEvent,
+	getViewProvider,
+	getActiveView,
+	getActivePanel,
+} from "./api/webview.js";
+
+export type { ExtensionManifest, ExtensionInfo, WebviewMessage } from "./types.js";

--- a/apps/desktop/src/main/lib/vscode-shim/index.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/index.ts
@@ -5,6 +5,7 @@
  * (Claude Code, ChatGPT/Codex) inside the Electron app.
  */
 
+export { clearWebviewHtml, setWebviewHtml } from "./api/protocol-handler";
 export {
 	getActivePanel,
 	getActiveView,

--- a/apps/desktop/src/main/lib/vscode-shim/index.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/index.ts
@@ -12,7 +12,7 @@ export {
 	onWebviewEvent,
 	resolveWebviewView,
 } from "./api/webview.js";
-export { handleUri } from "./api/window.js";
+export { handleUri, setActiveTextEditor } from "./api/window.js";
 export {
 	getActiveExtensions,
 	initExtensionHost,

--- a/apps/desktop/src/main/lib/vscode-shim/index.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/index.ts
@@ -28,4 +28,6 @@ export {
 	getActivePanel,
 } from "./api/webview.js";
 
+export { webviewBridge } from "./webview-bridge.js";
+
 export type { ExtensionManifest, ExtensionInfo, WebviewMessage } from "./types.js";

--- a/apps/desktop/src/main/lib/vscode-shim/index.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/index.ts
@@ -29,5 +29,6 @@ export {
 } from "./api/webview.js";
 
 export { webviewBridge } from "./webview-bridge.js";
+export { handleUri } from "./api/window.js";
 
 export type { ExtensionManifest, ExtensionInfo, WebviewMessage } from "./types.js";

--- a/apps/desktop/src/main/lib/vscode-shim/loader.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/loader.ts
@@ -9,6 +9,7 @@ import fs from "node:fs";
 import Module from "node:module";
 import path from "node:path";
 import { registerExtensionDefaults } from "./api/configuration";
+import { shimLog, shimWarn } from "./api/debug-log";
 import {
 	createExtensionContext,
 	type VscodeExtensionContext,
@@ -92,7 +93,7 @@ export function discoverExtensions(extensionsDir: string): ExtensionInfo[] {
 				isActive: false,
 			});
 		} catch (err) {
-			console.warn(`[vscode-shim] Failed to parse ${manifestPath}:`, err);
+			shimWarn(`[vscode-shim] Failed to parse ${manifestPath}:`, err);
 		}
 	}
 
@@ -128,7 +129,7 @@ export async function loadExtension(
 
 	// Load the extension's main module
 	const mainPath = path.resolve(info.extensionPath, info.manifest.main!);
-	console.log(`[vscode-shim] Loading extension: ${info.id} from ${mainPath}`);
+	shimLog(`[vscode-shim] Loading extension: ${info.id} from ${mainPath}`);
 
 	let extensionModule: Record<string, unknown>;
 	try {
@@ -140,11 +141,11 @@ export async function loadExtension(
 
 	// Activate the extension
 	if (typeof extensionModule.activate === "function") {
-		console.log(`[vscode-shim] Activating extension: ${info.id}`);
+		shimLog(`[vscode-shim] Activating extension: ${info.id}`);
 		try {
 			await extensionModule.activate(context);
 			info.isActive = true;
-			console.log(`[vscode-shim] Extension activated: ${info.id}`);
+			shimLog(`[vscode-shim] Extension activated: ${info.id}`);
 		} catch (err) {
 			console.error(`[vscode-shim] Failed to activate ${info.id}:`, err);
 			throw err;

--- a/apps/desktop/src/main/lib/vscode-shim/loader.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/loader.ts
@@ -1,0 +1,181 @@
+/**
+ * Extension loader: discovers, loads, and activates VS Code extensions.
+ *
+ * Intercepts `require('vscode')` via Module._resolveFilename so that
+ * extensions receive our shim instead of the real VS Code API.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import Module from "node:module";
+import { createVscodeApi } from "./vscode-api.js";
+import { createExtensionContext, type VscodeExtensionContext } from "./api/extension-context.js";
+import { registerExtensionDefaults } from "./api/configuration.js";
+import type { ExtensionManifest, ExtensionInfo } from "./types.js";
+
+const vscodeApi = createVscodeApi();
+let interceptInstalled = false;
+
+function installRequireIntercept(): void {
+	if (interceptInstalled) return;
+	interceptInstalled = true;
+
+	// Inject vscode shim into require cache so require('vscode') returns our API.
+	// We use _resolveFilename to redirect 'vscode' to a known cache key,
+	// and pre-populate the cache with our shim module.
+	const VSCODE_CACHE_KEY = path.join(__dirname, "__vscode_shim_module__.js");
+
+	// Pre-populate the require cache
+	require.cache[VSCODE_CACHE_KEY] = {
+		id: VSCODE_CACHE_KEY,
+		filename: VSCODE_CACHE_KEY,
+		loaded: true,
+		exports: vscodeApi,
+		children: [],
+		paths: [],
+		path: __dirname,
+		parent: null,
+		require,
+		isPreloading: false,
+	} as unknown as NodeModule;
+
+	const originalResolveFilename = (Module as unknown as { _resolveFilename: Function })._resolveFilename;
+	(Module as unknown as { _resolveFilename: Function })._resolveFilename = function (
+		request: string,
+		parent: unknown,
+		isMain: boolean,
+		options: unknown,
+	) {
+		if (request === "vscode") {
+			return VSCODE_CACHE_KEY;
+		}
+		return originalResolveFilename.call(this, request, parent, isMain, options);
+	};
+}
+
+export function discoverExtensions(extensionsDir: string): ExtensionInfo[] {
+	if (!fs.existsSync(extensionsDir)) return [];
+
+	const results: ExtensionInfo[] = [];
+	const entries = fs.readdirSync(extensionsDir, { withFileTypes: true });
+
+	for (const entry of entries) {
+		if (!entry.isDirectory()) continue;
+		const extPath = path.join(extensionsDir, entry.name);
+		const manifestPath = path.join(extPath, "package.json");
+
+		if (!fs.existsSync(manifestPath)) continue;
+
+		try {
+			const manifest: ExtensionManifest = JSON.parse(
+				fs.readFileSync(manifestPath, "utf-8"),
+			);
+			if (!manifest.main) continue;
+
+			const id = `${manifest.publisher}.${manifest.name}`.toLowerCase();
+			results.push({
+				id,
+				extensionPath: extPath,
+				manifest,
+				isActive: false,
+			});
+		} catch (err) {
+			console.warn(`[vscode-shim] Failed to parse ${manifestPath}:`, err);
+		}
+	}
+
+	return results;
+}
+
+interface LoadedExtension {
+	info: ExtensionInfo;
+	context: VscodeExtensionContext;
+	exports: Record<string, unknown>;
+}
+
+const loadedExtensions = new Map<string, LoadedExtension>();
+
+export async function loadExtension(info: ExtensionInfo): Promise<LoadedExtension> {
+	if (loadedExtensions.has(info.id)) {
+		return loadedExtensions.get(info.id)!;
+	}
+
+	installRequireIntercept();
+
+	// Register default configuration values
+	registerExtensionDefaults(info.manifest);
+
+	// Create extension context
+	const context = createExtensionContext(info.id, info.extensionPath, info.manifest);
+
+	// Load the extension's main module
+	const mainPath = path.resolve(info.extensionPath, info.manifest.main!);
+	console.log(`[vscode-shim] Loading extension: ${info.id} from ${mainPath}`);
+
+	let extensionModule: Record<string, unknown>;
+	try {
+		extensionModule = require(mainPath);
+	} catch (err) {
+		console.error(`[vscode-shim] Failed to require ${info.id}:`, err);
+		throw err;
+	}
+
+	// Activate the extension
+	if (typeof extensionModule.activate === "function") {
+		console.log(`[vscode-shim] Activating extension: ${info.id}`);
+		try {
+			await extensionModule.activate(context);
+			info.isActive = true;
+			console.log(`[vscode-shim] Extension activated: ${info.id}`);
+		} catch (err) {
+			console.error(`[vscode-shim] Failed to activate ${info.id}:`, err);
+			throw err;
+		}
+	}
+
+	const loaded: LoadedExtension = {
+		info,
+		context,
+		exports: extensionModule,
+	};
+
+	loadedExtensions.set(info.id, loaded);
+	return loaded;
+}
+
+export async function deactivateExtension(extensionId: string): Promise<void> {
+	const loaded = loadedExtensions.get(extensionId);
+	if (!loaded) return;
+
+	if (typeof loaded.exports.deactivate === "function") {
+		try {
+			await loaded.exports.deactivate();
+		} catch (err) {
+			console.error(`[vscode-shim] Failed to deactivate ${extensionId}:`, err);
+		}
+	}
+
+	// Dispose all subscriptions
+	for (const sub of loaded.context.subscriptions) {
+		try {
+			sub.dispose();
+		} catch {}
+	}
+
+	loaded.info.isActive = false;
+	loadedExtensions.delete(extensionId);
+}
+
+export async function deactivateAll(): Promise<void> {
+	for (const id of [...loadedExtensions.keys()]) {
+		await deactivateExtension(id);
+	}
+}
+
+export function getLoadedExtension(extensionId: string): LoadedExtension | undefined {
+	return loadedExtensions.get(extensionId);
+}
+
+export function getLoadedExtensions(): LoadedExtension[] {
+	return [...loadedExtensions.values()];
+}

--- a/apps/desktop/src/main/lib/vscode-shim/loader.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/loader.ts
@@ -8,13 +8,13 @@
 import fs from "node:fs";
 import Module from "node:module";
 import path from "node:path";
-import { registerExtensionDefaults } from "./api/configuration.js";
+import { registerExtensionDefaults } from "./api/configuration";
 import {
 	createExtensionContext,
 	type VscodeExtensionContext,
-} from "./api/extension-context.js";
-import type { ExtensionInfo, ExtensionManifest } from "./types.js";
-import { createVscodeApi } from "./vscode-api.js";
+} from "./api/extension-context";
+import type { ExtensionInfo, ExtensionManifest } from "./types";
+import { createVscodeApi } from "./vscode-api";
 
 const vscodeApi = createVscodeApi();
 let interceptInstalled = false;
@@ -26,7 +26,7 @@ function installRequireIntercept(): void {
 	// Inject vscode shim into require cache so require('vscode') returns our API.
 	// We use _resolveFilename to redirect 'vscode' to a known cache key,
 	// and pre-populate the cache with our shim module.
-	const VSCODE_CACHE_KEY = path.join(__dirname, "__vscode_shim_module__.js");
+	const VSCODE_CACHE_KEY = path.join(__dirname, "__vscode_shim_module__");
 
 	// Pre-populate the require cache
 	require.cache[VSCODE_CACHE_KEY] = {

--- a/apps/desktop/src/main/lib/vscode-shim/loader.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/loader.ts
@@ -6,12 +6,15 @@
  */
 
 import fs from "node:fs";
-import path from "node:path";
 import Module from "node:module";
-import { createVscodeApi } from "./vscode-api.js";
-import { createExtensionContext, type VscodeExtensionContext } from "./api/extension-context.js";
+import path from "node:path";
 import { registerExtensionDefaults } from "./api/configuration.js";
-import type { ExtensionManifest, ExtensionInfo } from "./types.js";
+import {
+	createExtensionContext,
+	type VscodeExtensionContext,
+} from "./api/extension-context.js";
+import type { ExtensionInfo, ExtensionManifest } from "./types.js";
+import { createVscodeApi } from "./vscode-api.js";
 
 const vscodeApi = createVscodeApi();
 let interceptInstalled = false;
@@ -39,18 +42,27 @@ function installRequireIntercept(): void {
 		isPreloading: false,
 	} as unknown as NodeModule;
 
-	const originalResolveFilename = (Module as unknown as { _resolveFilename: Function })._resolveFilename;
-	(Module as unknown as { _resolveFilename: Function })._resolveFilename = function (
-		request: string,
-		parent: unknown,
-		isMain: boolean,
-		options: unknown,
-	) {
-		if (request === "vscode") {
-			return VSCODE_CACHE_KEY;
-		}
-		return originalResolveFilename.call(this, request, parent, isMain, options);
-	};
+	const originalResolveFilename = (
+		Module as unknown as { _resolveFilename: Function }
+	)._resolveFilename;
+	(Module as unknown as { _resolveFilename: Function })._resolveFilename =
+		function (
+			request: string,
+			parent: unknown,
+			isMain: boolean,
+			options: unknown,
+		) {
+			if (request === "vscode") {
+				return VSCODE_CACHE_KEY;
+			}
+			return originalResolveFilename.call(
+				this,
+				request,
+				parent,
+				isMain,
+				options,
+			);
+		};
 }
 
 export function discoverExtensions(extensionsDir: string): ExtensionInfo[] {
@@ -95,7 +107,9 @@ interface LoadedExtension {
 
 const loadedExtensions = new Map<string, LoadedExtension>();
 
-export async function loadExtension(info: ExtensionInfo): Promise<LoadedExtension> {
+export async function loadExtension(
+	info: ExtensionInfo,
+): Promise<LoadedExtension> {
 	if (loadedExtensions.has(info.id)) {
 		return loadedExtensions.get(info.id)!;
 	}
@@ -106,7 +120,11 @@ export async function loadExtension(info: ExtensionInfo): Promise<LoadedExtensio
 	registerExtensionDefaults(info.manifest);
 
 	// Create extension context
-	const context = createExtensionContext(info.id, info.extensionPath, info.manifest);
+	const context = createExtensionContext(
+		info.id,
+		info.extensionPath,
+		info.manifest,
+	);
 
 	// Load the extension's main module
 	const mainPath = path.resolve(info.extensionPath, info.manifest.main!);
@@ -172,7 +190,9 @@ export async function deactivateAll(): Promise<void> {
 	}
 }
 
-export function getLoadedExtension(extensionId: string): LoadedExtension | undefined {
+export function getLoadedExtension(
+	extensionId: string,
+): LoadedExtension | undefined {
 	return loadedExtensions.get(extensionId);
 }
 

--- a/apps/desktop/src/main/lib/vscode-shim/types.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/types.ts
@@ -37,10 +37,11 @@ export interface ExtensionManifest {
 				icon: string;
 			}>;
 		};
-		configuration?:
-			| ConfigurationSchema
-			| ConfigurationSchema[];
-		menus?: Record<string, Array<{ command: string; when?: string; group?: string }>>;
+		configuration?: ConfigurationSchema | ConfigurationSchema[];
+		menus?: Record<
+			string,
+			Array<{ command: string; when?: string; group?: string }>
+		>;
 		keybindings?: Array<{
 			command: string;
 			key: string;
@@ -48,7 +49,11 @@ export interface ExtensionManifest {
 			when?: string;
 		}>;
 		jsonValidation?: Array<{ fileMatch: string; url: string }>;
-		languages?: Array<{ id: string; extensions?: string[]; filenames?: string[] }>;
+		languages?: Array<{
+			id: string;
+			extensions?: string[];
+			filenames?: string[];
+		}>;
 	};
 	extensionDependencies?: string[];
 	enabledApiProposals?: string[];

--- a/apps/desktop/src/main/lib/vscode-shim/types.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/types.ts
@@ -1,0 +1,82 @@
+/**
+ * Shared types for the VS Code extension host shim.
+ */
+
+export interface ExtensionManifest {
+	name: string;
+	publisher: string;
+	version: string;
+	main?: string;
+	activationEvents?: string[];
+	contributes?: {
+		commands?: Array<{
+			command: string;
+			title: string;
+			category?: string;
+			icon?: string | { light: string; dark: string };
+			enablement?: string;
+		}>;
+		views?: Record<
+			string,
+			Array<{
+				id: string;
+				name: string;
+				type?: string;
+				when?: string;
+			}>
+		>;
+		viewsContainers?: {
+			activitybar?: Array<{
+				id: string;
+				title: string;
+				icon: string;
+			}>;
+			panel?: Array<{
+				id: string;
+				title: string;
+				icon: string;
+			}>;
+		};
+		configuration?:
+			| ConfigurationSchema
+			| ConfigurationSchema[];
+		menus?: Record<string, Array<{ command: string; when?: string; group?: string }>>;
+		keybindings?: Array<{
+			command: string;
+			key: string;
+			mac?: string;
+			when?: string;
+		}>;
+		jsonValidation?: Array<{ fileMatch: string; url: string }>;
+		languages?: Array<{ id: string; extensions?: string[]; filenames?: string[] }>;
+	};
+	extensionDependencies?: string[];
+	enabledApiProposals?: string[];
+}
+
+interface ConfigurationSchema {
+	title?: string;
+	properties?: Record<
+		string,
+		{
+			type?: string;
+			default?: unknown;
+			description?: string;
+			enum?: unknown[];
+			enumDescriptions?: string[];
+		}
+	>;
+}
+
+export interface ExtensionInfo {
+	id: string;
+	extensionPath: string;
+	manifest: ExtensionManifest;
+	isActive: boolean;
+}
+
+export interface WebviewMessage {
+	viewId: string;
+	type: "html" | "message" | "title" | "options";
+	data: unknown;
+}

--- a/apps/desktop/src/main/lib/vscode-shim/vscode-api.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/vscode-api.ts
@@ -173,9 +173,9 @@ class TabInputTextDiff {
 
 // Languages namespace (stub)
 const languages = {
-	getDiagnostics(resource?: Uri): unknown[] {
-		// When called without args, ChatGPT expects iterable of [Uri, Diagnostic[]]
-		if (!resource) return [];
+	getDiagnostics(resource?: unknown): unknown[] {
+		// Without args: return iterable of [Uri, Diagnostic[]] pairs
+		// With uri arg: return Diagnostic[]
 		return [];
 	},
 	onDidChangeDiagnostics: new EventEmitter<unknown>().event,
@@ -190,6 +190,21 @@ const languages = {
 		};
 	},
 	registerCodeLensProvider(_selector: unknown, _provider: unknown): Disposable {
+		return new Disposable(() => {});
+	},
+	registerHoverProvider(_selector: unknown, _provider: unknown): Disposable {
+		return new Disposable(() => {});
+	},
+	registerDefinitionProvider(_selector: unknown, _provider: unknown): Disposable {
+		return new Disposable(() => {});
+	},
+	registerReferenceProvider(_selector: unknown, _provider: unknown): Disposable {
+		return new Disposable(() => {});
+	},
+	registerDocumentSymbolProvider(_selector: unknown, _provider: unknown): Disposable {
+		return new Disposable(() => {});
+	},
+	registerCompletionItemProvider(_selector: unknown, _provider: unknown, ..._triggerCharacters: string[]): Disposable {
 		return new Disposable(() => {});
 	},
 };

--- a/apps/desktop/src/main/lib/vscode-shim/vscode-api.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/vscode-api.ts
@@ -574,14 +574,49 @@ export function createVscodeApi(): Record<string, unknown> {
 		authentication,
 		l10n,
 
-		// Proposed API stubs
+		// Proposed API: chat sessions
 		chat: {
-			registerChatSessionItemProvider(_id: string, _provider: unknown) {
-				return new Disposable(() => {});
+			_providers: new Map<string, unknown>(),
+			registerChatSessionItemProvider(id: string, provider: unknown) {
+				(this as { _providers: Map<string, unknown> })._providers.set(
+					id,
+					provider,
+				);
+				return new Disposable(() => {
+					(this as { _providers: Map<string, unknown> })._providers.delete(id);
+				});
+			},
+			getSessionProvider(id: string): unknown {
+				return (this as { _providers: Map<string, unknown> })._providers.get(
+					id,
+				);
 			},
 		},
+
+		// Proposed API: language model
 		lm: {
-			getModelProxy: undefined,
+			_models: [] as Array<{
+				id: string;
+				vendor: string;
+				family: string;
+				version: string;
+			}>,
+			onDidChangeChatModels: new EventEmitter<void>().event,
+			async selectChatModels(_selector?: {
+				vendor?: string;
+				family?: string;
+				id?: string;
+			}): Promise<unknown[]> {
+				return [];
+			},
+			async sendChatRequest(
+				_model: unknown,
+				_messages: unknown[],
+				_options?: unknown,
+			): Promise<unknown> {
+				throw new Error("Language model API not available in Superset Desktop");
+			},
+			getModelProxy: undefined as unknown,
 			isModelProxyAvailable: false,
 		},
 

--- a/apps/desktop/src/main/lib/vscode-shim/vscode-api.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/vscode-api.ts
@@ -8,35 +8,136 @@
 
 import { commands } from "./api/commands.js";
 import {
+	CancellationTokenSource,
 	Disposable,
 	EventEmitter,
-	CancellationTokenSource,
-	type CancellationToken,
 } from "./api/event-emitter.js";
 import { Uri } from "./api/uri.js";
-import { workspace } from "./api/workspace.js";
 import { window } from "./api/window.js";
-import type { VscodeExtensionContext } from "./api/extension-context.js";
+import { workspace } from "./api/workspace.js";
 
 // VS Code enums
 const StatusBarAlignment = { Left: 1, Right: 2 } as const;
-const ViewColumn = { Active: -1, Beside: -2, One: 1, Two: 2, Three: 3, Four: 4 } as const;
-const ProgressLocation = { SourceControl: 1, Window: 10, Notification: 15 } as const;
-const ConfigurationTarget = { Global: 1, Workspace: 2, WorkspaceFolder: 3 } as const;
-const DiagnosticSeverity = { Error: 0, Warning: 1, Information: 2, Hint: 3 } as const;
-const FileType = { Unknown: 0, File: 1, Directory: 2, SymbolicLink: 64 } as const;
+const ViewColumn = {
+	Active: -1,
+	Beside: -2,
+	One: 1,
+	Two: 2,
+	Three: 3,
+	Four: 4,
+} as const;
+const ProgressLocation = {
+	SourceControl: 1,
+	Window: 10,
+	Notification: 15,
+} as const;
+const ConfigurationTarget = {
+	Global: 1,
+	Workspace: 2,
+	WorkspaceFolder: 3,
+} as const;
+const DiagnosticSeverity = {
+	Error: 0,
+	Warning: 1,
+	Information: 2,
+	Hint: 3,
+} as const;
+const FileType = {
+	Unknown: 0,
+	File: 1,
+	Directory: 2,
+	SymbolicLink: 64,
+} as const;
 const EndOfLine = { LF: 1, CRLF: 2 } as const;
 const OverviewRulerLane = { Left: 1, Center: 2, Right: 4, Full: 7 } as const;
 const ExtensionMode = { Production: 1, Development: 2, Test: 3 } as const;
-const TreeItemCollapsibleState = { None: 0, Collapsed: 1, Expanded: 2 } as const;
-const TextEditorRevealType = { Default: 0, InCenter: 1, InCenterIfOutsideViewport: 2, AtTop: 3 } as const;
-const EnvironmentVariableMutatorType = { Replace: 1, Append: 2, Prepend: 3 } as const;
+const TreeItemCollapsibleState = {
+	None: 0,
+	Collapsed: 1,
+	Expanded: 2,
+} as const;
+const TextEditorRevealType = {
+	Default: 0,
+	InCenter: 1,
+	InCenterIfOutsideViewport: 2,
+	AtTop: 3,
+} as const;
+const EnvironmentVariableMutatorType = {
+	Replace: 1,
+	Append: 2,
+	Prepend: 3,
+} as const;
 const UIKind = { Desktop: 1, Web: 2 } as const;
-const LogLevel = { Off: 0, Trace: 1, Debug: 2, Info: 3, Warning: 4, Error: 5 } as const;
+const LogLevel = {
+	Off: 0,
+	Trace: 1,
+	Debug: 2,
+	Info: 3,
+	Warning: 4,
+	Error: 5,
+} as const;
 const ExtensionKind = { UI: 1, Workspace: 2 } as const;
-const ColorThemeKind = { Light: 1, Dark: 2, HighContrast: 3, HighContrastLight: 4 } as const;
-const SymbolKind = { File: 0, Module: 1, Namespace: 2, Package: 3, Class: 4, Method: 5, Property: 6, Field: 7, Constructor: 8, Enum: 9, Interface: 10, Function: 11, Variable: 12, Constant: 13, String: 14, Number: 15, Boolean: 16, Array: 17, Object: 18, Key: 19, Null: 20, EnumMember: 21, Struct: 22, Event: 23, Operator: 24, TypeParameter: 25 } as const;
-const CompletionItemKind = { Text: 0, Method: 1, Function: 2, Constructor: 3, Field: 4, Variable: 5, Class: 6, Interface: 7, Module: 8, Property: 9, Unit: 10, Value: 11, Enum: 12, Keyword: 13, Snippet: 14, Color: 15, File: 16, Reference: 17, Folder: 18, EnumMember: 19, Constant: 20, Struct: 21, Event: 22, Operator: 23, TypeParameter: 24 } as const;
+const ColorThemeKind = {
+	Light: 1,
+	Dark: 2,
+	HighContrast: 3,
+	HighContrastLight: 4,
+} as const;
+const SymbolKind = {
+	File: 0,
+	Module: 1,
+	Namespace: 2,
+	Package: 3,
+	Class: 4,
+	Method: 5,
+	Property: 6,
+	Field: 7,
+	Constructor: 8,
+	Enum: 9,
+	Interface: 10,
+	Function: 11,
+	Variable: 12,
+	Constant: 13,
+	String: 14,
+	Number: 15,
+	Boolean: 16,
+	Array: 17,
+	Object: 18,
+	Key: 19,
+	Null: 20,
+	EnumMember: 21,
+	Struct: 22,
+	Event: 23,
+	Operator: 24,
+	TypeParameter: 25,
+} as const;
+const CompletionItemKind = {
+	Text: 0,
+	Method: 1,
+	Function: 2,
+	Constructor: 3,
+	Field: 4,
+	Variable: 5,
+	Class: 6,
+	Interface: 7,
+	Module: 8,
+	Property: 9,
+	Unit: 10,
+	Value: 11,
+	Enum: 12,
+	Keyword: 13,
+	Snippet: 14,
+	Color: 15,
+	File: 16,
+	Reference: 17,
+	Folder: 18,
+	EnumMember: 19,
+	Constant: 20,
+	Struct: 21,
+	Event: 22,
+	Operator: 23,
+	TypeParameter: 24,
+} as const;
 const TextDocumentChangeReason = { Undo: 1, Redo: 2 } as const;
 
 // Stub classes
@@ -47,18 +148,41 @@ class Position {
 		this.line = line;
 		this.character = character;
 	}
-	isEqual(other: Position): boolean { return this.line === other.line && this.character === other.character; }
-	isBefore(other: Position): boolean { return this.line < other.line || (this.line === other.line && this.character < other.character); }
-	isAfter(other: Position): boolean { return !this.isEqual(other) && !this.isBefore(other); }
-	translate(lineDelta?: number, characterDelta?: number): Position { return new Position(this.line + (lineDelta ?? 0), this.character + (characterDelta ?? 0)); }
-	with(line?: number, character?: number): Position { return new Position(line ?? this.line, character ?? this.character); }
-	compareTo(other: Position): number { return this.line - other.line || this.character - other.character; }
+	isEqual(other: Position): boolean {
+		return this.line === other.line && this.character === other.character;
+	}
+	isBefore(other: Position): boolean {
+		return (
+			this.line < other.line ||
+			(this.line === other.line && this.character < other.character)
+		);
+	}
+	isAfter(other: Position): boolean {
+		return !this.isEqual(other) && !this.isBefore(other);
+	}
+	translate(lineDelta?: number, characterDelta?: number): Position {
+		return new Position(
+			this.line + (lineDelta ?? 0),
+			this.character + (characterDelta ?? 0),
+		);
+	}
+	with(line?: number, character?: number): Position {
+		return new Position(line ?? this.line, character ?? this.character);
+	}
+	compareTo(other: Position): number {
+		return this.line - other.line || this.character - other.character;
+	}
 }
 
 class Range {
 	readonly start: Position;
 	readonly end: Position;
-	constructor(startLine: number | Position, startChar: number | Position, endLine?: number, endChar?: number) {
+	constructor(
+		startLine: number | Position,
+		startChar: number | Position,
+		endLine?: number,
+		endChar?: number,
+	) {
 		if (typeof startLine === "number") {
 			this.start = new Position(startLine, startChar as number);
 			this.end = new Position(endLine!, endChar!);
@@ -67,15 +191,26 @@ class Range {
 			this.end = startChar as Position;
 		}
 	}
-	get isEmpty(): boolean { return this.start.isEqual(this.end); }
-	contains(positionOrRange: Position | Range): boolean { return true; }
-	with(start?: Position, end?: Position): Range { return new Range(start ?? this.start, end ?? this.end); }
+	get isEmpty(): boolean {
+		return this.start.isEqual(this.end);
+	}
+	contains(_positionOrRange: Position | Range): boolean {
+		return true;
+	}
+	with(start?: Position, end?: Position): Range {
+		return new Range(start ?? this.start, end ?? this.end);
+	}
 }
 
 class Selection extends Range {
 	readonly anchor: Position;
 	readonly active: Position;
-	constructor(anchorLine: number | Position, anchorChar: number | Position, activeLine?: number, activeChar?: number) {
+	constructor(
+		anchorLine: number | Position,
+		anchorChar: number | Position,
+		activeLine?: number,
+		activeChar?: number,
+	) {
 		if (typeof anchorLine === "number") {
 			super(anchorLine, anchorChar as number, activeLine!, activeChar!);
 			this.anchor = new Position(anchorLine, anchorChar as number);
@@ -86,12 +221,16 @@ class Selection extends Range {
 			this.active = anchorChar as Position;
 		}
 	}
-	get isReversed(): boolean { return this.anchor.isAfter(this.active); }
+	get isReversed(): boolean {
+		return this.anchor.isAfter(this.active);
+	}
 }
 
 class ThemeColor {
 	readonly id: string;
-	constructor(id: string) { this.id = id; }
+	constructor(id: string) {
+		this.id = id;
+	}
 }
 
 class ThemeIcon {
@@ -99,7 +238,10 @@ class ThemeIcon {
 	static readonly Folder = new ThemeIcon("folder");
 	readonly id: string;
 	readonly color?: ThemeColor;
-	constructor(id: string, color?: ThemeColor) { this.id = id; this.color = color; }
+	constructor(id: string, color?: ThemeColor) {
+		this.id = id;
+		this.color = color;
+	}
 }
 
 class MarkdownString {
@@ -111,46 +253,114 @@ class MarkdownString {
 		this.value = value ?? "";
 		this.supportThemeIcons = supportThemeIcons;
 	}
-	appendText(value: string): MarkdownString { this.value += value; return this; }
-	appendMarkdown(value: string): MarkdownString { this.value += value; return this; }
-	appendCodeblock(code: string, language?: string): MarkdownString { this.value += `\n\`\`\`${language ?? ""}\n${code}\n\`\`\`\n`; return this; }
+	appendText(value: string): MarkdownString {
+		this.value += value;
+		return this;
+	}
+	appendMarkdown(value: string): MarkdownString {
+		this.value += value;
+		return this;
+	}
+	appendCodeblock(code: string, language?: string): MarkdownString {
+		this.value += `\n\`\`\`${language ?? ""}\n${code}\n\`\`\`\n`;
+		return this;
+	}
 }
 
 class WorkspaceEdit {
-	private _edits: Array<{ uri: Uri; edits: Array<{ range: Range; newText: string }> }> = [];
-	replace(uri: Uri, range: Range, newText: string): void { this._edits.push({ uri, edits: [{ range, newText }] }); }
-	insert(uri: Uri, position: Position, newText: string): void { this.replace(uri, new Range(position, position), newText); }
-	delete(uri: Uri, range: Range): void { this.replace(uri, range, ""); }
-	entries(): Array<[Uri, Array<{ range: Range; newText: string }>]> { return this._edits.map((e) => [e.uri, e.edits]); }
+	private _edits: Array<{
+		uri: Uri;
+		edits: Array<{ range: Range; newText: string }>;
+	}> = [];
+	replace(uri: Uri, range: Range, newText: string): void {
+		this._edits.push({ uri, edits: [{ range, newText }] });
+	}
+	insert(uri: Uri, position: Position, newText: string): void {
+		this.replace(uri, new Range(position, position), newText);
+	}
+	delete(uri: Uri, range: Range): void {
+		this.replace(uri, range, "");
+	}
+	entries(): Array<[Uri, Array<{ range: Range; newText: string }>]> {
+		return this._edits.map((e) => [e.uri, e.edits]);
+	}
 }
 
 class CodeLens {
 	readonly range: Range;
 	command?: { title: string; command: string; arguments?: unknown[] };
-	constructor(range: Range, command?: { title: string; command: string; arguments?: unknown[] }) { this.range = range; this.command = command; }
-	get isResolved(): boolean { return !!this.command; }
+	constructor(
+		range: Range,
+		command?: { title: string; command: string; arguments?: unknown[] },
+	) {
+		this.range = range;
+		this.command = command;
+	}
+	get isResolved(): boolean {
+		return !!this.command;
+	}
 }
 
 class TabInputText {
 	readonly uri: Uri;
-	constructor(uri: Uri) { this.uri = uri; }
+	constructor(uri: Uri) {
+		this.uri = uri;
+	}
 }
 
 class NotebookCellOutputItem {
 	readonly mime: string;
 	readonly data: Uint8Array;
-	constructor(data: Uint8Array, mime: string) { this.data = data; this.mime = mime; }
-	static text(value: string, mime?: string): NotebookCellOutputItem { return new NotebookCellOutputItem(new TextEncoder().encode(value), mime ?? "text/plain"); }
-	static json(value: unknown, mime?: string): NotebookCellOutputItem { return new NotebookCellOutputItem(new TextEncoder().encode(JSON.stringify(value)), mime ?? "application/json"); }
-	static stdout(value: string): NotebookCellOutputItem { return NotebookCellOutputItem.text(value, "application/vnd.code.notebook.stdout"); }
-	static stderr(value: string): NotebookCellOutputItem { return NotebookCellOutputItem.text(value, "application/vnd.code.notebook.stderr"); }
-	static error(err: Error): NotebookCellOutputItem { return NotebookCellOutputItem.text(JSON.stringify({ name: err.name, message: err.message, stack: err.stack }), "application/vnd.code.notebook.error"); }
+	constructor(data: Uint8Array, mime: string) {
+		this.data = data;
+		this.mime = mime;
+	}
+	static text(value: string, mime?: string): NotebookCellOutputItem {
+		return new NotebookCellOutputItem(
+			new TextEncoder().encode(value),
+			mime ?? "text/plain",
+		);
+	}
+	static json(value: unknown, mime?: string): NotebookCellOutputItem {
+		return new NotebookCellOutputItem(
+			new TextEncoder().encode(JSON.stringify(value)),
+			mime ?? "application/json",
+		);
+	}
+	static stdout(value: string): NotebookCellOutputItem {
+		return NotebookCellOutputItem.text(
+			value,
+			"application/vnd.code.notebook.stdout",
+		);
+	}
+	static stderr(value: string): NotebookCellOutputItem {
+		return NotebookCellOutputItem.text(
+			value,
+			"application/vnd.code.notebook.stderr",
+		);
+	}
+	static error(err: Error): NotebookCellOutputItem {
+		return NotebookCellOutputItem.text(
+			JSON.stringify({
+				name: err.name,
+				message: err.message,
+				stack: err.stack,
+			}),
+			"application/vnd.code.notebook.error",
+		);
+	}
 }
 
 class NotebookCellOutput {
 	readonly items: NotebookCellOutputItem[];
 	readonly metadata?: Record<string, unknown>;
-	constructor(items: NotebookCellOutputItem[], metadata?: Record<string, unknown>) { this.items = items; this.metadata = metadata; }
+	constructor(
+		items: NotebookCellOutputItem[],
+		metadata?: Record<string, unknown>,
+	) {
+		this.items = items;
+		this.metadata = metadata;
+	}
 }
 
 class NotebookCellKind {
@@ -159,21 +369,35 @@ class NotebookCellKind {
 }
 
 class NotebookEdit {
-	static replaceCells(_range: unknown, _cells: unknown[]): NotebookEdit { return new NotebookEdit(); }
-	static insertCells(_index: number, _cells: unknown[]): NotebookEdit { return new NotebookEdit(); }
-	static deleteCells(_range: unknown): NotebookEdit { return new NotebookEdit(); }
-	static updateCellMetadata(_index: number, _metadata: Record<string, unknown>): NotebookEdit { return new NotebookEdit(); }
+	static replaceCells(_range: unknown, _cells: unknown[]): NotebookEdit {
+		return new NotebookEdit();
+	}
+	static insertCells(_index: number, _cells: unknown[]): NotebookEdit {
+		return new NotebookEdit();
+	}
+	static deleteCells(_range: unknown): NotebookEdit {
+		return new NotebookEdit();
+	}
+	static updateCellMetadata(
+		_index: number,
+		_metadata: Record<string, unknown>,
+	): NotebookEdit {
+		return new NotebookEdit();
+	}
 }
 
 class TabInputTextDiff {
 	readonly original: Uri;
 	readonly modified: Uri;
-	constructor(original: Uri, modified: Uri) { this.original = original; this.modified = modified; }
+	constructor(original: Uri, modified: Uri) {
+		this.original = original;
+		this.modified = modified;
+	}
 }
 
 // Languages namespace (stub)
 const languages = {
-	getDiagnostics(resource?: unknown): unknown[] {
+	getDiagnostics(_resource?: unknown): unknown[] {
 		// Without args: return iterable of [Uri, Diagnostic[]] pairs
 		// With uri arg: return Diagnostic[]
 		return [];
@@ -183,10 +407,18 @@ const languages = {
 		const items = new Map<string, unknown[]>();
 		return {
 			name: _name ?? "",
-			set(uri: Uri, diagnostics: unknown[]) { items.set(uri.toString(), diagnostics); },
-			delete(uri: Uri) { items.delete(uri.toString()); },
-			clear() { items.clear(); },
-			dispose() { items.clear(); },
+			set(uri: Uri, diagnostics: unknown[]) {
+				items.set(uri.toString(), diagnostics);
+			},
+			delete(uri: Uri) {
+				items.delete(uri.toString());
+			},
+			clear() {
+				items.clear();
+			},
+			dispose() {
+				items.clear();
+			},
 		};
 	},
 	registerCodeLensProvider(_selector: unknown, _provider: unknown): Disposable {
@@ -195,16 +427,29 @@ const languages = {
 	registerHoverProvider(_selector: unknown, _provider: unknown): Disposable {
 		return new Disposable(() => {});
 	},
-	registerDefinitionProvider(_selector: unknown, _provider: unknown): Disposable {
+	registerDefinitionProvider(
+		_selector: unknown,
+		_provider: unknown,
+	): Disposable {
 		return new Disposable(() => {});
 	},
-	registerReferenceProvider(_selector: unknown, _provider: unknown): Disposable {
+	registerReferenceProvider(
+		_selector: unknown,
+		_provider: unknown,
+	): Disposable {
 		return new Disposable(() => {});
 	},
-	registerDocumentSymbolProvider(_selector: unknown, _provider: unknown): Disposable {
+	registerDocumentSymbolProvider(
+		_selector: unknown,
+		_provider: unknown,
+	): Disposable {
 		return new Disposable(() => {});
 	},
-	registerCompletionItemProvider(_selector: unknown, _provider: unknown, ..._triggerCharacters: string[]): Disposable {
+	registerCompletionItemProvider(
+		_selector: unknown,
+		_provider: unknown,
+		..._triggerCharacters: string[]
+	): Disposable {
 		return new Disposable(() => {});
 	},
 };
@@ -225,15 +470,21 @@ const env = {
 	appHost: "superset-desktop",
 	language: "en",
 	clipboard: {
-		async readText(): Promise<string> { return ""; },
+		async readText(): Promise<string> {
+			return "";
+		},
 		async writeText(_text: string): Promise<void> {},
 	},
 	machineId: "superset-desktop",
 	sessionId: `session-${Date.now()}`,
 	uriScheme: "vscode",
 	shell: process.env.SHELL ?? "/bin/zsh",
-	get uiKind() { return UIKind.Desktop; },
-	get logLevel() { return LogLevel.Info; },
+	get uiKind() {
+		return UIKind.Desktop;
+	},
+	get logLevel() {
+		return LogLevel.Info;
+	},
 	onDidChangeLogLevel: new EventEmitter<number>().event,
 	remoteName: undefined as string | undefined,
 	isNewAppInstall: false,
@@ -261,10 +512,19 @@ const env = {
 
 // Authentication namespace
 const authentication = {
-	getSession(_providerId: string, _scopes: string[], _options?: unknown): Promise<unknown> {
+	getSession(
+		_providerId: string,
+		_scopes: string[],
+		_options?: unknown,
+	): Promise<unknown> {
 		return Promise.resolve(undefined);
 	},
-	registerAuthenticationProvider(_id: string, _label: string, _provider: unknown, _options?: unknown): Disposable {
+	registerAuthenticationProvider(
+		_id: string,
+		_label: string,
+		_provider: unknown,
+		_options?: unknown,
+	): Disposable {
 		return new Disposable(() => {});
 	},
 	onDidChangeSessions: new EventEmitter<unknown>().event,
@@ -351,7 +611,9 @@ export function createVscodeApi(): Record<string, unknown> {
 	return new Proxy(api, {
 		get(target, prop, receiver) {
 			if (typeof prop === "string" && !(prop in target)) {
-				console.warn(`[vscode-shim] Unimplemented API accessed: vscode.${prop}`);
+				console.warn(
+					`[vscode-shim] Unimplemented API accessed: vscode.${prop}`,
+				);
 				return undefined;
 			}
 			return Reflect.get(target, prop, receiver);

--- a/apps/desktop/src/main/lib/vscode-shim/vscode-api.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/vscode-api.ts
@@ -482,7 +482,7 @@ const extensions = {
 // Env namespace
 const env = {
 	appName: "Visual Studio Code",
-	appRoot: "",
+	appRoot: process.cwd(),
 	appHost: "superset-desktop",
 	language: "en",
 	clipboard: {

--- a/apps/desktop/src/main/lib/vscode-shim/vscode-api.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/vscode-api.ts
@@ -456,7 +456,22 @@ const languages = {
 
 // Extensions namespace
 const extensions = {
-	getExtension(_extensionId: string): unknown {
+	getExtension(extensionId: string): unknown {
+		try {
+			const { getLoadedExtension } =
+				require("./loader") as typeof import("./loader");
+			const loaded = getLoadedExtension(extensionId);
+			if (loaded) {
+				return {
+					id: loaded.info.id,
+					extensionPath: loaded.info.extensionPath,
+					extensionUri: Uri.file(loaded.info.extensionPath),
+					isActive: loaded.info.isActive,
+					packageJSON: loaded.info.manifest,
+					exports: loaded.exports,
+				};
+			}
+		} catch {}
 		return undefined;
 	},
 	all: [] as unknown[],
@@ -544,6 +559,10 @@ export function createVscodeApi(): Record<string, unknown> {
 	const api: Record<string, unknown> = {
 		// Module interop flags
 		__esModule: true,
+
+		// VS Code version (extensions check this for feature availability)
+		version: "1.96.0",
+
 		// Namespaces
 		commands,
 		workspace,

--- a/apps/desktop/src/main/lib/vscode-shim/vscode-api.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/vscode-api.ts
@@ -7,6 +7,7 @@
  */
 
 import { commands } from "./api/commands";
+import { shimWarn } from "./api/debug-log";
 import {
 	CancellationTokenSource,
 	Disposable,
@@ -630,9 +631,7 @@ export function createVscodeApi(): Record<string, unknown> {
 	return new Proxy(api, {
 		get(target, prop, receiver) {
 			if (typeof prop === "string" && !(prop in target)) {
-				console.warn(
-					`[vscode-shim] Unimplemented API accessed: vscode.${prop}`,
-				);
+				shimWarn(`[vscode-shim] Unimplemented API accessed: vscode.${prop}`);
 				return undefined;
 			}
 			return Reflect.get(target, prop, receiver);

--- a/apps/desktop/src/main/lib/vscode-shim/vscode-api.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/vscode-api.ts
@@ -6,15 +6,15 @@
  * discover which APIs extensions actually use at runtime.
  */
 
-import { commands } from "./api/commands.js";
+import { commands } from "./api/commands";
 import {
 	CancellationTokenSource,
 	Disposable,
 	EventEmitter,
-} from "./api/event-emitter.js";
-import { Uri } from "./api/uri.js";
-import { window } from "./api/window.js";
-import { workspace } from "./api/workspace.js";
+} from "./api/event-emitter";
+import { Uri } from "./api/uri";
+import { window } from "./api/window";
+import { workspace } from "./api/workspace";
 
 // VS Code enums
 const StatusBarAlignment = { Left: 1, Right: 2 } as const;

--- a/apps/desktop/src/main/lib/vscode-shim/vscode-api.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/vscode-api.ts
@@ -1,0 +1,345 @@
+/**
+ * Factory that creates a `vscode` module-like namespace object.
+ * Extensions receive this when they `require('vscode')`.
+ *
+ * Unimplemented API accesses are logged via Proxy so we can
+ * discover which APIs extensions actually use at runtime.
+ */
+
+import { commands } from "./api/commands.js";
+import {
+	Disposable,
+	EventEmitter,
+	CancellationTokenSource,
+	type CancellationToken,
+} from "./api/event-emitter.js";
+import { Uri } from "./api/uri.js";
+import { workspace } from "./api/workspace.js";
+import { window } from "./api/window.js";
+import type { VscodeExtensionContext } from "./api/extension-context.js";
+
+// VS Code enums
+const StatusBarAlignment = { Left: 1, Right: 2 } as const;
+const ViewColumn = { Active: -1, Beside: -2, One: 1, Two: 2, Three: 3, Four: 4 } as const;
+const ProgressLocation = { SourceControl: 1, Window: 10, Notification: 15 } as const;
+const ConfigurationTarget = { Global: 1, Workspace: 2, WorkspaceFolder: 3 } as const;
+const DiagnosticSeverity = { Error: 0, Warning: 1, Information: 2, Hint: 3 } as const;
+const FileType = { Unknown: 0, File: 1, Directory: 2, SymbolicLink: 64 } as const;
+const EndOfLine = { LF: 1, CRLF: 2 } as const;
+const OverviewRulerLane = { Left: 1, Center: 2, Right: 4, Full: 7 } as const;
+const ExtensionMode = { Production: 1, Development: 2, Test: 3 } as const;
+const TreeItemCollapsibleState = { None: 0, Collapsed: 1, Expanded: 2 } as const;
+const TextEditorRevealType = { Default: 0, InCenter: 1, InCenterIfOutsideViewport: 2, AtTop: 3 } as const;
+const EnvironmentVariableMutatorType = { Replace: 1, Append: 2, Prepend: 3 } as const;
+const UIKind = { Desktop: 1, Web: 2 } as const;
+const LogLevel = { Off: 0, Trace: 1, Debug: 2, Info: 3, Warning: 4, Error: 5 } as const;
+const ExtensionKind = { UI: 1, Workspace: 2 } as const;
+const ColorThemeKind = { Light: 1, Dark: 2, HighContrast: 3, HighContrastLight: 4 } as const;
+const SymbolKind = { File: 0, Module: 1, Namespace: 2, Package: 3, Class: 4, Method: 5, Property: 6, Field: 7, Constructor: 8, Enum: 9, Interface: 10, Function: 11, Variable: 12, Constant: 13, String: 14, Number: 15, Boolean: 16, Array: 17, Object: 18, Key: 19, Null: 20, EnumMember: 21, Struct: 22, Event: 23, Operator: 24, TypeParameter: 25 } as const;
+const CompletionItemKind = { Text: 0, Method: 1, Function: 2, Constructor: 3, Field: 4, Variable: 5, Class: 6, Interface: 7, Module: 8, Property: 9, Unit: 10, Value: 11, Enum: 12, Keyword: 13, Snippet: 14, Color: 15, File: 16, Reference: 17, Folder: 18, EnumMember: 19, Constant: 20, Struct: 21, Event: 22, Operator: 23, TypeParameter: 24 } as const;
+const TextDocumentChangeReason = { Undo: 1, Redo: 2 } as const;
+
+// Stub classes
+class Position {
+	readonly line: number;
+	readonly character: number;
+	constructor(line: number, character: number) {
+		this.line = line;
+		this.character = character;
+	}
+	isEqual(other: Position): boolean { return this.line === other.line && this.character === other.character; }
+	isBefore(other: Position): boolean { return this.line < other.line || (this.line === other.line && this.character < other.character); }
+	isAfter(other: Position): boolean { return !this.isEqual(other) && !this.isBefore(other); }
+	translate(lineDelta?: number, characterDelta?: number): Position { return new Position(this.line + (lineDelta ?? 0), this.character + (characterDelta ?? 0)); }
+	with(line?: number, character?: number): Position { return new Position(line ?? this.line, character ?? this.character); }
+	compareTo(other: Position): number { return this.line - other.line || this.character - other.character; }
+}
+
+class Range {
+	readonly start: Position;
+	readonly end: Position;
+	constructor(startLine: number | Position, startChar: number | Position, endLine?: number, endChar?: number) {
+		if (typeof startLine === "number") {
+			this.start = new Position(startLine, startChar as number);
+			this.end = new Position(endLine!, endChar!);
+		} else {
+			this.start = startLine;
+			this.end = startChar as Position;
+		}
+	}
+	get isEmpty(): boolean { return this.start.isEqual(this.end); }
+	contains(positionOrRange: Position | Range): boolean { return true; }
+	with(start?: Position, end?: Position): Range { return new Range(start ?? this.start, end ?? this.end); }
+}
+
+class Selection extends Range {
+	readonly anchor: Position;
+	readonly active: Position;
+	constructor(anchorLine: number | Position, anchorChar: number | Position, activeLine?: number, activeChar?: number) {
+		if (typeof anchorLine === "number") {
+			super(anchorLine, anchorChar as number, activeLine!, activeChar!);
+			this.anchor = new Position(anchorLine, anchorChar as number);
+			this.active = new Position(activeLine!, activeChar!);
+		} else {
+			super(anchorLine, anchorChar as Position);
+			this.anchor = anchorLine;
+			this.active = anchorChar as Position;
+		}
+	}
+	get isReversed(): boolean { return this.anchor.isAfter(this.active); }
+}
+
+class ThemeColor {
+	readonly id: string;
+	constructor(id: string) { this.id = id; }
+}
+
+class ThemeIcon {
+	static readonly File = new ThemeIcon("file");
+	static readonly Folder = new ThemeIcon("folder");
+	readonly id: string;
+	readonly color?: ThemeColor;
+	constructor(id: string, color?: ThemeColor) { this.id = id; this.color = color; }
+}
+
+class MarkdownString {
+	value: string;
+	isTrusted?: boolean;
+	supportThemeIcons?: boolean;
+	supportHtml?: boolean;
+	constructor(value?: string, supportThemeIcons?: boolean) {
+		this.value = value ?? "";
+		this.supportThemeIcons = supportThemeIcons;
+	}
+	appendText(value: string): MarkdownString { this.value += value; return this; }
+	appendMarkdown(value: string): MarkdownString { this.value += value; return this; }
+	appendCodeblock(code: string, language?: string): MarkdownString { this.value += `\n\`\`\`${language ?? ""}\n${code}\n\`\`\`\n`; return this; }
+}
+
+class WorkspaceEdit {
+	private _edits: Array<{ uri: Uri; edits: Array<{ range: Range; newText: string }> }> = [];
+	replace(uri: Uri, range: Range, newText: string): void { this._edits.push({ uri, edits: [{ range, newText }] }); }
+	insert(uri: Uri, position: Position, newText: string): void { this.replace(uri, new Range(position, position), newText); }
+	delete(uri: Uri, range: Range): void { this.replace(uri, range, ""); }
+	entries(): Array<[Uri, Array<{ range: Range; newText: string }>]> { return this._edits.map((e) => [e.uri, e.edits]); }
+}
+
+class CodeLens {
+	readonly range: Range;
+	command?: { title: string; command: string; arguments?: unknown[] };
+	constructor(range: Range, command?: { title: string; command: string; arguments?: unknown[] }) { this.range = range; this.command = command; }
+	get isResolved(): boolean { return !!this.command; }
+}
+
+class TabInputText {
+	readonly uri: Uri;
+	constructor(uri: Uri) { this.uri = uri; }
+}
+
+class NotebookCellOutputItem {
+	readonly mime: string;
+	readonly data: Uint8Array;
+	constructor(data: Uint8Array, mime: string) { this.data = data; this.mime = mime; }
+	static text(value: string, mime?: string): NotebookCellOutputItem { return new NotebookCellOutputItem(new TextEncoder().encode(value), mime ?? "text/plain"); }
+	static json(value: unknown, mime?: string): NotebookCellOutputItem { return new NotebookCellOutputItem(new TextEncoder().encode(JSON.stringify(value)), mime ?? "application/json"); }
+	static stdout(value: string): NotebookCellOutputItem { return NotebookCellOutputItem.text(value, "application/vnd.code.notebook.stdout"); }
+	static stderr(value: string): NotebookCellOutputItem { return NotebookCellOutputItem.text(value, "application/vnd.code.notebook.stderr"); }
+	static error(err: Error): NotebookCellOutputItem { return NotebookCellOutputItem.text(JSON.stringify({ name: err.name, message: err.message, stack: err.stack }), "application/vnd.code.notebook.error"); }
+}
+
+class NotebookCellOutput {
+	readonly items: NotebookCellOutputItem[];
+	readonly metadata?: Record<string, unknown>;
+	constructor(items: NotebookCellOutputItem[], metadata?: Record<string, unknown>) { this.items = items; this.metadata = metadata; }
+}
+
+class NotebookCellKind {
+	static readonly Markup = 1;
+	static readonly Code = 2;
+}
+
+class NotebookEdit {
+	static replaceCells(_range: unknown, _cells: unknown[]): NotebookEdit { return new NotebookEdit(); }
+	static insertCells(_index: number, _cells: unknown[]): NotebookEdit { return new NotebookEdit(); }
+	static deleteCells(_range: unknown): NotebookEdit { return new NotebookEdit(); }
+	static updateCellMetadata(_index: number, _metadata: Record<string, unknown>): NotebookEdit { return new NotebookEdit(); }
+}
+
+class TabInputTextDiff {
+	readonly original: Uri;
+	readonly modified: Uri;
+	constructor(original: Uri, modified: Uri) { this.original = original; this.modified = modified; }
+}
+
+// Languages namespace (stub)
+const languages = {
+	getDiagnostics(resource?: Uri): unknown[] {
+		// When called without args, ChatGPT expects iterable of [Uri, Diagnostic[]]
+		if (!resource) return [];
+		return [];
+	},
+	onDidChangeDiagnostics: new EventEmitter<unknown>().event,
+	createDiagnosticCollection(_name?: string) {
+		const items = new Map<string, unknown[]>();
+		return {
+			name: _name ?? "",
+			set(uri: Uri, diagnostics: unknown[]) { items.set(uri.toString(), diagnostics); },
+			delete(uri: Uri) { items.delete(uri.toString()); },
+			clear() { items.clear(); },
+			dispose() { items.clear(); },
+		};
+	},
+	registerCodeLensProvider(_selector: unknown, _provider: unknown): Disposable {
+		return new Disposable(() => {});
+	},
+};
+
+// Extensions namespace
+const extensions = {
+	getExtension(_extensionId: string): unknown {
+		return undefined;
+	},
+	all: [] as unknown[],
+	onDidChange: new EventEmitter<void>().event,
+};
+
+// Env namespace
+const env = {
+	appName: "Visual Studio Code",
+	appRoot: "",
+	appHost: "superset-desktop",
+	language: "en",
+	clipboard: {
+		async readText(): Promise<string> { return ""; },
+		async writeText(_text: string): Promise<void> {},
+	},
+	machineId: "superset-desktop",
+	sessionId: `session-${Date.now()}`,
+	uriScheme: "vscode",
+	shell: process.env.SHELL ?? "/bin/zsh",
+	get uiKind() { return UIKind.Desktop; },
+	get logLevel() { return LogLevel.Info; },
+	onDidChangeLogLevel: new EventEmitter<number>().event,
+	remoteName: undefined as string | undefined,
+	isNewAppInstall: false,
+	isTelemetryEnabled: false,
+	onDidChangeTelemetryEnabled: new EventEmitter<boolean>().event,
+	createTelemetryLogger(_sender: unknown, _options?: unknown) {
+		return {
+			logUsage() {},
+			logError() {},
+			dispose() {},
+			onDidChangeEnableStates: new EventEmitter<unknown>().event,
+		};
+	},
+	async openExternal(_target: Uri): Promise<boolean> {
+		try {
+			const { shell } = require("electron");
+			shell.openExternal(_target.toString());
+		} catch {}
+		return true;
+	},
+	async asExternalUri(uri: Uri): Promise<Uri> {
+		return uri;
+	},
+};
+
+// Authentication namespace
+const authentication = {
+	getSession(_providerId: string, _scopes: string[], _options?: unknown): Promise<unknown> {
+		return Promise.resolve(undefined);
+	},
+	registerAuthenticationProvider(_id: string, _label: string, _provider: unknown, _options?: unknown): Disposable {
+		return new Disposable(() => {});
+	},
+	onDidChangeSessions: new EventEmitter<unknown>().event,
+};
+
+// l10n namespace
+const l10n = {
+	t(message: string, ..._args: unknown[]): string {
+		return message;
+	},
+	bundle: undefined as unknown,
+	uri: undefined as unknown,
+};
+
+// Build the vscode namespace
+export function createVscodeApi(): Record<string, unknown> {
+	const api: Record<string, unknown> = {
+		// Module interop flags
+		__esModule: true,
+		// Namespaces
+		commands,
+		workspace,
+		window,
+		languages,
+		extensions,
+		env,
+		authentication,
+		l10n,
+
+		// Proposed API stubs
+		chat: {
+			registerChatSessionItemProvider(_id: string, _provider: unknown) {
+				return new Disposable(() => {});
+			},
+		},
+		lm: {
+			getModelProxy: undefined,
+			isModelProxyAvailable: false,
+		},
+
+		// Classes
+		Uri,
+		Position,
+		Range,
+		Selection,
+		Disposable,
+		EventEmitter,
+		CancellationTokenSource,
+		ThemeColor,
+		ThemeIcon,
+		MarkdownString,
+		WorkspaceEdit,
+		TabInputText,
+		TabInputTextDiff,
+		NotebookCellOutputItem,
+		NotebookCellOutput,
+		NotebookCellKind,
+		NotebookEdit,
+		CodeLens,
+
+		// Enums
+		StatusBarAlignment,
+		ViewColumn,
+		ProgressLocation,
+		ConfigurationTarget,
+		DiagnosticSeverity,
+		FileType,
+		EndOfLine,
+		OverviewRulerLane,
+		ExtensionMode,
+		TreeItemCollapsibleState,
+		TextEditorRevealType,
+		EnvironmentVariableMutatorType,
+		UIKind,
+		LogLevel,
+		ExtensionKind,
+		ColorThemeKind,
+		SymbolKind,
+		CompletionItemKind,
+		TextDocumentChangeReason,
+	};
+
+	// Proxy logger: log access to unimplemented APIs
+	return new Proxy(api, {
+		get(target, prop, receiver) {
+			if (typeof prop === "string" && !(prop in target)) {
+				console.warn(`[vscode-shim] Unimplemented API accessed: vscode.${prop}`);
+				return undefined;
+			}
+			return Reflect.get(target, prop, receiver);
+		},
+	});
+}

--- a/apps/desktop/src/main/lib/vscode-shim/webview-bridge.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/webview-bridge.ts
@@ -29,10 +29,15 @@ class WebviewBridge extends EventEmitter {
 		super();
 		// Listen for events from the webview shim
 		onWebviewEvent((event: WebviewEvent) => {
+			console.log(
+				`[webview-bridge] Event: type=${event.type}, viewId=${event.viewId}, dataLen=${typeof event.data === "string" ? event.data.length : "N/A"}`,
+			);
 			if (event.type === "html") {
 				this._viewHtml.set(event.viewId, event.data as string);
-				// Also update protocol handler store so iframe can reload
 				setWebviewHtml(event.viewId, event.data as string);
+				console.log(
+					`[webview-bridge] Stored HTML for ${event.viewId}, htmlStore now has ${this._viewHtml.size} entries`,
+				);
 			}
 			this.emit("webview-event", event);
 		});

--- a/apps/desktop/src/main/lib/vscode-shim/webview-bridge.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/webview-bridge.ts
@@ -7,9 +7,9 @@
 
 import { EventEmitter } from "node:events";
 import {
+	getActiveView,
 	onWebviewEvent,
 	resolveWebviewView,
-	getActiveView,
 	type WebviewEvent,
 	type WebviewInternal,
 } from "./api/webview.js";
@@ -76,10 +76,15 @@ class WebviewBridge extends EventEmitter {
 	}
 
 	/** Subscribe to messages from extension to webview (postMessage calls) */
-	subscribeToExtensionMessages(viewId: string, callback: (message: unknown) => void): () => void {
+	subscribeToExtensionMessages(
+		viewId: string,
+		callback: (message: unknown) => void,
+	): () => void {
 		const view = getActiveView(viewId);
 		if (!view) return () => {};
-		const disposable = (view.webview as WebviewInternal)._onDidPostMessage.event(callback);
+		const disposable = (
+			view.webview as WebviewInternal
+		)._onDidPostMessage.event(callback);
 		return () => disposable.dispose();
 	}
 }

--- a/apps/desktop/src/main/lib/vscode-shim/webview-bridge.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/webview-bridge.ts
@@ -37,8 +37,12 @@ class WebviewBridge extends EventEmitter {
 
 	/** Resolve a webview view (called when renderer requests a sidebar view) */
 	resolveView(viewType: string, extensionPath: string): string | undefined {
+		console.log(`[vscode-shim] WebviewBridge.resolveView called: ${viewType}`);
 		const result = resolveWebviewView(viewType, extensionPath);
-		if (!result) return undefined;
+		if (!result) {
+			console.warn(`[vscode-shim] WebviewBridge.resolveView: no result for ${viewType}`);
+			return undefined;
+		}
 
 		const { viewId } = result;
 		this._viewIds.set(viewType, viewId);

--- a/apps/desktop/src/main/lib/vscode-shim/webview-bridge.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/webview-bridge.ts
@@ -6,6 +6,7 @@
  */
 
 import { EventEmitter } from "node:events";
+import { setWebviewHtml } from "./api/protocol-handler";
 import {
 	getActiveView,
 	onWebviewEvent,
@@ -30,6 +31,8 @@ class WebviewBridge extends EventEmitter {
 		onWebviewEvent((event: WebviewEvent) => {
 			if (event.type === "html") {
 				this._viewHtml.set(event.viewId, event.data as string);
+				// Also update protocol handler store so iframe can reload
+				setWebviewHtml(event.viewId, event.data as string);
 			}
 			this.emit("webview-event", event);
 		});
@@ -40,7 +43,9 @@ class WebviewBridge extends EventEmitter {
 		console.log(`[vscode-shim] WebviewBridge.resolveView called: ${viewType}`);
 		const result = resolveWebviewView(viewType, extensionPath);
 		if (!result) {
-			console.warn(`[vscode-shim] WebviewBridge.resolveView: no result for ${viewType}`);
+			console.warn(
+				`[vscode-shim] WebviewBridge.resolveView: no result for ${viewType}`,
+			);
 			return undefined;
 		}
 

--- a/apps/desktop/src/main/lib/vscode-shim/webview-bridge.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/webview-bridge.ts
@@ -14,7 +14,7 @@ import {
 	type WebviewEvent,
 	type WebviewInternal,
 } from "./api/webview";
-import { setWebviewHtml } from "./api/webview-server";
+import { clearWebviewHtml, setWebviewHtml } from "./api/webview-server";
 
 export interface WebviewBridgeEvent {
 	type: "html" | "message" | "title" | "dispose" | "panel-created";
@@ -39,6 +39,17 @@ class WebviewBridge extends EventEmitter {
 				shimLog(
 					`[webview-bridge] Stored HTML for ${event.viewId}, htmlStore now has ${this._viewHtml.size} entries`,
 				);
+			}
+			if (event.type === "dispose") {
+				this._viewHtml.delete(event.viewId);
+				clearWebviewHtml(event.viewId);
+				// Remove from viewType→viewId map
+				for (const [vt, vid] of this._viewIds) {
+					if (vid === event.viewId) {
+						this._viewIds.delete(vt);
+						break;
+					}
+				}
 			}
 			this.emit("webview-event", event);
 		});

--- a/apps/desktop/src/main/lib/vscode-shim/webview-bridge.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/webview-bridge.ts
@@ -6,6 +6,7 @@
  */
 
 import { EventEmitter } from "node:events";
+import { shimLog, shimWarn } from "./api/debug-log";
 import {
 	getActiveView,
 	onWebviewEvent,
@@ -29,13 +30,13 @@ class WebviewBridge extends EventEmitter {
 		super();
 		// Listen for events from the webview shim
 		onWebviewEvent((event: WebviewEvent) => {
-			console.log(
+			shimLog(
 				`[webview-bridge] Event: type=${event.type}, viewId=${event.viewId}, dataLen=${typeof event.data === "string" ? event.data.length : "N/A"}`,
 			);
 			if (event.type === "html") {
 				this._viewHtml.set(event.viewId, event.data as string);
 				setWebviewHtml(event.viewId, event.data as string);
-				console.log(
+				shimLog(
 					`[webview-bridge] Stored HTML for ${event.viewId}, htmlStore now has ${this._viewHtml.size} entries`,
 				);
 			}
@@ -45,10 +46,10 @@ class WebviewBridge extends EventEmitter {
 
 	/** Resolve a webview view (called when renderer requests a sidebar view) */
 	resolveView(viewType: string, extensionPath: string): string | undefined {
-		console.log(`[vscode-shim] WebviewBridge.resolveView called: ${viewType}`);
+		shimLog(`[vscode-shim] WebviewBridge.resolveView called: ${viewType}`);
 		const result = resolveWebviewView(viewType, extensionPath);
 		if (!result) {
-			console.warn(
+			shimWarn(
 				`[vscode-shim] WebviewBridge.resolveView: no result for ${viewType}`,
 			);
 			return undefined;

--- a/apps/desktop/src/main/lib/vscode-shim/webview-bridge.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/webview-bridge.ts
@@ -1,0 +1,87 @@
+/**
+ * Webview bridge: manages communication between VS Code extension webviews
+ * and the Superset Desktop renderer process via an EventEmitter.
+ *
+ * The tRPC router subscribes to these events and forwards them to the renderer.
+ */
+
+import { EventEmitter } from "node:events";
+import {
+	onWebviewEvent,
+	resolveWebviewView,
+	getActiveView,
+	type WebviewEvent,
+	type WebviewInternal,
+} from "./api/webview.js";
+
+export interface WebviewBridgeEvent {
+	type: "html" | "message" | "title" | "dispose";
+	viewId: string;
+	data: unknown;
+}
+
+class WebviewBridge extends EventEmitter {
+	private _viewHtml = new Map<string, string>();
+	private _viewIds = new Map<string, string>(); // viewType -> viewId
+
+	constructor() {
+		super();
+		// Listen for events from the webview shim
+		onWebviewEvent((event: WebviewEvent) => {
+			if (event.type === "html") {
+				this._viewHtml.set(event.viewId, event.data as string);
+			}
+			this.emit("webview-event", event);
+		});
+	}
+
+	/** Resolve a webview view (called when renderer requests a sidebar view) */
+	resolveView(viewType: string, extensionPath: string): string | undefined {
+		const view = resolveWebviewView(viewType, extensionPath);
+		if (!view) return undefined;
+
+		// The viewId is set via onWebviewEvent "html" event, extract from stored data
+		// Find the latest viewId matching this viewType
+		for (const [vid] of this._viewHtml) {
+			if (vid.startsWith(`view:${viewType}:`)) {
+				this._viewIds.set(viewType, vid);
+				return vid;
+			}
+		}
+
+		return undefined;
+	}
+
+	/** Get current HTML for a view */
+	getHtml(viewId: string): string | undefined {
+		return this._viewHtml.get(viewId);
+	}
+
+	/** Get all registered view types */
+	getViewTypes(): string[] {
+		return [...this._viewIds.keys()];
+	}
+
+	/** Get viewId for a viewType */
+	getViewId(viewType: string): string | undefined {
+		return this._viewIds.get(viewType);
+	}
+
+	/** Send message from renderer to extension webview */
+	postMessageToExtension(viewId: string, message: unknown): void {
+		const view = getActiveView(viewId);
+		if (view) {
+			(view.webview as WebviewInternal)._onDidReceiveMessage.fire(message);
+		}
+	}
+
+	/** Subscribe to messages from extension to webview (postMessage calls) */
+	subscribeToExtensionMessages(viewId: string, callback: (message: unknown) => void): () => void {
+		const view = getActiveView(viewId);
+		if (!view) return () => {};
+		const disposable = (view.webview as WebviewInternal)._onDidPostMessage.event(callback);
+		return () => disposable.dispose();
+	}
+}
+
+export const webviewBridge = new WebviewBridge();

--- a/apps/desktop/src/main/lib/vscode-shim/webview-bridge.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/webview-bridge.ts
@@ -6,7 +6,6 @@
  */
 
 import { EventEmitter } from "node:events";
-import { setWebviewHtml } from "./api/protocol-handler";
 import {
 	getActiveView,
 	onWebviewEvent,
@@ -14,6 +13,7 @@ import {
 	type WebviewEvent,
 	type WebviewInternal,
 } from "./api/webview";
+import { setWebviewHtml } from "./api/webview-server";
 
 export interface WebviewBridgeEvent {
 	type: "html" | "message" | "title" | "dispose";

--- a/apps/desktop/src/main/lib/vscode-shim/webview-bridge.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/webview-bridge.ts
@@ -37,19 +37,12 @@ class WebviewBridge extends EventEmitter {
 
 	/** Resolve a webview view (called when renderer requests a sidebar view) */
 	resolveView(viewType: string, extensionPath: string): string | undefined {
-		const view = resolveWebviewView(viewType, extensionPath);
-		if (!view) return undefined;
+		const result = resolveWebviewView(viewType, extensionPath);
+		if (!result) return undefined;
 
-		// The viewId is set via onWebviewEvent "html" event, extract from stored data
-		// Find the latest viewId matching this viewType
-		for (const [vid] of this._viewHtml) {
-			if (vid.startsWith(`view:${viewType}:`)) {
-				this._viewIds.set(viewType, vid);
-				return vid;
-			}
-		}
-
-		return undefined;
+		const { viewId } = result;
+		this._viewIds.set(viewType, viewId);
+		return viewId;
 	}
 
 	/** Get current HTML for a view */

--- a/apps/desktop/src/main/lib/vscode-shim/webview-bridge.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/webview-bridge.ts
@@ -17,7 +17,7 @@ import {
 import { setWebviewHtml } from "./api/webview-server";
 
 export interface WebviewBridgeEvent {
-	type: "html" | "message" | "title" | "dispose";
+	type: "html" | "message" | "title" | "dispose" | "panel-created";
 	viewId: string;
 	data: unknown;
 }

--- a/apps/desktop/src/main/lib/vscode-shim/webview-bridge.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/webview-bridge.ts
@@ -12,7 +12,7 @@ import {
 	resolveWebviewView,
 	type WebviewEvent,
 	type WebviewInternal,
-} from "./api/webview.js";
+} from "./api/webview";
 
 export interface WebviewBridgeEvent {
 	type: "html" | "message" | "title" | "dispose";

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/components/SettingsSidebar/GeneralSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/components/SettingsSidebar/GeneralSettings.tsx
@@ -37,6 +37,7 @@ type SettingsRoute =
 	| "/settings/models"
 	| "/settings/integrations"
 	| "/settings/extensions"
+	| "/settings/vscode-extensions"
 	| "/settings/billing"
 	| "/settings/api-keys"
 	| "/settings/permissions";
@@ -128,6 +129,12 @@ const SECTION_GROUPS: SectionGroup[] = [
 				section: "extensions",
 				label: "Extensions",
 				icon: <HiOutlineSquare3Stack3D className="h-4 w-4" />,
+			},
+			{
+				id: "/settings/vscode-extensions",
+				section: "vscodeExtensions",
+				label: "VS Code Extensions",
+				icon: <HiOutlinePuzzlePiece className="h-4 w-4" />,
 			},
 		],
 	},

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/layout.tsx
@@ -33,6 +33,7 @@ const SECTION_ORDER: SettingsSection[] = [
 	"terminal",
 	"models",
 	"extensions",
+	"vscodeExtensions",
 	"organization",
 	"integrations",
 	"billing",
@@ -52,6 +53,8 @@ function getSectionFromPath(pathname: string): SettingsSection | null {
 	if (pathname.includes("/settings/terminal")) return "terminal";
 	if (pathname.includes("/settings/models")) return "models";
 	if (pathname.includes("/settings/integrations")) return "integrations";
+	if (pathname.includes("/settings/vscode-extensions"))
+		return "vscodeExtensions";
 	if (pathname.includes("/settings/extensions")) return "extensions";
 	if (pathname.includes("/settings/permissions")) return "permissions";
 	if (pathname.includes("/settings/project")) return "project";
@@ -84,6 +87,8 @@ function getPathFromSection(section: SettingsSection): string {
 			return "/settings/integrations";
 		case "extensions":
 			return "/settings/extensions";
+		case "vscodeExtensions":
+			return "/settings/vscode-extensions";
 		case "permissions":
 			return "/settings/permissions";
 		default:

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/utils/settings-search/settings-search.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/utils/settings-search/settings-search.ts
@@ -68,6 +68,8 @@ export const SETTING_ITEM_ID = {
 
 	EXTENSIONS_BROWSER: "extensions-browser",
 
+	VSCODE_EXTENSIONS_MANAGE: "vscode-extensions-manage",
+
 	PERMISSIONS_FULL_DISK_ACCESS: "permissions-full-disk-access",
 	PERMISSIONS_ACCESSIBILITY: "permissions-accessibility",
 	PERMISSIONS_MICROPHONE: "permissions-microphone",
@@ -983,6 +985,24 @@ export const SETTINGS_ITEMS: SettingsItem[] = [
 			"plugin",
 			"install",
 			"crx",
+		],
+	},
+	{
+		id: SETTING_ITEM_ID.VSCODE_EXTENSIONS_MANAGE,
+		section: "vscodeExtensions",
+		title: "VS Code Extensions",
+		description:
+			"Manage VS Code extensions like Claude Code and ChatGPT running inside Superset",
+		keywords: [
+			"vscode",
+			"vs code",
+			"extension",
+			"claude",
+			"chatgpt",
+			"codex",
+			"ai",
+			"install",
+			"manage",
 		],
 	},
 	{

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/vscode-extensions/components/VscodeExtensionsSettings/VscodeExtensionsSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/vscode-extensions/components/VscodeExtensionsSettings/VscodeExtensionsSettings.tsx
@@ -1,4 +1,6 @@
 import { Button } from "@superset/ui/button";
+import { Switch } from "@superset/ui/switch";
+import { useState } from "react";
 import { LuBot, LuDownload, LuRefreshCw, LuSparkles } from "react-icons/lu";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import {
@@ -26,6 +28,7 @@ export function VscodeExtensionsSettings({
 		SETTING_ITEM_ID.VSCODE_EXTENSIONS_MANAGE,
 		visibleItems,
 	);
+	const [pendingRestart, setPendingRestart] = useState(false);
 
 	const { data: extensions, isLoading } =
 		electronTrpc.vscodeExtensions.getKnownExtensions.useQuery();
@@ -43,6 +46,13 @@ export function VscodeExtensionsSettings({
 				utils.vscodeExtensions.getKnownExtensions.invalidate();
 			},
 		});
+	const enabledMutation =
+		electronTrpc.vscodeExtensions.setExtensionEnabled.useMutation({
+			onSuccess: () => {
+				utils.vscodeExtensions.getKnownExtensions.invalidate();
+				setPendingRestart(true);
+			},
+		});
 
 	if (!showManage) return null;
 
@@ -54,6 +64,30 @@ export function VscodeExtensionsSettings({
 					Manage VS Code extensions running inside Superset Desktop.
 				</p>
 			</div>
+
+			{pendingRestart && (
+				<div className="mb-4 p-3 border rounded-lg bg-yellow-500/5 border-yellow-500/20 flex items-center justify-between">
+					<p className="text-sm text-yellow-600 dark:text-yellow-400">
+						Changes require app restart to take full effect.
+					</p>
+					<Button
+						variant="outline"
+						size="sm"
+						onClick={() => {
+							try {
+								const { BrowserWindow } = window.require("electron");
+								BrowserWindow.getFocusedWindow()?.reload();
+							} catch {
+								window.location.reload();
+							}
+						}}
+						className="gap-1.5"
+					>
+						<LuRefreshCw className="size-3.5" />
+						Restart Now
+					</Button>
+				</div>
+			)}
 
 			{isLoading ? (
 				<p className="text-sm text-muted-foreground">Loading...</p>
@@ -69,8 +103,15 @@ export function VscodeExtensionsSettings({
 								publisher={ext.publisher}
 								description={ext.description}
 								installed={ext.installed}
+								enabled={ext.enabled}
 								active={ext.active}
 								icon={Icon}
+								onToggleEnabled={(enabled) =>
+									enabledMutation.mutate({
+										extensionId: ext.id,
+										enabled,
+									})
+								}
 								onRestart={() =>
 									restartMutation.mutate({ extensionId: ext.id })
 								}
@@ -94,8 +135,10 @@ function ExtensionCard({
 	publisher,
 	description,
 	installed,
+	enabled,
 	active,
 	icon: Icon,
+	onToggleEnabled,
 	onRestart,
 	isRestarting,
 	onInstall,
@@ -106,8 +149,10 @@ function ExtensionCard({
 	publisher: string;
 	description: string;
 	installed: boolean;
+	enabled: boolean;
 	active: boolean;
 	icon: React.ComponentType<{ className?: string }>;
+	onToggleEnabled: (enabled: boolean) => void;
 	onRestart: () => void;
 	isRestarting: boolean;
 	onInstall: () => void;
@@ -124,14 +169,19 @@ function ExtensionCard({
 				<div className="flex items-center gap-2">
 					<h3 className="font-medium text-sm">{name}</h3>
 					<span className="text-xs text-muted-foreground">{publisher}</span>
-					{active && (
+					{active && enabled && (
 						<span className="text-xs bg-green-500/10 text-green-600 dark:text-green-400 px-1.5 py-0.5 rounded">
 							Active
 						</span>
 					)}
-					{installed && !active && (
+					{installed && !active && enabled && (
 						<span className="text-xs bg-yellow-500/10 text-yellow-600 dark:text-yellow-400 px-1.5 py-0.5 rounded">
 							Installed
+						</span>
+					)}
+					{installed && !enabled && (
+						<span className="text-xs bg-muted text-muted-foreground px-1.5 py-0.5 rounded">
+							Disabled
 						</span>
 					)}
 					{!installed && (
@@ -143,8 +193,17 @@ function ExtensionCard({
 				<p className="text-xs text-muted-foreground mt-1">{description}</p>
 				<p className="text-xs text-muted-foreground mt-0.5 font-mono">{id}</p>
 			</div>
-			<div className="flex items-center gap-2 flex-shrink-0">
+			<div className="flex items-center gap-3 flex-shrink-0">
 				{installed && (
+					<div className="flex items-center gap-2">
+						<Switch
+							checked={enabled}
+							onCheckedChange={onToggleEnabled}
+							aria-label={`${enabled ? "Disable" : "Enable"} ${name}`}
+						/>
+					</div>
+				)}
+				{installed && enabled && (
 					<Button
 						variant="outline"
 						size="sm"

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/vscode-extensions/components/VscodeExtensionsSettings/VscodeExtensionsSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/vscode-extensions/components/VscodeExtensionsSettings/VscodeExtensionsSettings.tsx
@@ -1,0 +1,165 @@
+import { Button } from "@superset/ui/button";
+import { LuBot, LuExternalLink, LuRefreshCw, LuSparkles } from "react-icons/lu";
+import { electronTrpc } from "renderer/lib/electron-trpc";
+import {
+	isItemVisible,
+	SETTING_ITEM_ID,
+	type SettingItemId,
+} from "../../../utils/settings-search";
+
+interface VscodeExtensionsSettingsProps {
+	visibleItems?: SettingItemId[] | null;
+}
+
+const EXTENSION_ICONS: Record<
+	string,
+	React.ComponentType<{ className?: string }>
+> = {
+	"anthropic.claude-code": LuBot,
+	"openai.chatgpt": LuSparkles,
+};
+
+export function VscodeExtensionsSettings({
+	visibleItems,
+}: VscodeExtensionsSettingsProps) {
+	const showManage = isItemVisible(
+		SETTING_ITEM_ID.VSCODE_EXTENSIONS_MANAGE,
+		visibleItems,
+	);
+
+	const { data: extensions, isLoading } =
+		electronTrpc.vscodeExtensions.getKnownExtensions.useQuery();
+	const utils = electronTrpc.useUtils();
+	const restartMutation =
+		electronTrpc.vscodeExtensions.restartExtension.useMutation({
+			onSuccess: () => {
+				utils.vscodeExtensions.getKnownExtensions.invalidate();
+				utils.vscodeExtensions.getExtensions.invalidate();
+			},
+		});
+
+	if (!showManage) return null;
+
+	return (
+		<div className="p-6 max-w-4xl w-full">
+			<div className="mb-8">
+				<h2 className="text-xl font-semibold">VS Code Extensions</h2>
+				<p className="text-sm text-muted-foreground mt-1">
+					Manage VS Code extensions running inside Superset Desktop. Extensions
+					must be installed in VS Code first.
+				</p>
+			</div>
+
+			{isLoading ? (
+				<p className="text-sm text-muted-foreground">Loading...</p>
+			) : (
+				<div className="space-y-4">
+					{extensions?.map((ext) => {
+						const Icon = EXTENSION_ICONS[ext.id] ?? LuBot;
+						return (
+							<ExtensionCard
+								key={ext.id}
+								id={ext.id}
+								name={ext.name}
+								publisher={ext.publisher}
+								description={ext.description}
+								marketplaceUrl={ext.marketplaceUrl}
+								installed={ext.installed}
+								active={ext.active}
+								icon={Icon}
+								onRestart={() =>
+									restartMutation.mutate({ extensionId: ext.id })
+								}
+								isRestarting={restartMutation.isPending}
+							/>
+						);
+					})}
+				</div>
+			)}
+		</div>
+	);
+}
+
+function ExtensionCard({
+	id,
+	name,
+	publisher,
+	description,
+	marketplaceUrl,
+	installed,
+	active,
+	icon: Icon,
+	onRestart,
+	isRestarting,
+}: {
+	id: string;
+	name: string;
+	publisher: string;
+	description: string;
+	marketplaceUrl: string;
+	installed: boolean;
+	active: boolean;
+	icon: React.ComponentType<{ className?: string }>;
+	onRestart: () => void;
+	isRestarting: boolean;
+}) {
+	return (
+		<div className="flex items-start gap-4 p-4 border rounded-lg">
+			<div className="flex-shrink-0 mt-0.5">
+				<div className="w-10 h-10 rounded-lg bg-muted flex items-center justify-center">
+					<Icon className="size-5 text-muted-foreground" />
+				</div>
+			</div>
+			<div className="flex-1 min-w-0">
+				<div className="flex items-center gap-2">
+					<h3 className="font-medium text-sm">{name}</h3>
+					<span className="text-xs text-muted-foreground">{publisher}</span>
+					{active && (
+						<span className="text-xs bg-green-500/10 text-green-600 dark:text-green-400 px-1.5 py-0.5 rounded">
+							Active
+						</span>
+					)}
+					{installed && !active && (
+						<span className="text-xs bg-yellow-500/10 text-yellow-600 dark:text-yellow-400 px-1.5 py-0.5 rounded">
+							Installed
+						</span>
+					)}
+					{!installed && (
+						<span className="text-xs bg-muted text-muted-foreground px-1.5 py-0.5 rounded">
+							Not Installed
+						</span>
+					)}
+				</div>
+				<p className="text-xs text-muted-foreground mt-1">{description}</p>
+				<p className="text-xs text-muted-foreground mt-0.5 font-mono">{id}</p>
+			</div>
+			<div className="flex items-center gap-2 flex-shrink-0">
+				{installed && (
+					<Button
+						variant="outline"
+						size="sm"
+						onClick={onRestart}
+						disabled={isRestarting}
+						className="gap-1.5"
+					>
+						<LuRefreshCw
+							className={`size-3.5 ${isRestarting ? "animate-spin" : ""}`}
+						/>
+						Restart
+					</Button>
+				)}
+				{!installed && (
+					<Button
+						variant="outline"
+						size="sm"
+						onClick={() => window.open(marketplaceUrl, "_blank")}
+						className="gap-1.5"
+					>
+						<LuExternalLink className="size-3.5" />
+						Install in VS Code
+					</Button>
+				)}
+			</div>
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/vscode-extensions/components/VscodeExtensionsSettings/VscodeExtensionsSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/vscode-extensions/components/VscodeExtensionsSettings/VscodeExtensionsSettings.tsx
@@ -1,5 +1,5 @@
 import { Button } from "@superset/ui/button";
-import { LuBot, LuExternalLink, LuRefreshCw, LuSparkles } from "react-icons/lu";
+import { LuBot, LuDownload, LuRefreshCw, LuSparkles } from "react-icons/lu";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import {
 	isItemVisible,
@@ -37,6 +37,12 @@ export function VscodeExtensionsSettings({
 				utils.vscodeExtensions.getExtensions.invalidate();
 			},
 		});
+	const installMutation =
+		electronTrpc.vscodeExtensions.installExtension.useMutation({
+			onSuccess: () => {
+				utils.vscodeExtensions.getKnownExtensions.invalidate();
+			},
+		});
 
 	if (!showManage) return null;
 
@@ -45,8 +51,7 @@ export function VscodeExtensionsSettings({
 			<div className="mb-8">
 				<h2 className="text-xl font-semibold">VS Code Extensions</h2>
 				<p className="text-sm text-muted-foreground mt-1">
-					Manage VS Code extensions running inside Superset Desktop. Extensions
-					must be installed in VS Code first.
+					Manage VS Code extensions running inside Superset Desktop.
 				</p>
 			</div>
 
@@ -63,7 +68,6 @@ export function VscodeExtensionsSettings({
 								name={ext.name}
 								publisher={ext.publisher}
 								description={ext.description}
-								marketplaceUrl={ext.marketplaceUrl}
 								installed={ext.installed}
 								active={ext.active}
 								icon={Icon}
@@ -71,6 +75,10 @@ export function VscodeExtensionsSettings({
 									restartMutation.mutate({ extensionId: ext.id })
 								}
 								isRestarting={restartMutation.isPending}
+								onInstall={() =>
+									installMutation.mutate({ extensionId: ext.id })
+								}
+								isInstalling={installMutation.isPending}
 							/>
 						);
 					})}
@@ -85,23 +93,25 @@ function ExtensionCard({
 	name,
 	publisher,
 	description,
-	marketplaceUrl,
 	installed,
 	active,
 	icon: Icon,
 	onRestart,
 	isRestarting,
+	onInstall,
+	isInstalling,
 }: {
 	id: string;
 	name: string;
 	publisher: string;
 	description: string;
-	marketplaceUrl: string;
 	installed: boolean;
 	active: boolean;
 	icon: React.ComponentType<{ className?: string }>;
 	onRestart: () => void;
 	isRestarting: boolean;
+	onInstall: () => void;
+	isInstalling: boolean;
 }) {
 	return (
 		<div className="flex items-start gap-4 p-4 border rounded-lg">
@@ -150,13 +160,23 @@ function ExtensionCard({
 				)}
 				{!installed && (
 					<Button
-						variant="outline"
+						variant="default"
 						size="sm"
-						onClick={() => window.open(marketplaceUrl, "_blank")}
+						onClick={onInstall}
+						disabled={isInstalling}
 						className="gap-1.5"
 					>
-						<LuExternalLink className="size-3.5" />
-						Install in VS Code
+						{isInstalling ? (
+							<>
+								<LuRefreshCw className="size-3.5 animate-spin" />
+								Installing...
+							</>
+						) : (
+							<>
+								<LuDownload className="size-3.5" />
+								Install
+							</>
+						)}
 					</Button>
 				)}
 			</div>

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/vscode-extensions/components/VscodeExtensionsSettings/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/vscode-extensions/components/VscodeExtensionsSettings/index.ts
@@ -1,0 +1,1 @@
+export { VscodeExtensionsSettings } from "./VscodeExtensionsSettings";

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/vscode-extensions/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/vscode-extensions/page.tsx
@@ -1,0 +1,24 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { useMemo } from "react";
+import { useSettingsSearchQuery } from "renderer/stores/settings-state";
+import { getMatchingItemsForSection } from "../utils/settings-search";
+import { VscodeExtensionsSettings } from "./components/VscodeExtensionsSettings";
+
+export const Route = createFileRoute(
+	"/_authenticated/settings/vscode-extensions/",
+)({
+	component: VscodeExtensionsSettingsPage,
+});
+
+function VscodeExtensionsSettingsPage() {
+	const searchQuery = useSettingsSearchQuery();
+
+	const visibleItems = useMemo(() => {
+		if (!searchQuery) return null;
+		return getMatchingItemsForSection(searchQuery, "vscodeExtensions").map(
+			(item) => item.id,
+		);
+	}, [searchQuery]);
+
+	return <VscodeExtensionsSettings visibleItems={visibleItems} />;
+}

--- a/apps/desktop/src/renderer/screens/main/components/VscodeExtensionButtons/VscodeExtensionButtons.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/VscodeExtensionButtons/VscodeExtensionButtons.tsx
@@ -41,7 +41,7 @@ function ExtensionButton({
 	const setRightSidebarTab = useSidebarStore((s) => s.setRightSidebarTab);
 	const setSidebarOpen = useSidebarStore((s) => s.setSidebarOpen);
 	const workspaceId = useWorkspaceId();
-	const addTab = useTabsStore((s) => s.addTab);
+	const addVscodeExtensionTab = useTabsStore((s) => s.addVscodeExtensionTab);
 
 	const isActive = isSidebarOpen && rightSidebarTab === tab;
 
@@ -58,22 +58,7 @@ function ExtensionButton({
 
 	const handleOpenAsTab = () => {
 		if (!workspaceId) return;
-		const { paneId } = addTab(workspaceId);
-		// Use getState() to read the freshly created pane (addTab updates synchronously)
-		const freshPanes = useTabsStore.getState().panes;
-		if (freshPanes[paneId]) {
-			useTabsStore.setState((state) => ({
-				panes: {
-					...state.panes,
-					[paneId]: {
-						...state.panes[paneId],
-						type: "vscode-extension" as const,
-						name: label,
-						vscodeExtension: { viewType, extensionId },
-					},
-				},
-			}));
-		}
+		addVscodeExtensionTab(workspaceId, extensionId, viewType, label);
 	};
 
 	return (

--- a/apps/desktop/src/renderer/screens/main/components/VscodeExtensionButtons/VscodeExtensionButtons.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/VscodeExtensionButtons/VscodeExtensionButtons.tsx
@@ -41,7 +41,6 @@ function ExtensionButton({
 	const setSidebarOpen = useSidebarStore((s) => s.setSidebarOpen);
 	const workspaceId = useWorkspaceId();
 	const addTab = useTabsStore((s) => s.addTab);
-	const panes = useTabsStore((s) => s.panes);
 
 	const isActive = isSidebarOpen && rightSidebarTab === tab;
 
@@ -59,9 +58,9 @@ function ExtensionButton({
 	const handleOpenAsTab = () => {
 		if (!workspaceId) return;
 		const { paneId } = addTab(workspaceId);
-		// Mutate the pane to be a vscode-extension pane
-		const pane = panes[paneId];
-		if (pane) {
+		// Use getState() to read the freshly created pane (addTab updates synchronously)
+		const freshPanes = useTabsStore.getState().panes;
+		if (freshPanes[paneId]) {
 			useTabsStore.setState((state) => ({
 				panes: {
 					...state.panes,

--- a/apps/desktop/src/renderer/screens/main/components/VscodeExtensionButtons/VscodeExtensionButtons.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/VscodeExtensionButtons/VscodeExtensionButtons.tsx
@@ -13,6 +13,7 @@ import {
 	LuSparkles,
 	LuSquareArrowOutUpRight,
 } from "react-icons/lu";
+import { electronTrpc } from "renderer/lib/electron-trpc";
 import { useWorkspaceId } from "renderer/screens/main/components/WorkspaceView/WorkspaceIdContext";
 import {
 	RightSidebarTab,
@@ -119,22 +120,33 @@ function ExtensionButton({
 }
 
 export function VscodeExtensionButtons() {
+	const { data: extensions } =
+		electronTrpc.vscodeExtensions.getKnownExtensions.useQuery();
+
+	// Only show buttons for installed extensions
+	const installed = extensions?.filter((e) => e.installed) ?? [];
+	if (installed.length === 0) return null;
+
 	return (
 		<div className="flex items-center gap-1">
-			<ExtensionButton
-				tab={RightSidebarTab.ClaudeCode}
-				icon={LuBot}
-				label="Claude"
-				viewType="claudeVSCodeSidebar"
-				extensionId="anthropic.claude-code"
-			/>
-			<ExtensionButton
-				tab={RightSidebarTab.Codex}
-				icon={LuSparkles}
-				label="Codex"
-				viewType="chatgpt.sidebarView"
-				extensionId="openai.chatgpt"
-			/>
+			{installed.some((e) => e.id === "anthropic.claude-code") && (
+				<ExtensionButton
+					tab={RightSidebarTab.ClaudeCode}
+					icon={LuBot}
+					label="Claude"
+					viewType="claudeVSCodeSidebar"
+					extensionId="anthropic.claude-code"
+				/>
+			)}
+			{installed.some((e) => e.id === "openai.chatgpt") && (
+				<ExtensionButton
+					tab={RightSidebarTab.Codex}
+					icon={LuSparkles}
+					label="Codex"
+					viewType="chatgpt.sidebarView"
+					extensionId="openai.chatgpt"
+				/>
+			)}
 		</div>
 	);
 }

--- a/apps/desktop/src/renderer/screens/main/components/VscodeExtensionButtons/VscodeExtensionButtons.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/VscodeExtensionButtons/VscodeExtensionButtons.tsx
@@ -1,0 +1,130 @@
+import { Button } from "@superset/ui/button";
+import {
+	ContextMenu,
+	ContextMenuContent,
+	ContextMenuItem,
+	ContextMenuTrigger,
+} from "@superset/ui/context-menu";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
+import { cn } from "@superset/ui/utils";
+import { LuBot, LuPanelRight, LuSparkles, LuSquareArrowOutUpRight } from "react-icons/lu";
+import {
+	RightSidebarTab,
+	useSidebarStore,
+} from "renderer/stores/sidebar-state";
+import { useWorkspaceId } from "renderer/screens/main/components/WorkspaceView/WorkspaceIdContext";
+import { useTabsStore } from "renderer/stores/tabs/store";
+
+interface ExtensionDef {
+	tab: RightSidebarTab;
+	icon: React.ComponentType<{ className?: string }>;
+	label: string;
+	viewType: string;
+	extensionId: string;
+}
+
+function ExtensionButton({ tab, icon: Icon, label, viewType, extensionId }: ExtensionDef) {
+	const rightSidebarTab = useSidebarStore((s) => s.rightSidebarTab);
+	const isSidebarOpen = useSidebarStore((s) => s.isSidebarOpen);
+	const setRightSidebarTab = useSidebarStore((s) => s.setRightSidebarTab);
+	const setSidebarOpen = useSidebarStore((s) => s.setSidebarOpen);
+	const workspaceId = useWorkspaceId();
+	const addTab = useTabsStore((s) => s.addTab);
+	const panes = useTabsStore((s) => s.panes);
+
+	const isActive = isSidebarOpen && rightSidebarTab === tab;
+
+	const handleClick = () => {
+		if (isActive) {
+			setSidebarOpen(false);
+		} else {
+			setRightSidebarTab(tab);
+			if (!isSidebarOpen) {
+				setSidebarOpen(true);
+			}
+		}
+	};
+
+	const handleOpenAsTab = () => {
+		if (!workspaceId) return;
+		const { tabId, paneId } = addTab(workspaceId);
+		// Mutate the pane to be a vscode-extension pane
+		const pane = panes[paneId];
+		if (pane) {
+			useTabsStore.setState((state) => ({
+				panes: {
+					...state.panes,
+					[paneId]: {
+						...state.panes[paneId],
+						type: "vscode-extension" as const,
+						name: label,
+						vscodeExtension: { viewType, extensionId },
+					},
+				},
+			}));
+		}
+	};
+
+	return (
+		<ContextMenu>
+			<ContextMenuTrigger asChild>
+				<span>
+					<Tooltip>
+						<TooltipTrigger asChild>
+							<Button
+								variant="ghost"
+								size="sm"
+								onClick={handleClick}
+								aria-label={label}
+								aria-pressed={isActive}
+								className={cn(
+									"no-drag gap-1.5 h-6 px-1.5 rounded",
+									isActive
+										? "font-semibold text-foreground bg-accent"
+										: "text-muted-foreground hover:text-foreground",
+								)}
+							>
+								<Icon className="size-3" />
+								<span className="text-xs">{label}</span>
+							</Button>
+						</TooltipTrigger>
+						<TooltipContent side="bottom" showArrow={false}>
+							{isActive ? `Hide ${label}` : `Open ${label} in sidebar`}
+						</TooltipContent>
+					</Tooltip>
+				</span>
+			</ContextMenuTrigger>
+			<ContextMenuContent>
+				<ContextMenuItem onClick={handleClick}>
+					<LuPanelRight className="size-4 mr-2" />
+					{isActive ? "Hide sidebar" : "Open in sidebar"}
+				</ContextMenuItem>
+				<ContextMenuItem onClick={handleOpenAsTab}>
+					<LuSquareArrowOutUpRight className="size-4 mr-2" />
+					Open as tab
+				</ContextMenuItem>
+			</ContextMenuContent>
+		</ContextMenu>
+	);
+}
+
+export function VscodeExtensionButtons() {
+	return (
+		<div className="flex items-center gap-1">
+			<ExtensionButton
+				tab={RightSidebarTab.ClaudeCode}
+				icon={LuBot}
+				label="Claude"
+				viewType="claudeVSCodeSidebar"
+				extensionId="anthropic.claude-code"
+			/>
+			<ExtensionButton
+				tab={RightSidebarTab.Codex}
+				icon={LuSparkles}
+				label="Codex"
+				viewType="chatgpt.sidebarView"
+				extensionId="openai.chatgpt"
+			/>
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/screens/main/components/VscodeExtensionButtons/VscodeExtensionButtons.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/VscodeExtensionButtons/VscodeExtensionButtons.tsx
@@ -7,12 +7,17 @@ import {
 } from "@superset/ui/context-menu";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { cn } from "@superset/ui/utils";
-import { LuBot, LuPanelRight, LuSparkles, LuSquareArrowOutUpRight } from "react-icons/lu";
+import {
+	LuBot,
+	LuPanelRight,
+	LuSparkles,
+	LuSquareArrowOutUpRight,
+} from "react-icons/lu";
+import { useWorkspaceId } from "renderer/screens/main/components/WorkspaceView/WorkspaceIdContext";
 import {
 	RightSidebarTab,
 	useSidebarStore,
 } from "renderer/stores/sidebar-state";
-import { useWorkspaceId } from "renderer/screens/main/components/WorkspaceView/WorkspaceIdContext";
 import { useTabsStore } from "renderer/stores/tabs/store";
 
 interface ExtensionDef {
@@ -23,7 +28,13 @@ interface ExtensionDef {
 	extensionId: string;
 }
 
-function ExtensionButton({ tab, icon: Icon, label, viewType, extensionId }: ExtensionDef) {
+function ExtensionButton({
+	tab,
+	icon: Icon,
+	label,
+	viewType,
+	extensionId,
+}: ExtensionDef) {
 	const rightSidebarTab = useSidebarStore((s) => s.rightSidebarTab);
 	const isSidebarOpen = useSidebarStore((s) => s.isSidebarOpen);
 	const setRightSidebarTab = useSidebarStore((s) => s.setRightSidebarTab);
@@ -47,7 +58,7 @@ function ExtensionButton({ tab, icon: Icon, label, viewType, extensionId }: Exte
 
 	const handleOpenAsTab = () => {
 		if (!workspaceId) return;
-		const { tabId, paneId } = addTab(workspaceId);
+		const { paneId } = addTab(workspaceId);
 		// Mutate the pane to be a vscode-extension pane
 		const pane = panes[paneId];
 		if (pane) {

--- a/apps/desktop/src/renderer/screens/main/components/VscodeExtensionButtons/index.ts
+++ b/apps/desktop/src/renderer/screens/main/components/VscodeExtensionButtons/index.ts
@@ -1,0 +1,1 @@
+export { VscodeExtensionButtons } from "./VscodeExtensionButtons";

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/VscodeExtensionPane/VscodeExtensionPane.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/VscodeExtensionPane/VscodeExtensionPane.tsx
@@ -1,0 +1,23 @@
+import { VscodeExtensionView } from "renderer/screens/main/components/WorkspaceView/RightSidebar/VscodeExtensionView";
+
+interface VscodeExtensionPaneProps {
+	paneId: string;
+	viewType: string;
+	extensionId: string;
+}
+
+export function VscodeExtensionPane({
+	paneId,
+	viewType,
+	extensionId,
+}: VscodeExtensionPaneProps) {
+	return (
+		<div className="h-full w-full flex flex-col">
+			<VscodeExtensionView
+				viewType={viewType}
+				extensionId={extensionId}
+				isActive={true}
+			/>
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/VscodeExtensionPane/index.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/VscodeExtensionPane/index.ts
@@ -1,0 +1,1 @@
+export { VscodeExtensionPane } from "./VscodeExtensionPane";

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/index.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/index.tsx
@@ -28,8 +28,8 @@ import { DatabaseExplorerPane } from "./DatabaseExplorerPane";
 import { DevToolsPane } from "./DevToolsPane";
 import { FileViewerPane } from "./FileViewerPane";
 import { GitGraphPane } from "./GitGraphPane";
-import { VscodeExtensionPane } from "./VscodeExtensionPane";
 import { TabPane } from "./TabPane";
+import { VscodeExtensionPane } from "./VscodeExtensionPane";
 
 export const MOSAIC_ID = "superset-mosaic";
 
@@ -387,10 +387,7 @@ export function TabView({ tab }: TabViewProps) {
 			}
 
 			// Route vscode-extension panes
-			if (
-				paneInfo.type === "vscode-extension" &&
-				paneInfo.vscodeExtension
-			) {
+			if (paneInfo.type === "vscode-extension" && paneInfo.vscodeExtension) {
 				return (
 					<VscodeExtensionPane
 						paneId={paneId}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/index.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/index.tsx
@@ -28,6 +28,7 @@ import { DatabaseExplorerPane } from "./DatabaseExplorerPane";
 import { DevToolsPane } from "./DevToolsPane";
 import { FileViewerPane } from "./FileViewerPane";
 import { GitGraphPane } from "./GitGraphPane";
+import { VscodeExtensionPane } from "./VscodeExtensionPane";
 import { TabPane } from "./TabPane";
 
 export const MOSAIC_ID = "superset-mosaic";
@@ -153,6 +154,7 @@ export function TabView({ tab }: TabViewProps) {
 				tabId: string;
 				type: string;
 				devtools?: { targetPaneId: string };
+				vscodeExtension?: { viewType: string; extensionId: string };
 			}
 		> = {};
 		for (const paneId of layoutPaneIds) {
@@ -162,6 +164,7 @@ export function TabView({ tab }: TabViewProps) {
 					tabId: pane.tabId,
 					type: pane.type,
 					devtools: pane.devtools,
+					vscodeExtension: pane.vscodeExtension,
 				};
 			}
 		}
@@ -379,6 +382,20 @@ export function TabView({ tab }: TabViewProps) {
 						onMoveToTab={(targetTabId) => movePaneToTab(paneId, targetTabId)}
 						onMoveToNewTab={() => movePaneToNewTab(paneId)}
 						onPopOut={isTearoff ? undefined : () => handlePopOut(paneId)}
+					/>
+				);
+			}
+
+			// Route vscode-extension panes
+			if (
+				paneInfo.type === "vscode-extension" &&
+				paneInfo.vscodeExtension
+			) {
+				return (
+					<VscodeExtensionPane
+						paneId={paneId}
+						viewType={paneInfo.vscodeExtension.viewType}
+						extensionId={paneInfo.vscodeExtension.extensionId}
 					/>
 				);
 			}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/index.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/index.tsx
@@ -37,9 +37,7 @@ export function ContentView({
 					trailingAction={
 						<div className="flex items-center gap-1">
 							<VscodeExtensionButtons />
-							{!isSidebarOpen && !isTearoffWindow() && (
-								<SidebarControl />
-							)}
+							{!isSidebarOpen && !isTearoffWindow() && <SidebarControl />}
 						</div>
 					}
 				>

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/index.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/index.tsx
@@ -4,6 +4,7 @@ import { electronTrpc } from "renderer/lib/electron-trpc";
 import { useBrowserFullscreenStore } from "renderer/stores/browser-fullscreen";
 import { useSidebarStore } from "renderer/stores/sidebar-state";
 import { SidebarControl } from "../../SidebarControl";
+import { VscodeExtensionButtons } from "../../VscodeExtensionButtons";
 import { ContentHeader } from "./ContentHeader";
 import { PresetsBar } from "./components/PresetsBar";
 import { TabsContent } from "./TabsContent";
@@ -34,9 +35,12 @@ export function ContentView({
 			{!isBrowserFullscreen && (
 				<ContentHeader
 					trailingAction={
-						!isSidebarOpen && !isTearoffWindow() ? (
-							<SidebarControl />
-						) : undefined
+						<div className="flex items-center gap-1">
+							<VscodeExtensionButtons />
+							{!isSidebarOpen && !isTearoffWindow() && (
+								<SidebarControl />
+							)}
+						</div>
 					}
 				>
 					<GroupStrip />

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/VscodeExtensionView/VscodeExtensionView.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/VscodeExtensionView/VscodeExtensionView.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 
 interface VscodeExtensionViewProps {
@@ -68,7 +68,7 @@ export function VscodeExtensionView({
 				},
 			},
 		);
-	}, [isActive, viewId, viewType]);
+	}, [isActive, viewId, viewType, resolveMutation.mutate]);
 
 	// Listen for messages from iframe -> forward to extension
 	useEffect(() => {
@@ -85,7 +85,7 @@ export function VscodeExtensionView({
 
 		window.addEventListener("message", handler);
 		return () => window.removeEventListener("message", handler);
-	}, [viewId]);
+	}, [viewId, postMessageMutation.mutate]);
 
 	if (error) {
 		return (

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/VscodeExtensionView/VscodeExtensionView.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/VscodeExtensionView/VscodeExtensionView.tsx
@@ -146,7 +146,7 @@ export function VscodeExtensionView({
 			ref={iframeRef}
 			srcDoc={bridgedHtml}
 			className="w-full h-full border-0"
-			sandbox="allow-scripts allow-forms allow-popups"
+			sandbox="allow-scripts allow-same-origin allow-forms allow-popups"
 			title={`${extensionId} webview`}
 		/>
 	);
@@ -161,6 +161,7 @@ function injectVscodeApiBridge(
 	bodyClass: string,
 ): string {
 	const bridgeScript = `
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'unsafe-inline' vscode-webview-resource:; style-src 'unsafe-inline' vscode-webview-resource:; img-src vscode-webview-resource: https: data:; font-src vscode-webview-resource: https: data:; connect-src https: wss: ws:;">
 <style>${themeCss}</style>
 <script>
 (function() {

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/VscodeExtensionView/VscodeExtensionView.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/VscodeExtensionView/VscodeExtensionView.tsx
@@ -31,18 +31,28 @@ export function VscodeExtensionView({
 	useEffect(() => {
 		if (!isActive || viewId) return;
 
+		console.log(`[VscodeExtensionView] Resolving webview: ${viewType}`);
 		resolveMutation.mutate(
 			{ viewType, extensionPath: "" },
 			{
 				onSuccess: (result) => {
+					console.log(
+						`[VscodeExtensionView] Resolve result:`,
+						JSON.stringify(result),
+					);
 					if (result.viewId && result.url) {
 						setViewId(result.viewId);
 						setIframeUrl(result.url);
+						console.log(
+							`[VscodeExtensionView] iframe URL set to: ${result.url}`,
+						);
 					} else {
+						console.warn(`[VscodeExtensionView] No viewId/url in result`);
 						setError(`Extension view "${viewType}" not found`);
 					}
 				},
 				onError: (err) => {
+					console.error(`[VscodeExtensionView] Resolve error:`, err);
 					setError(err.message);
 				},
 			},
@@ -71,6 +81,9 @@ export function VscodeExtensionView({
 	electronTrpc.vscodeExtensions.subscribeWebview.useSubscription(undefined, {
 		enabled: isActive && !!viewId,
 		onData: (event) => {
+			console.log(
+				`[VscodeExtensionView] Subscription event: type=${event.type}, eventViewId=${event.viewId}, myViewId=${viewId}`,
+			);
 			if (!viewId || event.viewId !== viewId) return;
 			if (event.type === "message") {
 				iframeRef.current?.contentWindow?.postMessage(
@@ -79,7 +92,9 @@ export function VscodeExtensionView({
 				);
 			}
 			if (event.type === "html" && iframeUrl) {
-				// Reload iframe to pick up updated HTML from server
+				console.log(
+					`[VscodeExtensionView] HTML updated, reloading iframe: ${iframeUrl}`,
+				);
 				const iframe = iframeRef.current;
 				if (iframe) {
 					iframe.src = iframeUrl;
@@ -110,6 +125,10 @@ export function VscodeExtensionView({
 			src={iframeUrl}
 			className="w-full h-full border-0"
 			sandbox="allow-scripts allow-same-origin allow-forms allow-popups"
+			onLoad={() =>
+				console.log(`[VscodeExtensionView] iframe loaded: ${iframeUrl}`)
+			}
+			onError={(e) => console.error(`[VscodeExtensionView] iframe error:`, e)}
 			title={`${extensionId} webview`}
 		/>
 	);

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/VscodeExtensionView/VscodeExtensionView.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/VscodeExtensionView/VscodeExtensionView.tsx
@@ -1,0 +1,163 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { electronTrpc } from "renderer/lib/electron-trpc";
+
+interface VscodeExtensionViewProps {
+	viewType: string;
+	extensionId: string;
+	isActive: boolean;
+}
+
+/**
+ * Renders a VS Code extension's webview inside an iframe.
+ * Bridges postMessage between the iframe and the extension host via tRPC.
+ */
+export function VscodeExtensionView({
+	viewType,
+	extensionId,
+	isActive,
+}: VscodeExtensionViewProps) {
+	const iframeRef = useRef<HTMLIFrameElement>(null);
+	const [viewId, setViewId] = useState<string | null>(null);
+	const [html, setHtml] = useState<string | null>(null);
+	const [error, setError] = useState<string | null>(null);
+
+	const resolveMutation =
+		electronTrpc.vscodeExtensions.resolveWebview.useMutation();
+	const postMessageMutation =
+		electronTrpc.vscodeExtensions.postMessageToExtension.useMutation();
+
+	// Subscribe to webview events
+	electronTrpc.vscodeExtensions.subscribeWebview.useSubscription(undefined, {
+		enabled: isActive && !!viewId,
+		onData: (event) => {
+			if (!viewId) return;
+			if (event.viewId !== viewId) return;
+
+			if (event.type === "html") {
+				setHtml(event.data as string);
+			} else if (event.type === "message") {
+				// Forward message from extension to iframe
+				iframeRef.current?.contentWindow?.postMessage(
+					{ type: "vscode-message", data: event.data },
+					"*",
+				);
+			}
+		},
+	});
+
+	// Resolve the webview when first becoming active
+	useEffect(() => {
+		if (!isActive || viewId) return;
+
+		resolveMutation.mutate(
+			{
+				viewType,
+				extensionPath: "", // Extension path is looked up by the host
+			},
+			{
+				onSuccess: (result) => {
+					if (result.viewId) {
+						setViewId(result.viewId);
+						setHtml(result.html);
+					} else {
+						setError(`Extension view "${viewType}" not found`);
+					}
+				},
+				onError: (err) => {
+					setError(err.message);
+				},
+			},
+		);
+	}, [isActive, viewId, viewType]);
+
+	// Listen for messages from iframe -> forward to extension
+	useEffect(() => {
+		if (!viewId) return;
+
+		const handler = (event: MessageEvent) => {
+			if (event.data?.type === "vscode-api") {
+				postMessageMutation.mutate({
+					viewId,
+					message: event.data.data,
+				});
+			}
+		};
+
+		window.addEventListener("message", handler);
+		return () => window.removeEventListener("message", handler);
+	}, [viewId]);
+
+	if (error) {
+		return (
+			<div className="flex-1 flex items-center justify-center text-muted-foreground text-sm p-4">
+				<p>{error}</p>
+			</div>
+		);
+	}
+
+	if (!html) {
+		return (
+			<div className="flex-1 flex items-center justify-center text-muted-foreground text-sm">
+				<p>Loading {extensionId}...</p>
+			</div>
+		);
+	}
+
+	// Inject acquireVsCodeApi bridge into the HTML
+	const bridgedHtml = injectVscodeApiBridge(html);
+
+	return (
+		<iframe
+			ref={iframeRef}
+			srcDoc={bridgedHtml}
+			className="w-full h-full border-0"
+			sandbox="allow-scripts allow-same-origin allow-forms allow-popups"
+			title={`${extensionId} webview`}
+		/>
+	);
+}
+
+/**
+ * Injects the acquireVsCodeApi() bridge script into extension webview HTML.
+ * This allows the extension's webview JS to communicate with the extension host.
+ */
+function injectVscodeApiBridge(html: string): string {
+	const bridgeScript = `
+<script>
+(function() {
+	const vscodeApi = {
+		postMessage(message) {
+			window.parent.postMessage({ type: 'vscode-api', data: message }, '*');
+		},
+		getState() {
+			try {
+				return JSON.parse(sessionStorage.getItem('vscodeState') || 'null');
+			} catch { return null; }
+		},
+		setState(state) {
+			sessionStorage.setItem('vscodeState', JSON.stringify(state));
+			return state;
+		}
+	};
+
+	window.acquireVsCodeApi = function() { return vscodeApi; };
+
+	// Listen for messages from the extension host (via parent)
+	window.addEventListener('message', function(event) {
+		if (event.data && event.data.type === 'vscode-message') {
+			// Re-dispatch as a regular message event for the webview
+			window.dispatchEvent(new MessageEvent('message', { data: event.data.data }));
+		}
+	});
+})();
+</script>`;
+
+	// Insert before </head> or at the start of <body>
+	if (html.includes("</head>")) {
+		return html.replace("</head>", `${bridgeScript}</head>`);
+	}
+	if (html.includes("<body")) {
+		return html.replace(/<body([^>]*)>/, `<body$1>${bridgeScript}`);
+	}
+	return `${bridgeScript}${html}`;
+}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/VscodeExtensionView/VscodeExtensionView.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/VscodeExtensionView/VscodeExtensionView.tsx
@@ -91,15 +91,8 @@ export function VscodeExtensionView({
 					"*",
 				);
 			}
-			if (event.type === "html" && iframeUrl) {
-				console.log(
-					`[VscodeExtensionView] HTML updated, reloading iframe: ${iframeUrl}`,
-				);
-				const iframe = iframeRef.current;
-				if (iframe) {
-					iframe.src = iframeUrl;
-				}
-			}
+			// Don't reload iframe on HTML updates - the initial load already has
+			// the correct content, and reloading would reset extension state
 		},
 	});
 

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/VscodeExtensionView/VscodeExtensionView.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/VscodeExtensionView/VscodeExtensionView.tsx
@@ -1,5 +1,9 @@
 import { useEffect, useRef, useState } from "react";
 import { electronTrpc } from "renderer/lib/electron-trpc";
+import {
+	generateVscodeThemeCss,
+	getVscodeBodyClass,
+} from "./vscode-theme-bridge";
 
 interface VscodeExtensionViewProps {
 	viewType: string;
@@ -10,6 +14,7 @@ interface VscodeExtensionViewProps {
 /**
  * Renders a VS Code extension's webview inside an iframe.
  * Bridges postMessage between the iframe and the extension host via tRPC.
+ * Injects Superset theme as VS Code CSS variables.
  */
 export function VscodeExtensionView({
 	viewType,
@@ -20,11 +25,41 @@ export function VscodeExtensionView({
 	const [viewId, setViewId] = useState<string | null>(null);
 	const [html, setHtml] = useState<string | null>(null);
 	const [error, setError] = useState<string | null>(null);
+	const [themeCss, setThemeCss] = useState("");
+	const [bodyClass, setBodyClass] = useState("vscode-dark");
 
 	const resolveMutation =
 		electronTrpc.vscodeExtensions.resolveWebview.useMutation();
 	const postMessageMutation =
 		electronTrpc.vscodeExtensions.postMessageToExtension.useMutation();
+
+	// Generate theme CSS on mount and when theme changes
+	useEffect(() => {
+		const updateTheme = () => {
+			setThemeCss(generateVscodeThemeCss());
+			setBodyClass(getVscodeBodyClass());
+		};
+		updateTheme();
+
+		// Watch for theme changes via class mutations on <html>
+		const observer = new MutationObserver((mutations) => {
+			for (const m of mutations) {
+				if (
+					m.type === "attributes" &&
+					(m.attributeName === "class" || m.attributeName === "style")
+				) {
+					updateTheme();
+					break;
+				}
+			}
+		});
+		observer.observe(document.documentElement, {
+			attributes: true,
+			attributeFilter: ["class", "style"],
+		});
+
+		return () => observer.disconnect();
+	}, []);
 
 	// Subscribe to webview events
 	electronTrpc.vscodeExtensions.subscribeWebview.useSubscription(undefined, {
@@ -36,7 +71,6 @@ export function VscodeExtensionView({
 			if (event.type === "html") {
 				setHtml(event.data as string);
 			} else if (event.type === "message") {
-				// Forward message from extension to iframe
 				iframeRef.current?.contentWindow?.postMessage(
 					{ type: "vscode-message", data: event.data },
 					"*",
@@ -52,7 +86,7 @@ export function VscodeExtensionView({
 		resolveMutation.mutate(
 			{
 				viewType,
-				extensionPath: "", // Extension path is looked up by the host
+				extensionPath: "",
 			},
 			{
 				onSuccess: (result) => {
@@ -103,8 +137,7 @@ export function VscodeExtensionView({
 		);
 	}
 
-	// Inject acquireVsCodeApi bridge into the HTML
-	const bridgedHtml = injectVscodeApiBridge(html);
+	const bridgedHtml = injectVscodeApiBridge(html, themeCss, bodyClass);
 
 	return (
 		<iframe
@@ -118,11 +151,15 @@ export function VscodeExtensionView({
 }
 
 /**
- * Injects the acquireVsCodeApi() bridge script into extension webview HTML.
- * This allows the extension's webview JS to communicate with the extension host.
+ * Injects acquireVsCodeApi() bridge + theme CSS into extension webview HTML.
  */
-function injectVscodeApiBridge(html: string): string {
+function injectVscodeApiBridge(
+	html: string,
+	themeCss: string,
+	bodyClass: string,
+): string {
 	const bridgeScript = `
+<style>${themeCss}</style>
 <script>
 (function() {
 	const vscodeApi = {
@@ -142,22 +179,28 @@ function injectVscodeApiBridge(html: string): string {
 
 	window.acquireVsCodeApi = function() { return vscodeApi; };
 
-	// Listen for messages from the extension host (via parent)
 	window.addEventListener('message', function(event) {
 		if (event.data && event.data.type === 'vscode-message') {
-			// Re-dispatch as a regular message event for the webview
 			window.dispatchEvent(new MessageEvent('message', { data: event.data.data }));
 		}
 	});
 })();
 </script>`;
 
-	// Insert before </head> or at the start of <body>
-	if (html.includes("</head>")) {
-		return html.replace("</head>", `${bridgeScript}</head>`);
+	// Replace body class for theme detection
+	const themedHtml = html.replace(
+		/<body([^>]*)>/,
+		`<body$1 class="${bodyClass}">`,
+	);
+
+	if (themedHtml.includes("</head>")) {
+		return themedHtml.replace("</head>", `${bridgeScript}</head>`);
 	}
-	if (html.includes("<body")) {
-		return html.replace(/<body([^>]*)>/, `<body$1>${bridgeScript}`);
+	if (themedHtml.includes("<body")) {
+		return themedHtml.replace(
+			/<body([^>]*)>/,
+			`<body$1 class="${bodyClass}">${bridgeScript}`,
+		);
 	}
-	return `${bridgeScript}${html}`;
+	return `${bridgeScript}${themedHtml}`;
 }

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/VscodeExtensionView/VscodeExtensionView.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/VscodeExtensionView/VscodeExtensionView.tsx
@@ -1,9 +1,5 @@
 import { useEffect, useRef, useState } from "react";
 import { electronTrpc } from "renderer/lib/electron-trpc";
-import {
-	generateVscodeThemeCss,
-	getVscodeBodyClass,
-} from "./vscode-theme-bridge";
 
 interface VscodeExtensionViewProps {
 	viewType: string;
@@ -13,8 +9,8 @@ interface VscodeExtensionViewProps {
 
 /**
  * Renders a VS Code extension's webview inside an iframe.
+ * Uses vscode-webview:// protocol to serve HTML with its own CSP.
  * Bridges postMessage between the iframe and the extension host via tRPC.
- * Injects Superset theme as VS Code CSS variables.
  */
 export function VscodeExtensionView({
 	viewType,
@@ -23,61 +19,13 @@ export function VscodeExtensionView({
 }: VscodeExtensionViewProps) {
 	const iframeRef = useRef<HTMLIFrameElement>(null);
 	const [viewId, setViewId] = useState<string | null>(null);
-	const [html, setHtml] = useState<string | null>(null);
+	const [webviewUrl, setWebviewUrl] = useState<string | null>(null);
 	const [error, setError] = useState<string | null>(null);
-	const [themeCss, setThemeCss] = useState("");
-	const [bodyClass, setBodyClass] = useState("vscode-dark");
 
 	const resolveMutation =
 		electronTrpc.vscodeExtensions.resolveWebview.useMutation();
 	const postMessageMutation =
 		electronTrpc.vscodeExtensions.postMessageToExtension.useMutation();
-
-	// Generate theme CSS on mount and when theme changes
-	useEffect(() => {
-		const updateTheme = () => {
-			setThemeCss(generateVscodeThemeCss());
-			setBodyClass(getVscodeBodyClass());
-		};
-		updateTheme();
-
-		// Watch for theme changes via class mutations on <html>
-		const observer = new MutationObserver((mutations) => {
-			for (const m of mutations) {
-				if (
-					m.type === "attributes" &&
-					(m.attributeName === "class" || m.attributeName === "style")
-				) {
-					updateTheme();
-					break;
-				}
-			}
-		});
-		observer.observe(document.documentElement, {
-			attributes: true,
-			attributeFilter: ["class", "style"],
-		});
-
-		return () => observer.disconnect();
-	}, []);
-
-	// Subscribe to webview events
-	electronTrpc.vscodeExtensions.subscribeWebview.useSubscription(undefined, {
-		enabled: isActive && !!viewId,
-		onData: (event) => {
-			if (!viewId) return;
-			if (event.viewId !== viewId) return;
-
-			if (event.type === "html") {
-				setHtml(event.data as string);
-			} else if (event.type === "message") {
-				iframeRef.current?.contentWindow?.postMessage(
-					{ type: "vscode-message", data: event.data },
-					"*",
-				);
-			}
-		},
-	});
 
 	// Resolve the webview when first becoming active
 	useEffect(() => {
@@ -90,9 +38,9 @@ export function VscodeExtensionView({
 			},
 			{
 				onSuccess: (result) => {
-					if (result.viewId) {
+					if (result.viewId && result.url) {
 						setViewId(result.viewId);
-						setHtml(result.html);
+						setWebviewUrl(result.url);
 					} else {
 						setError(`Extension view "${viewType}" not found`);
 					}
@@ -123,6 +71,22 @@ export function VscodeExtensionView({
 		return () => window.removeEventListener("message", handler);
 	}, [viewId, postMessageMutation.mutate]);
 
+	// Subscribe to webview events for message forwarding (extension -> webview)
+	electronTrpc.vscodeExtensions.subscribeWebview.useSubscription(undefined, {
+		enabled: isActive && !!viewId,
+		onData: (event) => {
+			if (!viewId || event.viewId !== viewId) return;
+			if (event.type === "message") {
+				iframeRef.current?.contentWindow?.postMessage(
+					{ type: "vscode-message", data: event.data },
+					"*",
+				);
+			}
+			// HTML updates trigger protocol store update on main process side
+			// iframe will get fresh content on next load
+		},
+	});
+
 	if (error) {
 		return (
 			<div className="flex-1 flex items-center justify-center text-muted-foreground text-sm p-4">
@@ -131,7 +95,7 @@ export function VscodeExtensionView({
 		);
 	}
 
-	if (!html) {
+	if (!webviewUrl) {
 		return (
 			<div className="flex-1 flex items-center justify-center text-muted-foreground text-sm">
 				<p>Loading {extensionId}...</p>
@@ -139,70 +103,13 @@ export function VscodeExtensionView({
 		);
 	}
 
-	const bridgedHtml = injectVscodeApiBridge(html, themeCss, bodyClass);
-
 	return (
 		<iframe
 			ref={iframeRef}
-			srcDoc={bridgedHtml}
+			src={webviewUrl}
 			className="w-full h-full border-0"
 			sandbox="allow-scripts allow-same-origin allow-forms allow-popups"
 			title={`${extensionId} webview`}
 		/>
 	);
-}
-
-/**
- * Injects acquireVsCodeApi() bridge + theme CSS into extension webview HTML.
- */
-function injectVscodeApiBridge(
-	html: string,
-	themeCss: string,
-	bodyClass: string,
-): string {
-	const bridgeScript = `
-<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'unsafe-inline' vscode-webview-resource:; style-src 'unsafe-inline' vscode-webview-resource:; img-src vscode-webview-resource: https: data:; font-src vscode-webview-resource: https: data:; connect-src https: wss: ws:;">
-<style>${themeCss}</style>
-<script>
-(function() {
-	let _state = null;
-	const vscodeApi = {
-		postMessage(message) {
-			window.parent.postMessage({ type: 'vscode-api', data: message }, '*');
-		},
-		getState() {
-			return _state;
-		},
-		setState(state) {
-			_state = state;
-			return state;
-		}
-	};
-
-	window.acquireVsCodeApi = function() { return vscodeApi; };
-
-	window.addEventListener('message', function(event) {
-		if (event.data && event.data.type === 'vscode-message') {
-			window.dispatchEvent(new MessageEvent('message', { data: event.data.data }));
-		}
-	});
-})();
-</script>`;
-
-	// Replace body class for theme detection
-	const themedHtml = html.replace(
-		/<body([^>]*)>/,
-		`<body$1 class="${bodyClass}">`,
-	);
-
-	if (themedHtml.includes("</head>")) {
-		return themedHtml.replace("</head>", `${bridgeScript}</head>`);
-	}
-	if (themedHtml.includes("<body")) {
-		return themedHtml.replace(
-			/<body([^>]*)>/,
-			`<body$1 class="${bodyClass}">${bridgeScript}`,
-		);
-	}
-	return `${bridgeScript}${themedHtml}`;
 }

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/VscodeExtensionView/VscodeExtensionView.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/VscodeExtensionView/VscodeExtensionView.tsx
@@ -7,35 +7,10 @@ interface VscodeExtensionViewProps {
 	isActive: boolean;
 }
 
-const BRIDGE_SCRIPT = `<script>
-(function() {
-	let _state = null;
-	const vscodeApi = {
-		postMessage(message) {
-			window.parent.postMessage({ type: 'vscode-api', data: message }, '*');
-		},
-		getState() { return _state; },
-		setState(state) { _state = state; return state; }
-	};
-	window.acquireVsCodeApi = function() { return vscodeApi; };
-	window.addEventListener('message', function(event) {
-		if (event.data && event.data.type === 'vscode-message') {
-			window.dispatchEvent(new MessageEvent('message', { data: event.data.data }));
-		}
-	});
-})();
-</script>`;
-
-function injectBridge(html: string): string {
-	if (html.includes("</head>")) {
-		return html.replace("</head>", `${BRIDGE_SCRIPT}</head>`);
-	}
-	return `${BRIDGE_SCRIPT}${html}`;
-}
-
 /**
- * Renders a VS Code extension's webview inside an iframe using Blob URLs.
- * Blob URLs bypass the parent page's CSP entirely.
+ * Renders a VS Code extension's webview inside an iframe.
+ * Uses a local HTTP server to serve the HTML (bypasses all CSP/protocol issues).
+ * The server also rewrites vscode-webview-resource:// URLs to HTTP.
  */
 export function VscodeExtensionView({
 	viewType,
@@ -44,7 +19,7 @@ export function VscodeExtensionView({
 }: VscodeExtensionViewProps) {
 	const iframeRef = useRef<HTMLIFrameElement>(null);
 	const [viewId, setViewId] = useState<string | null>(null);
-	const [blobUrl, setBlobUrl] = useState<string | null>(null);
+	const [iframeUrl, setIframeUrl] = useState<string | null>(null);
 	const [error, setError] = useState<string | null>(null);
 
 	const resolveMutation =
@@ -60,12 +35,9 @@ export function VscodeExtensionView({
 			{ viewType, extensionPath: "" },
 			{
 				onSuccess: (result) => {
-					if (result.viewId && result.html) {
+					if (result.viewId && result.url) {
 						setViewId(result.viewId);
-						// Create blob URL from HTML with bridge injected
-						const bridgedHtml = injectBridge(result.html);
-						const blob = new Blob([bridgedHtml], { type: "text/html" });
-						setBlobUrl(URL.createObjectURL(blob));
+						setIframeUrl(result.url);
 					} else {
 						setError(`Extension view "${viewType}" not found`);
 					}
@@ -76,13 +48,6 @@ export function VscodeExtensionView({
 			},
 		);
 	}, [isActive, viewId, viewType, resolveMutation.mutate]);
-
-	// Cleanup blob URL on unmount
-	useEffect(() => {
-		return () => {
-			if (blobUrl) URL.revokeObjectURL(blobUrl);
-		};
-	}, [blobUrl]);
 
 	// Listen for messages from iframe -> forward to extension
 	useEffect(() => {
@@ -102,7 +67,7 @@ export function VscodeExtensionView({
 		return () => window.removeEventListener("message", handler);
 	}, [viewId, postMessageMutation.mutate]);
 
-	// Subscribe to webview events (extension -> webview messages, HTML updates)
+	// Subscribe to webview events (extension -> webview messages)
 	electronTrpc.vscodeExtensions.subscribeWebview.useSubscription(undefined, {
 		enabled: isActive && !!viewId,
 		onData: (event) => {
@@ -113,12 +78,12 @@ export function VscodeExtensionView({
 					"*",
 				);
 			}
-			if (event.type === "html" && typeof event.data === "string") {
-				// Update blob URL with new HTML
-				if (blobUrl) URL.revokeObjectURL(blobUrl);
-				const bridgedHtml = injectBridge(event.data);
-				const blob = new Blob([bridgedHtml], { type: "text/html" });
-				setBlobUrl(URL.createObjectURL(blob));
+			if (event.type === "html" && iframeUrl) {
+				// Reload iframe to pick up updated HTML from server
+				const iframe = iframeRef.current;
+				if (iframe) {
+					iframe.src = iframeUrl;
+				}
 			}
 		},
 	});
@@ -131,7 +96,7 @@ export function VscodeExtensionView({
 		);
 	}
 
-	if (!blobUrl) {
+	if (!iframeUrl) {
 		return (
 			<div className="flex-1 flex items-center justify-center text-muted-foreground text-sm">
 				<p>Loading {extensionId}...</p>
@@ -142,7 +107,7 @@ export function VscodeExtensionView({
 	return (
 		<iframe
 			ref={iframeRef}
-			src={blobUrl}
+			src={iframeUrl}
 			className="w-full h-full border-0"
 			sandbox="allow-scripts allow-same-origin allow-forms allow-popups"
 			title={`${extensionId} webview`}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/VscodeExtensionView/VscodeExtensionView.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/VscodeExtensionView/VscodeExtensionView.tsx
@@ -7,10 +7,35 @@ interface VscodeExtensionViewProps {
 	isActive: boolean;
 }
 
+const BRIDGE_SCRIPT = `<script>
+(function() {
+	let _state = null;
+	const vscodeApi = {
+		postMessage(message) {
+			window.parent.postMessage({ type: 'vscode-api', data: message }, '*');
+		},
+		getState() { return _state; },
+		setState(state) { _state = state; return state; }
+	};
+	window.acquireVsCodeApi = function() { return vscodeApi; };
+	window.addEventListener('message', function(event) {
+		if (event.data && event.data.type === 'vscode-message') {
+			window.dispatchEvent(new MessageEvent('message', { data: event.data.data }));
+		}
+	});
+})();
+</script>`;
+
+function injectBridge(html: string): string {
+	if (html.includes("</head>")) {
+		return html.replace("</head>", `${BRIDGE_SCRIPT}</head>`);
+	}
+	return `${BRIDGE_SCRIPT}${html}`;
+}
+
 /**
- * Renders a VS Code extension's webview inside an iframe.
- * Uses vscode-webview:// protocol to serve HTML with its own CSP.
- * Bridges postMessage between the iframe and the extension host via tRPC.
+ * Renders a VS Code extension's webview inside an iframe using Blob URLs.
+ * Blob URLs bypass the parent page's CSP entirely.
  */
 export function VscodeExtensionView({
 	viewType,
@@ -19,7 +44,7 @@ export function VscodeExtensionView({
 }: VscodeExtensionViewProps) {
 	const iframeRef = useRef<HTMLIFrameElement>(null);
 	const [viewId, setViewId] = useState<string | null>(null);
-	const [webviewUrl, setWebviewUrl] = useState<string | null>(null);
+	const [blobUrl, setBlobUrl] = useState<string | null>(null);
 	const [error, setError] = useState<string | null>(null);
 
 	const resolveMutation =
@@ -32,15 +57,15 @@ export function VscodeExtensionView({
 		if (!isActive || viewId) return;
 
 		resolveMutation.mutate(
-			{
-				viewType,
-				extensionPath: "",
-			},
+			{ viewType, extensionPath: "" },
 			{
 				onSuccess: (result) => {
-					if (result.viewId && result.url) {
+					if (result.viewId && result.html) {
 						setViewId(result.viewId);
-						setWebviewUrl(result.url);
+						// Create blob URL from HTML with bridge injected
+						const bridgedHtml = injectBridge(result.html);
+						const blob = new Blob([bridgedHtml], { type: "text/html" });
+						setBlobUrl(URL.createObjectURL(blob));
 					} else {
 						setError(`Extension view "${viewType}" not found`);
 					}
@@ -52,12 +77,18 @@ export function VscodeExtensionView({
 		);
 	}, [isActive, viewId, viewType, resolveMutation.mutate]);
 
+	// Cleanup blob URL on unmount
+	useEffect(() => {
+		return () => {
+			if (blobUrl) URL.revokeObjectURL(blobUrl);
+		};
+	}, [blobUrl]);
+
 	// Listen for messages from iframe -> forward to extension
 	useEffect(() => {
 		if (!viewId) return;
 
 		const handler = (event: MessageEvent) => {
-			// Verify message source is our iframe
 			if (event.source !== iframeRef.current?.contentWindow) return;
 			if (event.data?.type === "vscode-api") {
 				postMessageMutation.mutate({
@@ -71,7 +102,7 @@ export function VscodeExtensionView({
 		return () => window.removeEventListener("message", handler);
 	}, [viewId, postMessageMutation.mutate]);
 
-	// Subscribe to webview events for message forwarding (extension -> webview)
+	// Subscribe to webview events (extension -> webview messages, HTML updates)
 	electronTrpc.vscodeExtensions.subscribeWebview.useSubscription(undefined, {
 		enabled: isActive && !!viewId,
 		onData: (event) => {
@@ -82,8 +113,13 @@ export function VscodeExtensionView({
 					"*",
 				);
 			}
-			// HTML updates trigger protocol store update on main process side
-			// iframe will get fresh content on next load
+			if (event.type === "html" && typeof event.data === "string") {
+				// Update blob URL with new HTML
+				if (blobUrl) URL.revokeObjectURL(blobUrl);
+				const bridgedHtml = injectBridge(event.data);
+				const blob = new Blob([bridgedHtml], { type: "text/html" });
+				setBlobUrl(URL.createObjectURL(blob));
+			}
 		},
 	});
 
@@ -95,7 +131,7 @@ export function VscodeExtensionView({
 		);
 	}
 
-	if (!webviewUrl) {
+	if (!blobUrl) {
 		return (
 			<div className="flex-1 flex items-center justify-center text-muted-foreground text-sm">
 				<p>Loading {extensionId}...</p>
@@ -106,7 +142,7 @@ export function VscodeExtensionView({
 	return (
 		<iframe
 			ref={iframeRef}
-			src={webviewUrl}
+			src={blobUrl}
 			className="w-full h-full border-0"
 			sandbox="allow-scripts allow-same-origin allow-forms allow-popups"
 			title={`${extensionId} webview`}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/VscodeExtensionView/VscodeExtensionView.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/VscodeExtensionView/VscodeExtensionView.tsx
@@ -109,6 +109,8 @@ export function VscodeExtensionView({
 		if (!viewId) return;
 
 		const handler = (event: MessageEvent) => {
+			// Verify message source is our iframe
+			if (event.source !== iframeRef.current?.contentWindow) return;
 			if (event.data?.type === "vscode-api") {
 				postMessageMutation.mutate({
 					viewId,
@@ -144,7 +146,7 @@ export function VscodeExtensionView({
 			ref={iframeRef}
 			srcDoc={bridgedHtml}
 			className="w-full h-full border-0"
-			sandbox="allow-scripts allow-same-origin allow-forms allow-popups"
+			sandbox="allow-scripts allow-forms allow-popups"
 			title={`${extensionId} webview`}
 		/>
 	);
@@ -162,17 +164,16 @@ function injectVscodeApiBridge(
 <style>${themeCss}</style>
 <script>
 (function() {
+	let _state = null;
 	const vscodeApi = {
 		postMessage(message) {
 			window.parent.postMessage({ type: 'vscode-api', data: message }, '*');
 		},
 		getState() {
-			try {
-				return JSON.parse(sessionStorage.getItem('vscodeState') || 'null');
-			} catch { return null; }
+			return _state;
 		},
 		setState(state) {
-			sessionStorage.setItem('vscodeState', JSON.stringify(state));
+			_state = state;
 			return state;
 		}
 	};

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/VscodeExtensionView/index.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/VscodeExtensionView/index.tsx
@@ -1,0 +1,1 @@
+export { VscodeExtensionView } from "./VscodeExtensionView";

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/VscodeExtensionView/vscode-theme-bridge.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/VscodeExtensionView/vscode-theme-bridge.ts
@@ -1,0 +1,156 @@
+/**
+ * Maps Superset CSS variables to VS Code CSS variables.
+ *
+ * VS Code extensions' webviews depend on `--vscode-*` CSS variables
+ * for styling. This module reads Superset's current theme and generates
+ * a <style> block that defines the equivalent VS Code variables.
+ */
+
+/**
+ * Mapping from VS Code CSS variable to Superset CSS variable (or fallback).
+ * VS Code has ~200+ variables, but extensions typically use a subset.
+ * This covers the most commonly used ones by Claude Code and ChatGPT.
+ */
+const VSCODE_TO_SUPERSET: Record<string, string> = {
+	// Editor
+	"--vscode-editor-background": "--background",
+	"--vscode-editor-foreground": "--foreground",
+
+	// Sidebar
+	"--vscode-sideBar-background": "--sidebar",
+	"--vscode-sideBar-foreground": "--sidebar-foreground",
+	"--vscode-sideBar-border": "--sidebar-border",
+	"--vscode-sideBarTitle-foreground": "--sidebar-foreground",
+	"--vscode-sideBarSectionHeader-background": "--sidebar-accent",
+	"--vscode-sideBarSectionHeader-foreground": "--sidebar-accent-foreground",
+
+	// Panel
+	"--vscode-panel-background": "--background",
+	"--vscode-panel-foreground": "--foreground",
+	"--vscode-panel-border": "--border",
+	"--vscode-panelTitle-activeForeground": "--foreground",
+	"--vscode-panelTitle-inactiveForeground": "--muted-foreground",
+
+	// Input
+	"--vscode-input-background": "--input",
+	"--vscode-input-foreground": "--foreground",
+	"--vscode-input-border": "--border",
+	"--vscode-input-placeholderForeground": "--muted-foreground",
+	"--vscode-inputOption-activeBorder": "--primary",
+	"--vscode-inputOption-activeBackground": "--accent",
+	"--vscode-inputOption-activeForeground": "--accent-foreground",
+
+	// Button
+	"--vscode-button-background": "--primary",
+	"--vscode-button-foreground": "--primary-foreground",
+	"--vscode-button-hoverBackground": "--primary",
+	"--vscode-button-secondaryBackground": "--secondary",
+	"--vscode-button-secondaryForeground": "--secondary-foreground",
+
+	// Badge
+	"--vscode-badge-background": "--primary",
+	"--vscode-badge-foreground": "--primary-foreground",
+
+	// Focus
+	"--vscode-focusBorder": "--ring",
+
+	// Text
+	"--vscode-foreground": "--foreground",
+	"--vscode-descriptionForeground": "--muted-foreground",
+	"--vscode-disabledForeground": "--muted-foreground",
+	"--vscode-errorForeground": "--destructive",
+
+	// Widget
+	"--vscode-widget-shadow": "--border",
+	"--vscode-widget-border": "--border",
+
+	// List
+	"--vscode-list-hoverBackground": "--accent",
+	"--vscode-list-hoverForeground": "--accent-foreground",
+	"--vscode-list-activeSelectionBackground": "--primary",
+	"--vscode-list-activeSelectionForeground": "--primary-foreground",
+	"--vscode-list-inactiveSelectionBackground": "--secondary",
+	"--vscode-list-inactiveSelectionForeground": "--secondary-foreground",
+
+	// Dropdown
+	"--vscode-dropdown-background": "--popover",
+	"--vscode-dropdown-foreground": "--popover-foreground",
+	"--vscode-dropdown-border": "--border",
+
+	// Scrollbar
+	"--vscode-scrollbarSlider-background": "--muted",
+	"--vscode-scrollbarSlider-hoverBackground": "--accent",
+	"--vscode-scrollbarSlider-activeBackground": "--accent",
+
+	// TextLink
+	"--vscode-textLink-foreground": "--primary",
+	"--vscode-textLink-activeForeground": "--primary",
+
+	// Checkbox
+	"--vscode-checkbox-background": "--input",
+	"--vscode-checkbox-border": "--border",
+	"--vscode-checkbox-foreground": "--foreground",
+
+	// Toolbar
+	"--vscode-toolbar-hoverBackground": "--accent",
+
+	// Tab
+	"--vscode-tab-activeBackground": "--background",
+	"--vscode-tab-activeForeground": "--foreground",
+	"--vscode-tab-inactiveBackground": "--muted",
+	"--vscode-tab-inactiveForeground": "--muted-foreground",
+	"--vscode-tab-border": "--border",
+
+	// Notification
+	"--vscode-notifications-background": "--card",
+	"--vscode-notifications-foreground": "--card-foreground",
+	"--vscode-notifications-border": "--border",
+};
+
+/**
+ * Generates a CSS style block that maps Superset theme to VS Code variables.
+ * Reads current computed CSS variable values from the document root.
+ */
+export function generateVscodeThemeCss(): string {
+	const root = document.documentElement;
+	const computedStyle = getComputedStyle(root);
+	const isDark = root.classList.contains("dark");
+
+	const lines: string[] = [];
+	lines.push(":root {");
+
+	// Map Superset variables to VS Code variables
+	for (const [vscodeVar, supersetVar] of Object.entries(VSCODE_TO_SUPERSET)) {
+		const value = computedStyle.getPropertyValue(supersetVar).trim();
+		if (value) {
+			lines.push(`  ${vscodeVar}: ${value};`);
+		}
+	}
+
+	// VS Code font variables
+	lines.push(
+		'  --vscode-font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;',
+	);
+	lines.push("  --vscode-font-size: 13px;");
+	lines.push("  --vscode-font-weight: normal;");
+	lines.push(
+		'  --vscode-editor-font-family: "SF Mono", Monaco, Menlo, Consolas, monospace;',
+	);
+	lines.push("  --vscode-editor-font-size: 13px;");
+
+	lines.push("}");
+
+	// Dark/light body class for extensions that check it
+	lines.push(`body { color-scheme: ${isDark ? "dark" : "light"}; }`);
+	lines.push(`body.vscode-dark, body.vscode-light { margin: 0; padding: 0; }`);
+
+	return lines.join("\n");
+}
+
+/**
+ * Returns the VS Code body class based on current theme.
+ */
+export function getVscodeBodyClass(): string {
+	const isDark = document.documentElement.classList.contains("dark");
+	return isDark ? "vscode-dark" : "vscode-light";
+}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/index.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/index.tsx
@@ -31,6 +31,7 @@ import {
 } from "react";
 import type { IconType } from "react-icons";
 import {
+	LuBot,
 	LuBox,
 	LuCircleAlert,
 	LuDatabase,
@@ -40,9 +41,8 @@ import {
 	LuGitCompareArrows,
 	LuSearch,
 	LuShrink,
-	LuX,
-	LuBot,
 	LuSparkles,
+	LuX,
 } from "react-icons/lu";
 import { HotkeyLabel } from "renderer/hotkeys";
 import { electronTrpc } from "renderer/lib/electron-trpc";

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/index.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/index.tsx
@@ -41,6 +41,8 @@ import {
 	LuSearch,
 	LuShrink,
 	LuX,
+	LuBot,
+	LuSparkles,
 } from "react-icons/lu";
 import { HotkeyLabel } from "renderer/hotkeys";
 import { electronTrpc } from "renderer/lib/electron-trpc";
@@ -61,6 +63,7 @@ import { FilesView } from "./FilesView";
 import { getSidebarHeaderTabButtonClassName } from "./headerTabStyles";
 import { ProblemsView } from "./ProblemsView";
 import { SearchView } from "./SearchView";
+import { VscodeExtensionView } from "./VscodeExtensionView";
 
 interface SidebarTabDefinition {
 	id: RightSidebarTab;
@@ -96,6 +99,14 @@ const RIGHT_SIDEBAR_TAB_METADATA: Record<
 	[RightSidebarTab.Databases]: {
 		label: "Databases",
 		icon: LuDatabase,
+	},
+	[RightSidebarTab.ClaudeCode]: {
+		label: "Claude",
+		icon: LuBot,
+	},
+	[RightSidebarTab.Codex]: {
+		label: "Codex",
+		icon: LuSparkles,
 	},
 };
 
@@ -749,6 +760,32 @@ export function RightSidebar({ isActive = true }: { isActive?: boolean }) {
 				}
 			>
 				<DatabasesView onOpenExplorer={handleOpenDatabaseExplorer} />
+			</div>
+			<div
+				className={
+					rightSidebarTab === RightSidebarTab.ClaudeCode
+						? "flex-1 min-h-0 flex flex-col overflow-hidden"
+						: "hidden"
+				}
+			>
+				<VscodeExtensionView
+					viewType="claudeVSCodeSidebar"
+					extensionId="anthropic.claude-code"
+					isActive={rightSidebarTab === RightSidebarTab.ClaudeCode}
+				/>
+			</div>
+			<div
+				className={
+					rightSidebarTab === RightSidebarTab.Codex
+						? "flex-1 min-h-0 flex flex-col overflow-hidden"
+						: "hidden"
+				}
+			>
+				<VscodeExtensionView
+					viewType="chatgpt.sidebarView"
+					extensionId="openai.chatgpt"
+					isActive={rightSidebarTab === RightSidebarTab.Codex}
+				/>
 			</div>
 		</aside>
 	);

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/index.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/index.tsx
@@ -275,6 +275,18 @@ export function RightSidebar({ isActive = true }: { isActive?: boolean }) {
 			staleTime: 10000,
 		},
 	);
+	const knownExtensionsQuery =
+		electronTrpc.vscodeExtensions.getKnownExtensions.useQuery(undefined, {
+			enabled: isActive,
+			staleTime: 30000,
+		});
+	const installedExtensionIds = new Set(
+		(knownExtensionsQuery.data ?? [])
+			.filter((ext) => ext.installed)
+			.map((ext) => ext.id),
+	);
+	const showClaudeCodeTab = installedExtensionIds.has("anthropic.claude-code");
+	const showCodexTab = installedExtensionIds.has("openai.chatgpt");
 	const hasProblemErrors = (workspaceDiagnostics?.summary.errorCount ?? 0) > 0;
 	const dockerComposeFiles = dockerComposeFilesQuery.data;
 	const isResolvingDockerVisibility =
@@ -303,6 +315,12 @@ export function RightSidebar({ isActive = true }: { isActive?: boolean }) {
 				if (tabId === RightSidebarTab.Docker) {
 					return showDockerTab;
 				}
+				if (tabId === RightSidebarTab.ClaudeCode) {
+					return showClaudeCodeTab;
+				}
+				if (tabId === RightSidebarTab.Codex) {
+					return showCodexTab;
+				}
 				return true;
 			})
 			.map((tabId) => ({
@@ -311,7 +329,14 @@ export function RightSidebar({ isActive = true }: { isActive?: boolean }) {
 				hasAlert:
 					tabId === RightSidebarTab.Problems ? hasProblemErrors : undefined,
 			}));
-	}, [hasProblemErrors, rightSidebarTabOrder, showChangesTab, showDockerTab]);
+	}, [
+		hasProblemErrors,
+		rightSidebarTabOrder,
+		showChangesTab,
+		showDockerTab,
+		showClaudeCodeTab,
+		showCodexTab,
+	]);
 
 	useEffect(() => {
 		if (!isActive) {
@@ -761,32 +786,36 @@ export function RightSidebar({ isActive = true }: { isActive?: boolean }) {
 			>
 				<DatabasesView onOpenExplorer={handleOpenDatabaseExplorer} />
 			</div>
-			<div
-				className={
-					rightSidebarTab === RightSidebarTab.ClaudeCode
-						? "flex-1 min-h-0 flex flex-col overflow-hidden"
-						: "hidden"
-				}
-			>
-				<VscodeExtensionView
-					viewType="claudeVSCodeSidebar"
-					extensionId="anthropic.claude-code"
-					isActive={rightSidebarTab === RightSidebarTab.ClaudeCode}
-				/>
-			</div>
-			<div
-				className={
-					rightSidebarTab === RightSidebarTab.Codex
-						? "flex-1 min-h-0 flex flex-col overflow-hidden"
-						: "hidden"
-				}
-			>
-				<VscodeExtensionView
-					viewType="chatgpt.sidebarView"
-					extensionId="openai.chatgpt"
-					isActive={rightSidebarTab === RightSidebarTab.Codex}
-				/>
-			</div>
+			{showClaudeCodeTab && (
+				<div
+					className={
+						rightSidebarTab === RightSidebarTab.ClaudeCode
+							? "flex-1 min-h-0 flex flex-col overflow-hidden"
+							: "hidden"
+					}
+				>
+					<VscodeExtensionView
+						viewType="claudeVSCodeSidebar"
+						extensionId="anthropic.claude-code"
+						isActive={rightSidebarTab === RightSidebarTab.ClaudeCode}
+					/>
+				</div>
+			)}
+			{showCodexTab && (
+				<div
+					className={
+						rightSidebarTab === RightSidebarTab.Codex
+							? "flex-1 min-h-0 flex flex-col overflow-hidden"
+							: "hidden"
+					}
+				>
+					<VscodeExtensionView
+						viewType="chatgpt.sidebarView"
+						extensionId="openai.chatgpt"
+						isActive={rightSidebarTab === RightSidebarTab.Codex}
+					/>
+				</div>
+			)}
 		</aside>
 	);
 }

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/WorkspaceLayout/WorkspaceLayout.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/WorkspaceLayout/WorkspaceLayout.tsx
@@ -12,6 +12,7 @@ import { ChangesContent, ScrollProvider } from "../ChangesContent";
 import { ContentView } from "../ContentView";
 import { useActiveEditorSync } from "../hooks/useActiveEditorSync";
 import { useBrowserLifecycle } from "../hooks/useBrowserLifecycle";
+import { useVscodeExtensionPanelSync } from "../hooks/useVscodeExtensionPanelSync";
 import { RightSidebar } from "../RightSidebar";
 
 interface WorkspaceLayoutProps {
@@ -31,6 +32,7 @@ export function WorkspaceLayout({
 }: WorkspaceLayoutProps) {
 	useBrowserLifecycle();
 	useActiveEditorSync();
+	useVscodeExtensionPanelSync();
 	const isSidebarOpen = useSidebarStore((s) => s.isSidebarOpen);
 	const sidebarWidth = useSidebarStore((s) => s.sidebarWidth);
 	const setSidebarWidth = useSidebarStore((s) => s.setSidebarWidth);

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/WorkspaceLayout/WorkspaceLayout.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/WorkspaceLayout/WorkspaceLayout.tsx
@@ -10,6 +10,7 @@ import {
 import { ResizablePanel } from "../../ResizablePanel";
 import { ChangesContent, ScrollProvider } from "../ChangesContent";
 import { ContentView } from "../ContentView";
+import { useActiveEditorSync } from "../hooks/useActiveEditorSync";
 import { useBrowserLifecycle } from "../hooks/useBrowserLifecycle";
 import { RightSidebar } from "../RightSidebar";
 
@@ -29,6 +30,7 @@ export function WorkspaceLayout({
 	onOpenQuickOpen,
 }: WorkspaceLayoutProps) {
 	useBrowserLifecycle();
+	useActiveEditorSync();
 	const isSidebarOpen = useSidebarStore((s) => s.isSidebarOpen);
 	const sidebarWidth = useSidebarStore((s) => s.sidebarWidth);
 	const setSidebarWidth = useSidebarStore((s) => s.setSidebarWidth);

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/WorkspaceLayout/WorkspaceLayout.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/WorkspaceLayout/WorkspaceLayout.tsx
@@ -13,6 +13,7 @@ import { ContentView } from "../ContentView";
 import { useActiveEditorSync } from "../hooks/useActiveEditorSync";
 import { useBrowserLifecycle } from "../hooks/useBrowserLifecycle";
 import { useVscodeExtensionPanelSync } from "../hooks/useVscodeExtensionPanelSync";
+import { useVscodeOpenFileSync } from "../hooks/useVscodeOpenFileSync";
 import { RightSidebar } from "../RightSidebar";
 
 interface WorkspaceLayoutProps {
@@ -33,6 +34,7 @@ export function WorkspaceLayout({
 	useBrowserLifecycle();
 	useActiveEditorSync();
 	useVscodeExtensionPanelSync();
+	useVscodeOpenFileSync();
 	const isSidebarOpen = useSidebarStore((s) => s.isSidebarOpen);
 	const sidebarWidth = useSidebarStore((s) => s.sidebarWidth);
 	const setSidebarWidth = useSidebarStore((s) => s.setSidebarWidth);

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/hooks/useActiveEditorSync.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/hooks/useActiveEditorSync.ts
@@ -1,0 +1,72 @@
+import { useEffect, useRef } from "react";
+import { electronTrpc } from "renderer/lib/electron-trpc";
+import { useTabsStore } from "renderer/stores/tabs/store";
+import { useWorkspaceId } from "../WorkspaceIdContext";
+
+/**
+ * Syncs the currently focused file-viewer pane to the VS Code extension host's
+ * activeTextEditor, so extensions know which file the user is looking at.
+ */
+export function useActiveEditorSync() {
+	const workspaceId = useWorkspaceId();
+	const activeTabIds = useTabsStore((s) => s.activeTabIds);
+	const focusedPaneIds = useTabsStore((s) => s.focusedPaneIds);
+	const panes = useTabsStore((s) => s.panes);
+	const lastFilePath = useRef<string | null>(null);
+
+	const setActiveEditorMutation =
+		electronTrpc.vscodeExtensions.setActiveEditor.useMutation();
+
+	useEffect(() => {
+		if (!workspaceId) return;
+
+		const activeTabId = activeTabIds[workspaceId];
+		if (!activeTabId) return;
+
+		const focusedPaneId = focusedPaneIds[activeTabId];
+		if (!focusedPaneId) return;
+
+		const pane = panes[focusedPaneId];
+		if (!pane) return;
+
+		let filePath: string | null = null;
+		let languageId: string | undefined;
+
+		if (pane.type === "file-viewer" && pane.fileViewer?.filePath) {
+			filePath = pane.fileViewer.filePath;
+			// Derive languageId from file extension
+			const ext = filePath.split(".").pop()?.toLowerCase();
+			const EXT_TO_LANG: Record<string, string> = {
+				ts: "typescript",
+				tsx: "typescriptreact",
+				js: "javascript",
+				jsx: "javascriptreact",
+				py: "python",
+				rs: "rust",
+				go: "go",
+				json: "json",
+				md: "markdown",
+				css: "css",
+				html: "html",
+				yaml: "yaml",
+				yml: "yaml",
+				toml: "toml",
+				sh: "shellscript",
+				sql: "sql",
+			};
+			languageId = ext ? (EXT_TO_LANG[ext] ?? ext) : "plaintext";
+		}
+
+		// Only notify if the file actually changed
+		if (filePath !== lastFilePath.current) {
+			lastFilePath.current = filePath;
+			setActiveEditorMutation.mutate({ filePath, languageId });
+		}
+	}, [
+		workspaceId,
+		activeTabIds,
+		focusedPaneIds,
+		panes,
+		setActiveEditorMutation.mutate,
+	]);
+}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/hooks/useActiveEditorSync.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/hooks/useActiveEditorSync.ts
@@ -4,8 +4,9 @@ import { useTabsStore } from "renderer/stores/tabs/store";
 import { useWorkspaceId } from "../WorkspaceIdContext";
 
 /**
- * Syncs the currently focused file-viewer pane to the VS Code extension host's
- * activeTextEditor, so extensions know which file the user is looking at.
+ * Syncs the active workspace path and focused file to the VS Code extension host.
+ * - workspace path → vscode.workspace.workspaceFolders (needed for extensions to operate)
+ * - focused file → vscode.window.activeTextEditor
  */
 export function useActiveEditorSync() {
 	const workspaceId = useWorkspaceId();
@@ -13,10 +14,29 @@ export function useActiveEditorSync() {
 	const focusedPaneIds = useTabsStore((s) => s.focusedPaneIds);
 	const panes = useTabsStore((s) => s.panes);
 	const lastFilePath = useRef<string | null>(null);
+	const lastWorkspacePath = useRef<string | null>(null);
+
+	const { data: workspace } = electronTrpc.workspaces.get.useQuery(
+		{ id: workspaceId ?? "" },
+		{ enabled: !!workspaceId },
+	);
 
 	const setActiveEditorMutation =
 		electronTrpc.vscodeExtensions.setActiveEditor.useMutation();
+	const setWorkspacePathMutation =
+		electronTrpc.vscodeExtensions.setWorkspacePath.useMutation();
 
+	// Sync workspace path when workspace changes
+	useEffect(() => {
+		const worktreePath = workspace?.worktreePath;
+		if (!worktreePath) return;
+		if (worktreePath === lastWorkspacePath.current) return;
+
+		lastWorkspacePath.current = worktreePath;
+		setWorkspacePathMutation.mutate({ workspacePath: worktreePath });
+	}, [workspace?.worktreePath, setWorkspacePathMutation.mutate]);
+
+	// Sync active file
 	useEffect(() => {
 		if (!workspaceId) return;
 
@@ -34,7 +54,6 @@ export function useActiveEditorSync() {
 
 		if (pane.type === "file-viewer" && pane.fileViewer?.filePath) {
 			filePath = pane.fileViewer.filePath;
-			// Derive languageId from file extension
 			const ext = filePath.split(".").pop()?.toLowerCase();
 			const EXT_TO_LANG: Record<string, string> = {
 				ts: "typescript",
@@ -57,7 +76,6 @@ export function useActiveEditorSync() {
 			languageId = ext ? (EXT_TO_LANG[ext] ?? ext) : "plaintext";
 		}
 
-		// Only notify if the file actually changed
 		if (filePath !== lastFilePath.current) {
 			lastFilePath.current = filePath;
 			setActiveEditorMutation.mutate({ filePath, languageId });

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/hooks/useVscodeExtensionPanelSync.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/hooks/useVscodeExtensionPanelSync.ts
@@ -1,0 +1,36 @@
+import { electronTrpc } from "renderer/lib/electron-trpc";
+import { useTabsStore } from "renderer/stores/tabs/store";
+import { useWorkspaceId } from "../WorkspaceIdContext";
+
+/**
+ * Listens for VS Code extension panel creation events and
+ * automatically opens them as tabs in the current workspace.
+ */
+export function useVscodeExtensionPanelSync() {
+	const workspaceId = useWorkspaceId();
+	const addVscodeExtensionTab = useTabsStore((s) => s.addVscodeExtensionTab);
+
+	electronTrpc.vscodeExtensions.subscribeWebview.useSubscription(undefined, {
+		enabled: !!workspaceId,
+		onData: (event) => {
+			if (
+				event.type === "panel-created" &&
+				workspaceId &&
+				typeof event.data === "object" &&
+				event.data !== null
+			) {
+				const { viewType, title, panelId } = event.data as {
+					viewType: string;
+					title: string;
+					panelId: string;
+				};
+				addVscodeExtensionTab(
+					workspaceId,
+					viewType,
+					viewType,
+					title || "Extension Panel",
+				);
+			}
+		},
+	});
+}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/hooks/useVscodeExtensionPanelSync.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/hooks/useVscodeExtensionPanelSync.ts
@@ -1,6 +1,22 @@
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { useTabsStore } from "renderer/stores/tabs/store";
+import type { Pane } from "shared/tabs-types";
 import { useWorkspaceId } from "../WorkspaceIdContext";
+
+/**
+ * Derive extensionId from extensionPath (format: publisher.name-version)
+ * e.g. "/home/user/.vscode/extensions/anthropic.claude-code-1.2.3" -> "anthropic.claude-code"
+ */
+function extensionIdFromPath(extensionPath: string): string | null {
+	const lastSep = Math.max(
+		extensionPath.lastIndexOf("/"),
+		extensionPath.lastIndexOf("\\"),
+	);
+	const dirName =
+		lastSep >= 0 ? extensionPath.slice(lastSep + 1) : extensionPath;
+	const match = dirName.match(/^([a-zA-Z0-9_-]+\.[a-zA-Z0-9_-]+)/);
+	return match?.[1] ?? null;
+}
 
 /**
  * Listens for VS Code extension panel creation events and
@@ -19,14 +35,32 @@ export function useVscodeExtensionPanelSync() {
 				typeof event.data === "object" &&
 				event.data !== null
 			) {
-				const { viewType, title, panelId } = event.data as {
+				const { viewType, title, extensionPath } = event.data as {
 					viewType: string;
 					title: string;
 					panelId: string;
+					extensionPath?: string;
 				};
+
+				// Derive extensionId from extensionPath or fall back to viewType
+				const extensionId =
+					(extensionPath ? extensionIdFromPath(extensionPath) : null) ??
+					viewType;
+
+				// Dedup: skip if a vscode-extension pane with the same viewType already exists
+				const panes = useTabsStore.getState().panes;
+				const alreadyExists = Object.values(panes).some(
+					(pane: Pane) =>
+						pane.type === "vscode-extension" &&
+						pane.vscodeExtension?.viewType === viewType,
+				);
+				if (alreadyExists) {
+					return;
+				}
+
 				addVscodeExtensionTab(
 					workspaceId,
-					viewType,
+					extensionId,
 					viewType,
 					title || "Extension Panel",
 				);

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/hooks/useVscodeOpenFileSync.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/hooks/useVscodeOpenFileSync.ts
@@ -1,0 +1,24 @@
+import { electronTrpc } from "renderer/lib/electron-trpc";
+import { useTabsStore } from "renderer/stores/tabs/store";
+import { useWorkspaceId } from "../WorkspaceIdContext";
+
+/**
+ * Listens for file open requests from VS Code extensions
+ * (showTextDocument calls) and opens them in Superset's file viewer.
+ */
+export function useVscodeOpenFileSync() {
+	const workspaceId = useWorkspaceId();
+	const addFileViewerPane = useTabsStore((s) => s.addFileViewerPane);
+
+	electronTrpc.vscodeExtensions.subscribeOpenFile.useSubscription(undefined, {
+		enabled: !!workspaceId,
+		onData: (data) => {
+			if (!workspaceId) return;
+			addFileViewerPane(workspaceId, {
+				filePath: data.filePath,
+				line: data.line,
+				viewMode: "raw",
+			});
+		},
+	});
+}

--- a/apps/desktop/src/renderer/stores/settings-state.ts
+++ b/apps/desktop/src/renderer/stores/settings-state.ts
@@ -18,7 +18,8 @@ export type SettingsSection =
 	| "billing"
 	| "apikeys"
 	| "permissions"
-	| "project";
+	| "project"
+	| "vscodeExtensions";
 
 interface SettingsState {
 	activeSection: SettingsSection;

--- a/apps/desktop/src/renderer/stores/sidebar-state.ts
+++ b/apps/desktop/src/renderer/stores/sidebar-state.ts
@@ -13,6 +13,8 @@ export enum RightSidebarTab {
 	Search = "search",
 	Problems = "problems",
 	Databases = "databases",
+	ClaudeCode = "claude-code",
+	Codex = "codex",
 }
 
 export const DEFAULT_RIGHT_SIDEBAR_TAB_ORDER = [
@@ -22,6 +24,8 @@ export const DEFAULT_RIGHT_SIDEBAR_TAB_ORDER = [
 	RightSidebarTab.Search,
 	RightSidebarTab.Problems,
 	RightSidebarTab.Databases,
+	RightSidebarTab.ClaudeCode,
+	RightSidebarTab.Codex,
 ] as const satisfies RightSidebarTab[];
 
 export const DEFAULT_SIDEBAR_WIDTH = 250;

--- a/apps/desktop/src/renderer/stores/tabs/store.ts
+++ b/apps/desktop/src/renderer/stores/tabs/store.ts
@@ -43,6 +43,7 @@ import {
 	createGitGraphTabWithPane,
 	createPane,
 	createTabWithPane,
+	createVscodeExtensionTabWithPane,
 	equalizeSplitPercentages,
 	extractPaneIdsFromLayout,
 	findReusableFileViewerPane,
@@ -1717,6 +1718,56 @@ export const useTabsStore = create<TabsStore>()(
 
 					posthog.capture("panel_opened", {
 						panel_type: "database-explorer",
+						workspace_id: workspaceId,
+						pane_id: pane.id,
+					});
+
+					return { tabId: tab.id, paneId: pane.id };
+				},
+
+				addVscodeExtensionTab: (
+					workspaceId: string,
+					extensionId: string,
+					viewType: string,
+					name: string,
+				) => {
+					const state = get();
+
+					const { tab, pane } = createVscodeExtensionTabWithPane(
+						workspaceId,
+						extensionId,
+						viewType,
+						name,
+					);
+
+					const currentActiveId = state.activeTabIds[workspaceId];
+					const historyStack = state.tabHistoryStacks[workspaceId] || [];
+					const newHistoryStack = currentActiveId
+						? [
+								currentActiveId,
+								...historyStack.filter((id) => id !== currentActiveId),
+							]
+						: historyStack;
+
+					set({
+						tabs: [...state.tabs, tab],
+						panes: { ...state.panes, [pane.id]: pane },
+						activeTabIds: {
+							...state.activeTabIds,
+							[workspaceId]: tab.id,
+						},
+						focusedPaneIds: {
+							...state.focusedPaneIds,
+							[tab.id]: pane.id,
+						},
+						tabHistoryStacks: {
+							...state.tabHistoryStacks,
+							[workspaceId]: newHistoryStack,
+						},
+					});
+
+					posthog.capture("panel_opened", {
+						panel_type: "vscode-extension",
 						workspace_id: workspaceId,
 						pane_id: pane.id,
 					});

--- a/apps/desktop/src/renderer/stores/tabs/types.ts
+++ b/apps/desktop/src/renderer/stores/tabs/types.ts
@@ -211,6 +211,12 @@ export interface TabsStore extends TabsState {
 		workspaceId: string,
 		connectionId?: string | null,
 	) => { tabId: string; paneId: string };
+	addVscodeExtensionTab: (
+		workspaceId: string,
+		extensionId: string,
+		viewType: string,
+		name: string,
+	) => { tabId: string; paneId: string };
 	addGitGraphTab: (
 		workspaceId: string,
 		worktreePath: string,

--- a/apps/desktop/src/renderer/stores/tabs/utils.ts
+++ b/apps/desktop/src/renderer/stores/tabs/utils.ts
@@ -1049,3 +1049,39 @@ export const activatePaneInWorkspace = ({
 		},
 	};
 };
+
+export const createVscodeExtensionPane = (
+	tabId: string,
+	extensionId: string,
+	viewType: string,
+	name: string,
+): Pane => {
+	const id = generateId("pane");
+	return {
+		id,
+		tabId,
+		type: "vscode-extension",
+		name,
+		vscodeExtension: { viewType, extensionId },
+	};
+};
+
+export const createVscodeExtensionTabWithPane = (
+	workspaceId: string,
+	extensionId: string,
+	viewType: string,
+	name: string,
+): { tab: Tab; pane: Pane } => {
+	const tabId = generateId("tab");
+	const pane = createVscodeExtensionPane(tabId, extensionId, viewType, name);
+
+	const tab: Tab = {
+		id: tabId,
+		name,
+		workspaceId,
+		layout: pane.id,
+		createdAt: Date.now(),
+	};
+
+	return { tab, pane };
+};

--- a/apps/desktop/src/shared/tabs-types.ts
+++ b/apps/desktop/src/shared/tabs-types.ts
@@ -16,7 +16,8 @@ export type PaneType =
 	| "devtools"
 	| "git-graph"
 	| "database-explorer"
-	| "action-logs";
+	| "action-logs"
+	| "vscode-extension";
 
 /**
  * Pane status for agent lifecycle indicators
@@ -148,6 +149,7 @@ export interface Pane {
 	gitGraph?: GitGraphPaneState; // For git-graph panes
 	databaseExplorer?: DatabaseExplorerPaneState; // For database explorer panes
 	actionLogs?: ActionLogsPaneState; // For GitHub Actions log panes
+	vscodeExtension?: { viewType: string; extensionId: string };
 	workspaceRun?: {
 		workspaceId: string;
 		state: "running" | "stopped-by-user" | "stopped-by-exit";


### PR DESCRIPTION
## 概要

Superset Desktop に VS Code 拡張機能ホストシム層を追加し、公式の **Claude Code** および **ChatGPT/Codex** 拡張機能をネイティブに動作させる。

フルの VS Code / Theia を組み込むことなく、両拡張が使用する VS Code API のサブセット (~30 API) をシム実装し、拡張機能の Webview UI を既存のサイドバー/タブシステムに統合する。

## 動作確認済み

- Claude Code: 完全なチャットUI表示、認証成功、MCP サーバー接続、双方向メッセージング
- Codex/ChatGPT: チャットUI表示、postMessage 通信、app-server 接続
- 両拡張: \`activate()\` 成功、webview レンダリング、VS Code テーマ変数適用
- ファイルリンククリック → Superset のファイルビューワーで開く
- typecheck: Pass
- lint errors: 0 (warnings のみ)
- unit tests: 1401 pass / 2 fail (既存の無関係な失敗)
- build: DMG 生成成功 (\`SUPERSET_WORKSPACE_NAME=superset\`)

## 実装内容

### VS Code API シム層 (\`apps/desktop/src/main/lib/vscode-shim/\`)
- **API プリミティブ**: \`Uri\`, \`EventEmitter\`, \`Disposable\`, \`CancellationTokenSource\`, \`Position\`, \`Range\`, \`Selection\`
- **Commands**: \`registerCommand\` / \`executeCommand\` / \`setContext\` + 12個の組み込みコマンドハンドラ (vscode.diff, revealInExplorer, reloadWindow 等)
- **Workspace**: \`workspaceFolders\`, \`fs\` (カスタムスキーム対応), \`openTextDocument\`, \`getConfiguration\`, \`findFiles\`, \`onDidChangeWorkspaceFolders\`
- **Window**: \`createTerminal\` (DaemonTerminalManager連携), \`showMessage系\` (Electron dialog), \`createWebviewPanel\` (UI自動連携), \`registerWebviewViewProvider\`, \`activeTextEditor\`, \`showTextDocument\` → ファイルビューワー連携
- **ExtensionContext**: \`globalState\`/\`workspaceState\` (JSON永続化), \`secrets\` (safeStorage暗号化), \`environmentVariableCollection\` (サンドボックス化)
- **Extension Loader**: \`require('vscode')\` インターセプト、\`package.json\` 解析、activate/deactivate ライフサイクル
- **Proxy ロガー**: 未実装 API アクセスの自動ログ (dev モードのみ)

### Webview 配信 (\`webview-server.ts\`)
- localhost HTTP サーバーで webview HTML + 拡張リソース (JS/CSS/画像) を配信
- \`vscode-webview-resource://\` URL を \`http://127.0.0.1:PORT/resource/\` に自動書き換え
- 拡張の CSP meta タグ除去 + 独自 CSP ヘッダー付与
- VS Code dark theme CSS 変数 ~70個を注入
- \`acquireVsCodeApi()\` ブリッジスクリプト注入 (postMessage + state管理)
- Codex の message-bus origin バリデーション対応 (MessageEvent origin 設定)

### UI 統合
- **ContentHeader ボタン**: 左クリック=サイドバー、右クリック=コンテキストメニュー (Open in sidebar / Open as tab)
- **サイドバータブ**: RightSidebar に Claude Code / Codex タブ (インストール済みのみ表示)
- **メインタブ**: \`addVscodeExtensionTab\` ストアアクション (正しい PaneType で作成)
- **パネル自動作成**: \`createWebviewPanel\` → tRPC event → renderer で自動タブ追加 (重複防止付き)
- **ファイルリンク**: 拡張内のファイルリンク → \`showTextDocument\` → Superset ファイルビューワーで開く
- **設定ページ**: Settings > VS Code Extensions (オン/オフ Switch、Install ボタン、Restart ボタン)
- **マーケットプレイス自動DL**: VS Code Marketplace API から .vsix をダウンロード・展開

### ワークスペース連携
- \`activeTextEditor\`: focusedPane → main process 同期
- \`workspaceFolders\`: アクティブワークスペースの worktreePath を自動設定
- 起動時に最後のワークスペースパスを localDb から取得して初期化
- ターミナル cwd のデフォルトをワークスペースパスに設定

## セキュリティ対応

- パストラバーサル防止: \`~/.vscode/extensions/\` のみ許可するホワイトリスト
- コマンドインジェクション防止: \`spawnSync\` 引数配列形式 + \`fs.cpSync\`
- extensionId バリデーション: KNOWN_EXTENSIONS ホワイトリスト + 正規表現
- SecretStorage: \`electron.safeStorage\` で暗号化してからファイル保存
- EnvironmentVariableCollection: \`process.env\` 直接変更を廃止、内部 Map のみ
- iframe postMessage: \`event.source\` 検証
- CORS ワイルドカード削除
- setExtensionEnabled: KNOWN_EXTENSIONS 検証追加
- 404ページ: 内部情報露出を削除
- デバッグログ: \`shimLog\`/\`shimWarn\` で development モードのみ表示
- メモリリーク対策: terminal exit リスナー自己削除、webview htmlStore dispose クリーンアップ

## ファイル構成

\`\`\`
apps/desktop/src/main/lib/vscode-shim/          # VS Code API シム (18ファイル)
├── api/                                         # 個別 API 実装
│   ├── commands.ts, configuration.ts, debug-log.ts
│   ├── event-emitter.ts, extension-context.ts, output-channel.ts
│   ├── protocol-handler.ts, terminal-shim.ts, uri.ts
│   ├── webview.ts, webview-server.ts, window.ts, workspace.ts
├── extension-host.ts, loader.ts, vscode-api.ts
├── webview-bridge.ts, types.ts, index.ts

apps/desktop/src/lib/trpc/routers/vscode-extensions/  # tRPC ルーター
apps/desktop/src/renderer/.../VscodeExtensionView/     # Webview レンダラー
apps/desktop/src/renderer/.../VscodeExtensionButtons/  # ヘッダーボタン
apps/desktop/src/renderer/.../VscodeExtensionPane/     # タブペイン
apps/desktop/src/renderer/routes/.../vscode-extensions/ # 設定ページ
\`\`\`

49ファイル変更、+5,491行

## 既知の制約・TODO

- [ ] \`bypassCSP: true\` の必要性検証 (拡張別に unsafe-eval が必要か確認)
- [ ] スタブ API の動作検証マトリックス (showQuickPick, applyEdit 等)
- [ ] Webview CSS テーマのライトモード対応
- [ ] 複数ワークスペース同時利用時の拡張状態管理
- [ ] Windows クロスプラットフォーム対応 (unzip → Node.js ネイティブ)