### PR TITLE
fix: prevent inline completion plugin recreation loop in DiffViewer

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/components/CodeMirrorDiffViewer/CodeMirrorDiffViewer.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/components/CodeMirrorDiffViewer/CodeMirrorDiffViewer.tsx
@@ -235,18 +235,9 @@ export function CodeMirrorDiffViewer({
 	const editorFontSize = fontSettings?.editorFontSize ?? undefined;
 	const editorTheme = getEditorTheme(activeTheme);
 
-	useEffect(() => {
-		onChangeRef.current = onChange;
-	}, [onChange]);
-
-	useEffect(() => {
-		onSaveRef.current = onSave;
-	}, [onSave]);
-
-	useEffect(() => {
-		inlineCompletionRequestRef.current = inlineCompletionRequest;
-	// biome-ignore lint/correctness/useExhaustiveDependencies: coerce to boolean to avoid unnecessary ref updates on callback reference changes
-	}, [Boolean(inlineCompletionRequest)]);
+	onChangeRef.current = onChange;
+	onSaveRef.current = onSave;
+	inlineCompletionRequestRef.current = inlineCompletionRequest;
 
 	// biome-ignore lint/correctness/useExhaustiveDependencies: MergeView is created once and destroyed on unmount
 	useEffect(() => {

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/components/CodeMirrorDiffViewer/CodeMirrorDiffViewer.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/components/CodeMirrorDiffViewer/CodeMirrorDiffViewer.tsx
@@ -245,7 +245,8 @@ export function CodeMirrorDiffViewer({
 
 	useEffect(() => {
 		inlineCompletionRequestRef.current = inlineCompletionRequest;
-	}, [inlineCompletionRequest]);
+	// biome-ignore lint/correctness/useExhaustiveDependencies: coerce to boolean to avoid unnecessary ref updates on callback reference changes
+	}, [Boolean(inlineCompletionRequest)]);
 
 	// biome-ignore lint/correctness/useExhaustiveDependencies: MergeView is created once and destroyed on unmount
 	useEffect(() => {
@@ -418,7 +419,8 @@ export function CodeMirrorDiffViewer({
 					: [],
 			),
 		});
-	}, [inlineCompletionCompartmentB, inlineCompletionRequest]);
+	// biome-ignore lint/correctness/useExhaustiveDependencies: intentionally coerce to boolean to avoid re-creating the plugin on every render when the callback reference changes
+	}, [inlineCompletionCompartmentB, Boolean(inlineCompletionRequest)]);
 
 	return <div ref={containerRef} className="h-full w-full overflow-auto" />;
 }


### PR DESCRIPTION
## Summary
- CodeMirrorDiffViewerのuseEffect依存配列で`inlineCompletionRequest`を直接参照していたのを`Boolean(inlineCompletionRequest)`に修正
- CodeEditor.tsxと同じバグ（5531bd6e9で修正済み）がDiffViewer側にも存在していた
- コールバック参照が毎レンダーで変わるため、プラグインが無限に再生成され補完が壊れる+リクエストスパムが発生していた

## Test plan
- [ ] DiffViewerでインライン補完が正常に表示されること
- [ ] コンソールにNextEdit/InlineCompletionのリクエストスパムが出ないこと