### PR TITLE
desktop: expected な filesystem / external エラーを正規化

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/external/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/external/index.ts
@@ -1,4 +1,4 @@
-import { readFile, writeFile } from "node:fs/promises";
+import { access, readFile, writeFile } from "node:fs/promises";
 import {
 	EXTERNAL_APPS,
 	NON_EDITOR_APPS,
@@ -40,7 +40,33 @@ function isMissingExternalAppError(error: unknown): boolean {
 	);
 }
 
+function isMissingPathError(error: unknown): boolean {
+	return (
+		error instanceof Error &&
+		"code" in error &&
+		error.code === "ENOENT"
+	);
+}
+
+async function assertPathExists(filePath: string): Promise<void> {
+	try {
+		await access(filePath);
+	} catch (error) {
+		// Missing paths are expected in stale UI selections and should not hit Sentry.
+		if (isMissingPathError(error)) {
+			throw new TRPCError({
+				code: "NOT_FOUND",
+				message: `The file ${filePath} does not exist.`,
+			});
+		}
+		throw error;
+	}
+}
+
 function normalizeOpenInAppError(error: unknown): never {
+	if (error instanceof TRPCError) {
+		throw error;
+	}
 	if (isMissingExternalAppError(error)) {
 		throw new TRPCError({
 			code: "BAD_REQUEST",
@@ -150,6 +176,8 @@ export const createExternalRouter = () => {
 		openInDefaultApp: publicProcedure
 			.input(z.string())
 			.mutation(async ({ input }) => {
+				// Surface missing files as a typed user-facing error before invoking the shell.
+				await assertPathExists(input);
 				const openError = await shell.openPath(input);
 				if (openError) {
 					throw new TRPCError({
@@ -168,6 +196,8 @@ export const createExternalRouter = () => {
 				}),
 			)
 			.mutation(async ({ input }) => {
+				// Avoid turning deleted/moved files into INTERNAL_SERVER_ERROR during app launch.
+				await assertPathExists(input.path);
 				try {
 					await openPathInApp(input.path, input.app);
 				} catch (error) {
@@ -308,6 +338,8 @@ export const createExternalRouter = () => {
 			)
 			.mutation(async ({ input }) => {
 				const filePath = resolvePath(input.path, input.cwd);
+				// Editor open is also triggered from stale paths in the UI, so normalize ENOENT here too.
+				await assertPathExists(filePath);
 				const app = resolveDefaultEditor(input.projectId);
 
 				if (!app) {

--- a/apps/desktop/src/lib/trpc/routers/filesystem/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/filesystem/index.ts
@@ -1,4 +1,8 @@
-import { toErrorMessage } from "@superset/workspace-fs/host";
+import {
+	toErrorMessage,
+	WorkspaceFsPathError,
+} from "@superset/workspace-fs/host";
+import { TRPCError } from "@trpc/server";
 import { observable } from "@trpc/server/observable";
 import { z } from "zod";
 import { publicProcedure, router } from "../..";
@@ -10,6 +14,95 @@ function isClosedStreamError(error: unknown): boolean {
 		"code" in error &&
 		error.code === "ERR_INVALID_STATE"
 	);
+}
+
+function getErrorCode(error: unknown): string | null {
+	if (!(error instanceof Error) || !("code" in error)) {
+		return null;
+	}
+
+	return typeof error.code === "string" ? error.code : null;
+}
+
+function throwFilesystemError(error: unknown): never {
+	if (error instanceof TRPCError) {
+		throw error;
+	}
+
+	// Most filesystem failures here are expected user/state conditions, so normalize
+	// them to typed tRPC errors and reserve INTERNAL_SERVER_ERROR for real surprises.
+	if (error instanceof WorkspaceFsPathError) {
+		switch (error.code) {
+			case "OUTSIDE_ROOT":
+			case "INVALID_TARGET":
+				throw new TRPCError({
+					code: "BAD_REQUEST",
+					message: error.message,
+				});
+			case "SYMLINK_ESCAPE":
+				throw new TRPCError({
+					code: "PRECONDITION_FAILED",
+					message: error.message,
+				});
+		}
+	}
+
+	const errorCode = getErrorCode(error);
+	if (errorCode === "ENOENT") {
+		throw new TRPCError({
+			code: "NOT_FOUND",
+			message: toErrorMessage(error),
+		});
+	}
+	if (
+		errorCode === "EISDIR" ||
+		errorCode === "ENOTDIR" ||
+		errorCode === "ERR_FS_EISDIR"
+	) {
+		throw new TRPCError({
+			code: "PRECONDITION_FAILED",
+			message: toErrorMessage(error),
+		});
+	}
+	if (errorCode === "EACCES" || errorCode === "EPERM") {
+		throw new TRPCError({
+			code: "FORBIDDEN",
+			message: toErrorMessage(error),
+		});
+	}
+	if (errorCode === "EEXIST") {
+		throw new TRPCError({
+			code: "CONFLICT",
+			message: toErrorMessage(error),
+		});
+	}
+	if (
+		error instanceof Error &&
+		error.message.includes("Path is outside workspace root")
+	) {
+		// workspace-fs still emits a plain Error for some outside-root checks.
+		// Keep this router-side fallback until that package fully types the error.
+		throw new TRPCError({
+			code: "BAD_REQUEST",
+			message: error.message,
+		});
+	}
+
+	throw new TRPCError({
+		code: "INTERNAL_SERVER_ERROR",
+		message: toErrorMessage(error),
+	});
+}
+
+async function withFilesystemErrorBoundary<T>(
+	operation: () => Promise<T>,
+): Promise<T> {
+	try {
+		return await operation();
+	} catch (error) {
+		// Keep every filesystem procedure aligned on the same error semantics.
+		throwFilesystemError(error);
+	}
 }
 
 const writeFileContentSchema = z.union([
@@ -61,9 +154,11 @@ export const createFilesystemRouter = () => {
 				}),
 			)
 			.query(async ({ input }) => {
-				const service = getServiceForWorkspace(input.workspaceId);
-				return await service.listDirectory({
-					absolutePath: input.absolutePath,
+				return await withFilesystemErrorBoundary(async () => {
+					const service = getServiceForWorkspace(input.workspaceId);
+					return await service.listDirectory({
+						absolutePath: input.absolutePath,
+					});
 				});
 			}),
 
@@ -78,22 +173,24 @@ export const createFilesystemRouter = () => {
 				}),
 			)
 			.query(async ({ input }) => {
-				const service = getServiceForWorkspace(input.workspaceId);
-				const result = await service.readFile({
-					absolutePath: input.absolutePath,
-					offset: input.offset,
-					maxBytes: input.maxBytes,
-					encoding: input.encoding,
+				return await withFilesystemErrorBoundary(async () => {
+					const service = getServiceForWorkspace(input.workspaceId);
+					const result = await service.readFile({
+						absolutePath: input.absolutePath,
+						offset: input.offset,
+						maxBytes: input.maxBytes,
+						encoding: input.encoding,
+					});
+
+					if (result.kind === "bytes") {
+						return {
+							...result,
+							content: Buffer.from(result.content).toString("base64"),
+						};
+					}
+
+					return result;
 				});
-
-				if (result.kind === "bytes") {
-					return {
-						...result,
-						content: Buffer.from(result.content).toString("base64"),
-					};
-				}
-
-				return result;
 			}),
 
 		getMetadata: publicProcedure
@@ -104,9 +201,11 @@ export const createFilesystemRouter = () => {
 				}),
 			)
 			.query(async ({ input }) => {
-				const service = getServiceForWorkspace(input.workspaceId);
-				return await service.getMetadata({
-					absolutePath: input.absolutePath,
+				return await withFilesystemErrorBoundary(async () => {
+					const service = getServiceForWorkspace(input.workspaceId);
+					return await service.getMetadata({
+						absolutePath: input.absolutePath,
+					});
 				});
 			}),
 
@@ -131,18 +230,20 @@ export const createFilesystemRouter = () => {
 				}),
 			)
 			.mutation(async ({ input }) => {
-				const service = getServiceForWorkspace(input.workspaceId);
-				const content =
-					typeof input.content === "string"
-						? input.content
-						: new Uint8Array(Buffer.from(input.content.data, "base64"));
+				return await withFilesystemErrorBoundary(async () => {
+					const service = getServiceForWorkspace(input.workspaceId);
+					const content =
+						typeof input.content === "string"
+							? input.content
+							: new Uint8Array(Buffer.from(input.content.data, "base64"));
 
-				return await service.writeFile({
-					absolutePath: input.absolutePath,
-					content,
-					encoding: input.encoding,
-					options: input.options,
-					precondition: input.precondition,
+					return await service.writeFile({
+						absolutePath: input.absolutePath,
+						content,
+						encoding: input.encoding,
+						options: input.options,
+						precondition: input.precondition,
+					});
 				});
 			}),
 
@@ -155,10 +256,12 @@ export const createFilesystemRouter = () => {
 				}),
 			)
 			.mutation(async ({ input }) => {
-				const service = getServiceForWorkspace(input.workspaceId);
-				return await service.createDirectory({
-					absolutePath: input.absolutePath,
-					recursive: input.recursive,
+				return await withFilesystemErrorBoundary(async () => {
+					const service = getServiceForWorkspace(input.workspaceId);
+					return await service.createDirectory({
+						absolutePath: input.absolutePath,
+						recursive: input.recursive,
+					});
 				});
 			}),
 
@@ -171,10 +274,12 @@ export const createFilesystemRouter = () => {
 				}),
 			)
 			.mutation(async ({ input }) => {
-				const service = getServiceForWorkspace(input.workspaceId);
-				return await service.deletePath({
-					absolutePath: input.absolutePath,
-					permanent: input.permanent,
+				return await withFilesystemErrorBoundary(async () => {
+					const service = getServiceForWorkspace(input.workspaceId);
+					return await service.deletePath({
+						absolutePath: input.absolutePath,
+						permanent: input.permanent,
+					});
 				});
 			}),
 
@@ -187,10 +292,12 @@ export const createFilesystemRouter = () => {
 				}),
 			)
 			.mutation(async ({ input }) => {
-				const service = getServiceForWorkspace(input.workspaceId);
-				return await service.movePath({
-					sourceAbsolutePath: input.sourceAbsolutePath,
-					destinationAbsolutePath: input.destinationAbsolutePath,
+				return await withFilesystemErrorBoundary(async () => {
+					const service = getServiceForWorkspace(input.workspaceId);
+					return await service.movePath({
+						sourceAbsolutePath: input.sourceAbsolutePath,
+						destinationAbsolutePath: input.destinationAbsolutePath,
+					});
 				});
 			}),
 
@@ -203,10 +310,12 @@ export const createFilesystemRouter = () => {
 				}),
 			)
 			.mutation(async ({ input }) => {
-				const service = getServiceForWorkspace(input.workspaceId);
-				return await service.copyPath({
-					sourceAbsolutePath: input.sourceAbsolutePath,
-					destinationAbsolutePath: input.destinationAbsolutePath,
+				return await withFilesystemErrorBoundary(async () => {
+					const service = getServiceForWorkspace(input.workspaceId);
+					return await service.copyPath({
+						sourceAbsolutePath: input.sourceAbsolutePath,
+						destinationAbsolutePath: input.destinationAbsolutePath,
+					});
 				});
 			}),
 
@@ -227,13 +336,15 @@ export const createFilesystemRouter = () => {
 					return { matches: [] };
 				}
 
-				const service = getServiceForWorkspace(input.workspaceId);
-				return await service.searchFiles({
-					query: trimmedQuery,
-					includeHidden: input.includeHidden,
-					includePattern: input.includePattern,
-					excludePattern: input.excludePattern,
-					limit: input.limit,
+				return await withFilesystemErrorBoundary(async () => {
+					const service = getServiceForWorkspace(input.workspaceId);
+					return await service.searchFiles({
+						query: trimmedQuery,
+						includeHidden: input.includeHidden,
+						includePattern: input.includePattern,
+						excludePattern: input.excludePattern,
+						limit: input.limit,
+					});
 				});
 			}),
 
@@ -245,15 +356,17 @@ export const createFilesystemRouter = () => {
 					return { matches: [] };
 				}
 
-				const service = getServiceForWorkspace(input.workspaceId);
-				return await service.searchContent({
-					query: trimmedQuery,
-					includeHidden: input.includeHidden,
-					includePattern: input.includePattern,
-					excludePattern: input.excludePattern,
-					limit: input.limit,
-					isRegex: input.isRegex,
-					caseSensitive: input.caseSensitive,
+				return await withFilesystemErrorBoundary(async () => {
+					const service = getServiceForWorkspace(input.workspaceId);
+					return await service.searchContent({
+						query: trimmedQuery,
+						includeHidden: input.includeHidden,
+						includePattern: input.includePattern,
+						excludePattern: input.excludePattern,
+						limit: input.limit,
+						isRegex: input.isRegex,
+						caseSensitive: input.caseSensitive,
+					});
 				});
 			}),
 
@@ -270,16 +383,18 @@ export const createFilesystemRouter = () => {
 					};
 				}
 
-				const service = getServiceForWorkspace(input.workspaceId);
-				return await service.replaceContent({
-					query: input.query,
-					replacement: input.replacement,
-					includeHidden: input.includeHidden,
-					includePattern: input.includePattern,
-					excludePattern: input.excludePattern,
-					isRegex: input.isRegex,
-					caseSensitive: input.caseSensitive,
-					paths: input.paths,
+				return await withFilesystemErrorBoundary(async () => {
+					const service = getServiceForWorkspace(input.workspaceId);
+					return await service.replaceContent({
+						query: input.query,
+						replacement: input.replacement,
+						includeHidden: input.includeHidden,
+						includePattern: input.includePattern,
+						excludePattern: input.excludePattern,
+						isRegex: input.isRegex,
+						caseSensitive: input.caseSensitive,
+						paths: input.paths,
+					});
 				});
 			}),
 

--- a/apps/desktop/src/lib/trpc/routers/workspace-fs-service.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspace-fs-service.ts
@@ -6,6 +6,7 @@ import {
 	toRelativePath,
 	type WorkspaceFsPathError,
 } from "@superset/workspace-fs/host";
+import { TRPCError } from "@trpc/server";
 import { shell } from "electron";
 import { getWorkspace } from "./workspaces/utils/db-helpers";
 import { execWithShellEnv } from "./workspaces/utils/shell-env";
@@ -82,7 +83,12 @@ export function toRegisteredWorktreeRelativePath(
 		relativePath.startsWith(`..${path.sep}`) ||
 		path.isAbsolute(relativePath)
 	) {
-		throw new Error(`Path is outside worktree: ${absolutePath}`);
+		// This helper is only consumed by tRPC routers, so out-of-worktree access
+		// should be surfaced directly as BAD_REQUEST instead of bubbling as internal.
+		throw new TRPCError({
+			code: "BAD_REQUEST",
+			message: `Path is outside worktree: ${absolutePath}`,
+		});
 	}
 
 	return relativePath.replace(/\\/g, "/");

--- a/apps/desktop/src/lib/trpc/routers/workspaces/procedures/git-status.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/procedures/git-status.ts
@@ -107,6 +107,34 @@ const ghRepositoryAssigneeSchema = z.object({
 	avatar_url: z.string().optional(),
 });
 
+async function loadGitHubOverviewSegment<T>({
+	label,
+	load,
+	fallback,
+	workspaceId,
+	repositoryNameWithOwner,
+}: {
+	label: string;
+	load: () => Promise<T>;
+	fallback: T;
+	workspaceId: string;
+	repositoryNameWithOwner: string;
+}): Promise<T> {
+	try {
+		return await load();
+	} catch (error) {
+		// Overview data is best-effort. A flaky GitHub endpoint should degrade this
+		// segment to empty data rather than failing the entire repository overview.
+		console.warn("[git-status/github-overview] Falling back to empty segment", {
+			label,
+			workspaceId,
+			repositoryNameWithOwner,
+			error,
+		});
+		return fallback;
+	}
+}
+
 function sanitizeIssueAssetBasename(value: string): string {
 	return value
 		.toLowerCase()
@@ -537,56 +565,88 @@ async function getGitHubRepositoryOverview(workspaceId: string) {
 		defaultBranch,
 	} = await resolveRepositoryTargetForWorkspace(workspaceId);
 
-	const [pullRequestsResult, workflowsResult, labelsResult, assigneesResult] =
-		await Promise.all([
-			execWithShellEnv(
-				"gh",
-				[
-					"pr",
-					"list",
-					"--repo",
-					repositoryNameWithOwner,
-					"--state",
-					"open",
-					"--limit",
-					"8",
-					"--json",
-					"number,title,url,state,isDraft,headRefName,updatedAt,author",
-				],
-				{ cwd: repoPath },
-			),
-			execWithShellEnv(
-				"gh",
-				[
-					"api",
-					`repos/${repositoryNameWithOwner}/actions/workflows?per_page=100`,
-				],
-				{ cwd: repoPath },
-			),
-			execWithShellEnv(
-				"gh",
-				["api", `repos/${repositoryNameWithOwner}/labels?per_page=100`],
-				{ cwd: repoPath },
-			),
-			execWithShellEnv(
-				"gh",
-				["api", `repos/${repositoryNameWithOwner}/assignees?per_page=100`],
-				{ cwd: repoPath },
-			),
-		]);
-
-	const rawPullRequests = JSON.parse(pullRequestsResult.stdout) as unknown;
-	const pullRequests = z
-		.array(ghRepositoryPullRequestSchema)
-		.parse(rawPullRequests);
-
-	const rawWorkflows = JSON.parse(workflowsResult.stdout) as unknown;
-	const workflows =
-		ghRepositoryWorkflowsResponseSchema.parse(rawWorkflows).workflows ?? [];
-	const rawLabels = JSON.parse(labelsResult.stdout) as unknown;
-	const labels = z.array(ghRepositoryLabelSchema).parse(rawLabels);
-	const rawAssignees = JSON.parse(assigneesResult.stdout) as unknown;
-	const assignees = z.array(ghRepositoryAssigneeSchema).parse(rawAssignees);
+	const [pullRequests, workflows, labels, assignees] = await Promise.all([
+		loadGitHubOverviewSegment({
+			label: "pullRequests",
+			workspaceId,
+			repositoryNameWithOwner,
+			fallback: [] as Array<z.infer<typeof ghRepositoryPullRequestSchema>>,
+			load: async () => {
+				const result = await execWithShellEnv(
+					"gh",
+					[
+						"pr",
+						"list",
+						"--repo",
+						repositoryNameWithOwner,
+						"--state",
+						"open",
+						"--limit",
+						"8",
+						"--json",
+						"number,title,url,state,isDraft,headRefName,updatedAt,author",
+					],
+					{ cwd: repoPath },
+				);
+				return z
+					.array(ghRepositoryPullRequestSchema)
+					.parse(JSON.parse(result.stdout) as unknown);
+			},
+		}),
+		loadGitHubOverviewSegment({
+			label: "workflows",
+			workspaceId,
+			repositoryNameWithOwner,
+			fallback: [] as Array<z.infer<typeof ghRepositoryWorkflowSchema>>,
+			load: async () => {
+				const result = await execWithShellEnv(
+					"gh",
+					[
+						"api",
+						`repos/${repositoryNameWithOwner}/actions/workflows?per_page=100`,
+					],
+					{ cwd: repoPath },
+				);
+				return (
+					ghRepositoryWorkflowsResponseSchema.parse(
+						JSON.parse(result.stdout) as unknown,
+					).workflows ?? []
+				);
+			},
+		}),
+		loadGitHubOverviewSegment({
+			label: "labels",
+			workspaceId,
+			repositoryNameWithOwner,
+			fallback: [] as Array<z.infer<typeof ghRepositoryLabelSchema>>,
+			load: async () => {
+				const result = await execWithShellEnv(
+					"gh",
+					["api", `repos/${repositoryNameWithOwner}/labels?per_page=100`],
+					{ cwd: repoPath },
+				);
+				return z
+					.array(ghRepositoryLabelSchema)
+					.parse(JSON.parse(result.stdout) as unknown);
+			},
+		}),
+		loadGitHubOverviewSegment({
+			label: "assignees",
+			workspaceId,
+			repositoryNameWithOwner,
+			fallback: [] as Array<z.infer<typeof ghRepositoryAssigneeSchema>>,
+			load: async () => {
+				const result = await execWithShellEnv(
+					"gh",
+					["api", `repos/${repositoryNameWithOwner}/assignees?per_page=100`],
+					{ cwd: repoPath },
+				);
+				return z
+					.array(ghRepositoryAssigneeSchema)
+					.parse(JSON.parse(result.stdout) as unknown);
+			},
+		}),
+	]);
 
 	return {
 		repositoryNameWithOwner,

--- a/apps/desktop/src/main/lib/app-state/index.ts
+++ b/apps/desktop/src/main/lib/app-state/index.ts
@@ -10,6 +10,37 @@ type AppStateDB = Awaited<ReturnType<typeof JSONFilePreset<AppState>>>;
 
 let _appState: AppStateDB | null = null;
 
+function isMissingPathError(error: unknown): boolean {
+	return (
+		error instanceof Error &&
+		"code" in error &&
+		error.code === "ENOENT"
+	);
+}
+
+function withWriteRetry(appStateDb: AppStateDB): AppStateDB {
+	const originalWrite = appStateDb.write.bind(appStateDb);
+
+	appStateDb.write = async () => {
+		// The Superset home directory can disappear after startup. Recreate it before
+		// each write and retry once on ENOENT so app-state persistence self-heals.
+		ensureSupersetHomeDirExists();
+
+		try {
+			await originalWrite();
+		} catch (error) {
+			if (!isMissingPathError(error)) {
+				throw error;
+			}
+
+			ensureSupersetHomeDirExists();
+			await originalWrite();
+		}
+	};
+
+	return appStateDb;
+}
+
 /**
  * Ensures loaded data has the correct shape by merging with defaults.
  * Handles legacy app-state.json files that may have a different structure
@@ -40,7 +71,9 @@ export async function initAppState(): Promise<void> {
 	if (_appState) return;
 
 	ensureSupersetHomeDirExists();
-	_appState = await JSONFilePreset<AppState>(APP_STATE_PATH, defaultAppState);
+	_appState = withWriteRetry(
+		await JSONFilePreset<AppState>(APP_STATE_PATH, defaultAppState),
+	);
 
 	// Reshape data to ensure it has the correct structure (handles legacy formats)
 	_appState.data = ensureValidShape(_appState.data);

--- a/bun.lock
+++ b/bun.lock
@@ -2960,9 +2960,9 @@
 
     "@vscode/l10n": ["@vscode/l10n@0.0.18", "", {}, "sha512-KYSIHVmslkaCDyw013pphY+d7x1qV8IZupYfeIfzNA+nsaWHbn5uPuQRvdRFsa9zFzGeudPuoGoZ1Op4jrJXIQ=="],
 
-    "@vue/compiler-core": ["@vue/compiler-core@3.5.31", "", { "dependencies": { "@babel/parser": "^7.29.2", "@vue/shared": "3.5.31", "entities": "^7.0.1", "estree-walker": "^2.0.2", "source-map-js": "^1.2.1" } }, "sha512-k/ueL14aNIEy5Onf0OVzR8kiqF/WThgLdFhxwa4e/KF/0qe38IwIdofoSWBTvvxQOesaz6riAFAUaYjoF9fLLQ=="],
+    "@vue/compiler-core": ["@vue/compiler-core@3.5.32", "", { "dependencies": { "@babel/parser": "^7.29.2", "@vue/shared": "3.5.32", "entities": "^7.0.1", "estree-walker": "^2.0.2", "source-map-js": "^1.2.1" } }, "sha512-4x74Tbtqnda8s/NSD6e1Dr5p1c8HdMU5RWSjMSUzb8RTcUQqevDCxVAitcLBKT+ie3o0Dl9crc/S/opJM7qBGQ=="],
 
-    "@vue/compiler-dom": ["@vue/compiler-dom@3.5.31", "", { "dependencies": { "@vue/compiler-core": "3.5.31", "@vue/shared": "3.5.31" } }, "sha512-BMY/ozS/xxjYqRFL+tKdRpATJYDTTgWSo0+AJvJNg4ig+Hgb0dOsHPXvloHQ5hmlivUqw1Yt2pPIqp4e0v1GUw=="],
+    "@vue/compiler-dom": ["@vue/compiler-dom@3.5.32", "", { "dependencies": { "@vue/compiler-core": "3.5.32", "@vue/shared": "3.5.32" } }, "sha512-ybHAu70NtiEI1fvAUz3oXZqkUYEe5J98GjMDpTGl5iHb0T15wQYLR4wE3h9xfuTNA+Cm2f4czfe8B4s+CCH57Q=="],
 
     "@vue/compiler-sfc": ["@vue/compiler-sfc@3.5.32", "", { "dependencies": { "@babel/parser": "^7.29.2", "@vue/compiler-core": "3.5.32", "@vue/compiler-dom": "3.5.32", "@vue/compiler-ssr": "3.5.32", "@vue/shared": "3.5.32", "estree-walker": "^2.0.2", "magic-string": "^0.30.21", "postcss": "^8.5.8", "source-map-js": "^1.2.1" } }, "sha512-8UYUYo71cP/0YHMO814TRZlPuUUw3oifHuMR7Wp9SNoRSrxRQnhMLNlCeaODNn6kNTJsjFoQ/kqIj4qGvya4Xg=="],
 
@@ -2976,7 +2976,7 @@
 
     "@vue/server-renderer": ["@vue/server-renderer@3.5.32", "", { "dependencies": { "@vue/compiler-ssr": "3.5.32", "@vue/shared": "3.5.32" }, "peerDependencies": { "vue": "3.5.32" } }, "sha512-IOjm2+JQwRFS7W28HNuJeXQle9KdZbODFY7hFGVtnnghF51ta20EWAZJHX+zLGtsHhaU6uC9BGPV52KVpYryMQ=="],
 
-    "@vue/shared": ["@vue/shared@3.5.31", "", {}, "sha512-nBxuiuS9Lj5bPkPbWogPUnjxxWpkRniX7e5UBQDWl6Fsf4roq9wwV+cR7ezQ4zXswNvPIlsdj1slcLB7XCsRAw=="],
+    "@vue/shared": ["@vue/shared@3.5.32", "", {}, "sha512-ksNyrmRQzWJJ8n3cRDuSF7zNNontuJg1YHnmWRJd2AMu8Ij2bqwiiri2lH5rHtYPZjj4STkNcgcmiQqlOjiYGg=="],
 
     "@webassemblyjs/ast": ["@webassemblyjs/ast@1.14.1", "", { "dependencies": { "@webassemblyjs/helper-numbers": "1.13.2", "@webassemblyjs/helper-wasm-bytecode": "1.13.2" } }, "sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ=="],
 
@@ -5992,6 +5992,8 @@
 
     "@babel/polyfill/core-js": ["core-js@2.6.12", "", {}, "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ=="],
 
+    "@code-inspector/core/@vue/compiler-dom": ["@vue/compiler-dom@3.5.31", "", { "dependencies": { "@vue/compiler-core": "3.5.31", "@vue/shared": "3.5.31" } }, "sha512-BMY/ozS/xxjYqRFL+tKdRpATJYDTTgWSo0+AJvJNg4ig+Hgb0dOsHPXvloHQ5hmlivUqw1Yt2pPIqp4e0v1GUw=="],
+
     "@code-inspector/core/chalk": ["chalk@4.1.1", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg=="],
 
     "@code-inspector/core/dotenv": ["dotenv@16.6.1", "", {}, "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow=="],
@@ -6311,24 +6313,6 @@
     "@upstash/qstash/jose": ["jose@5.10.0", "", {}, "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg=="],
 
     "@vue/compiler-core/entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
-
-    "@vue/compiler-sfc/@vue/compiler-core": ["@vue/compiler-core@3.5.32", "", { "dependencies": { "@babel/parser": "^7.29.2", "@vue/shared": "3.5.32", "entities": "^7.0.1", "estree-walker": "^2.0.2", "source-map-js": "^1.2.1" } }, "sha512-4x74Tbtqnda8s/NSD6e1Dr5p1c8HdMU5RWSjMSUzb8RTcUQqevDCxVAitcLBKT+ie3o0Dl9crc/S/opJM7qBGQ=="],
-
-    "@vue/compiler-sfc/@vue/compiler-dom": ["@vue/compiler-dom@3.5.32", "", { "dependencies": { "@vue/compiler-core": "3.5.32", "@vue/shared": "3.5.32" } }, "sha512-ybHAu70NtiEI1fvAUz3oXZqkUYEe5J98GjMDpTGl5iHb0T15wQYLR4wE3h9xfuTNA+Cm2f4czfe8B4s+CCH57Q=="],
-
-    "@vue/compiler-sfc/@vue/shared": ["@vue/shared@3.5.32", "", {}, "sha512-ksNyrmRQzWJJ8n3cRDuSF7zNNontuJg1YHnmWRJd2AMu8Ij2bqwiiri2lH5rHtYPZjj4STkNcgcmiQqlOjiYGg=="],
-
-    "@vue/compiler-ssr/@vue/compiler-dom": ["@vue/compiler-dom@3.5.32", "", { "dependencies": { "@vue/compiler-core": "3.5.32", "@vue/shared": "3.5.32" } }, "sha512-ybHAu70NtiEI1fvAUz3oXZqkUYEe5J98GjMDpTGl5iHb0T15wQYLR4wE3h9xfuTNA+Cm2f4czfe8B4s+CCH57Q=="],
-
-    "@vue/compiler-ssr/@vue/shared": ["@vue/shared@3.5.32", "", {}, "sha512-ksNyrmRQzWJJ8n3cRDuSF7zNNontuJg1YHnmWRJd2AMu8Ij2bqwiiri2lH5rHtYPZjj4STkNcgcmiQqlOjiYGg=="],
-
-    "@vue/reactivity/@vue/shared": ["@vue/shared@3.5.32", "", {}, "sha512-ksNyrmRQzWJJ8n3cRDuSF7zNNontuJg1YHnmWRJd2AMu8Ij2bqwiiri2lH5rHtYPZjj4STkNcgcmiQqlOjiYGg=="],
-
-    "@vue/runtime-core/@vue/shared": ["@vue/shared@3.5.32", "", {}, "sha512-ksNyrmRQzWJJ8n3cRDuSF7zNNontuJg1YHnmWRJd2AMu8Ij2bqwiiri2lH5rHtYPZjj4STkNcgcmiQqlOjiYGg=="],
-
-    "@vue/runtime-dom/@vue/shared": ["@vue/shared@3.5.32", "", {}, "sha512-ksNyrmRQzWJJ8n3cRDuSF7zNNontuJg1YHnmWRJd2AMu8Ij2bqwiiri2lH5rHtYPZjj4STkNcgcmiQqlOjiYGg=="],
-
-    "@vue/server-renderer/@vue/shared": ["@vue/shared@3.5.32", "", {}, "sha512-ksNyrmRQzWJJ8n3cRDuSF7zNNontuJg1YHnmWRJd2AMu8Ij2bqwiiri2lH5rHtYPZjj4STkNcgcmiQqlOjiYGg=="],
 
     "@xterm/addon-ligatures/lru-cache": ["lru-cache@6.0.0", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA=="],
 
@@ -6858,10 +6842,6 @@
 
     "vscode-markdown-languageservice/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 
-    "vue/@vue/compiler-dom": ["@vue/compiler-dom@3.5.32", "", { "dependencies": { "@vue/compiler-core": "3.5.32", "@vue/shared": "3.5.32" } }, "sha512-ybHAu70NtiEI1fvAUz3oXZqkUYEe5J98GjMDpTGl5iHb0T15wQYLR4wE3h9xfuTNA+Cm2f4czfe8B4s+CCH57Q=="],
-
-    "vue/@vue/shared": ["@vue/shared@3.5.32", "", {}, "sha512-ksNyrmRQzWJJ8n3cRDuSF7zNNontuJg1YHnmWRJd2AMu8Ij2bqwiiri2lH5rHtYPZjj4STkNcgcmiQqlOjiYGg=="],
-
     "webpack/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
 
     "wrangler/esbuild": ["esbuild@0.27.3", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.3", "@esbuild/android-arm": "0.27.3", "@esbuild/android-arm64": "0.27.3", "@esbuild/android-x64": "0.27.3", "@esbuild/darwin-arm64": "0.27.3", "@esbuild/darwin-x64": "0.27.3", "@esbuild/freebsd-arm64": "0.27.3", "@esbuild/freebsd-x64": "0.27.3", "@esbuild/linux-arm": "0.27.3", "@esbuild/linux-arm64": "0.27.3", "@esbuild/linux-ia32": "0.27.3", "@esbuild/linux-loong64": "0.27.3", "@esbuild/linux-mips64el": "0.27.3", "@esbuild/linux-ppc64": "0.27.3", "@esbuild/linux-riscv64": "0.27.3", "@esbuild/linux-s390x": "0.27.3", "@esbuild/linux-x64": "0.27.3", "@esbuild/netbsd-arm64": "0.27.3", "@esbuild/netbsd-x64": "0.27.3", "@esbuild/openbsd-arm64": "0.27.3", "@esbuild/openbsd-x64": "0.27.3", "@esbuild/openharmony-arm64": "0.27.3", "@esbuild/sunos-x64": "0.27.3", "@esbuild/win32-arm64": "0.27.3", "@esbuild/win32-ia32": "0.27.3", "@esbuild/win32-x64": "0.27.3" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg=="],
@@ -6927,6 +6907,10 @@
     "@ai-sdk/ui-utils-v5/@ai-sdk/provider-utils/nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
     "@babel/helper-compilation-targets/lru-cache/yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
+
+    "@code-inspector/core/@vue/compiler-dom/@vue/compiler-core": ["@vue/compiler-core@3.5.31", "", { "dependencies": { "@babel/parser": "^7.29.2", "@vue/shared": "3.5.31", "entities": "^7.0.1", "estree-walker": "^2.0.2", "source-map-js": "^1.2.1" } }, "sha512-k/ueL14aNIEy5Onf0OVzR8kiqF/WThgLdFhxwa4e/KF/0qe38IwIdofoSWBTvvxQOesaz6riAFAUaYjoF9fLLQ=="],
+
+    "@code-inspector/core/@vue/compiler-dom/@vue/shared": ["@vue/shared@3.5.31", "", {}, "sha512-nBxuiuS9Lj5bPkPbWogPUnjxxWpkRniX7e5UBQDWl6Fsf4roq9wwV+cR7ezQ4zXswNvPIlsdj1slcLB7XCsRAw=="],
 
     "@develar/schema-utils/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
 
@@ -7243,10 +7227,6 @@
     "@tailwindcss/node/lightningcss/lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.32.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q=="],
 
     "@tanstack/router-plugin/unplugin/webpack-virtual-modules": ["webpack-virtual-modules@0.6.2", "", {}, "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ=="],
-
-    "@vue/compiler-sfc/@vue/compiler-core/entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
-
-    "@vue/compiler-ssr/@vue/compiler-dom/@vue/compiler-core": ["@vue/compiler-core@3.5.32", "", { "dependencies": { "@babel/parser": "^7.29.2", "@vue/shared": "3.5.32", "entities": "^7.0.1", "estree-walker": "^2.0.2", "source-map-js": "^1.2.1" } }, "sha512-4x74Tbtqnda8s/NSD6e1Dr5p1c8HdMU5RWSjMSUzb8RTcUQqevDCxVAitcLBKT+ie3o0Dl9crc/S/opJM7qBGQ=="],
 
     "app-builder-lib/@electron/get/fs-extra": ["fs-extra@8.1.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^4.0.0", "universalify": "^0.1.0" } }, "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g=="],
 
@@ -7664,8 +7644,6 @@
 
     "vscode-languageserver/vscode-languageserver-protocol/vscode-languageserver-types": ["vscode-languageserver-types@3.17.2", "", {}, "sha512-zHhCWatviizPIq9B7Vh9uvrH6x3sK8itC84HkamnBWoDFJtzBf7SWlpLCZUit72b3os45h6RWQNC9xHRDF8dRA=="],
 
-    "vue/@vue/compiler-dom/@vue/compiler-core": ["@vue/compiler-core@3.5.32", "", { "dependencies": { "@babel/parser": "^7.29.2", "@vue/shared": "3.5.32", "entities": "^7.0.1", "estree-walker": "^2.0.2", "source-map-js": "^1.2.1" } }, "sha512-4x74Tbtqnda8s/NSD6e1Dr5p1c8HdMU5RWSjMSUzb8RTcUQqevDCxVAitcLBKT+ie3o0Dl9crc/S/opJM7qBGQ=="],
-
     "webpack/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
 
     "wrangler/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.3", "", { "os": "aix", "cpu": "ppc64" }, "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg=="],
@@ -7742,6 +7720,8 @@
 
     "@a2a-js/sdk/express/type-is/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
 
+    "@code-inspector/core/@vue/compiler-dom/@vue/compiler-core/entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
+
     "@electron/asar/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
     "@electron/rebuild/ora/cli-cursor/restore-cursor": ["restore-cursor@3.1.0", "", { "dependencies": { "onetime": "^5.1.0", "signal-exit": "^3.0.2" } }, "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA=="],
@@ -7815,8 +7795,6 @@
     "@sentry/vite-plugin/@sentry/bundler-plugin-core/glob/minimatch": ["minimatch@9.0.9", "", { "dependencies": { "brace-expansion": "^2.0.2" } }, "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg=="],
 
     "@sentry/vite-plugin/@sentry/bundler-plugin-core/glob/path-scurry": ["path-scurry@1.11.1", "", { "dependencies": { "lru-cache": "^10.2.0", "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0" } }, "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA=="],
-
-    "@vue/compiler-ssr/@vue/compiler-dom/@vue/compiler-core/entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
 
     "app-builder-lib/@electron/get/fs-extra/jsonfile": ["jsonfile@4.0.0", "", { "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg=="],
 
@@ -7913,8 +7891,6 @@
     "vscode-langservers-extracted/vscode-languageserver/vscode-languageserver-protocol/vscode-jsonrpc": ["vscode-jsonrpc@9.0.0-next.11", "", {}, "sha512-u6LElQNbSiE9OugEEmrUKwH6+8BpPz2S5MDHvQUqHL//I4Q8GPikKLOUf856UnbLkZdhxaPrExac1lA3XwpIPA=="],
 
     "vscode-langservers-extracted/vscode-languageserver/vscode-languageserver-protocol/vscode-languageserver-types": ["vscode-languageserver-types@3.17.6-next.6", "", {}, "sha512-aiJY5/yW+xzw7KPNlwi3gQtddq/3EIn5z8X8nCgJfaiAij2R1APKePngv+MUdLdYJBVTLu+Qa0ODsT+pHgYguQ=="],
-
-    "vue/@vue/compiler-dom/@vue/compiler-core/entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
 
     "zip-stream/archiver-utils/glob/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
 


### PR DESCRIPTION
## 概要
- stale path や workspace 外 path など、expected な失敗を `INTERNAL_SERVER_ERROR` ではなく適切な `TRPCError` に正規化
- GitHub overview 取得時に一部の `gh` API が失敗しても、画面全体を落とさず degraded に返すよう変更
- app-state 書き込み時の `ENOENT` を 1 回リトライして自動復旧するよう変更
- `bun.lock` の更新も同梱

## 変更内容
- `external` router で open 前に path 存在確認を追加し、missing file を `NOT_FOUND` に変更
- `filesystem` router に共通の error boundary を追加し、`ENOENT` / `EISDIR` / `ENOTDIR` / `EACCES` / `EPERM` / `EEXIST` / `WorkspaceFsPathError` を expected error として返すよう変更
- `workspace-fs-service` の worktree 外 path を `BAD_REQUEST` で返すよう変更
- `git-status` の repository overview を segment ごとの best-effort 取得に変更
- `app-state` の write 前にホームディレクトリ再生成を行い、`ENOENT` 時は 1 回再試行するよう変更
- 変更意図が追えるよう、判断が分かれやすい箇所にコメントを追加
- `bun.lock` を更新

## 背景
Sentry 上で stale path や一時的な GitHub API 失敗が `INTERNAL_SERVER_ERROR` として記録されており、実装バグと expected な失敗が混ざっていました。今回の変更は既存フローを大きく変えずに、ユーザー起因・状態起因のエラーを expected error として扱うことを目的にしています。

## 確認
- テストは未実行
