### PR TITLE
fix: vscode.diff コマンドを Superset の diff viewer で開くよう実装

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/vscode-extensions/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/vscode-extensions/index.ts
@@ -438,6 +438,26 @@ export const createVscodeExtensionsRouter = () => {
 				});
 			}),
 
+		/** Subscribe to diff open requests from extensions (vscode.diff calls) */
+		subscribeDiff: publicProcedure
+			.input(z.object({ workspaceId: z.string().optional() }).optional())
+			.subscription(({ input }) => {
+				return observable<{ leftUri: string; rightUri: string; title?: string }>((emit) => {
+					const manager = getExtensionHostManager();
+					const handler = (
+						wsId: string,
+						data: { leftUri: string; rightUri: string; title?: string },
+					) => {
+						if (input?.workspaceId && wsId !== input.workspaceId) return;
+						emit.next(data);
+					};
+					manager.on("open-diff", handler);
+					return () => {
+						manager.off("open-diff", handler);
+					};
+				});
+			}),
+
 		/** Subscribe to webview events (HTML changes, messages from extension) */
 		subscribeWebview: publicProcedure
 			.input(z.object({ workspaceId: z.string().optional() }).optional())

--- a/apps/desktop/src/main/extension-host-worker/index.ts
+++ b/apps/desktop/src/main/extension-host-worker/index.ts
@@ -33,9 +33,10 @@ async function main() {
 
 	// Import shim modules (each process gets its own copy)
 	const { setWorkspacePath } = await import("../lib/vscode-shim/api/workspace");
-	const { setActiveTextEditor, onOpenFile, onOpenDiff } = await import(
+	const { setActiveTextEditor, onOpenFile, onOpenDiff, setSendToMain, resolveDialogResult, resolveOpenDialogResult } = await import(
 		"../lib/vscode-shim/api/window"
 	);
+	setSendToMain(send);
 	const { commands } = await import("../lib/vscode-shim/api/commands");
 	const { discoverExtensions, loadExtension, deactivateAll } = await import(
 		"../lib/vscode-shim/loader"
@@ -203,6 +204,14 @@ async function main() {
 			case "shutdown":
 				await deactivateAll();
 				process.exit(0);
+				break;
+
+			case "dialog-result":
+				resolveDialogResult(msg.requestId, msg.selectedIndex);
+				break;
+
+			case "open-dialog-result":
+				resolveOpenDialogResult(msg.requestId, msg.filePaths);
 				break;
 		}
 	});

--- a/apps/desktop/src/main/extension-host-worker/index.ts
+++ b/apps/desktop/src/main/extension-host-worker/index.ts
@@ -33,7 +33,7 @@ async function main() {
 
 	// Import shim modules (each process gets its own copy)
 	const { setWorkspacePath } = await import("../lib/vscode-shim/api/workspace");
-	const { setActiveTextEditor, onOpenFile } = await import(
+	const { setActiveTextEditor, onOpenFile, onOpenDiff } = await import(
 		"../lib/vscode-shim/api/window"
 	);
 	const { commands } = await import("../lib/vscode-shim/api/commands");
@@ -81,6 +81,11 @@ async function main() {
 	// Listen for file open requests
 	onOpenFile((data) => {
 		send({ type: "open-file", filePath: data.filePath, line: data.line });
+	});
+
+	// Listen for diff open requests
+	onOpenDiff((data) => {
+		send({ type: "open-diff", leftUri: data.leftUri, rightUri: data.rightUri, title: data.title });
 	});
 
 	// Supported extension IDs

--- a/apps/desktop/src/main/lib/vscode-shim/api/commands.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/api/commands.ts
@@ -4,6 +4,7 @@
 
 import { shimLog, shimWarn } from "./debug-log";
 import { Disposable } from "./event-emitter";
+import { fireOpenDiff } from "./window";
 
 const UNHANDLED = Symbol("unhandled");
 
@@ -16,15 +17,17 @@ function handleBuiltinCommand(
 	args: unknown[],
 ): unknown | typeof UNHANDLED {
 	switch (command) {
-		// Diff view (Claude Code uses this for file diffs)
+		// Diff view (Claude Code / Codex uses this for file diffs)
 		case "vscode.diff": {
-			shimLog(
-				`[vscode-shim] vscode.diff called with`,
-				args[0],
-				args[1],
-				args[2],
-			);
-			// TODO: could open diff in Superset's file viewer
+			const leftUri = args[0] as { fsPath?: string; toString?(): string } | undefined;
+			const rightUri = args[1] as { fsPath?: string; toString?(): string } | undefined;
+			const title = args[2] as string | undefined;
+			const left = leftUri?.fsPath ?? leftUri?.toString?.() ?? "";
+			const right = rightUri?.fsPath ?? rightUri?.toString?.() ?? "";
+			shimLog(`[vscode-shim] vscode.diff called: ${left} → ${right}`);
+			if (left && right) {
+				fireOpenDiff(left, right, title);
+			}
 			return undefined;
 		}
 

--- a/apps/desktop/src/main/lib/vscode-shim/api/window.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/api/window.ts
@@ -2,16 +2,7 @@
  * VS Code window API shim.
  */
 
-function getDialog(): typeof import("electron").dialog {
-	try {
-		return require("electron").dialog;
-	} catch {
-		return {
-			showMessageBox: async () => ({ response: 0, checkboxChecked: false }),
-		} as unknown as typeof import("electron").dialog;
-	}
-}
-
+import type { WorkerToMainMessage } from "../ipc-types";
 import { shimLog, shimWarn } from "./debug-log";
 import { Disposable, type Event, EventEmitter } from "./event-emitter";
 import { createOutputChannel, type OutputChannel } from "./output-channel";
@@ -85,6 +76,39 @@ export const onOpenDiff = _openDiffEmitter.event;
 export function fireOpenDiff(leftUri: string, rightUri: string, title?: string): void {
 	_openDiffEmitter.fire({ leftUri, rightUri, title });
 }
+
+// IPC send function — injected from worker process so dialog calls go via main
+let _sendToMain: ((msg: WorkerToMainMessage) => void) | null = null;
+export function setSendToMain(fn: (msg: WorkerToMainMessage) => void): void {
+	_sendToMain = fn;
+}
+
+// Pending dialog requests waiting for main-process response
+const _pendingDialogs = new Map<string, (result: unknown) => void>();
+export function resolveDialogResult(requestId: string, selectedIndex: number): void {
+	_pendingDialogs.get(requestId)?.(selectedIndex);
+	_pendingDialogs.delete(requestId);
+}
+export function resolveOpenDialogResult(requestId: string, filePaths: string[] | null): void {
+	_pendingDialogs.get(requestId)?.(filePaths);
+	_pendingDialogs.delete(requestId);
+}
+
+async function showMessageViaIpc(
+	method: "showInformationMessage" | "showWarningMessage" | "showErrorMessage",
+	message: string,
+	items: string[],
+): Promise<string | undefined> {
+	if (!_sendToMain) return undefined;
+	const requestId = crypto.randomUUID();
+	const selectedIndex = await new Promise<number>((resolve) => {
+		_pendingDialogs.set(requestId, (v) => resolve(v as number));
+		_sendToMain!({ type: "show-dialog", requestId, method, message, items });
+	});
+	if (selectedIndex < 0) return undefined;
+	return items[selectedIndex];
+}
+
 // Active text editor state — updated from renderer via tRPC
 let _activeTextEditor: TextEditor | undefined;
 const _visibleTextEditors: TextEditor[] = [];
@@ -203,7 +227,7 @@ export const window = {
 		},
 	},
 
-	// Messages
+	// Messages — sent via IPC to main process (Worker cannot access Electron dialog directly)
 	async showInformationMessage(
 		message: string,
 		...items: string[]
@@ -212,12 +236,7 @@ export const window = {
 			shimLog(`[vscode-shim] INFO: ${message}`);
 			return undefined;
 		}
-		const result = await getDialog().showMessageBox({
-			type: "info",
-			message,
-			buttons: items,
-		});
-		return items[result.response];
+		return showMessageViaIpc("showInformationMessage", message, items);
 	},
 
 	async showWarningMessage(
@@ -228,12 +247,7 @@ export const window = {
 			shimWarn(`[vscode-shim] WARN: ${message}`);
 			return undefined;
 		}
-		const result = await getDialog().showMessageBox({
-			type: "warning",
-			message,
-			buttons: items,
-		});
-		return items[result.response];
+		return showMessageViaIpc("showWarningMessage", message, items);
 	},
 
 	async showErrorMessage(
@@ -244,12 +258,7 @@ export const window = {
 			console.error(`[vscode-shim] ERROR: ${message}`);
 			return undefined;
 		}
-		const result = await getDialog().showMessageBox({
-			type: "error",
-			message,
-			buttons: items,
-		});
-		return items[result.response];
+		return showMessageViaIpc("showErrorMessage", message, items);
 	},
 
 	async showQuickPick(
@@ -267,20 +276,17 @@ export const window = {
 		const labels = resolved.map((item) =>
 			typeof item === "string" ? item : item.label,
 		);
-		try {
-			const { dialog } = require("electron") as typeof import("electron");
-			const result = await dialog.showMessageBox({
-				type: "question",
-				title: options?.placeHolder ?? "Select",
-				message: options?.placeHolder ?? "Select an option",
-				buttons: [...labels, "Cancel"],
-				cancelId: labels.length,
-			});
-			if (result.response === labels.length) return undefined;
-			return resolved[result.response];
-		} catch {
-			return resolved[0];
+		if (!_sendToMain) {
+			shimWarn("[vscode-shim] showQuickPick: no IPC channel available");
+			return undefined;
 		}
+		const requestId = crypto.randomUUID();
+		const selectedIndex = await new Promise<number>((resolve) => {
+			_pendingDialogs.set(requestId, (v) => resolve(v as number));
+			_sendToMain!({ type: "show-quickpick", requestId, labels, placeHolder: options?.placeHolder });
+		});
+		if (selectedIndex < 0) return undefined;
+		return resolved[selectedIndex];
 	},
 
 	async showInputBox(_options?: {
@@ -302,36 +308,32 @@ export const window = {
 			defaultUri?: Uri;
 		},
 	): Promise<Uri[] | undefined> {
-		try {
-			const { dialog } = require("electron") as typeof import("electron");
-			const properties: Array<
-				"openFile" | "openDirectory" | "multiSelections"
-			> = [];
-			if (options?.canSelectFolders) {
-				properties.push("openDirectory");
-			} else {
-				properties.push("openFile");
-			}
-			if (options?.canSelectMany) {
-				properties.push("multiSelections");
-			}
-			const filters = options?.filters
-				? Object.entries(options.filters).map(([name, extensions]) => ({
-						name,
-						extensions,
-					}))
-				: undefined;
-			const result = await dialog.showOpenDialog({
-				properties,
+		if (!_sendToMain) {
+			shimWarn("[vscode-shim] showOpenDialog: no IPC channel available");
+			return undefined;
+		}
+		const filters = options?.filters
+			? Object.entries(options.filters).map(([name, extensions]) => ({
+					name,
+					extensions,
+				}))
+			: undefined;
+		const requestId = crypto.randomUUID();
+		const filePaths = await new Promise<string[] | null>((resolve) => {
+			_pendingDialogs.set(requestId, (v) => resolve(v as string[] | null));
+			_sendToMain!({
+				type: "show-open-dialog",
+				requestId,
+				canSelectFiles: options?.canSelectFiles,
+				canSelectFolders: options?.canSelectFolders,
+				canSelectMany: options?.canSelectMany,
 				title: options?.title,
 				filters,
 				defaultPath: options?.defaultUri?.fsPath,
 			});
-			if (result.canceled || result.filePaths.length === 0) return undefined;
-			return result.filePaths.map((p) => Uri.file(p));
-		} catch {
-			return undefined;
-		}
+		});
+		if (!filePaths || filePaths.length === 0) return undefined;
+		return filePaths.map((p) => Uri.file(p));
 	},
 
 	async showTextDocument(

--- a/apps/desktop/src/main/lib/vscode-shim/api/window.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/api/window.ts
@@ -74,6 +74,17 @@ const _openFileEmitter = new EventEmitter<{
 	line?: number;
 }>();
 export const onOpenFile = _openFileEmitter.event;
+
+// Emits when vscode.diff is called - renderer listens to open diff viewer
+const _openDiffEmitter = new EventEmitter<{
+	leftUri: string;
+	rightUri: string;
+	title?: string;
+}>();
+export const onOpenDiff = _openDiffEmitter.event;
+export function fireOpenDiff(leftUri: string, rightUri: string, title?: string): void {
+	_openDiffEmitter.fire({ leftUri, rightUri, title });
+}
 // Active text editor state — updated from renderer via tRPC
 let _activeTextEditor: TextEditor | undefined;
 const _visibleTextEditors: TextEditor[] = [];

--- a/apps/desktop/src/main/lib/vscode-shim/api/window.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/api/window.ts
@@ -253,13 +253,34 @@ export const window = {
 	},
 
 	async showQuickPick(
-		items: string[] | Promise<string[]>,
-		_options?: { placeHolder?: string; canPickMany?: boolean },
-	): Promise<string | undefined> {
+		items:
+			| string[]
+			| Array<{ label: string; description?: string; detail?: string }>
+			| Promise<
+					| string[]
+					| Array<{ label: string; description?: string; detail?: string }>
+			  >,
+		options?: { placeHolder?: string; canPickMany?: boolean },
+	): Promise<string | { label: string } | undefined> {
 		const resolved = await items;
-		// For MVP, return first item. In Phase 3, render a proper picker in renderer
-		shimWarn("[vscode-shim] showQuickPick stub, returning first item");
-		return resolved[0];
+		if (!resolved || resolved.length === 0) return undefined;
+		const labels = resolved.map((item) =>
+			typeof item === "string" ? item : item.label,
+		);
+		try {
+			const { dialog } = require("electron") as typeof import("electron");
+			const result = await dialog.showMessageBox({
+				type: "question",
+				title: options?.placeHolder ?? "Select",
+				message: options?.placeHolder ?? "Select an option",
+				buttons: [...labels, "Cancel"],
+				cancelId: labels.length,
+			});
+			if (result.response === labels.length) return undefined;
+			return resolved[result.response];
+		} catch {
+			return resolved[0];
+		}
 	},
 
 	async showInputBox(_options?: {
@@ -271,9 +292,46 @@ export const window = {
 		return undefined;
 	},
 
-	async showOpenDialog(_options?: unknown): Promise<Uri[] | undefined> {
-		shimWarn("[vscode-shim] showOpenDialog stub");
-		return undefined;
+	async showOpenDialog(
+		options?: {
+			canSelectFiles?: boolean;
+			canSelectFolders?: boolean;
+			canSelectMany?: boolean;
+			title?: string;
+			filters?: Record<string, string[]>;
+			defaultUri?: Uri;
+		},
+	): Promise<Uri[] | undefined> {
+		try {
+			const { dialog } = require("electron") as typeof import("electron");
+			const properties: Array<
+				"openFile" | "openDirectory" | "multiSelections"
+			> = [];
+			if (options?.canSelectFolders) {
+				properties.push("openDirectory");
+			} else {
+				properties.push("openFile");
+			}
+			if (options?.canSelectMany) {
+				properties.push("multiSelections");
+			}
+			const filters = options?.filters
+				? Object.entries(options.filters).map(([name, extensions]) => ({
+						name,
+						extensions,
+					}))
+				: undefined;
+			const result = await dialog.showOpenDialog({
+				properties,
+				title: options?.title,
+				filters,
+				defaultPath: options?.defaultUri?.fsPath,
+			});
+			if (result.canceled || result.filePaths.length === 0) return undefined;
+			return result.filePaths.map((p) => Uri.file(p));
+		} catch {
+			return undefined;
+		}
 	},
 
 	async showTextDocument(

--- a/apps/desktop/src/main/lib/vscode-shim/api/workspace.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/api/workspace.ts
@@ -220,10 +220,11 @@ export const workspace = {
 					const { start, end } = te.range;
 					if (start.line === end.line) {
 						const line = lines[start.line] ?? "";
-						lines[start.line] =
+						const merged =
 							line.slice(0, start.character) +
 							te.newText +
 							line.slice(end.character);
+						lines.splice(start.line, 1, ...merged.split("\n"));
 					} else {
 						const startLine = lines[start.line] ?? "";
 						const endLine = lines[end.line] ?? "";

--- a/apps/desktop/src/main/lib/vscode-shim/api/workspace.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/api/workspace.ts
@@ -25,8 +25,13 @@ interface TextDocument {
 	save(): Promise<boolean>;
 }
 
+interface TextEditRange {
+	start: { line: number; character: number };
+	end: { line: number; character: number };
+}
+
 interface WorkspaceEdit {
-	entries(): Array<[Uri, Array<{ range: unknown; newText: string }>]>;
+	entries(): Array<[Uri, Array<{ range: TextEditRange; newText: string }>]>;
 }
 
 interface FileSystemWatcher {
@@ -199,9 +204,44 @@ export const workspace = {
 		}
 	},
 
-	async applyEdit(_edit: WorkspaceEdit): Promise<boolean> {
-		shimWarn("[vscode-shim] workspace.applyEdit is a stub");
-		return true;
+	async applyEdit(edit: WorkspaceEdit): Promise<boolean> {
+		try {
+			for (const [uri, textEdits] of edit.entries()) {
+				if (uri.scheme !== "file" || !uri.fsPath || textEdits.length === 0)
+					continue;
+				const content = fs.readFileSync(uri.fsPath, "utf-8");
+				const lines = content.split("\n");
+				// 後ろから適用することでインデックスのずれを防ぐ
+				const sorted = [...textEdits].sort((a, b) => {
+					const dl = b.range.start.line - a.range.start.line;
+					return dl !== 0 ? dl : b.range.start.character - a.range.start.character;
+				});
+				for (const te of sorted) {
+					const { start, end } = te.range;
+					if (start.line === end.line) {
+						const line = lines[start.line] ?? "";
+						lines[start.line] =
+							line.slice(0, start.character) +
+							te.newText +
+							line.slice(end.character);
+					} else {
+						const startLine = lines[start.line] ?? "";
+						const endLine = lines[end.line] ?? "";
+						const merged =
+							startLine.slice(0, start.character) +
+							te.newText +
+							endLine.slice(end.character);
+						lines.splice(start.line, end.line - start.line + 1, ...merged.split("\n"));
+					}
+				}
+				fs.writeFileSync(uri.fsPath, lines.join("\n"), "utf-8");
+				shimLog(`[vscode-shim] workspace.applyEdit: wrote ${uri.fsPath}`);
+			}
+			return true;
+		} catch (err) {
+			shimWarn("[vscode-shim] workspace.applyEdit failed:", err);
+			return false;
+		}
 	},
 
 	createFileSystemWatcher(

--- a/apps/desktop/src/main/lib/vscode-shim/extension-host-manager.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/extension-host-manager.ts
@@ -237,6 +237,10 @@ export class ExtensionHostManager extends EventEmitter {
 				this.emit("open-file", workspaceId, msg);
 				break;
 
+			case "open-diff":
+				this.emit("open-diff", workspaceId, msg);
+				break;
+
 			case "show-dialog":
 				// Proxy dialog calls to Electron main process
 				this.handleDialogRequest(msg);

--- a/apps/desktop/src/main/lib/vscode-shim/extension-host-manager.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/extension-host-manager.ts
@@ -242,18 +242,27 @@ export class ExtensionHostManager extends EventEmitter {
 				break;
 
 			case "show-dialog":
-				// Proxy dialog calls to Electron main process
-				this.handleDialogRequest(msg);
+				// Proxy dialog calls to Electron main process and return result
+				this.handleDialogRequest(workspaceId, msg);
+				break;
+
+			case "show-quickpick":
+				this.handleQuickPickRequest(workspaceId, msg);
+				break;
+
+			case "show-open-dialog":
+				this.handleOpenDialogRequest(workspaceId, msg);
 				break;
 		}
 	}
 
 	private async handleDialogRequest(
+		workspaceId: string,
 		msg: Extract<WorkerToMainMessage, { type: "show-dialog" }>,
 	): Promise<void> {
 		try {
 			const { dialog } = require("electron");
-			const _result = await dialog.showMessageBox({
+			const result = await dialog.showMessageBox({
 				type:
 					msg.method === "showErrorMessage"
 						? "error"
@@ -263,8 +272,64 @@ export class ExtensionHostManager extends EventEmitter {
 				message: msg.message,
 				buttons: msg.items,
 			});
-			// Could send result back via IPC if needed
-		} catch {}
+			this.sendToWorker(workspaceId, {
+				type: "dialog-result",
+				requestId: msg.requestId,
+				selectedIndex: result.response,
+			});
+		} catch {
+			this.sendToWorker(workspaceId, {
+				type: "dialog-result",
+				requestId: msg.requestId,
+				selectedIndex: -1,
+			});
+		}
+	}
+
+	private async handleQuickPickRequest(
+		workspaceId: string,
+		msg: Extract<WorkerToMainMessage, { type: "show-quickpick" }>,
+	): Promise<void> {
+		try {
+			const { dialog } = require("electron");
+			const result = await dialog.showMessageBox({
+				type: "question",
+				title: msg.placeHolder ?? "Select",
+				message: msg.placeHolder ?? "Select an option",
+				buttons: [...msg.labels, "Cancel"],
+				cancelId: msg.labels.length,
+			});
+			const selectedIndex = result.response === msg.labels.length ? -1 : result.response;
+			this.sendToWorker(workspaceId, { type: "dialog-result", requestId: msg.requestId, selectedIndex });
+		} catch {
+			this.sendToWorker(workspaceId, { type: "dialog-result", requestId: msg.requestId, selectedIndex: -1 });
+		}
+	}
+
+	private async handleOpenDialogRequest(
+		workspaceId: string,
+		msg: Extract<WorkerToMainMessage, { type: "show-open-dialog" }>,
+	): Promise<void> {
+		try {
+			const { dialog } = require("electron");
+			const properties: Array<"openFile" | "openDirectory" | "multiSelections"> = [];
+			if (msg.canSelectFolders) properties.push("openDirectory");
+			if (msg.canSelectFiles !== false) properties.push("openFile");
+			if (msg.canSelectMany) properties.push("multiSelections");
+			const result = await dialog.showOpenDialog({
+				properties,
+				title: msg.title,
+				filters: msg.filters,
+				defaultPath: msg.defaultPath,
+			});
+			this.sendToWorker(workspaceId, {
+				type: "open-dialog-result",
+				requestId: msg.requestId,
+				filePaths: result.canceled || result.filePaths.length === 0 ? null : result.filePaths,
+			});
+		} catch {
+			this.sendToWorker(workspaceId, { type: "open-dialog-result", requestId: msg.requestId, filePaths: null });
+		}
 	}
 
 	async resolveWebview(

--- a/apps/desktop/src/main/lib/vscode-shim/ipc-types.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/ipc-types.ts
@@ -34,6 +34,7 @@ export type WorkerToMainMessage =
 			html: string | null;
 	  }
 	| { type: "open-file"; filePath: string; line?: number }
+	| { type: "open-diff"; leftUri: string; rightUri: string; title?: string }
 	| {
 			type: "show-dialog";
 			requestId: string;

--- a/apps/desktop/src/main/lib/vscode-shim/ipc-types.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/ipc-types.ts
@@ -14,7 +14,9 @@ export type MainToWorkerMessage =
 			extensionPath: string;
 	  }
 	| { type: "post-message"; viewId: string; message: unknown }
-	| { type: "shutdown" };
+	| { type: "shutdown" }
+	| { type: "dialog-result"; requestId: string; selectedIndex: number }
+	| { type: "open-dialog-result"; requestId: string; filePaths: string[] | null };
 
 /** Messages sent FROM worker TO main process */
 export type WorkerToMainMessage =
@@ -44,4 +46,15 @@ export type WorkerToMainMessage =
 				| "showErrorMessage";
 			message: string;
 			items: string[];
+	  }
+	| { type: "show-quickpick"; requestId: string; labels: string[]; placeHolder?: string }
+	| {
+			type: "show-open-dialog";
+			requestId: string;
+			canSelectFiles?: boolean;
+			canSelectFolders?: boolean;
+			canSelectMany?: boolean;
+			title?: string;
+			filters?: Array<{ name: string; extensions: string[] }>;
+			defaultPath?: string;
 	  };

--- a/apps/desktop/src/main/lib/vscode-shim/vscode-api.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/vscode-api.ts
@@ -282,6 +282,20 @@ class WorkspaceEdit {
 	delete(uri: Uri, range: Range): void {
 		this.replace(uri, range, "");
 	}
+	/** Set all edits for a given URI (replaces existing edits for that URI) */
+	set(uri: Uri, edits: Array<{ range: Range; newText: string } | unknown>): void {
+		const textEdits = (edits as Array<{ range?: Range; newText?: string }>)
+			.filter((e) => e && "range" in e && "newText" in e)
+			.map((e) => ({ range: e.range as Range, newText: e.newText as string }));
+		const existing = this._edits.find(
+			(e) => e.uri.toString() === uri.toString(),
+		);
+		if (existing) {
+			existing.edits = textEdits;
+		} else if (textEdits.length > 0) {
+			this._edits.push({ uri, edits: textEdits });
+		}
+	}
 	entries(): Array<[Uri, Array<{ range: Range; newText: string }>]> {
 		return this._edits.map((e) => [e.uri, e.edits]);
 	}
@@ -487,9 +501,19 @@ const env = {
 	language: "en",
 	clipboard: {
 		async readText(): Promise<string> {
-			return "";
+			try {
+				const { clipboard } = require("electron");
+				return clipboard.readText();
+			} catch {
+				return "";
+			}
 		},
-		async writeText(_text: string): Promise<void> {},
+		async writeText(text: string): Promise<void> {
+			try {
+				const { clipboard } = require("electron");
+				clipboard.writeText(text);
+			} catch {}
+		},
 	},
 	machineId: "superset-desktop",
 	sessionId: `session-${Date.now()}`,

--- a/apps/desktop/src/renderer/lib/dev-chat.ts
+++ b/apps/desktop/src/renderer/lib/dev-chat.ts
@@ -34,28 +34,8 @@ export const DEV_CHAT_MODELS: ModelOption[] = [
 		provider: "OpenAI",
 	},
 	{
-		id: "openai/gpt-5.2-codex",
-		name: "GPT-5.2-Codex",
-		provider: "OpenAI",
-	},
-	{
 		id: "openai/gpt-5.2",
 		name: "GPT-5.2",
-		provider: "OpenAI",
-	},
-	{
-		id: "openai/gpt-5.1-codex",
-		name: "GPT-5.1-Codex",
-		provider: "OpenAI",
-	},
-	{
-		id: "openai/gpt-5.1-codex-max",
-		name: "GPT-5.1-Codex-Max",
-		provider: "OpenAI",
-	},
-	{
-		id: "openai/gpt-5.1-codex-mini",
-		name: "GPT-5.1-Codex-Mini",
 		provider: "OpenAI",
 	},
 ];

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatPane/components/WorkspaceChatInterface/ChatPaneInterface.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatPane/components/WorkspaceChatInterface/ChatPaneInterface.tsx
@@ -140,21 +140,25 @@ function useAvailableModels(): {
 		enabled: !isDesktopChatDevMode(),
 		staleTime: Number.POSITIVE_INFINITY,
 	});
-	const { data: anthropicStatus } =
+	const { data: anthropicStatus, isLoading: anthropicLoading } =
 		chatServiceTrpc.auth.getAnthropicStatus.useQuery();
-	const { data: openaiStatus } =
+	const { data: openaiStatus, isLoading: openaiLoading } =
 		chatServiceTrpc.auth.getOpenAIStatus.useQuery();
 
 	const allModels =
 		localModels.length > 0 ? localModels : (data?.models ?? []);
 
-	const models = allModels.filter((model) => {
-		if (model.id.startsWith("anthropic/"))
-			return anthropicStatus?.authenticated ?? false;
-		if (model.id.startsWith("openai/"))
-			return openaiStatus?.authenticated ?? false;
-		return true;
-	});
+	// ローディング中はフィルタをスキップして全モデルを表示する（フラッシュ防止）
+	const authLoading = anthropicLoading || openaiLoading;
+	const models = authLoading
+		? allModels
+		: allModels.filter((model) => {
+				if (model.id.startsWith("anthropic/"))
+					return anthropicStatus?.authenticated ?? false;
+				if (model.id.startsWith("openai/"))
+					return openaiStatus?.authenticated ?? false;
+				return true;
+			});
 
 	return { models, defaultModel: models[0] ?? null };
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatPane/components/WorkspaceChatInterface/ChatPaneInterface.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatPane/components/WorkspaceChatInterface/ChatPaneInterface.tsx
@@ -1,3 +1,4 @@
+import { chatServiceTrpc } from "@superset/chat/client";
 import {
 	PromptInputAttachment,
 	type PromptInputMessage,
@@ -139,7 +140,22 @@ function useAvailableModels(): {
 		enabled: !isDesktopChatDevMode(),
 		staleTime: Number.POSITIVE_INFINITY,
 	});
-	const models = localModels.length > 0 ? localModels : (data?.models ?? []);
+	const { data: anthropicStatus } =
+		chatServiceTrpc.auth.getAnthropicStatus.useQuery();
+	const { data: openaiStatus } =
+		chatServiceTrpc.auth.getOpenAIStatus.useQuery();
+
+	const allModels =
+		localModels.length > 0 ? localModels : (data?.models ?? []);
+
+	const models = allModels.filter((model) => {
+		if (model.id.startsWith("anthropic/"))
+			return anthropicStatus?.authenticated ?? false;
+		if (model.id.startsWith("openai/"))
+			return openaiStatus?.authenticated ?? false;
+		return true;
+	});
+
 	return { models, defaultModel: models[0] ?? null };
 }
 

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/GroupStrip/GroupItem.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/GroupStrip/GroupItem.tsx
@@ -84,6 +84,8 @@ export function GroupItem({
 		}),
 	);
 
+	const setTabDragging = useDragPaneStore((s) => s.setTabDragging);
+
 	// Use MosaicDragType.WINDOW so Mosaic's built-in drop targets (blue split indicators) activate
 	const [{ isDragging }, drag, preview] = useDrag<
 		TabDragItem,
@@ -94,16 +96,20 @@ export function GroupItem({
 		const canDropOntoActiveTab = activeTabId != null && activeTabId !== tab.id;
 		return {
 			type: MosaicDragType.WINDOW,
-			item: {
-				mosaicId: canDropOntoActiveTab
-					? `${MOSAIC_ID}-${activeTabId}`
-					: TAB_DRAG_NO_MATCH_ID,
-				hideTimer: 0,
-				tabId: tab.id,
-				index,
-				isTabDrag: true,
+			item: () => {
+				setTabDragging(true);
+				return {
+					mosaicId: canDropOntoActiveTab
+						? `${MOSAIC_ID}-${activeTabId}`
+						: TAB_DRAG_NO_MATCH_ID,
+					hideTimer: 0,
+					tabId: tab.id,
+					index,
+					isTabDrag: true,
+				};
 			},
 			end: (item, monitor) => {
+				setTabDragging(false);
 				const dropResult = monitor.getDropResult();
 				if (!dropResult?.position || !dropResult?.path) return;
 

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatPane/ChatPaneInterface/ChatPaneInterface.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatPane/ChatPaneInterface/ChatPaneInterface.tsx
@@ -139,21 +139,25 @@ function useAvailableModels(): {
 		enabled: !isDesktopChatDevMode(),
 		staleTime: Number.POSITIVE_INFINITY,
 	});
-	const { data: anthropicStatus } =
+	const { data: anthropicStatus, isLoading: anthropicLoading } =
 		chatServiceTrpc.auth.getAnthropicStatus.useQuery();
-	const { data: openaiStatus } =
+	const { data: openaiStatus, isLoading: openaiLoading } =
 		chatServiceTrpc.auth.getOpenAIStatus.useQuery();
 
 	const allModels =
 		localModels.length > 0 ? localModels : (data?.models ?? []);
 
-	const models = allModels.filter((model) => {
-		if (model.id.startsWith("anthropic/"))
-			return anthropicStatus?.authenticated ?? false;
-		if (model.id.startsWith("openai/"))
-			return openaiStatus?.authenticated ?? false;
-		return true;
-	});
+	// ローディング中はフィルタをスキップして全モデルを表示する（フラッシュ防止）
+	const authLoading = anthropicLoading || openaiLoading;
+	const models = authLoading
+		? allModels
+		: allModels.filter((model) => {
+				if (model.id.startsWith("anthropic/"))
+					return anthropicStatus?.authenticated ?? false;
+				if (model.id.startsWith("openai/"))
+					return openaiStatus?.authenticated ?? false;
+				return true;
+			});
 
 	return { models, defaultModel: models[0] ?? null };
 }

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatPane/ChatPaneInterface/ChatPaneInterface.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatPane/ChatPaneInterface/ChatPaneInterface.tsx
@@ -139,7 +139,22 @@ function useAvailableModels(): {
 		enabled: !isDesktopChatDevMode(),
 		staleTime: Number.POSITIVE_INFINITY,
 	});
-	const models = localModels.length > 0 ? localModels : (data?.models ?? []);
+	const { data: anthropicStatus } =
+		chatServiceTrpc.auth.getAnthropicStatus.useQuery();
+	const { data: openaiStatus } =
+		chatServiceTrpc.auth.getOpenAIStatus.useQuery();
+
+	const allModels =
+		localModels.length > 0 ? localModels : (data?.models ?? []);
+
+	const models = allModels.filter((model) => {
+		if (model.id.startsWith("anthropic/"))
+			return anthropicStatus?.authenticated ?? false;
+		if (model.id.startsWith("openai/"))
+			return openaiStatus?.authenticated ?? false;
+		return true;
+	});
+
 	return { models, defaultModel: models[0] ?? null };
 }
 

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/components/BasePaneWindow/BasePaneWindow.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/components/BasePaneWindow/BasePaneWindow.tsx
@@ -69,6 +69,7 @@ export function BasePaneWindow({
 	const containerRef = useRef<HTMLDivElement>(null);
 	const splitOrientation = useSplitOrientation(containerRef);
 	const isDragging = useDragPaneStore((s) => s.draggingPaneId !== null);
+	const isTabDragging = useDragPaneStore((s) => s.isTabDragging);
 	const isResizing = useDragPaneStore((s) => s.isResizing);
 	const setDragging = useDragPaneStore((s) => s.setDragging);
 	const clearDragging = useDragPaneStore((s) => s.clearDragging);
@@ -131,7 +132,7 @@ export function BasePaneWindow({
 			<div
 				ref={containerRef}
 				className={contentClassName}
-				style={isDragging || isResizing ? { pointerEvents: "none" } : undefined}
+				style={isDragging || isTabDragging || isResizing ? { pointerEvents: "none" } : undefined}
 				onClick={handleFocus}
 			>
 				{children}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/components/MosaicSplitOverlay/MosaicSplitOverlay.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/components/MosaicSplitOverlay/MosaicSplitOverlay.tsx
@@ -164,6 +164,13 @@ function SplitHandle({ split, layout, onLayoutChange }: SplitHandleProps) {
 			isDragging.current = true;
 			setResizing(true);
 
+			// Immediately disable pointer events on all iframes to prevent them
+			// from swallowing mousemove/mouseup events during resize
+			const iframes = document.querySelectorAll<HTMLIFrameElement>("iframe");
+			for (const iframe of iframes) {
+				iframe.style.pointerEvents = "none";
+			}
+
 			document.body.style.userSelect = "none";
 			document.body.style.cursor = isRow ? "col-resize" : "row-resize";
 
@@ -192,6 +199,12 @@ function SplitHandle({ split, layout, onLayoutChange }: SplitHandleProps) {
 			const onMouseUp = () => {
 				isDragging.current = false;
 				setResizing(false);
+
+				// Restore pointer events on all iframes
+				for (const iframe of iframes) {
+					iframe.style.pointerEvents = "";
+				}
+
 				document.body.style.userSelect = "";
 				document.body.style.cursor = "";
 				document.removeEventListener("mousemove", onMouseMove);

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/WorkspaceLayout/WorkspaceLayout.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/WorkspaceLayout/WorkspaceLayout.tsx
@@ -13,6 +13,7 @@ import { ContentView } from "../ContentView";
 import { useActiveEditorSync } from "../hooks/useActiveEditorSync";
 import { useBrowserLifecycle } from "../hooks/useBrowserLifecycle";
 import { useVscodeExtensionPanelSync } from "../hooks/useVscodeExtensionPanelSync";
+import { useVscodeDiffSync } from "../hooks/useVscodeDiffSync";
 import { useVscodeOpenFileSync } from "../hooks/useVscodeOpenFileSync";
 import { useVscodeThemeSync } from "../hooks/useVscodeThemeSync";
 import { RightSidebar } from "../RightSidebar";
@@ -36,6 +37,7 @@ export function WorkspaceLayout({
 	useActiveEditorSync();
 	useVscodeExtensionPanelSync();
 	useVscodeOpenFileSync();
+	useVscodeDiffSync();
 	useVscodeThemeSync(
 		typeof localStorage !== "undefined"
 			? localStorage.getItem("vscode-use-superset-theme") === "true"

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/hooks/useVscodeDiffSync.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/hooks/useVscodeDiffSync.ts
@@ -1,0 +1,27 @@
+import { electronTrpc } from "renderer/lib/electron-trpc";
+import { useTabsStore } from "renderer/stores/tabs/store";
+import { useWorkspaceId } from "../WorkspaceIdContext";
+
+/**
+ * Listens for diff open requests from VS Code extensions
+ * (vscode.diff command calls) and opens them in Superset's file viewer.
+ */
+export function useVscodeDiffSync() {
+	const workspaceId = useWorkspaceId();
+	const addFileViewerPane = useTabsStore((s) => s.addFileViewerPane);
+
+	electronTrpc.vscodeExtensions.subscribeDiff.useSubscription(
+		{ workspaceId: workspaceId ?? undefined },
+		{
+			enabled: !!workspaceId,
+			onData: (data) => {
+				if (!workspaceId) return;
+				addFileViewerPane(workspaceId, {
+					filePath: data.rightUri,
+					viewMode: "diff",
+					diffCategory: "unstaged",
+				});
+			},
+		},
+	);
+}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/hooks/useVscodeDiffSync.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/hooks/useVscodeDiffSync.ts
@@ -16,10 +16,16 @@ export function useVscodeDiffSync() {
 			enabled: !!workspaceId,
 			onData: (data) => {
 				if (!workspaceId) return;
+				// leftUri がファイルシステムパスかつ rightUri と異なる場合はリネーム/移動。
+				// git URI (例: git:///path?ref) の場合は unstaged diff として git が差分を解決するため oldPath 不要。
+				const leftIsFilePath =
+					data.leftUri.startsWith("/") || data.leftUri.startsWith("file://");
+				const isRename = leftIsFilePath && data.leftUri !== data.rightUri;
 				addFileViewerPane(workspaceId, {
 					filePath: data.rightUri,
 					viewMode: "diff",
 					diffCategory: "unstaged",
+					...(isRename ? { oldPath: data.leftUri } : {}),
 				});
 			},
 		},

--- a/apps/desktop/src/renderer/stores/drag-pane-store.ts
+++ b/apps/desktop/src/renderer/stores/drag-pane-store.ts
@@ -4,12 +4,14 @@ interface DragPaneState {
 	draggingPaneId: string | null;
 	draggingSourceTabId: string | null;
 	isResizing: boolean;
+	isTabDragging: boolean;
 }
 
 interface DragPaneActions {
 	setDragging: (paneId: string, tabId: string) => void;
 	clearDragging: () => void;
 	setResizing: (value: boolean) => void;
+	setTabDragging: (value: boolean) => void;
 }
 
 export const useDragPaneStore = create<DragPaneState & DragPaneActions>(
@@ -17,10 +19,12 @@ export const useDragPaneStore = create<DragPaneState & DragPaneActions>(
 		draggingPaneId: null,
 		draggingSourceTabId: null,
 		isResizing: false,
+		isTabDragging: false,
 		setDragging: (paneId, tabId) =>
 			set({ draggingPaneId: paneId, draggingSourceTabId: tabId }),
 		clearDragging: () =>
 			set({ draggingPaneId: null, draggingSourceTabId: null }),
 		setResizing: (value) => set({ isResizing: value }),
+		setTabDragging: (value) => set({ isTabDragging: value }),
 	}),
 );

--- a/packages/chat/src/server/desktop/small-model/small-model.ts
+++ b/packages/chat/src/server/desktop/small-model/small-model.ts
@@ -38,7 +38,7 @@ export interface SmallModelProvider {
 
 const OPENAI_CODEX_API_ENDPOINT =
 	"https://chatgpt.com/backend-api/codex/responses";
-const OPENAI_CODEX_SMALL_MODEL_ID = "gpt-5.1-codex-mini";
+const OPENAI_CODEX_SMALL_MODEL_ID = "gpt-5.4-mini";
 const OPENAI_API_SMALL_MODEL_ID = "gpt-4o-mini";
 
 function createOpenAICodexOAuthModel(credentials: OpenAICredentials) {

--- a/packages/trpc/src/router/chat/chat.ts
+++ b/packages/trpc/src/router/chat/chat.ts
@@ -39,28 +39,8 @@ const AVAILABLE_MODELS = [
 		provider: "OpenAI",
 	},
 	{
-		id: "openai/gpt-5.2-codex",
-		name: "GPT-5.2-Codex",
-		provider: "OpenAI",
-	},
-	{
 		id: "openai/gpt-5.2",
 		name: "GPT-5.2",
-		provider: "OpenAI",
-	},
-	{
-		id: "openai/gpt-5.1-codex",
-		name: "GPT-5.1-Codex",
-		provider: "OpenAI",
-	},
-	{
-		id: "openai/gpt-5.1-codex-max",
-		name: "GPT-5.1-Codex-Max",
-		provider: "OpenAI",
-	},
-	{
-		id: "openai/gpt-5.1-codex-mini",
-		name: "GPT-5.1-Codex-Mini",
 		provider: "OpenAI",
 	},
 ];


### PR DESCRIPTION
## Summary

- codex 拡張機能の「Review changes」ボタン押下時に新しいタブでエラーが表示される問題を修正 (closes #97)
- `vscode.diff` コマンドのシムを実装し、`showTextDocument` → `open-file` の既存パターンと同様に `open-diff` イベントとして renderer へ伝達
- Superset の file-viewer ペイン (`viewMode: "diff"`) で差分を表示するよう対応
- 認証済みプロバイダーのモデルのみ表示するよう修正。Codex のみ連携時に Anthropic モデルが選択されて subagent が失敗する問題を解消 (closes #99)
- OpenAI が 2026-04-14 に廃止する `gpt-5.2-codex` / `gpt-5.1-codex` / `gpt-5.1-codex-max` / `gpt-5.1-codex-mini` をモデルリストから削除
- vscode-shim の dialog API（showQuickPick / showOpenDialog / showInformation/Warning/ErrorMessage）が Worker プロセスから `require('electron').dialog` を直接呼び出していた問題を修正。全て Worker→Main IPC 経由に変更
- モデル認証状態ローディング中に全モデルが一時消失するフラッシュを修正
- 拡張機能(iframe)ペインが存在するときにタブドラッグでの分割プレビュー(青いオーバーレイ)が表示されない問題と、分割境界のリサイズが不安定になる問題を修正

## Changes

### vscode.diff 対応
- `ipc-types.ts` — `WorkerToMainMessage` に `open-diff` 型を追加
- `api/window.ts` — `_openDiffEmitter` / `onOpenDiff` / `fireOpenDiff` を追加
- `api/commands.ts` — `vscode.diff` ケースで `fireOpenDiff()` を呼び出すよう実装
- `extension-host-worker/index.ts` — `onOpenDiff` を main プロセスへ転送
- `extension-host-manager.ts` — `open-diff` メッセージを受け取り emit
- `vscode-extensions/index.ts` — `subscribeDiff` tRPC サブスクリプションを追加
- `hooks/useVscodeDiffSync.ts` — 新規作成。diff イベントを受け取り `addFileViewerPane` を呼び出す
- `WorkspaceLayout.tsx` — `useVscodeDiffSync()` を組み込み

### モデルフィルタリング & 廃止モデル削除
- `ChatPaneInterface.tsx` (旧UI・v2) — `getAnthropicStatus` / `getOpenAIStatus` を参照して未認証プロバイダーのモデルをフィルタリング。isLoading 中はフィルタをスキップしフラッシュを防止
- `chat.ts` / `dev-chat.ts` — 廃止 OpenAI モデルをリストから削除

### dialog IPC 修正
- `ipc-types.ts` — `show-quickpick` / `show-open-dialog` を `WorkerToMainMessage` に追加、`dialog-result` / `open-dialog-result` を `MainToWorkerMessage` に追加
- `api/window.ts` — `getDialog()` 直接呼び出しを廃止。全 dialog API を `setSendToMain` 経由の IPC に変更。`resolveDialogResult` / `resolveOpenDialogResult` エクスポートを追加
- `extension-host-worker/index.ts` — `setSendToMain(send)` を呼び出し IPC チャネルを注入。`dialog-result` / `open-dialog-result` の応答ハンドリングを追加
- `extension-host-manager.ts` — `show-quickpick` / `show-open-dialog` / `show-dialog` の各ハンドラを実装し結果を worker へ返送

### iframe ペインのドラッグ・リサイズ修正
- `drag-pane-store.ts` — `isTabDragging` フラグと `setTabDragging` アクションを追加
- `GroupItem.tsx` — `useDrag` のドラッグ開始/終了時に `setTabDragging` を呼び出し
- `BasePaneWindow.tsx` — `isTabDragging` 時も `pointerEvents: none` を適用
- `MosaicSplitOverlay.tsx` — `mousedown` 時に全 iframe の `pointerEvents` を直接無効化し、`mouseup` 時に復元

## Test plan

- [ ] codex 拡張機能をインストールした状態でワークスペースを開く
- [ ] エージェントに変更を加えさせた後、「Review changes」ボタンを押す
- [ ] 新しいタブが開かずに Superset の diff viewer ペインで差分が表示されることを確認
- [ ] Codex のみ連携している状態でチャットを開き、モデル選択に Anthropic モデルが表示されないことを確認
- [ ] subagent を起動して「Not logged in to Anthropic」エラーが出ないことを確認
- [ ] 拡張機能から `showQuickPick` を呼び出したときにダイアログが正常表示されることを確認
- [ ] 拡張機能から `showOpenDialog` を呼び出したときにファイル選択ダイアログが正常表示されることを確認
- [ ] 拡張機能ペインを含むタブをドラッグしたとき、青い分割プレビューが表示されることを確認
- [ ] 拡張機能ペインとターミナルペインの分割境界をドラッグリサイズし、マウスリリース時に正しく停止することを確認