### PR TITLE
fix(desktop): 拡張機能ホストのメモリリークを修正してセッションリセット問題を解消

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/vscode-extensions/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/vscode-extensions/index.ts
@@ -10,6 +10,7 @@ import {
 	getActiveView,
 } from "main/lib/vscode-shim/api/webview";
 import {
+	clearWebviewHtml,
 	getWebviewUrl,
 	hasWebviewHtml,
 	setCustomThemeCss,
@@ -343,10 +344,12 @@ export const createVscodeExtensionsRouter = () => {
 			.mutation(({ input }) => {
 				const panel = getActivePanel(input.viewId);
 				if (!panel) {
+					clearWebviewHtml(input.viewId);
 					return { success: false };
 				}
 
 				panel.dispose();
+				clearWebviewHtml(input.viewId);
 				return { success: true };
 			}),
 

--- a/apps/desktop/src/main/extension-host-worker/index.ts
+++ b/apps/desktop/src/main/extension-host-worker/index.ts
@@ -161,23 +161,37 @@ async function main() {
 					// If HTML not yet set, wait up to 5s
 					if (!html) {
 						html = await new Promise<string | null>((resolve) => {
+							let settled = false;
+							let interval: ReturnType<typeof setInterval> | null = null;
+							let timeout: ReturnType<typeof setTimeout> | null = null;
+
+							const finish = (value: string | null) => {
+								if (settled) return;
+								settled = true;
+								if (interval !== null) {
+									clearInterval(interval);
+									interval = null;
+								}
+								if (timeout !== null) {
+									clearTimeout(timeout);
+									timeout = null;
+								}
+								resolve(value);
+							};
+
 							const checkHtml = () =>
 								(view.webview as { html?: string }).html ?? null;
 							const immediate = checkHtml();
 							if (immediate) {
-								resolve(immediate);
+								finish(immediate);
 								return;
 							}
-							const interval = setInterval(() => {
+							interval = setInterval(() => {
 								const h = checkHtml();
-								if (h) {
-									clearInterval(interval);
-									resolve(h);
-								}
+								if (h) finish(h);
 							}, 200);
-							setTimeout(() => {
-								clearInterval(interval);
-								resolve(checkHtml());
+							timeout = setTimeout(() => {
+								finish(checkHtml());
 							}, 5000);
 						});
 					}

--- a/apps/desktop/src/main/lib/vscode-shim/extension-host-manager.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/extension-host-manager.ts
@@ -12,6 +12,7 @@ import { randomUUID } from "node:crypto";
 import { EventEmitter } from "node:events";
 import os from "node:os";
 import path from "node:path";
+import { clearWebviewHtml } from "./api/webview-server";
 import type { MainToWorkerMessage, WorkerToMainMessage } from "./ipc-types";
 
 const BASE_RESTART_DELAY = 1000;
@@ -133,16 +134,18 @@ export class ExtensionHostManager extends EventEmitter {
 		instance.process = child;
 
 		// Pipe stdout/stderr with workspace prefix
-		child.stdout?.on("data", (data: Buffer) => {
+		const onStdout = (data: Buffer) => {
 			for (const line of data.toString().split("\n").filter(Boolean)) {
 				console.log(line);
 			}
-		});
-		child.stderr?.on("data", (data: Buffer) => {
+		};
+		const onStderr = (data: Buffer) => {
 			for (const line of data.toString().split("\n").filter(Boolean)) {
 				console.error(line);
 			}
-		});
+		};
+		child.stdout?.on("data", onStdout);
+		child.stderr?.on("data", onStderr);
 
 		// Handle IPC messages from worker
 		child.on("message", (msg: WorkerToMainMessage) => {
@@ -159,12 +162,12 @@ export class ExtensionHostManager extends EventEmitter {
 			instance.process = null;
 			instance.lastCrash = Date.now();
 
-			// Clean up viewId mappings
-			for (const [vid, wsId] of this.viewIdToWorkspace) {
-				if (wsId === workspaceId) {
-					this.viewIdToWorkspace.delete(vid);
-				}
-			}
+			// Release stdout/stderr listeners to prevent accumulation
+			child.stdout?.off("data", onStdout);
+			child.stderr?.off("data", onStderr);
+
+			// Clean up viewId mappings and htmlStore for this workspace
+			this.clearTrackedWebviewsForWorkspace(workspaceId);
 
 			// Schedule restart if not intentionally stopped
 			if (!wasStopped) {
@@ -174,7 +177,12 @@ export class ExtensionHostManager extends EventEmitter {
 
 		// Wait for ready message
 		await new Promise<void>((resolve, reject) => {
+			let settled = false;
+
 			const timer = setTimeout(() => {
+				if (settled) return;
+				settled = true;
+				child.off("message", onMessage);
 				reject(
 					new Error(
 						`Extension host worker ${workspaceId} failed to become ready within ${READY_TIMEOUT}ms`,
@@ -184,8 +192,10 @@ export class ExtensionHostManager extends EventEmitter {
 
 			const onMessage = (msg: WorkerToMainMessage) => {
 				if (msg.type === "ready") {
+					if (settled) return;
+					settled = true;
 					clearTimeout(timer);
-					child.removeListener("message", onMessage);
+					child.off("message", onMessage);
 					instance.status = "running";
 					instance.restartCount = 0;
 					resolve();
@@ -194,7 +204,10 @@ export class ExtensionHostManager extends EventEmitter {
 			child.on("message", onMessage);
 
 			child.on("error", (err) => {
+				if (settled) return;
+				settled = true;
 				clearTimeout(timer);
+				child.off("message", onMessage);
 				reject(err);
 			});
 		});
@@ -468,6 +481,14 @@ export class ExtensionHostManager extends EventEmitter {
 		return [...this.instances.entries()]
 			.filter(([, instance]) => instance.status === "running")
 			.map(([workspaceId]) => workspaceId);
+	}
+
+	private clearTrackedWebviewsForWorkspace(workspaceId: string): void {
+		for (const [viewId, wsId] of this.viewIdToWorkspace) {
+			if (wsId !== workspaceId) continue;
+			this.viewIdToWorkspace.delete(viewId);
+			clearWebviewHtml(viewId);
+		}
 	}
 
 	private sendToWorker(workspaceId: string, msg: MainToWorkerMessage): void {

--- a/apps/desktop/src/main/lib/vscode-shim/extension-host-manager.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/extension-host-manager.ts
@@ -103,12 +103,14 @@ export class ExtensionHostManager extends EventEmitter {
 		workspaceId: string,
 		workspacePath: string,
 	): Promise<void> {
+		// Inherit restartCount from previous instance so MAX_RESTART_ATTEMPTS is respected
+		const prevRestartCount = this.instances.get(workspaceId)?.restartCount ?? 0;
 		const instance: ExtensionHostProcess = {
 			workspaceId,
 			workspacePath,
 			process: null,
 			status: "starting",
-			restartCount: 0,
+			restartCount: prevRestartCount,
 		};
 		this.instances.set(workspaceId, instance);
 
@@ -524,8 +526,10 @@ export class ExtensionHostManager extends EventEmitter {
 
 		const timer = setTimeout(() => {
 			this.scheduledRestarts.delete(workspaceId);
-			if (instance.status === "degraded") {
-				this.spawn(workspaceId, instance.workspacePath).catch((err) => {
+			// Use start() instead of spawn() directly so startPromises dedup is respected
+			const current = this.instances.get(workspaceId);
+			if (current?.status === "degraded") {
+				this.start(workspaceId, current.workspacePath).catch((err) => {
 					console.error(
 						`[ext-host-manager] Restart failed for ${workspaceId}:`,
 						err,

--- a/apps/desktop/src/main/lib/vscode-shim/extension-host-manager.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/extension-host-manager.ts
@@ -152,27 +152,27 @@ export class ExtensionHostManager extends EventEmitter {
 			this.handleWorkerMessage(workspaceId, msg);
 		});
 
+		// Shared cleanup called from both exit and error handlers.
+		// Guards against double-execution via instance.process identity check.
+		const cleanupWorker = (intentional: boolean) => {
+			if (instance.process !== child) return;
+			child.stdout?.off("data", onStdout);
+			child.stderr?.off("data", onStderr);
+			this.clearTrackedWebviewsForWorkspace(workspaceId);
+			instance.status = "degraded";
+			instance.process = null;
+			instance.lastCrash = Date.now();
+			if (!intentional) {
+				this.scheduleRestart(workspaceId);
+			}
+		};
+
 		// Handle exit
 		child.on("exit", (code) => {
 			console.log(
 				`[ext-host-manager] Worker ${workspaceId} exited with code ${code}`,
 			);
-			const wasStopped = instance.status === "stopped";
-			instance.status = "degraded";
-			instance.process = null;
-			instance.lastCrash = Date.now();
-
-			// Release stdout/stderr listeners to prevent accumulation
-			child.stdout?.off("data", onStdout);
-			child.stderr?.off("data", onStderr);
-
-			// Clean up viewId mappings and htmlStore for this workspace
-			this.clearTrackedWebviewsForWorkspace(workspaceId);
-
-			// Schedule restart if not intentionally stopped
-			if (!wasStopped) {
-				this.scheduleRestart(workspaceId);
-			}
+			cleanupWorker(instance.status === "stopped");
 		});
 
 		// Wait for ready message
@@ -208,12 +208,8 @@ export class ExtensionHostManager extends EventEmitter {
 				settled = true;
 				clearTimeout(timer);
 				child.off("message", onMessage);
-				// error event may not be followed by exit; clean up here as well
-				child.stdout?.off("data", onStdout);
-				child.stderr?.off("data", onStderr);
-				this.clearTrackedWebviewsForWorkspace(workspaceId);
-				instance.status = "degraded";
-				instance.process = null;
+				// error may not be followed by exit; run cleanup + restart here as well
+				cleanupWorker(false);
 				reject(err);
 			});
 		});

--- a/apps/desktop/src/main/lib/vscode-shim/extension-host-manager.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/extension-host-manager.ts
@@ -208,6 +208,12 @@ export class ExtensionHostManager extends EventEmitter {
 				settled = true;
 				clearTimeout(timer);
 				child.off("message", onMessage);
+				// error event may not be followed by exit; clean up here as well
+				child.stdout?.off("data", onStdout);
+				child.stderr?.off("data", onStderr);
+				this.clearTrackedWebviewsForWorkspace(workspaceId);
+				instance.status = "degraded";
+				instance.process = null;
 				reject(err);
 			});
 		});


### PR DESCRIPTION
## 概要

時間経過後にcodex/Claude Code拡張機能のセッションが1からになる問題（Issue #118）を修正します。

PCがスリープしていないにもかかわらずセッションがリセットされる原因として、拡張機能ホストワーカーの複数のメモリリークが蓄積し、内部的に再起動が発生していることが判明しました。

## 修正内容

### P1: stdout/stderrリスナーの解放漏れ
- ハンドラを名前付き関数に変更し、ワーカーのexit時に `off()` で明示的に解除
- `removeAllListeners()` は他のリスナーも消えるため使用しない

### P2: startup用メッセージリスナーの残留
- `ready`/`error`/タイムアウトで解決した後に startup 用の `onMessage` リスナーを `off()` で明示解除
- 常時受信する本流の `handleWorkerMessage` リスナーはそのまま残す
- `settled` フラグで二重resolveも防止

### P3: htmlStoreのクリア漏れ
- `clearTrackedWebviewsForWorkspace()` ヘルパーを追加し、ワーカーexit時に関連する全viewIdのHTMLを一括削除
- `disposeWebview` tRPCミューテーションでも `clearWebviewHtml()` を呼ぶように修正

### P5: タイマークリアの不確実性
- HTML待機の `setInterval` と `setTimeout` のクリアを `finish()` 関数に集約
- `settled` フラグで二重resolveを防止

### レビュー指摘対応: cleanupWorkerへの統合
- `exit`/`error` 両ハンドラで共通の `cleanupWorker(intentional)` 関数を呼ぶよう統合
- `instance.process !== child` ガードにより `error` → `exit` 連続発火時の二重実行を防止
- `error` 時にも `scheduleRestart` が呼ばれるようになり、spawn失敗時にプロセスが復旧しない問題を解消

## 変更ファイル

- `apps/desktop/src/main/lib/vscode-shim/extension-host-manager.ts`
- `apps/desktop/src/main/extension-host-worker/index.ts`
- `apps/desktop/src/lib/trpc/routers/vscode-extensions/index.ts`

Closes #118