### PR TITLE
GitHub の no-PR 探索を最適化

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/github/cache.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/github/cache.ts
@@ -12,12 +12,14 @@ const GITHUB_PR_COMMENTS_CACHE_TTL_MS = 60_000;
 const GITHUB_PREVIEW_URL_CACHE_TTL_MS = 10 * 60 * 1000;
 const GITHUB_REPO_CONTEXT_CACHE_TTL_MS = 300_000;
 const GITHUB_COMMIT_AUTHOR_CACHE_TTL_MS = 300_000;
+const GITHUB_NO_PR_MATCH_CACHE_TTL_MS = 120_000;
 
 const MAX_GITHUB_STATUS_CACHE_ENTRIES = 256;
 const MAX_GITHUB_PR_COMMENTS_CACHE_ENTRIES = 512;
 const MAX_GITHUB_PREVIEW_URL_CACHE_ENTRIES = 512;
 const MAX_GITHUB_REPO_CONTEXT_CACHE_ENTRIES = 256;
 const MAX_GITHUB_COMMIT_AUTHOR_CACHE_ENTRIES = 2048;
+const MAX_GITHUB_NO_PR_MATCH_CACHE_ENTRIES = 512;
 
 const githubStatusResource = createCachedResource<GitHubStatus | null>({
 	ttlMs: GITHUB_STATUS_CACHE_TTL_MS,
@@ -37,6 +39,11 @@ const previewUrlResource = createCachedResource<string | null>({
 const repoContextResource = createCachedResource<RepoContext | null>({
 	ttlMs: GITHUB_REPO_CONTEXT_CACHE_TTL_MS,
 	maxEntries: MAX_GITHUB_REPO_CONTEXT_CACHE_ENTRIES,
+});
+
+const noPullRequestMatchResource = createCachedResource<true>({
+	ttlMs: GITHUB_NO_PR_MATCH_CACHE_TTL_MS,
+	maxEntries: MAX_GITHUB_NO_PR_MATCH_CACHE_ENTRIES,
 });
 
 export interface GitHubCommitAuthor {
@@ -203,6 +210,36 @@ export function makeGitHubPreviewCachePrefix(worktreePath: string): string {
 	return `${worktreePath}::preview::`;
 }
 
+export function makeGitHubNoPullRequestCachePrefix(
+	worktreePath: string,
+): string {
+	return `${worktreePath}::no-pr::`;
+}
+
+export function makeGitHubNoPullRequestCacheKey({
+	worktreePath,
+	localBranch,
+	headSha,
+}: {
+	worktreePath: string;
+	localBranch: string;
+	headSha?: string;
+}): string {
+	return `${makeGitHubNoPullRequestCachePrefix(worktreePath)}${localBranch}::${headSha ?? "no-head"}`;
+}
+
+export function hasCachedNoPullRequestMatch(cacheKey: string): boolean {
+	return noPullRequestMatchResource.get(cacheKey) === true;
+}
+
+export function setCachedNoPullRequestMatch(cacheKey: string): void {
+	noPullRequestMatchResource.set(cacheKey, true);
+}
+
+export function clearCachedNoPullRequestMatch(cacheKey: string): void {
+	noPullRequestMatchResource.invalidate(cacheKey);
+}
+
 export function makeGitHubPreviewCacheKey({
 	worktreePath,
 	repoNameWithOwner,
@@ -329,6 +366,9 @@ export function clearGitHubCachesForWorktree(worktreePath: string): void {
 	});
 	pullRequestCommentsResource.invalidatePrefix(
 		makePullRequestCommentsCachePrefix(worktreePath),
+	);
+	noPullRequestMatchResource.invalidatePrefix(
+		makeGitHubNoPullRequestCachePrefix(worktreePath),
 	);
 	recordGitHubCacheMetric({
 		kind: "comments",

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/github/pr-resolution.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/github/pr-resolution.ts
@@ -1,7 +1,16 @@
 import type { CheckItem, GitHubStatus } from "@superset/local-db";
 import { execGitWithShellPath } from "../git-client";
 import { execWithShellEnv } from "../shell-env";
-import { trackGitHubOperation } from "./github-metrics";
+import {
+	clearCachedNoPullRequestMatch,
+	hasCachedNoPullRequestMatch,
+	makeGitHubNoPullRequestCacheKey,
+	setCachedNoPullRequestMatch,
+} from "./cache";
+import {
+	trackGitHubOperation,
+	trackGitHubOperationEvent,
+} from "./github-metrics";
 import { getPullRequestRepoNamesForWorktree } from "./repo-context";
 import {
 	type GHPRResponse,
@@ -20,18 +29,33 @@ function getPullRequestRepoArgSets(repoNames: string[]): string[][] {
 	return repoNames.map((repoName) => ["--repo", repoName]);
 }
 
+interface PullRequestLookupResult {
+	pr: GitHubStatus["pr"];
+	hadLookupFailure: boolean;
+}
+
 export async function getPRForBranch(
 	worktreePath: string,
 	localBranch: string,
 	repoContext?: RepoContext,
 	headSha?: string,
 ): Promise<GitHubStatus["pr"]> {
+	const noPullRequestCacheKey = makeGitHubNoPullRequestCacheKey({
+		worktreePath,
+		localBranch,
+		headSha,
+	});
+	if (hasCachedNoPullRequestMatch(noPullRequestCacheKey)) {
+		return null;
+	}
+
 	const byTracking = await getPRByBranchTracking(
 		worktreePath,
 		localBranch,
 		headSha,
 	);
 	if (byTracking) {
+		clearCachedNoPullRequestMatch(noPullRequestCacheKey);
 		return byTracking;
 	}
 
@@ -46,11 +70,25 @@ export async function getPRForBranch(
 		repoNames,
 		headSha,
 	);
-	if (byHeadBranch) {
-		return byHeadBranch;
+	if (byHeadBranch.pr) {
+		clearCachedNoPullRequestMatch(noPullRequestCacheKey);
+		return byHeadBranch.pr;
 	}
 
-	return findPRByHeadCommit(worktreePath, repoNames, headSha);
+	const byHeadCommit = await findPRByHeadCommit(
+		worktreePath,
+		repoNames,
+		headSha,
+	);
+	if (byHeadCommit.pr) {
+		clearCachedNoPullRequestMatch(noPullRequestCacheKey);
+		return byHeadCommit.pr;
+	}
+
+	if (!byHeadBranch.hadLookupFailure && !byHeadCommit.hadLookupFailure) {
+		setCachedNoPullRequestMatch(noPullRequestCacheKey);
+	}
+	return null;
 }
 
 /**
@@ -183,15 +221,19 @@ async function getPRByBranchTracking(
 	localBranch: string,
 	headSha?: string,
 ): Promise<GitHubStatus["pr"]> {
+	const startedAt = Date.now();
 	try {
-		const { stdout } = await trackGitHubOperation({
+		const { stdout } = await execWithShellEnv(
+			"gh",
+			["pr", "view", "--json", PR_JSON_FIELDS],
+			{ cwd: worktreePath },
+		);
+		trackGitHubOperationEvent({
 			name: "gh_pr_view",
 			category: "gh",
 			worktreePath,
-			fn: () =>
-				execWithShellEnv("gh", ["pr", "view", "--json", PR_JSON_FIELDS], {
-					cwd: worktreePath,
-				}),
+			success: true,
+			durationMs: Date.now() - startedAt,
 		});
 
 		const data = parsePRResponse(stdout);
@@ -213,8 +255,23 @@ async function getPRByBranchTracking(
 			error instanceof Error &&
 			error.message.toLowerCase().includes("no pull requests found")
 		) {
+			trackGitHubOperationEvent({
+				name: "gh_pr_view_no_match",
+				category: "gh",
+				worktreePath,
+				success: true,
+				durationMs: Date.now() - startedAt,
+			});
 			return null;
 		}
+		trackGitHubOperationEvent({
+			name: "gh_pr_view",
+			category: "gh",
+			worktreePath,
+			success: false,
+			durationMs: Date.now() - startedAt,
+			error,
+		});
 		throw error;
 	}
 }
@@ -228,10 +285,11 @@ async function findPRByHeadBranch(
 	localBranch: string,
 	repoNames: string[],
 	headSha?: string,
-): Promise<GitHubStatus["pr"]> {
+): Promise<PullRequestLookupResult> {
 	try {
 		const matches = new Map<number, GHPRResponse>();
 		const repoArgSets = getPullRequestRepoArgSets(repoNames);
+		let hadLookupFailure = false;
 
 		for (const repoArgs of repoArgSets) {
 			for (const branchCandidate of getPRHeadBranchCandidates(localBranch)) {
@@ -261,6 +319,7 @@ async function findPRByHeadBranch(
 							),
 					}));
 				} catch (error) {
+					hadLookupFailure = true;
 					console.warn(
 						"[GitHub/findPRByHeadBranch] Failed repo-scoped PR lookup:",
 						{
@@ -282,9 +341,15 @@ async function findPRByHeadBranch(
 		}
 
 		const bestMatch = sortPRCandidates([...matches.values()], headSha)[0];
-		return bestMatch ? formatPRData(bestMatch) : null;
+		return {
+			pr: bestMatch ? formatPRData(bestMatch) : null,
+			hadLookupFailure,
+		};
 	} catch {
-		return null;
+		return {
+			pr: null,
+			hadLookupFailure: true,
+		};
 	}
 }
 
@@ -296,7 +361,7 @@ async function findPRByHeadCommit(
 	worktreePath: string,
 	repoNames: string[],
 	providedSha?: string,
-): Promise<GitHubStatus["pr"]> {
+): Promise<PullRequestLookupResult> {
 	try {
 		let headSha = providedSha;
 		if (!headSha) {
@@ -311,6 +376,7 @@ async function findPRByHeadCommit(
 		}
 
 		const exactHeadMatches: GHPRResponse[] = [];
+		let hadLookupFailure = false;
 		for (const repoArgs of getPullRequestRepoArgSets(repoNames)) {
 			let stdout: string;
 			try {
@@ -338,6 +404,7 @@ async function findPRByHeadCommit(
 						),
 				}));
 			} catch (error) {
+				hadLookupFailure = true;
 				console.warn(
 					"[GitHub/findPRByHeadCommit] Failed repo-scoped PR lookup:",
 					{
@@ -357,13 +424,15 @@ async function findPRByHeadCommit(
 		}
 
 		const bestMatch = sortPRCandidates(exactHeadMatches, headSha)[0];
-		if (bestMatch) {
-			return formatPRData(bestMatch);
-		}
-
-		return null;
+		return {
+			pr: bestMatch ? formatPRData(bestMatch) : null,
+			hadLookupFailure,
+		};
 	} catch {
-		return null;
+		return {
+			pr: null,
+			hadLookupFailure: true,
+		};
 	}
 }
 

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/github/pr-resolution.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/github/pr-resolution.ts
@@ -372,7 +372,10 @@ async function findPRByHeadCommit(
 			headSha = headOutput.trim();
 		}
 		if (!headSha) {
-			return null;
+			return {
+				pr: null,
+				hadLookupFailure: false,
+			};
 		}
 
 		const exactHeadMatches: GHPRResponse[] = [];


### PR DESCRIPTION
## 概要

GitHub 同期で PR が存在しないブランチに対して、同じ探索を繰り返し続ける問題を改善します。

## 変更内容

- `worktree + branch + head SHA` 単位の短時間 negative cache を追加
- `gh pr view` が `no pull requests found` を返した場合は失敗ではなく通常の no match として扱うよう変更
- repo-scoped lookup が一時的に失敗した場合は negative cache しないようにして誤判定を防止

## 期待する効果

- `main` のように通常 PR が付かないブランチでの無駄な `gh pr view` / `gh pr list` 呼び出しを削減
- GitHub metrics 上で `no PR` を failure として数えないようになり、実際の異常を見分けやすくする
- UX を保ったまま、不要な GitHub API トラフィックを減らす

## 確認

- 変更対象の `biome check` は通過
- repo 全体の `lint` / `typecheck` は既存の unrelated エラーで失敗する状態のまま
