### PR TITLE
fix: preserve VS Code extension pane state across moves

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/PersistentTabRenderer.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/PersistentTabRenderer.tsx
@@ -11,14 +11,12 @@ interface PersistentTabRendererProps {
 }
 
 /**
- * Renders workspace tabs, keeping only those that contain a browser (webview)
- * pane mounted when inactive. Tabs without webviews are unmounted normally.
+ * Renders workspace tabs, keeping tabs with persistent embedded views mounted
+ * when inactive. Regular tabs are unmounted normally.
  *
- * Electron's <webview> tag reloads its content whenever it is reparented in the
- * DOM. By keeping webview-containing tabs mounted (but off-screen), webview
- * elements stay in their original DOM parent and never reparent, eliminating
- * the reload. Non-webview tabs (terminals, chat, files) can safely unmount and
- * remount without data loss.
+ * Browser panes use Electron <webview>, and VS Code extension panes use iframes
+ * backed by persistent view IDs. Keeping these tabs mounted avoids dropping
+ * subscriptions or forcing unnecessary view resolution while the tab is hidden.
  */
 export function PersistentTabRenderer({
 	isWorkspaceActive,
@@ -27,11 +25,16 @@ export function PersistentTabRenderer({
 }: PersistentTabRendererProps) {
 	const panes = useTabsStore((s) => s.panes);
 
-	const tabsWithWebview = useMemo(() => {
+	const tabsWithPersistentViews = useMemo(() => {
 		const ids = new Set<string>();
 		for (const tab of tabs) {
 			const paneIds = extractPaneIdsFromLayout(tab.layout);
-			if (paneIds.some((id) => panes[id]?.type === "webview")) {
+			if (
+				paneIds.some((id) => {
+					const type = panes[id]?.type;
+					return type === "webview" || type === "vscode-extension";
+				})
+			) {
 				ids.add(tab.id);
 			}
 		}
@@ -42,10 +45,9 @@ export function PersistentTabRenderer({
 		<>
 			{tabs.map((tab) => {
 				const isActive = tab.id === activeTabId;
-				const hasWebview = tabsWithWebview.has(tab.id);
+				const hasPersistentView = tabsWithPersistentViews.has(tab.id);
 
-				// Tabs without webviews: only render when active (original behavior)
-				if (!hasWebview && !isActive) return null;
+				if (!hasPersistentView && !isActive) return null;
 
 				return (
 					<div

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/VscodeExtensionPane/VscodeExtensionPane.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/VscodeExtensionPane/VscodeExtensionPane.tsx
@@ -1,5 +1,6 @@
 import type { MosaicBranch } from "react-mosaic-component";
 import { VscodeExtensionView } from "renderer/screens/main/components/WorkspaceView/RightSidebar/VscodeExtensionView";
+import { createVscodeExtensionPanePersistenceId } from "renderer/screens/main/components/WorkspaceView/RightSidebar/VscodeExtensionView/runtime";
 import { useTabsStore } from "renderer/stores/tabs/store";
 import { BasePaneWindow, PaneTitle, PaneToolbarActions } from "../components";
 
@@ -66,6 +67,7 @@ export function VscodeExtensionPane({
 					viewType={viewType}
 					extensionId={extensionId}
 					isActive={true}
+					persistenceId={createVscodeExtensionPanePersistenceId(paneId)}
 				/>
 			</div>
 		</BasePaneWindow>

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/VscodeExtensionView/VscodeExtensionView.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/VscodeExtensionView/VscodeExtensionView.tsx
@@ -1,11 +1,17 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { useWorkspaceId } from "../../WorkspaceIdContext";
+import {
+	getPersistentVscodeExtensionHost,
+	parkPersistentVscodeExtensionHost,
+	setPersistentVscodeExtensionHost,
+} from "./runtime";
 
 interface VscodeExtensionViewProps {
 	viewType: string;
 	extensionId: string;
 	isActive: boolean;
+	persistenceId: string;
 }
 
 /**
@@ -17,6 +23,7 @@ export function VscodeExtensionView({
 	viewType,
 	extensionId,
 	isActive,
+	persistenceId,
 }: VscodeExtensionViewProps) {
 	const workspaceId = useWorkspaceId();
 	const { data: workspace } = electronTrpc.workspaces.get.useQuery(
@@ -24,20 +31,62 @@ export function VscodeExtensionView({
 		{ enabled: !!workspaceId },
 	);
 	const iframeRef = useRef<HTMLIFrameElement>(null);
-	const [viewId, setViewId] = useState<string | null>(null);
-	const [iframeUrl, setIframeUrl] = useState<string | null>(null);
+	const containerRef = useRef<HTMLDivElement>(null);
+	const persistentHostId = useMemo(
+		() => `${workspaceId ?? "no-workspace"}:${persistenceId}`,
+		[workspaceId, persistenceId],
+	);
+	const [viewId, setViewId] = useState<string | null>(() => {
+		const host = getPersistentVscodeExtensionHost(persistentHostId);
+		return host?.viewId ?? null;
+	});
+	const [iframeAttached, setIframeAttached] = useState<boolean>(() =>
+		Boolean(getPersistentVscodeExtensionHost(persistentHostId)),
+	);
 	const [error, setError] = useState<string | null>(null);
 
 	const resolveMutation =
 		electronTrpc.vscodeExtensions.resolveWebview.useMutation();
 	const postMessageMutation =
 		electronTrpc.vscodeExtensions.postMessageToExtension.useMutation();
+	const resolveWebviewRef = useRef(resolveMutation.mutate);
+	resolveWebviewRef.current = resolveMutation.mutate;
 
-	// Resolve the webview when first becoming active
 	useEffect(() => {
-		if (!isActive || viewId || !workspaceId || !workspace?.worktreePath) return;
+		const existingHost = getPersistentVscodeExtensionHost(persistentHostId);
+		iframeRef.current = existingHost?.iframe ?? null;
+		setViewId(existingHost?.viewId ?? null);
+		setIframeAttached(Boolean(existingHost));
+		setError(null);
+	}, [persistentHostId]);
 
-		resolveMutation.mutate(
+	useEffect(() => {
+		const container = containerRef.current;
+		if (!container) return;
+
+		let cancelled = false;
+		const existingHost = getPersistentVscodeExtensionHost(persistentHostId);
+		if (existingHost) {
+			iframeRef.current = existingHost.iframe;
+			container.appendChild(existingHost.wrapper);
+			setViewId(existingHost.viewId);
+			setIframeAttached(true);
+			setError(null);
+
+			return () => {
+				parkPersistentVscodeExtensionHost(persistentHostId);
+			};
+		}
+
+		if (!isActive || !workspaceId || !workspace?.worktreePath) {
+			setIframeAttached(false);
+			return;
+		}
+
+		setIframeAttached(false);
+		setError(null);
+
+		resolveWebviewRef.current(
 			{
 				workspaceId,
 				workspacePath: workspace.worktreePath,
@@ -46,25 +95,62 @@ export function VscodeExtensionView({
 			},
 			{
 				onSuccess: (result) => {
-					if (result.viewId && result.url) {
-						setViewId(result.viewId);
-						setIframeUrl(result.url);
-					} else {
+					if (cancelled) return;
+					if (!result.viewId || !result.url) {
 						setError(`Extension view "${viewType}" not found`);
+						return;
 					}
+
+					const wrapper = document.createElement("div");
+					wrapper.style.display = "flex";
+					wrapper.style.flex = "1";
+					wrapper.style.width = "100%";
+					wrapper.style.height = "100%";
+					wrapper.style.minHeight = "0";
+
+					const iframe = document.createElement("iframe");
+					iframe.src = result.url;
+					iframe.className = "w-full h-full border-0";
+					iframe.sandbox.add(
+						"allow-scripts",
+						"allow-same-origin",
+						"allow-forms",
+						"allow-popups",
+						"allow-modals",
+						"allow-downloads",
+					);
+					iframe.allow = "clipboard-read; clipboard-write; microphone; camera";
+					iframe.title = `${extensionId} webview`;
+
+					wrapper.appendChild(iframe);
+					container.appendChild(wrapper);
+					iframeRef.current = iframe;
+					setPersistentVscodeExtensionHost(persistentHostId, {
+						wrapper,
+						iframe,
+						viewId: result.viewId,
+					});
+					setViewId(result.viewId);
+					setIframeAttached(true);
 				},
 				onError: (err) => {
+					if (cancelled) return;
 					setError(err.message);
 				},
 			},
 		);
+
+		return () => {
+			cancelled = true;
+			parkPersistentVscodeExtensionHost(persistentHostId);
+		};
 	}, [
 		isActive,
-		viewId,
 		viewType,
 		workspaceId,
 		workspace?.worktreePath,
-		resolveMutation.mutate,
+		extensionId,
+		persistentHostId,
 	]);
 
 	// Listen for messages from iframe -> forward to extension
@@ -90,7 +176,7 @@ export function VscodeExtensionView({
 	electronTrpc.vscodeExtensions.subscribeWebview.useSubscription(
 		{ workspaceId: workspaceId ?? undefined },
 		{
-			enabled: isActive && !!viewId && !!workspaceId,
+			enabled: !!viewId && !!workspaceId,
 			onData: (event) => {
 				if (!viewId || event.viewId !== viewId) return;
 				if (event.type === "message") {
@@ -113,22 +199,22 @@ export function VscodeExtensionView({
 		);
 	}
 
-	if (!iframeUrl) {
+	if (!iframeAttached) {
 		return (
-			<div className="flex-1 flex items-center justify-center text-muted-foreground text-sm">
-				<p>Loading {extensionId}...</p>
+			<div className="flex-1 flex min-h-0 flex-col overflow-hidden">
+				<div ref={containerRef} className="hidden" />
+				{isActive ? (
+					<div className="flex flex-1 items-center justify-center text-muted-foreground text-sm">
+						<p>Loading {extensionId}...</p>
+					</div>
+				) : null}
 			</div>
 		);
 	}
 
 	return (
-		<iframe
-			ref={iframeRef}
-			src={iframeUrl}
-			className="w-full h-full border-0"
-			sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-modals allow-downloads"
-			allow="clipboard-read; clipboard-write; microphone; camera"
-			title={`${extensionId} webview`}
-		/>
+		<div className="flex-1 flex min-h-0 flex-col overflow-hidden">
+			<div ref={containerRef} className="flex-1 min-h-0" />
+		</div>
 	);
 }

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/VscodeExtensionView/VscodeExtensionView.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/VscodeExtensionView/VscodeExtensionView.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { useWorkspaceId } from "../../WorkspaceIdContext";
 import {
+	createPersistentVscodeExtensionHostId,
 	getPersistentVscodeExtensionHost,
 	parkPersistentVscodeExtensionHost,
 	setPersistentVscodeExtensionHost,
@@ -33,7 +34,11 @@ export function VscodeExtensionView({
 	const iframeRef = useRef<HTMLIFrameElement>(null);
 	const containerRef = useRef<HTMLDivElement>(null);
 	const persistentHostId = useMemo(
-		() => `${workspaceId ?? "no-workspace"}:${persistenceId}`,
+		() =>
+			createPersistentVscodeExtensionHostId(
+				workspaceId ?? "no-workspace",
+				persistenceId,
+			),
 		[workspaceId, persistenceId],
 	);
 	const [viewId, setViewId] = useState<string | null>(() => {

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/VscodeExtensionView/runtime.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/VscodeExtensionView/runtime.ts
@@ -1,0 +1,59 @@
+interface PersistentVscodeExtensionHost {
+	wrapper: HTMLDivElement;
+	iframe: HTMLIFrameElement;
+	viewId: string;
+}
+
+const hostRegistry = new Map<string, PersistentVscodeExtensionHost>();
+let hiddenContainer: HTMLDivElement | null = null;
+
+function getHiddenContainer(): HTMLDivElement {
+	if (!hiddenContainer) {
+		hiddenContainer = document.createElement("div");
+		hiddenContainer.style.position = "fixed";
+		hiddenContainer.style.left = "-9999px";
+		hiddenContainer.style.top = "-9999px";
+		hiddenContainer.style.width = "100vw";
+		hiddenContainer.style.height = "100vh";
+		hiddenContainer.style.overflow = "hidden";
+		hiddenContainer.style.pointerEvents = "none";
+		document.body.appendChild(hiddenContainer);
+	}
+	return hiddenContainer;
+}
+
+export function createVscodeExtensionPanePersistenceId(paneId: string): string {
+	return `pane:${paneId}`;
+}
+
+export function createVscodeExtensionSidebarPersistenceId(
+	viewType: string,
+): string {
+	return `sidebar:${viewType}`;
+}
+
+export function getPersistentVscodeExtensionHost(
+	hostId: string,
+): PersistentVscodeExtensionHost | undefined {
+	return hostRegistry.get(hostId);
+}
+
+export function setPersistentVscodeExtensionHost(
+	hostId: string,
+	host: PersistentVscodeExtensionHost,
+): void {
+	hostRegistry.set(hostId, host);
+}
+
+export function parkPersistentVscodeExtensionHost(hostId: string): void {
+	const host = hostRegistry.get(hostId);
+	if (!host) return;
+	getHiddenContainer().appendChild(host.wrapper);
+}
+
+export function destroyPersistentVscodeExtensionHost(hostId: string): void {
+	const host = hostRegistry.get(hostId);
+	if (!host) return;
+	host.wrapper.remove();
+	hostRegistry.delete(hostId);
+}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/VscodeExtensionView/runtime.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/VscodeExtensionView/runtime.ts
@@ -32,6 +32,13 @@ export function createVscodeExtensionSidebarPersistenceId(
 	return `sidebar:${viewType}`;
 }
 
+export function createPersistentVscodeExtensionHostId(
+	workspaceId: string,
+	persistenceId: string,
+): string {
+	return `${workspaceId}:${persistenceId}`;
+}
+
 export function getPersistentVscodeExtensionHost(
 	hostId: string,
 ): PersistentVscodeExtensionHost | undefined {
@@ -56,4 +63,17 @@ export function destroyPersistentVscodeExtensionHost(hostId: string): void {
 	if (!host) return;
 	host.wrapper.remove();
 	hostRegistry.delete(hostId);
+}
+
+export function destroyPersistentVscodeExtensionHostsForWorkspace(
+	workspaceId: string,
+): void {
+	const workspacePrefix = `${workspaceId}:`;
+	const hostIds = [...hostRegistry.keys()].filter((hostId) =>
+		hostId.startsWith(workspacePrefix),
+	);
+
+	for (const hostId of hostIds) {
+		destroyPersistentVscodeExtensionHost(hostId);
+	}
 }

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/index.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/index.tsx
@@ -64,6 +64,7 @@ import { getSidebarHeaderTabButtonClassName } from "./headerTabStyles";
 import { ProblemsView } from "./ProblemsView";
 import { SearchView } from "./SearchView";
 import { VscodeExtensionView } from "./VscodeExtensionView";
+import { createVscodeExtensionSidebarPersistenceId } from "./VscodeExtensionView/runtime";
 
 interface SidebarTabDefinition {
 	id: RightSidebarTab;
@@ -798,6 +799,9 @@ export function RightSidebar({ isActive = true }: { isActive?: boolean }) {
 						viewType="claudeVSCodeSidebar"
 						extensionId="anthropic.claude-code"
 						isActive={rightSidebarTab === RightSidebarTab.ClaudeCode}
+						persistenceId={createVscodeExtensionSidebarPersistenceId(
+							"claudeVSCodeSidebar",
+						)}
 					/>
 				</div>
 			)}
@@ -813,6 +817,9 @@ export function RightSidebar({ isActive = true }: { isActive?: boolean }) {
 						viewType="chatgpt.sidebarView"
 						extensionId="openai.chatgpt"
 						isActive={rightSidebarTab === RightSidebarTab.Codex}
+						persistenceId={createVscodeExtensionSidebarPersistenceId(
+							"chatgpt.sidebarView",
+						)}
 					/>
 				</div>
 			)}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/WorkspaceLayout/WorkspaceLayout.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/WorkspaceLayout/WorkspaceLayout.tsx
@@ -35,7 +35,7 @@ export function WorkspaceLayout({
 	onOpenQuickOpen,
 }: WorkspaceLayoutProps) {
 	useBrowserLifecycle();
-	useVscodeExtensionLifecycle();
+	useVscodeExtensionLifecycle(workspaceId);
 	useActiveEditorSync();
 	useVscodeExtensionPanelSync();
 	useVscodeOpenFileSync();

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/WorkspaceLayout/WorkspaceLayout.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/WorkspaceLayout/WorkspaceLayout.tsx
@@ -13,6 +13,7 @@ import { ContentView } from "../ContentView";
 import { useActiveEditorSync } from "../hooks/useActiveEditorSync";
 import { useBrowserLifecycle } from "../hooks/useBrowserLifecycle";
 import { useVscodeDiffSync } from "../hooks/useVscodeDiffSync";
+import { useVscodeExtensionLifecycle } from "../hooks/useVscodeExtensionLifecycle";
 import { useVscodeExtensionPanelSync } from "../hooks/useVscodeExtensionPanelSync";
 import { useVscodeOpenFileSync } from "../hooks/useVscodeOpenFileSync";
 import { useVscodeThemeSync } from "../hooks/useVscodeThemeSync";
@@ -34,6 +35,7 @@ export function WorkspaceLayout({
 	onOpenQuickOpen,
 }: WorkspaceLayoutProps) {
 	useBrowserLifecycle();
+	useVscodeExtensionLifecycle();
 	useActiveEditorSync();
 	useVscodeExtensionPanelSync();
 	useVscodeOpenFileSync();

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/hooks/useVscodeExtensionLifecycle/index.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/hooks/useVscodeExtensionLifecycle/index.ts
@@ -1,0 +1,1 @@
+export { useVscodeExtensionLifecycle } from "./useVscodeExtensionLifecycle";

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/hooks/useVscodeExtensionLifecycle/useVscodeExtensionLifecycle.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/hooks/useVscodeExtensionLifecycle/useVscodeExtensionLifecycle.ts
@@ -1,0 +1,37 @@
+import { useEffect, useRef } from "react";
+import {
+	createVscodeExtensionPanePersistenceId,
+	destroyPersistentVscodeExtensionHost,
+} from "renderer/screens/main/components/WorkspaceView/RightSidebar/VscodeExtensionView/runtime";
+import { useTabsStore } from "renderer/stores/tabs/store";
+
+export function useVscodeExtensionLifecycle() {
+	const previousPaneIdsRef = useRef<Set<string>>(new Set());
+
+	useEffect(() => {
+		const state = useTabsStore.getState();
+		previousPaneIdsRef.current = new Set(
+			Object.entries(state.panes)
+				.filter(([, pane]) => pane.type === "vscode-extension")
+				.map(([paneId]) => paneId),
+		);
+
+		return useTabsStore.subscribe((nextState) => {
+			const currentPaneIds = new Set(
+				Object.entries(nextState.panes)
+					.filter(([, pane]) => pane.type === "vscode-extension")
+					.map(([paneId]) => paneId),
+			);
+
+			for (const previousPaneId of previousPaneIdsRef.current) {
+				if (!currentPaneIds.has(previousPaneId)) {
+					destroyPersistentVscodeExtensionHost(
+						createVscodeExtensionPanePersistenceId(previousPaneId),
+					);
+				}
+			}
+
+			previousPaneIdsRef.current = currentPaneIds;
+		});
+	}, []);
+}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/hooks/useVscodeExtensionLifecycle/useVscodeExtensionLifecycle.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/hooks/useVscodeExtensionLifecycle/useVscodeExtensionLifecycle.ts
@@ -1,37 +1,65 @@
 import { useEffect, useRef } from "react";
 import {
+	createPersistentVscodeExtensionHostId,
 	createVscodeExtensionPanePersistenceId,
 	destroyPersistentVscodeExtensionHost,
+	destroyPersistentVscodeExtensionHostsForWorkspace,
 } from "renderer/screens/main/components/WorkspaceView/RightSidebar/VscodeExtensionView/runtime";
 import { useTabsStore } from "renderer/stores/tabs/store";
 
-export function useVscodeExtensionLifecycle() {
+function getWorkspaceVscodeExtensionPaneIds(
+	state: ReturnType<typeof useTabsStore.getState>,
+	workspaceId: string,
+): Set<string> {
+	const workspaceTabIds = new Set(
+		state.tabs
+			.filter((tab) => tab.workspaceId === workspaceId)
+			.map((tab) => tab.id),
+	);
+
+	return new Set(
+		Object.entries(state.panes)
+			.filter(
+				([, pane]) =>
+					pane.type === "vscode-extension" && workspaceTabIds.has(pane.tabId),
+			)
+			.map(([paneId]) => paneId),
+	);
+}
+
+export function useVscodeExtensionLifecycle(workspaceId: string) {
 	const previousPaneIdsRef = useRef<Set<string>>(new Set());
 
 	useEffect(() => {
 		const state = useTabsStore.getState();
-		previousPaneIdsRef.current = new Set(
-			Object.entries(state.panes)
-				.filter(([, pane]) => pane.type === "vscode-extension")
-				.map(([paneId]) => paneId),
+		previousPaneIdsRef.current = getWorkspaceVscodeExtensionPaneIds(
+			state,
+			workspaceId,
 		);
 
-		return useTabsStore.subscribe((nextState) => {
-			const currentPaneIds = new Set(
-				Object.entries(nextState.panes)
-					.filter(([, pane]) => pane.type === "vscode-extension")
-					.map(([paneId]) => paneId),
+		const unsubscribe = useTabsStore.subscribe((nextState) => {
+			const currentPaneIds = getWorkspaceVscodeExtensionPaneIds(
+				nextState,
+				workspaceId,
 			);
 
 			for (const previousPaneId of previousPaneIdsRef.current) {
 				if (!currentPaneIds.has(previousPaneId)) {
 					destroyPersistentVscodeExtensionHost(
-						createVscodeExtensionPanePersistenceId(previousPaneId),
+						createPersistentVscodeExtensionHostId(
+							workspaceId,
+							createVscodeExtensionPanePersistenceId(previousPaneId),
+						),
 					);
 				}
 			}
 
 			previousPaneIdsRef.current = currentPaneIds;
 		});
-	}, []);
+
+		return () => {
+			unsubscribe();
+			destroyPersistentVscodeExtensionHostsForWorkspace(workspaceId);
+		};
+	}, [workspaceId]);
 }


### PR DESCRIPTION
## 概要
- VS Code 拡張 pane の `iframe` を host ID 単位で永続化し、pane の移動や再マウント時に新しい webview セッションを作らず既存セッションを再利用するようにしました
- `vscode-extension` pane を含むタブも inactive 時に keep-alive し、browser pane と同じく非表示時の state 消失を防ぐようにしました
- pane が実際に閉じられたときだけ永続 host を cleanup する lifecycle を追加しました

## 変更内容
- `VscodeExtensionView` に persistent host runtime を追加
- pane 用 / 右サイドバー用の persistence ID を導入
- `PersistentTabRenderer` の keep-alive 対象に `vscode-extension` を追加
- `vscode-extension` pane 削除時の cleanup hook を追加

## 検証
- `bunx @biomejs/biome check apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/VscodeExtensionView/VscodeExtensionView.tsx apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/VscodeExtensionView/runtime.ts apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/VscodeExtensionPane/VscodeExtensionPane.tsx apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/index.tsx apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/PersistentTabRenderer.tsx apps/desktop/src/renderer/screens/main/components/WorkspaceView/hooks/useVscodeExtensionLifecycle/useVscodeExtensionLifecycle.ts apps/desktop/src/renderer/screens/main/components/WorkspaceView/hooks/useVscodeExtensionLifecycle/index.ts apps/desktop/src/renderer/screens/main/components/WorkspaceView/WorkspaceLayout/WorkspaceLayout.tsx`
- `bun run lint`
  - 既存のリポジトリ起因エラーで失敗
  - `apps/desktop/src/main/lib/vscode-shim/*`
  - `apps/desktop/src/renderer/screens/main/components/WorkspaceView/components/CodeEditor/CodeEditor.tsx`
- `bun run --cwd apps/desktop typecheck`
  - 既存のリポジトリ起因エラーで失敗
  - `src/renderer/routes/_authenticated/settings/models/components/ModelsSettings/ModelsSettings.tsx`

## 補足
- VS Code shim 全体の webview 再利用セマンティクスは変更していません
- 影響範囲を renderer 側に限定し、pane / sidebar インスタンス単位で解決済み `iframe` host を保持する形に留めています
