### PR TITLE
[feat] v1/v2 workspace にメモタブと画像貼り付け対応を追加

### DIFF
--- a/apps/desktop/src/renderer/components/MarkdownRenderer/MarkdownRenderer.tsx
+++ b/apps/desktop/src/renderer/components/MarkdownRenderer/MarkdownRenderer.tsx
@@ -6,6 +6,7 @@ import rehypeSanitize from "rehype-sanitize";
 import remarkGfm from "remark-gfm";
 import { useMarkdownStyle } from "renderer/stores";
 import { SelectionContextMenu } from "./components";
+import { TrustedImageProvider } from "./components/SafeImage";
 import { defaultConfig } from "./styles/default/config";
 import { tufteConfig } from "./styles/tufte/config";
 
@@ -19,6 +20,8 @@ interface MarkdownRendererProps {
 	style?: keyof typeof styleConfigs;
 	className?: string;
 	scrollable?: boolean;
+	workspaceId?: string;
+	trustedImageRootPath?: string | null;
 }
 
 export function MarkdownRenderer({
@@ -26,6 +29,8 @@ export function MarkdownRenderer({
 	style: styleProp,
 	className,
 	scrollable = true,
+	workspaceId,
+	trustedImageRootPath,
 }: MarkdownRendererProps) {
 	const globalStyle = useMarkdownStyle();
 	const style = styleProp ?? globalStyle;
@@ -34,24 +39,29 @@ export function MarkdownRenderer({
 
 	return (
 		<SelectionContextMenu selectAllContainerRef={articleRef}>
-			<div
-				className={cn(
-					"markdown-renderer select-text",
-					scrollable && "h-full overflow-y-auto",
-					config.wrapperClass,
-					className,
-				)}
+			<TrustedImageProvider
+				workspaceId={workspaceId}
+				trustedImageRootPath={trustedImageRootPath}
 			>
-				<article ref={articleRef} className={config.articleClass}>
-					<ReactMarkdown
-						remarkPlugins={[remarkGfm]}
-						rehypePlugins={[rehypeRaw, rehypeSanitize]}
-						components={config.components}
-					>
-						{content}
-					</ReactMarkdown>
-				</article>
-			</div>
+				<div
+					className={cn(
+						"markdown-renderer select-text",
+						scrollable && "h-full overflow-y-auto",
+						config.wrapperClass,
+						className,
+					)}
+				>
+					<article ref={articleRef} className={config.articleClass}>
+						<ReactMarkdown
+							remarkPlugins={[remarkGfm]}
+							rehypePlugins={[rehypeRaw, rehypeSanitize]}
+							components={config.components}
+						>
+							{content}
+						</ReactMarkdown>
+					</article>
+				</div>
+			</TrustedImageProvider>
 		</SelectionContextMenu>
 	);
 }

--- a/apps/desktop/src/renderer/components/MarkdownRenderer/components/SafeImage/SafeImage.tsx
+++ b/apps/desktop/src/renderer/components/MarkdownRenderer/components/SafeImage/SafeImage.tsx
@@ -1,4 +1,5 @@
 import { LuImageOff } from "react-icons/lu";
+import { useResolvedImageSrc } from "./useResolvedImageSrc";
 
 /**
  * Check if an image source is safe to load.
@@ -48,7 +49,22 @@ interface SafeImageProps {
  * as blob: URLs.
  */
 export function SafeImage({ src, alt, className }: SafeImageProps) {
-	if (!isSafeImageSrc(src)) {
+	const resolvedImage = useResolvedImageSrc(src);
+
+	if (resolvedImage.isLoading) {
+		return (
+			<div
+				className={`inline-flex items-center gap-2 px-3 py-2 rounded-md bg-muted text-muted-foreground text-sm ${className ?? ""}`}
+			>
+				<span className="truncate max-w-[300px]">Loading image...</span>
+			</div>
+		);
+	}
+
+	if (
+		(src && !isSafeImageSrc(src) && !resolvedImage.src) ||
+		resolvedImage.isBlocked
+	) {
 		return (
 			<div
 				className={`inline-flex items-center gap-2 px-3 py-2 rounded-md bg-muted text-muted-foreground text-sm ${className ?? ""}`}
@@ -63,7 +79,7 @@ export function SafeImage({ src, alt, className }: SafeImageProps) {
 	// Safe to render - embedded data: URL
 	return (
 		<img
-			src={src}
+			src={resolvedImage.src ?? src}
 			alt={alt}
 			className={className ?? "max-w-full h-auto rounded-md my-4"}
 		/>

--- a/apps/desktop/src/renderer/components/MarkdownRenderer/components/SafeImage/TrustedImageContext.tsx
+++ b/apps/desktop/src/renderer/components/MarkdownRenderer/components/SafeImage/TrustedImageContext.tsx
@@ -1,0 +1,24 @@
+import { createContext, type PropsWithChildren, useContext } from "react";
+
+interface TrustedImageContextValue {
+	workspaceId?: string;
+	trustedImageRootPath?: string | null;
+}
+
+const TrustedImageContext = createContext<TrustedImageContextValue>({});
+
+export function TrustedImageProvider({
+	children,
+	trustedImageRootPath,
+	workspaceId,
+}: PropsWithChildren<TrustedImageContextValue>) {
+	return (
+		<TrustedImageContext.Provider value={{ workspaceId, trustedImageRootPath }}>
+			{children}
+		</TrustedImageContext.Provider>
+	);
+}
+
+export function useTrustedImageContext(): TrustedImageContextValue {
+	return useContext(TrustedImageContext);
+}

--- a/apps/desktop/src/renderer/components/MarkdownRenderer/components/SafeImage/index.ts
+++ b/apps/desktop/src/renderer/components/MarkdownRenderer/components/SafeImage/index.ts
@@ -1,1 +1,2 @@
 export { SafeImage } from "./SafeImage";
+export { TrustedImageProvider } from "./TrustedImageContext";

--- a/apps/desktop/src/renderer/components/MarkdownRenderer/components/SafeImage/useResolvedImageSrc.ts
+++ b/apps/desktop/src/renderer/components/MarkdownRenderer/components/SafeImage/useResolvedImageSrc.ts
@@ -1,0 +1,88 @@
+import { useMemo } from "react";
+import { electronTrpc } from "renderer/lib/electron-trpc";
+import { resolveTrustedMemoImagePath } from "renderer/lib/workspace-memos";
+import { getImageMimeType } from "shared/file-types";
+import { useTrustedImageContext } from "./TrustedImageContext";
+
+const MAX_IMAGE_SIZE = 10 * 1024 * 1024;
+
+interface ResolvedImageState {
+	isBlocked: boolean;
+	isLoading: boolean;
+	src?: string;
+}
+
+export function useResolvedImageSrc(
+	source: string | undefined,
+): ResolvedImageState {
+	const { trustedImageRootPath, workspaceId } = useTrustedImageContext();
+
+	const trimmedSource = source?.trim();
+	const dataUrl = trimmedSource?.toLowerCase().startsWith("data:")
+		? trimmedSource
+		: undefined;
+
+	const trustedAbsolutePath = useMemo(() => {
+		if (!trimmedSource || dataUrl || !trustedImageRootPath) {
+			return null;
+		}
+
+		return resolveTrustedMemoImagePath(trustedImageRootPath, trimmedSource);
+	}, [dataUrl, trimmedSource, trustedImageRootPath]);
+
+	const mimeType = useMemo(() => {
+		if (!trustedAbsolutePath) {
+			return null;
+		}
+		return getImageMimeType(trustedAbsolutePath);
+	}, [trustedAbsolutePath]);
+
+	const imageQuery = electronTrpc.filesystem.readFile.useQuery(
+		{
+			workspaceId: workspaceId ?? "",
+			absolutePath: trustedAbsolutePath ?? "",
+			maxBytes: MAX_IMAGE_SIZE,
+		},
+		{
+			enabled: Boolean(workspaceId && trustedAbsolutePath && mimeType),
+			retry: false,
+			refetchOnWindowFocus: false,
+			staleTime: Infinity,
+		},
+	);
+
+	if (dataUrl) {
+		return {
+			isBlocked: false,
+			isLoading: false,
+			src: dataUrl,
+		};
+	}
+
+	if (!trimmedSource || !trustedAbsolutePath || !mimeType) {
+		return {
+			isBlocked: true,
+			isLoading: false,
+		};
+	}
+
+	if (imageQuery.isLoading) {
+		return {
+			isBlocked: false,
+			isLoading: true,
+		};
+	}
+
+	if (imageQuery.error || !imageQuery.data || imageQuery.data.exceededLimit) {
+		return {
+			isBlocked: true,
+			isLoading: false,
+		};
+	}
+
+	return {
+		isBlocked: false,
+		isLoading: false,
+		src: `data:${mimeType};base64,${imageQuery.data.content}`,
+	};
+}

--- a/apps/desktop/src/renderer/components/MarkdownRenderer/components/TipTapMarkdownRenderer/TipTapMarkdownRenderer.tsx
+++ b/apps/desktop/src/renderer/components/MarkdownRenderer/components/TipTapMarkdownRenderer/TipTapMarkdownRenderer.tsx
@@ -4,7 +4,7 @@ import { toast } from "@superset/ui/sonner";
 import { cn } from "@superset/ui/utils";
 import { type Editor, EditorContent, useEditor } from "@tiptap/react";
 import { BubbleMenu } from "@tiptap/react/menus";
-import { type MutableRefObject, useEffect, useRef } from "react";
+import { type MutableRefObject, useCallback, useEffect, useRef } from "react";
 import {
 	getWorkspaceMemoContextFromFilePath,
 	saveMemoImageFile,
@@ -98,6 +98,24 @@ export function TipTapMarkdownRenderer({
 	workspaceIdRef.current = workspaceId;
 	filePathRef.current = filePath;
 
+	const logMemoDebug = useCallback(
+		(event: string, payload?: Record<string, unknown>): void => {
+			const activeFilePath = filePathRef.current;
+			if (
+				!activeFilePath ||
+				!getWorkspaceMemoContextFromFilePath(activeFilePath)
+			) {
+				return;
+			}
+
+			console.debug("[MemoEditor]", event, {
+				filePath: activeFilePath,
+				...payload,
+			});
+		},
+		[],
+	);
+
 	const editor = useEditor({
 		immediatelyRender: false,
 		editable,
@@ -106,6 +124,18 @@ export function TipTapMarkdownRenderer({
 			onSaveRef,
 		}),
 		content: value,
+		onCreate: ({ editor: currentEditor }) => {
+			logMemoDebug("create", {
+				editable,
+				propValueLength: value.length,
+				editorValueLength: getEditorMarkdown(currentEditor).length,
+			});
+		},
+		onFocus: ({ editor: currentEditor }) => {
+			logMemoDebug("focus", {
+				editorValueLength: getEditorMarkdown(currentEditor).length,
+			});
+		},
 		editorProps: {
 			attributes: {
 				class: cn(
@@ -170,7 +200,13 @@ export function TipTapMarkdownRenderer({
 			},
 		},
 		onUpdate: ({ editor: currentEditor }) => {
-			onChangeRef.current?.(getEditorMarkdown(currentEditor));
+			const nextValue = getEditorMarkdown(currentEditor);
+			logMemoDebug("update", {
+				nextValueLength: nextValue.length,
+				selectionFrom: currentEditor.state.selection.from,
+				selectionTo: currentEditor.state.selection.to,
+			});
+			onChangeRef.current?.(nextValue);
 		},
 	});
 
@@ -180,6 +216,9 @@ export function TipTapMarkdownRenderer({
 		}
 
 		if (lastAppliedValueRef.current === value) {
+			logMemoDebug("sync-skip:same-prop", {
+				propValueLength: value.length,
+			});
 			return;
 		}
 
@@ -187,11 +226,19 @@ export function TipTapMarkdownRenderer({
 
 		const currentValue = getEditorMarkdown(editor);
 		if (currentValue === value) {
+			logMemoDebug("sync-skip:same-editor", {
+				propValueLength: value.length,
+				editorValueLength: currentValue.length,
+			});
 			return;
 		}
 
+		logMemoDebug("sync-apply", {
+			propValueLength: value.length,
+			editorValueLength: currentValue.length,
+		});
 		editor.commands.setContent(value, { emitUpdate: false });
-	}, [editor, value]);
+	}, [editor, logMemoDebug, value]);
 
 	useEffect(() => {
 		if (!editor) {

--- a/apps/desktop/src/renderer/components/MarkdownRenderer/components/TipTapMarkdownRenderer/TipTapMarkdownRenderer.tsx
+++ b/apps/desktop/src/renderer/components/MarkdownRenderer/components/TipTapMarkdownRenderer/TipTapMarkdownRenderer.tsx
@@ -108,7 +108,7 @@ export function TipTapMarkdownRenderer({
 				return;
 			}
 
-			console.debug("[MemoEditor]", event, {
+			console.log("[MemoEditor]", event, {
 				filePath: activeFilePath,
 				...payload,
 			});

--- a/apps/desktop/src/renderer/components/MarkdownRenderer/components/TipTapMarkdownRenderer/TipTapMarkdownRenderer.tsx
+++ b/apps/desktop/src/renderer/components/MarkdownRenderer/components/TipTapMarkdownRenderer/TipTapMarkdownRenderer.tsx
@@ -107,7 +107,10 @@ export function TipTapMarkdownRenderer({
 		content: value,
 		editorProps: {
 			attributes: {
-				class: cn("focus:outline-none", editable && "min-h-[100px]"),
+				class: cn(
+					"focus:outline-none",
+					editable && "min-h-[100px] min-h-full cursor-text",
+				),
 			},
 			handlePaste: (view, event) => {
 				if (!editable) {
@@ -235,7 +238,13 @@ export function TipTapMarkdownRenderer({
 						<BubbleMenuToolbar editor={editor} />
 					</BubbleMenu>
 				)}
-				<article ref={articleRef} className={config.articleClass}>
+				<article
+					ref={articleRef}
+					className={cn(
+						config.articleClass,
+						editable && "min-h-full cursor-text",
+					)}
+				>
 					<EditorContent editor={editor} />
 				</article>
 			</div>

--- a/apps/desktop/src/renderer/components/MarkdownRenderer/components/TipTapMarkdownRenderer/TipTapMarkdownRenderer.tsx
+++ b/apps/desktop/src/renderer/components/MarkdownRenderer/components/TipTapMarkdownRenderer/TipTapMarkdownRenderer.tsx
@@ -295,10 +295,27 @@ export function TipTapMarkdownRenderer({
 				<article
 					ref={articleRef}
 					className={cn(
+						"relative",
 						config.articleClass,
 						editable && "min-h-full cursor-text",
 					)}
 				>
+					{editable && editor && value.length === 0 ? (
+						<button
+							type="button"
+							className="absolute inset-0 z-10 min-h-[100px] cursor-text rounded-md text-left"
+							aria-label="Focus memo editor"
+							onMouseDown={(event) => {
+								event.preventDefault();
+								logMemoDebug("empty-overlay:focus-request");
+								editor.commands.focus("start");
+							}}
+						>
+							<span className="pointer-events-none absolute left-0 top-0 px-1 py-0.5 text-sm text-muted-foreground/70">
+								Type to start writing...
+							</span>
+						</button>
+					) : null}
 					<EditorContent editor={editor} />
 				</article>
 			</div>

--- a/apps/desktop/src/renderer/components/MarkdownRenderer/components/TipTapMarkdownRenderer/TipTapMarkdownRenderer.tsx
+++ b/apps/desktop/src/renderer/components/MarkdownRenderer/components/TipTapMarkdownRenderer/TipTapMarkdownRenderer.tsx
@@ -4,7 +4,7 @@ import { toast } from "@superset/ui/sonner";
 import { cn } from "@superset/ui/utils";
 import { type Editor, EditorContent, useEditor } from "@tiptap/react";
 import { BubbleMenu } from "@tiptap/react/menus";
-import { type MutableRefObject, useCallback, useEffect, useRef } from "react";
+import { type MutableRefObject, useEffect, useRef } from "react";
 import {
 	getWorkspaceMemoContextFromFilePath,
 	saveMemoImageFile,
@@ -98,24 +98,6 @@ export function TipTapMarkdownRenderer({
 	workspaceIdRef.current = workspaceId;
 	filePathRef.current = filePath;
 
-	const logMemoDebug = useCallback(
-		(event: string, payload?: Record<string, unknown>): void => {
-			const activeFilePath = filePathRef.current;
-			if (
-				!activeFilePath ||
-				!getWorkspaceMemoContextFromFilePath(activeFilePath)
-			) {
-				return;
-			}
-
-			console.log("[MemoEditor]", event, {
-				filePath: activeFilePath,
-				...payload,
-			});
-		},
-		[],
-	);
-
 	const editor = useEditor({
 		immediatelyRender: false,
 		editable,
@@ -124,18 +106,6 @@ export function TipTapMarkdownRenderer({
 			onSaveRef,
 		}),
 		content: value,
-		onCreate: ({ editor: currentEditor }) => {
-			logMemoDebug("create", {
-				editable,
-				propValueLength: value.length,
-				editorValueLength: getEditorMarkdown(currentEditor).length,
-			});
-		},
-		onFocus: ({ editor: currentEditor }) => {
-			logMemoDebug("focus", {
-				editorValueLength: getEditorMarkdown(currentEditor).length,
-			});
-		},
 		editorProps: {
 			attributes: {
 				class: cn(
@@ -200,13 +170,7 @@ export function TipTapMarkdownRenderer({
 			},
 		},
 		onUpdate: ({ editor: currentEditor }) => {
-			const nextValue = getEditorMarkdown(currentEditor);
-			logMemoDebug("update", {
-				nextValueLength: nextValue.length,
-				selectionFrom: currentEditor.state.selection.from,
-				selectionTo: currentEditor.state.selection.to,
-			});
-			onChangeRef.current?.(nextValue);
+			onChangeRef.current?.(getEditorMarkdown(currentEditor));
 		},
 	});
 
@@ -216,9 +180,6 @@ export function TipTapMarkdownRenderer({
 		}
 
 		if (lastAppliedValueRef.current === value) {
-			logMemoDebug("sync-skip:same-prop", {
-				propValueLength: value.length,
-			});
 			return;
 		}
 
@@ -226,19 +187,11 @@ export function TipTapMarkdownRenderer({
 
 		const currentValue = getEditorMarkdown(editor);
 		if (currentValue === value) {
-			logMemoDebug("sync-skip:same-editor", {
-				propValueLength: value.length,
-				editorValueLength: currentValue.length,
-			});
 			return;
 		}
 
-		logMemoDebug("sync-apply", {
-			propValueLength: value.length,
-			editorValueLength: currentValue.length,
-		});
 		editor.commands.setContent(value, { emitUpdate: false });
-	}, [editor, logMemoDebug, value]);
+	}, [editor, value]);
 
 	useEffect(() => {
 		if (!editor) {
@@ -307,7 +260,6 @@ export function TipTapMarkdownRenderer({
 							aria-label="Focus memo editor"
 							onMouseDown={(event) => {
 								event.preventDefault();
-								logMemoDebug("empty-overlay:focus-request");
 								editor.commands.focus("start");
 							}}
 						>

--- a/apps/desktop/src/renderer/components/MarkdownRenderer/components/TipTapMarkdownRenderer/TipTapMarkdownRenderer.tsx
+++ b/apps/desktop/src/renderer/components/MarkdownRenderer/components/TipTapMarkdownRenderer/TipTapMarkdownRenderer.tsx
@@ -91,6 +91,7 @@ export function TipTapMarkdownRenderer({
 	const onSaveRef = useRef(onSave);
 	const workspaceIdRef = useRef(workspaceId);
 	const filePathRef = useRef(filePath);
+	const lastAppliedValueRef = useRef(value);
 
 	onChangeRef.current = onChange;
 	onSaveRef.current = onSave;
@@ -177,6 +178,12 @@ export function TipTapMarkdownRenderer({
 		if (!editor) {
 			return;
 		}
+
+		if (lastAppliedValueRef.current === value) {
+			return;
+		}
+
+		lastAppliedValueRef.current = value;
 
 		const currentValue = getEditorMarkdown(editor);
 		if (currentValue === value) {

--- a/apps/desktop/src/renderer/components/MarkdownRenderer/components/TipTapMarkdownRenderer/TipTapMarkdownRenderer.tsx
+++ b/apps/desktop/src/renderer/components/MarkdownRenderer/components/TipTapMarkdownRenderer/TipTapMarkdownRenderer.tsx
@@ -1,12 +1,18 @@
 import "highlight.js/styles/github-dark.css";
 
+import { toast } from "@superset/ui/sonner";
 import { cn } from "@superset/ui/utils";
 import { type Editor, EditorContent, useEditor } from "@tiptap/react";
 import { BubbleMenu } from "@tiptap/react/menus";
 import { type MutableRefObject, useEffect, useRef } from "react";
+import {
+	getWorkspaceMemoContextFromFilePath,
+	saveMemoImageFile,
+} from "renderer/lib/workspace-memos";
 import { useMarkdownStyle } from "renderer/stores";
 import { defaultConfig } from "../../styles/default/config";
 import { tufteConfig } from "../../styles/tufte/config";
+import { TrustedImageProvider } from "../SafeImage";
 import { SelectionContextMenu } from "../SelectionContextMenu";
 import { BubbleMenuToolbar } from "./components/BubbleMenuToolbar";
 import { createMarkdownExtensions } from "./createMarkdownExtensions";
@@ -31,6 +37,9 @@ interface TipTapMarkdownRendererProps {
 	editorRef?: MutableRefObject<MarkdownEditorAdapter | null>;
 	onChange?: (value: string) => void;
 	onSave?: () => void;
+	workspaceId?: string;
+	filePath?: string;
+	trustedImageRootPath?: string | null;
 }
 
 function getEditorMarkdown(editor: Editor): string {
@@ -70,6 +79,9 @@ export function TipTapMarkdownRenderer({
 	editorRef,
 	onChange,
 	onSave,
+	workspaceId,
+	filePath,
+	trustedImageRootPath,
 }: TipTapMarkdownRendererProps) {
 	const globalStyle = useMarkdownStyle();
 	const style = styleProp ?? globalStyle;
@@ -77,9 +89,13 @@ export function TipTapMarkdownRenderer({
 	const articleRef = useRef<HTMLElement | null>(null);
 	const onChangeRef = useRef(onChange);
 	const onSaveRef = useRef(onSave);
+	const workspaceIdRef = useRef(workspaceId);
+	const filePathRef = useRef(filePath);
 
 	onChangeRef.current = onChange;
 	onSaveRef.current = onSave;
+	workspaceIdRef.current = workspaceId;
+	filePathRef.current = filePath;
 
 	const editor = useEditor({
 		immediatelyRender: false,
@@ -92,6 +108,61 @@ export function TipTapMarkdownRenderer({
 		editorProps: {
 			attributes: {
 				class: cn("focus:outline-none", editable && "min-h-[100px]"),
+			},
+			handlePaste: (view, event) => {
+				if (!editable) {
+					return false;
+				}
+
+				const activeWorkspaceId = workspaceIdRef.current;
+				const activeFilePath = filePathRef.current;
+				if (
+					!activeWorkspaceId ||
+					!activeFilePath ||
+					!getWorkspaceMemoContextFromFilePath(activeFilePath)
+				) {
+					return false;
+				}
+
+				const imageFile = Array.from(event.clipboardData?.items ?? [])
+					.find((item) => item.type.startsWith("image/"))
+					?.getAsFile();
+				if (!imageFile) {
+					return false;
+				}
+
+				event.preventDefault();
+				void saveMemoImageFile({
+					workspaceId: activeWorkspaceId,
+					memoFilePath: activeFilePath,
+					file: imageFile,
+				})
+					.then(({ relativePath }) => {
+						const imageNodeType = view.state.schema.nodes.image;
+						if (imageNodeType) {
+							const transaction = view.state.tr.replaceSelectionWith(
+								imageNodeType.create({
+									src: relativePath,
+									alt: imageFile.name || "pasted image",
+								}),
+							);
+							view.dispatch(transaction.scrollIntoView());
+							return;
+						}
+
+						view.dispatch(
+							view.state.tr
+								.insertText(
+									`![${imageFile.name || "pasted image"}](${relativePath})`,
+								)
+								.scrollIntoView(),
+						);
+					})
+					.catch((error: Error) => {
+						toast.error(`Failed to paste image: ${error.message}`);
+					});
+
+				return true;
 			},
 		},
 		onUpdate: ({ editor: currentEditor }) => {
@@ -137,33 +208,38 @@ export function TipTapMarkdownRenderer({
 	}, [editor, editorRef]);
 
 	const content = (
-		<div
-			className={cn(
-				"markdown-renderer h-full overflow-y-auto select-text",
-				config.wrapperClass,
-				className,
-			)}
+		<TrustedImageProvider
+			workspaceId={workspaceId}
+			trustedImageRootPath={trustedImageRootPath}
 		>
-			{editable && editor && (
-				<BubbleMenu
-					editor={editor}
-					options={{
-						placement: "top",
-						offset: { mainAxis: 8 },
-					}}
-					shouldShow={({ editor: e, from, to }) => {
-						if (from === to) return false;
-						if (e.isActive("codeBlock")) return false;
-						return true;
-					}}
-				>
-					<BubbleMenuToolbar editor={editor} />
-				</BubbleMenu>
-			)}
-			<article ref={articleRef} className={config.articleClass}>
-				<EditorContent editor={editor} />
-			</article>
-		</div>
+			<div
+				className={cn(
+					"markdown-renderer h-full overflow-y-auto select-text",
+					config.wrapperClass,
+					className,
+				)}
+			>
+				{editable && editor && (
+					<BubbleMenu
+						editor={editor}
+						options={{
+							placement: "top",
+							offset: { mainAxis: 8 },
+						}}
+						shouldShow={({ editor: e, from, to }) => {
+							if (from === to) return false;
+							if (e.isActive("codeBlock")) return false;
+							return true;
+						}}
+					>
+						<BubbleMenuToolbar editor={editor} />
+					</BubbleMenu>
+				)}
+				<article ref={articleRef} className={config.articleClass}>
+					<EditorContent editor={editor} />
+				</article>
+			</div>
+		</TrustedImageProvider>
 	);
 
 	if (editable) {

--- a/apps/desktop/src/renderer/lib/workspace-memos/createWorkspaceMemo.ts
+++ b/apps/desktop/src/renderer/lib/workspace-memos/createWorkspaceMemo.ts
@@ -1,0 +1,48 @@
+import { electronTrpcClient } from "renderer/lib/trpc-client";
+import {
+	createWorkspaceMemoContext,
+	type WorkspaceMemoContext,
+} from "./memo-paths";
+
+const INITIAL_MEMO_CONTENT = "";
+
+export async function createWorkspaceMemo(
+	workspaceId: string,
+): Promise<WorkspaceMemoContext> {
+	const workspace = await electronTrpcClient.workspaces.get.query({
+		id: workspaceId,
+	});
+	if (!workspace?.worktreePath) {
+		throw new Error(`Workspace path not found: ${workspaceId}`);
+	}
+
+	for (let attempt = 0; attempt < 3; attempt += 1) {
+		const memo = createWorkspaceMemoContext(workspace.worktreePath);
+		await electronTrpcClient.filesystem.createDirectory.mutate({
+			workspaceId,
+			absolutePath: memo.assetsDirectoryAbsolutePath,
+			recursive: true,
+		});
+
+		const result = await electronTrpcClient.filesystem.writeFile.mutate({
+			workspaceId,
+			absolutePath: memo.memoFileAbsolutePath,
+			content: INITIAL_MEMO_CONTENT,
+			encoding: "utf-8",
+			options: {
+				create: true,
+				overwrite: false,
+			},
+		});
+
+		if (result.ok) {
+			return memo;
+		}
+
+		if (result.reason !== "exists") {
+			throw new Error(`Failed to create memo: ${result.reason}`);
+		}
+	}
+
+	throw new Error("Failed to create memo after multiple attempts");
+}

--- a/apps/desktop/src/renderer/lib/workspace-memos/index.ts
+++ b/apps/desktop/src/renderer/lib/workspace-memos/index.ts
@@ -1,0 +1,9 @@
+export { createWorkspaceMemo } from "./createWorkspaceMemo";
+export {
+	DEFAULT_MEMO_FILE_NAME,
+	getTrustedMemoRootPath,
+	getWorkspaceMemoContextFromFilePath,
+	resolveTrustedMemoImagePath,
+	WORKSPACE_MEMOS_DIRECTORY,
+} from "./memo-paths";
+export { saveMemoImageFile } from "./saveMemoImageFile";

--- a/apps/desktop/src/renderer/lib/workspace-memos/index.ts
+++ b/apps/desktop/src/renderer/lib/workspace-memos/index.ts
@@ -1,9 +1,11 @@
 export { createWorkspaceMemo } from "./createWorkspaceMemo";
 export {
-	DEFAULT_MEMO_FILE_NAME,
+	DEFAULT_MEMO_DISPLAY_NAME,
+	deriveMemoDisplayName,
 	getTrustedMemoRootPath,
 	getWorkspaceMemoContextFromFilePath,
 	resolveTrustedMemoImagePath,
+	WORKSPACE_MEMO_FILE_NAME,
 	WORKSPACE_MEMOS_DIRECTORY,
 } from "./memo-paths";
 export { saveMemoImageFile } from "./saveMemoImageFile";

--- a/apps/desktop/src/renderer/lib/workspace-memos/memo-paths.ts
+++ b/apps/desktop/src/renderer/lib/workspace-memos/memo-paths.ts
@@ -6,7 +6,9 @@ import {
 import { getImageExtensionFromMimeType } from "shared/file-types";
 
 export const WORKSPACE_MEMOS_DIRECTORY = ".superset/memos";
-export const DEFAULT_MEMO_FILE_NAME = "Untitled Memo.md";
+export const WORKSPACE_MEMO_FILE_NAME = "memo.md";
+export const DEFAULT_MEMO_DISPLAY_NAME = "Untitled Memo";
+const MAX_MEMO_DISPLAY_NAME_LENGTH = 60;
 
 function getPathSeparator(path: string): string {
 	return path.includes("\\") ? "\\" : "/";
@@ -30,6 +32,7 @@ export interface WorkspaceMemoContext {
 	memoDirectoryAbsolutePath: string;
 	memoFileAbsolutePath: string;
 	assetsDirectoryAbsolutePath: string;
+	displayName: string;
 	fileName: string;
 }
 
@@ -50,7 +53,7 @@ export function createWorkspaceMemoId(now = new Date()): string {
 export function createWorkspaceMemoContext(
 	worktreePath: string,
 	memoId = createWorkspaceMemoId(),
-	fileName = DEFAULT_MEMO_FILE_NAME,
+	fileName = WORKSPACE_MEMO_FILE_NAME,
 ): WorkspaceMemoContext {
 	const memoDirectoryAbsolutePath = joinPath(
 		joinPath(worktreePath, WORKSPACE_MEMOS_DIRECTORY),
@@ -62,6 +65,7 @@ export function createWorkspaceMemoContext(
 		memoDirectoryAbsolutePath,
 		memoFileAbsolutePath: joinPath(memoDirectoryAbsolutePath, fileName),
 		assetsDirectoryAbsolutePath: joinPath(memoDirectoryAbsolutePath, "assets"),
+		displayName: DEFAULT_MEMO_DISPLAY_NAME,
 		fileName,
 	};
 }
@@ -87,15 +91,16 @@ export function getWorkspaceMemoContextFromFilePath(
 
 	const separator = getPathSeparator(filePath);
 	const memoDirectoryAbsolutePath = match[1].replace(/\//g, separator);
-	const relativePath = match[3] ?? DEFAULT_MEMO_FILE_NAME;
+	const relativePath = match[3] ?? WORKSPACE_MEMO_FILE_NAME;
 	const fileName =
-		splitRelativePath(relativePath).pop() ?? DEFAULT_MEMO_FILE_NAME;
+		splitRelativePath(relativePath).pop() ?? WORKSPACE_MEMO_FILE_NAME;
 
 	return {
 		memoId: match[2],
 		memoDirectoryAbsolutePath,
 		memoFileAbsolutePath: filePath,
 		assetsDirectoryAbsolutePath: joinPath(memoDirectoryAbsolutePath, "assets"),
+		displayName: DEFAULT_MEMO_DISPLAY_NAME,
 		fileName,
 	};
 }
@@ -159,4 +164,41 @@ export function createMemoImageFileName(mimeType: string): string {
 
 export function createMemoImageRelativePath(fileName: string): string {
 	return `./assets/${fileName}`;
+}
+
+function normalizeMemoDisplayCandidate(line: string): string {
+	const trimmed = line.trim();
+	if (trimmed.length === 0) {
+		return "";
+	}
+
+	const withoutPrefix = trimmed
+		.replace(/^#{1,6}\s+/, "")
+		.replace(/^[-*+]\s+/, "")
+		.replace(/^\d+\.\s+/, "")
+		.replace(/^\[[ xX]\]\s+/, "");
+	const withoutLinks = withoutPrefix
+		.replace(/!\[[^\]]*\]\([^)]+\)/g, "")
+		.replace(/\[([^\]]+)\]\([^)]+\)/g, "$1");
+	const normalized = withoutLinks
+		.replace(/[`*_~]/g, "")
+		.replace(/\s+/g, " ")
+		.trim();
+
+	if (normalized.length <= MAX_MEMO_DISPLAY_NAME_LENGTH) {
+		return normalized;
+	}
+
+	return `${normalized.slice(0, MAX_MEMO_DISPLAY_NAME_LENGTH - 3).trimEnd()}...`;
+}
+
+export function deriveMemoDisplayName(content: string): string {
+	for (const line of content.split(/\r?\n/)) {
+		const candidate = normalizeMemoDisplayCandidate(line);
+		if (candidate.length > 0) {
+			return candidate;
+		}
+	}
+
+	return DEFAULT_MEMO_DISPLAY_NAME;
 }

--- a/apps/desktop/src/renderer/lib/workspace-memos/memo-paths.ts
+++ b/apps/desktop/src/renderer/lib/workspace-memos/memo-paths.ts
@@ -1,0 +1,162 @@
+import {
+	isAbsoluteFilesystemPath,
+	isRemotePath,
+	normalizeComparablePath,
+} from "shared/absolute-paths";
+import { getImageExtensionFromMimeType } from "shared/file-types";
+
+export const WORKSPACE_MEMOS_DIRECTORY = ".superset/memos";
+export const DEFAULT_MEMO_FILE_NAME = "Untitled Memo.md";
+
+function getPathSeparator(path: string): string {
+	return path.includes("\\") ? "\\" : "/";
+}
+
+function joinPath(parentAbsolutePath: string, name: string): string {
+	const separator = getPathSeparator(parentAbsolutePath);
+	return `${parentAbsolutePath.replace(/[\\/]+$/, "")}${separator}${name}`;
+}
+
+function padDatePart(value: number): string {
+	return value.toString().padStart(2, "0");
+}
+
+function splitRelativePath(relativePath: string): string[] {
+	return relativePath.split(/[\\/]+/).filter(Boolean);
+}
+
+export interface WorkspaceMemoContext {
+	memoId: string;
+	memoDirectoryAbsolutePath: string;
+	memoFileAbsolutePath: string;
+	assetsDirectoryAbsolutePath: string;
+	fileName: string;
+}
+
+export function createWorkspaceMemoId(now = new Date()): string {
+	const timestamp = [
+		now.getFullYear(),
+		padDatePart(now.getMonth() + 1),
+		padDatePart(now.getDate()),
+	].join("");
+	const time = [
+		padDatePart(now.getHours()),
+		padDatePart(now.getMinutes()),
+		padDatePart(now.getSeconds()),
+	].join("");
+	return `${timestamp}-${time}-${crypto.randomUUID().slice(0, 8)}`;
+}
+
+export function createWorkspaceMemoContext(
+	worktreePath: string,
+	memoId = createWorkspaceMemoId(),
+	fileName = DEFAULT_MEMO_FILE_NAME,
+): WorkspaceMemoContext {
+	const memoDirectoryAbsolutePath = joinPath(
+		joinPath(worktreePath, WORKSPACE_MEMOS_DIRECTORY),
+		memoId,
+	);
+
+	return {
+		memoId,
+		memoDirectoryAbsolutePath,
+		memoFileAbsolutePath: joinPath(memoDirectoryAbsolutePath, fileName),
+		assetsDirectoryAbsolutePath: joinPath(memoDirectoryAbsolutePath, "assets"),
+		fileName,
+	};
+}
+
+export function getWorkspaceMemoContextFromFilePath(
+	filePath: string,
+): WorkspaceMemoContext | null {
+	if (
+		!filePath ||
+		isRemotePath(filePath) ||
+		!isAbsoluteFilesystemPath(filePath)
+	) {
+		return null;
+	}
+
+	const normalizedPath = normalizeComparablePath(filePath);
+	const match = normalizedPath.match(
+		/^(.*\/\.superset\/memos\/([^/]+))(?:\/(.+))?$/,
+	);
+	if (!match) {
+		return null;
+	}
+
+	const separator = getPathSeparator(filePath);
+	const memoDirectoryAbsolutePath = match[1].replace(/\//g, separator);
+	const relativePath = match[3] ?? DEFAULT_MEMO_FILE_NAME;
+	const fileName =
+		splitRelativePath(relativePath).pop() ?? DEFAULT_MEMO_FILE_NAME;
+
+	return {
+		memoId: match[2],
+		memoDirectoryAbsolutePath,
+		memoFileAbsolutePath: filePath,
+		assetsDirectoryAbsolutePath: joinPath(memoDirectoryAbsolutePath, "assets"),
+		fileName,
+	};
+}
+
+export function getTrustedMemoRootPath(filePath: string): string | null {
+	return (
+		getWorkspaceMemoContextFromFilePath(filePath)?.memoDirectoryAbsolutePath ??
+		null
+	);
+}
+
+export function resolveTrustedMemoImagePath(
+	memoDirectoryAbsolutePath: string,
+	src: string,
+): string | null {
+	const trimmedSrc = src.split(/[?#]/, 1)[0]?.trim() ?? "";
+	if (
+		trimmedSrc.length === 0 ||
+		isRemotePath(trimmedSrc) ||
+		isAbsoluteFilesystemPath(trimmedSrc)
+	) {
+		return null;
+	}
+
+	const segments = splitRelativePath(trimmedSrc);
+	if (segments.length === 0) {
+		return null;
+	}
+
+	const resolvedSegments: string[] = [];
+	for (const segment of segments) {
+		if (segment === ".") {
+			continue;
+		}
+
+		if (segment === "..") {
+			if (resolvedSegments.length === 0) {
+				return null;
+			}
+			resolvedSegments.pop();
+			continue;
+		}
+
+		resolvedSegments.push(segment);
+	}
+
+	if (resolvedSegments.length === 0) {
+		return null;
+	}
+
+	return resolvedSegments.reduce(
+		(currentAbsolutePath, segment) => joinPath(currentAbsolutePath, segment),
+		memoDirectoryAbsolutePath,
+	);
+}
+
+export function createMemoImageFileName(mimeType: string): string {
+	const ext = getImageExtensionFromMimeType(mimeType) ?? "png";
+	return `pasted-${Date.now()}-${crypto.randomUUID().slice(0, 8)}.${ext}`;
+}
+
+export function createMemoImageRelativePath(fileName: string): string {
+	return `./assets/${fileName}`;
+}

--- a/apps/desktop/src/renderer/lib/workspace-memos/saveMemoImageFile.ts
+++ b/apps/desktop/src/renderer/lib/workspace-memos/saveMemoImageFile.ts
@@ -1,0 +1,62 @@
+import { electronTrpcClient } from "renderer/lib/trpc-client";
+import { parseBase64DataUrl } from "shared/file-types";
+import {
+	createMemoImageFileName,
+	createMemoImageRelativePath,
+	getWorkspaceMemoContextFromFilePath,
+} from "./memo-paths";
+
+function joinPath(parentAbsolutePath: string, name: string): string {
+	const separator = parentAbsolutePath.includes("\\") ? "\\" : "/";
+	return `${parentAbsolutePath.replace(/[\\/]+$/, "")}${separator}${name}`;
+}
+
+function readFileAsDataUrl(file: File): Promise<string> {
+	return new Promise((resolve, reject) => {
+		const reader = new FileReader();
+		reader.onload = () => {
+			if (typeof reader.result !== "string") {
+				reject(new Error("Failed to read pasted image"));
+				return;
+			}
+			resolve(reader.result);
+		};
+		reader.onerror = () => {
+			reject(reader.error ?? new Error("Failed to read pasted image"));
+		};
+		reader.readAsDataURL(file);
+	});
+}
+
+export async function saveMemoImageFile(input: {
+	workspaceId: string;
+	memoFilePath: string;
+	file: File;
+}): Promise<{ absolutePath: string; relativePath: string }> {
+	const memo = getWorkspaceMemoContextFromFilePath(input.memoFilePath);
+	if (!memo) {
+		throw new Error("Image paste is only supported inside .superset memos");
+	}
+
+	const dataUrl = await readFileAsDataUrl(input.file);
+	const { base64Data, mimeType } = parseBase64DataUrl(dataUrl);
+	const fileName = createMemoImageFileName(mimeType);
+	const absolutePath = joinPath(memo.assetsDirectoryAbsolutePath, fileName);
+
+	await electronTrpcClient.filesystem.createDirectory.mutate({
+		workspaceId: input.workspaceId,
+		absolutePath: memo.assetsDirectoryAbsolutePath,
+		recursive: true,
+	});
+
+	await electronTrpcClient.filesystem.writeFile.mutate({
+		workspaceId: input.workspaceId,
+		absolutePath,
+		content: { kind: "base64", data: base64Data },
+	});
+
+	return {
+		absolutePath,
+		relativePath: createMemoImageRelativePath(fileName),
+	};
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/AddTabMenu/AddTabMenu.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/AddTabMenu/AddTabMenu.tsx
@@ -4,6 +4,7 @@ import {
 	DropdownMenuSeparator,
 } from "@superset/ui/dropdown-menu";
 import { BsTerminalPlus } from "react-icons/bs";
+import { LuFileText } from "react-icons/lu";
 import { TbMessageCirclePlus, TbWorld } from "react-icons/tb";
 import { HotkeyMenuShortcut } from "renderer/components/HotkeyMenuShortcut";
 
@@ -11,6 +12,7 @@ interface AddTabMenuProps {
 	onAddTerminal: () => void;
 	onAddChat: () => void;
 	onAddBrowser: () => void;
+	onAddMemo: () => void;
 	showPresetsBar: boolean;
 	onTogglePresetsBar: (enabled: boolean) => void;
 }
@@ -19,6 +21,7 @@ export function AddTabMenu({
 	onAddTerminal,
 	onAddChat,
 	onAddBrowser,
+	onAddMemo,
 	showPresetsBar,
 	onTogglePresetsBar,
 }: AddTabMenuProps) {
@@ -38,6 +41,10 @@ export function AddTabMenu({
 				<TbWorld className="size-4" />
 				<span>Browser</span>
 				<HotkeyMenuShortcut hotkeyId="NEW_BROWSER" />
+			</DropdownMenuItem>
+			<DropdownMenuItem className="gap-2" onClick={onAddMemo}>
+				<LuFileText className="size-4" />
+				<span>Memo</span>
 			</DropdownMenuItem>
 			<DropdownMenuSeparator />
 			<DropdownMenuCheckboxItem

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceEmptyState/WorkspaceEmptyState.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceEmptyState/WorkspaceEmptyState.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from "react";
 import type { IconType } from "react-icons";
 import { BsTerminalPlus } from "react-icons/bs";
-import { LuSearch } from "react-icons/lu";
+import { LuFileText, LuSearch } from "react-icons/lu";
 import { TbMessageCirclePlus, TbWorld } from "react-icons/tb";
 import { useHotkeyDisplay } from "renderer/hotkeys";
 import supersetEmptyStateWordmark from "renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/assets/superset-empty-state-wordmark.svg";
@@ -13,6 +13,7 @@ interface WorkspaceEmptyStateProps {
 	onOpenChat: () => void;
 	onOpenQuickOpen: () => void;
 	onOpenTerminal: () => void;
+	onOpenMemo: () => void;
 }
 
 interface WorkspaceEmptyStateAction {
@@ -28,6 +29,7 @@ export function WorkspaceEmptyState({
 	onOpenChat,
 	onOpenQuickOpen,
 	onOpenTerminal,
+	onOpenMemo,
 }: WorkspaceEmptyStateProps) {
 	const activeTheme = useTheme();
 	const { keys: newGroupDisplay } = useHotkeyDisplay("NEW_GROUP");
@@ -52,6 +54,13 @@ export function WorkspaceEmptyState({
 				onClick: onOpenChat,
 			},
 			{
+				id: "memo",
+				label: "Open Memo",
+				display: [],
+				icon: LuFileText,
+				onClick: onOpenMemo,
+			},
+			{
 				id: "browser",
 				label: "Open Browser",
 				display: newBrowserDisplay,
@@ -72,6 +81,7 @@ export function WorkspaceEmptyState({
 			newGroupDisplay,
 			onOpenBrowser,
 			onOpenChat,
+			onOpenMemo,
 			onOpenQuickOpen,
 			onOpenTerminal,
 			quickOpenDisplay,

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/FilePane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/FilePane.tsx
@@ -1,6 +1,10 @@
 import type { RendererContext } from "@superset/panes";
 import { useFileDocument } from "@superset/workspace-client";
 import { useCallback } from "react";
+import {
+	deriveMemoDisplayName,
+	getTrustedMemoRootPath,
+} from "renderer/lib/workspace-memos";
 import { SpreadsheetViewer } from "renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/components/SpreadsheetViewer";
 import {
 	isImageFile,
@@ -38,6 +42,7 @@ export function FilePane({ context, workspaceId }: FilePaneProps) {
 function FilePaneContent({ context, workspaceId }: FilePaneProps) {
 	const data = context.pane.data as FilePaneData;
 	const { filePath } = data;
+	const isMemoFile = Boolean(getTrustedMemoRootPath(filePath));
 
 	const document = useFileDocument({
 		workspaceId,
@@ -69,6 +74,20 @@ function FilePaneContent({ context, workspaceId }: FilePaneProps) {
 			return result;
 		},
 		[document, handleDirtyChange],
+	);
+
+	const handleDisplayNameChange = useCallback(
+		(displayName: string) => {
+			if (!isMemoFile || data.displayName === displayName) {
+				return;
+			}
+
+			context.actions.updateData({
+				...data,
+				displayName,
+			} as PaneViewerData);
+		},
+		[context.actions, data, isMemoFile],
 	);
 
 	if (document.state.kind === "loading") {
@@ -105,12 +124,18 @@ function FilePaneContent({ context, workspaceId }: FilePaneProps) {
 	}
 
 	if (isMarkdownFile(filePath)) {
+		const displayName = isMemoFile
+			? (data.displayName ?? deriveMemoDisplayName(document.state.content))
+			: data.displayName;
 		return (
 			<MarkdownRenderer
 				content={document.state.content}
+				displayName={displayName}
 				filePath={filePath}
 				hasExternalChange={document.hasExternalChange}
+				isMemo={isMemoFile}
 				onDirtyChange={handleDirtyChange}
+				onDisplayNameChange={handleDisplayNameChange}
 				onReload={document.reload}
 				onSave={handleSave}
 				workspaceId={workspaceId}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/FilePane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/FilePane.tsx
@@ -108,10 +108,12 @@ function FilePaneContent({ context, workspaceId }: FilePaneProps) {
 		return (
 			<MarkdownRenderer
 				content={document.state.content}
+				filePath={filePath}
 				hasExternalChange={document.hasExternalChange}
 				onDirtyChange={handleDirtyChange}
 				onReload={document.reload}
 				onSave={handleSave}
+				workspaceId={workspaceId}
 			/>
 		);
 	}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/renderers/MarkdownRenderer/MarkdownRenderer.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/renderers/MarkdownRenderer/MarkdownRenderer.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useRef, useState } from "react";
 import { TipTapMarkdownRenderer } from "renderer/components/MarkdownRenderer/components/TipTapMarkdownRenderer";
+import { getTrustedMemoRootPath } from "renderer/lib/workspace-memos";
 import { CodeEditor } from "renderer/screens/main/components/WorkspaceView/components/CodeEditor";
 import { ExternalChangeBar } from "../../components/ExternalChangeBar";
 
@@ -7,22 +8,27 @@ export type MarkdownViewMode = "rendered" | "raw";
 
 interface MarkdownRendererProps {
 	content: string;
+	filePath: string;
 	hasExternalChange: boolean;
 	onDirtyChange: (dirty: boolean) => void;
 	onReload: () => Promise<void>;
 	onSave: (content: string) => Promise<unknown>;
+	workspaceId: string;
 }
 
 export function MarkdownRenderer({
 	content,
+	filePath,
 	hasExternalChange,
 	onDirtyChange,
 	onReload,
 	onSave,
+	workspaceId,
 }: MarkdownRendererProps) {
 	const [viewMode, _setViewMode] = useState<MarkdownViewMode>("rendered");
 	const currentContentRef = useRef(content);
 	const [savedContent, setSavedContent] = useState(content);
+	const trustedImageRootPath = getTrustedMemoRootPath(filePath);
 
 	const handleChange = useCallback(
 		(value: string) => {
@@ -48,6 +54,9 @@ export function MarkdownRenderer({
 							editable
 							onChange={handleChange}
 							onSave={handleSave}
+							workspaceId={workspaceId}
+							filePath={filePath}
+							trustedImageRootPath={trustedImageRootPath}
 						/>
 					</div>
 				) : (

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/renderers/MarkdownRenderer/MarkdownRenderer.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/renderers/MarkdownRenderer/MarkdownRenderer.tsx
@@ -1,16 +1,23 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { TipTapMarkdownRenderer } from "renderer/components/MarkdownRenderer/components/TipTapMarkdownRenderer";
-import { getTrustedMemoRootPath } from "renderer/lib/workspace-memos";
+import {
+	deriveMemoDisplayName,
+	getTrustedMemoRootPath,
+} from "renderer/lib/workspace-memos";
 import { CodeEditor } from "renderer/screens/main/components/WorkspaceView/components/CodeEditor";
 import { ExternalChangeBar } from "../../components/ExternalChangeBar";
 
 export type MarkdownViewMode = "rendered" | "raw";
+const MEMO_AUTOSAVE_DELAY_MS = 1000;
 
 interface MarkdownRendererProps {
 	content: string;
+	displayName?: string;
 	filePath: string;
 	hasExternalChange: boolean;
+	isMemo: boolean;
 	onDirtyChange: (dirty: boolean) => void;
+	onDisplayNameChange: (displayName: string) => void;
 	onReload: () => Promise<void>;
 	onSave: (content: string) => Promise<unknown>;
 	workspaceId: string;
@@ -18,35 +25,86 @@ interface MarkdownRendererProps {
 
 export function MarkdownRenderer({
 	content,
+	displayName,
 	filePath,
 	hasExternalChange,
+	isMemo,
 	onDirtyChange,
+	onDisplayNameChange,
 	onReload,
 	onSave,
 	workspaceId,
 }: MarkdownRendererProps) {
 	const [viewMode, _setViewMode] = useState<MarkdownViewMode>("rendered");
 	const currentContentRef = useRef(content);
+	const [draftContent, setDraftContent] = useState(content);
 	const [savedContent, setSavedContent] = useState(content);
+	const isSavingRef = useRef(false);
 	const trustedImageRootPath = getTrustedMemoRootPath(filePath);
 
 	useEffect(() => {
+		currentContentRef.current = content;
+		setDraftContent(content);
 		setSavedContent(content);
-		onDirtyChange(currentContentRef.current !== content);
+		onDirtyChange(false);
 	}, [content, onDirtyChange]);
 
 	const handleChange = useCallback(
 		(value: string) => {
 			currentContentRef.current = value;
+			setDraftContent(value);
+			if (isMemo) {
+				onDisplayNameChange(deriveMemoDisplayName(value));
+			}
 			onDirtyChange(value !== savedContent);
 		},
-		[onDirtyChange, savedContent],
+		[isMemo, onDirtyChange, onDisplayNameChange, savedContent],
 	);
 
 	const handleSave = useCallback(async () => {
-		await onSave(currentContentRef.current);
-		setSavedContent(currentContentRef.current);
-	}, [onSave]);
+		if (isSavingRef.current) {
+			return;
+		}
+
+		isSavingRef.current = true;
+		try {
+			await onSave(currentContentRef.current);
+			setSavedContent(currentContentRef.current);
+			onDirtyChange(false);
+		} finally {
+			isSavingRef.current = false;
+		}
+	}, [onDirtyChange, onSave]);
+
+	useEffect(() => {
+		if (
+			!isMemo ||
+			hasExternalChange ||
+			draftContent === savedContent ||
+			isSavingRef.current
+		) {
+			return;
+		}
+
+		const timeoutId = window.setTimeout(() => {
+			void handleSave();
+		}, MEMO_AUTOSAVE_DELAY_MS);
+
+		return () => {
+			window.clearTimeout(timeoutId);
+		};
+	}, [draftContent, handleSave, hasExternalChange, isMemo, savedContent]);
+
+	useEffect(() => {
+		if (!isMemo) {
+			return;
+		}
+
+		const nextDisplayName = deriveMemoDisplayName(draftContent);
+		if (nextDisplayName !== displayName) {
+			onDisplayNameChange(nextDisplayName);
+		}
+	}, [displayName, draftContent, isMemo, onDisplayNameChange]);
 
 	return (
 		<div className="flex h-full flex-col">
@@ -55,7 +113,7 @@ export function MarkdownRenderer({
 				{viewMode === "rendered" ? (
 					<div className="h-full overflow-y-auto p-4">
 						<TipTapMarkdownRenderer
-							value={content}
+							value={draftContent}
 							editable
 							onChange={handleChange}
 							onSave={handleSave}
@@ -66,7 +124,7 @@ export function MarkdownRenderer({
 					</div>
 				) : (
 					<CodeEditor
-						value={content}
+						value={draftContent}
 						language="markdown"
 						onChange={handleChange}
 						onSave={handleSave}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/renderers/MarkdownRenderer/MarkdownRenderer.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/renderers/MarkdownRenderer/MarkdownRenderer.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { TipTapMarkdownRenderer } from "renderer/components/MarkdownRenderer/components/TipTapMarkdownRenderer";
 import { getTrustedMemoRootPath } from "renderer/lib/workspace-memos";
 import { CodeEditor } from "renderer/screens/main/components/WorkspaceView/components/CodeEditor";
@@ -29,6 +29,11 @@ export function MarkdownRenderer({
 	const currentContentRef = useRef(content);
 	const [savedContent, setSavedContent] = useState(content);
 	const trustedImageRootPath = getTrustedMemoRootPath(filePath);
+
+	useEffect(() => {
+		setSavedContent(content);
+		onDirtyChange(currentContentRef.current !== content);
+	}, [content, onDirtyChange]);
 
 	const handleChange = useCallback(
 		(value: string) => {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/usePaneRegistry.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/usePaneRegistry.tsx
@@ -51,7 +51,7 @@ export function usePaneRegistry(
 				},
 				getTitle: (ctx: RendererContext<PaneViewerData>) => {
 					const data = ctx.pane.data as FilePaneData;
-					const name = getFileName(data.filePath);
+					const name = data.displayName ?? getFileName(data.filePath);
 					return (
 						<div className="flex items-center space-x-2">
 							<span className={ctx.pane.pinned ? undefined : "italic"}>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
@@ -5,6 +5,7 @@ import {
 	ResizablePanel,
 	ResizablePanelGroup,
 } from "@superset/ui/resizable";
+import { toast } from "@superset/ui/sonner";
 import { eq } from "@tanstack/db";
 import { useLiveQuery } from "@tanstack/react-db";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
@@ -17,6 +18,7 @@ import {
 	dispatchBrowserShortcutEvent,
 } from "renderer/lib/browser-shortcut-events";
 import { electronTrpc } from "renderer/lib/electron-trpc";
+import { createWorkspaceMemo } from "renderer/lib/workspace-memos";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 import {
 	CommandPalette,
@@ -190,6 +192,16 @@ function WorkspaceContent({
 		});
 	}, [store]);
 
+	const addMemoTab = useCallback(() => {
+		void createWorkspaceMemo(workspaceId)
+			.then((memo) => {
+				openFilePane(memo.memoFileAbsolutePath);
+			})
+			.catch((error: Error) => {
+				toast.error(`Failed to create memo: ${error.message}`);
+			});
+	}, [openFilePane, workspaceId]);
+
 	const commandPalette = useCommandPalette({
 		workspaceId,
 		navigate,
@@ -294,6 +306,7 @@ function WorkspaceContent({
 									onAddTerminal={addTerminalTab}
 									onAddChat={addChatTab}
 									onAddBrowser={addBrowserTab}
+									onAddMemo={addMemoTab}
 									showPresetsBar={showPresetsBar ?? false}
 									onTogglePresetsBar={(enabled) =>
 										setShowPresetsBar.mutate({ enabled })
@@ -304,6 +317,7 @@ function WorkspaceContent({
 								<WorkspaceEmptyState
 									onOpenBrowser={addBrowserTab}
 									onOpenChat={addChatTab}
+									onOpenMemo={addMemoTab}
 									onOpenQuickOpen={handleQuickOpen}
 									onOpenTerminal={addTerminalTab}
 								/>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
@@ -126,13 +126,25 @@ function WorkspaceContent({
 	});
 
 	const openFilePane = useCallback(
-		(filePath: string) => {
+		(filePath: string, displayName?: string) => {
 			const state = store.getState();
 			const active = state.getActivePane();
 			if (
 				active?.pane.kind === "file" &&
 				(active.pane.data as FilePaneData).filePath === filePath
 			) {
+				if (
+					displayName &&
+					(active.pane.data as FilePaneData).displayName !== displayName
+				) {
+					state.setPaneData({
+						paneId: active.pane.id,
+						data: {
+							...(active.pane.data as FilePaneData),
+							displayName,
+						} as FilePaneData,
+					});
+				}
 				state.setPanePinned({ paneId: active.pane.id, pinned: true });
 				return;
 			}
@@ -143,6 +155,7 @@ function WorkspaceContent({
 						filePath,
 						mode: "editor",
 						hasChanges: false,
+						displayName,
 					} as FilePaneData,
 				},
 				tabTitle: "Files",
@@ -195,7 +208,7 @@ function WorkspaceContent({
 	const addMemoTab = useCallback(() => {
 		void createWorkspaceMemo(workspaceId)
 			.then((memo) => {
-				openFilePane(memo.memoFileAbsolutePath);
+				openFilePane(memo.memoFileAbsolutePath, memo.displayName);
 			})
 			.catch((error: Error) => {
 				toast.error(`Failed to create memo: ${error.message}`);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/types.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/types.ts
@@ -2,6 +2,7 @@ export interface FilePaneData {
 	filePath: string;
 	mode: "editor" | "diff" | "preview";
 	hasChanges: boolean;
+	displayName?: string;
 	language?: string;
 }
 

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/EmptyTabView.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/EmptyTabView.tsx
@@ -1,12 +1,14 @@
 import type { ExternalApp } from "@superset/local-db";
+import { toast } from "@superset/ui/sonner";
 import { useCallback, useMemo } from "react";
 import type { IconType } from "react-icons";
 import { BsTerminalPlus } from "react-icons/bs";
-import { LuExternalLink, LuSearch, LuTrash2 } from "react-icons/lu";
+import { LuExternalLink, LuFileText, LuSearch, LuTrash2 } from "react-icons/lu";
 import { TbMessageCirclePlus, TbWorld } from "react-icons/tb";
 import { getAppOption } from "renderer/components/OpenInExternalDropdown";
 import { useHotkeyDisplay } from "renderer/hotkeys";
 import { electronTrpc } from "renderer/lib/electron-trpc";
+import { createWorkspaceMemo } from "renderer/lib/workspace-memos";
 import { useWorkspaceDeleteHandler } from "renderer/react-query/workspaces";
 import { DeleteWorkspaceDialog } from "renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/components/DeleteWorkspaceDialog/DeleteWorkspaceDialog";
 import { useWorkspaceId } from "renderer/screens/main/components/WorkspaceView/WorkspaceIdContext";
@@ -38,6 +40,7 @@ export function EmptyTabView({
 	const workspaceId = useWorkspaceId();
 	const addChatTab = useTabsStore((s) => s.addChatTab);
 	const addBrowserTab = useTabsStore((s) => s.addBrowserTab);
+	const addFileViewerPane = useTabsStore((s) => s.addFileViewerPane);
 	const activeTheme = useTheme();
 
 	const { data: workspace } = electronTrpc.workspaces.get.useQuery({
@@ -66,6 +69,21 @@ export function EmptyTabView({
 		addBrowserTab(workspaceId);
 	}, [addBrowserTab, workspaceId]);
 
+	const handleOpenMemo = useCallback(async () => {
+		try {
+			const memo = await createWorkspaceMemo(workspaceId);
+			addFileViewerPane(workspaceId, {
+				filePath: memo.memoFileAbsolutePath,
+				displayName: memo.fileName,
+				isPinned: true,
+			});
+		} catch (error) {
+			const message =
+				error instanceof Error ? error.message : "Failed to create memo";
+			toast.error(message);
+		}
+	}, [addFileViewerPane, workspaceId]);
+
 	const openInActionLabel = useMemo(() => {
 		const appOption = getAppOption(resolvedExternalApp);
 		const appName = appOption?.displayLabel ?? appOption?.label;
@@ -87,6 +105,13 @@ export function EmptyTabView({
 				display: newChatDisplay,
 				icon: TbMessageCirclePlus,
 				onClick: handleNewAgent,
+			},
+			{
+				id: "memo",
+				label: "Open Memo",
+				display: [],
+				icon: LuFileText,
+				onClick: handleOpenMemo,
 			},
 		];
 
@@ -119,6 +144,7 @@ export function EmptyTabView({
 		return baseActions;
 	}, [
 		handleNewAgent,
+		handleOpenMemo,
 		handleOpenBrowser,
 		handleShowTerminal,
 		newBrowserDisplay,

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/EmptyTabView.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/EmptyTabView.tsx
@@ -74,7 +74,7 @@ export function EmptyTabView({
 			const memo = await createWorkspaceMemo(workspaceId);
 			addFileViewerPane(workspaceId, {
 				filePath: memo.memoFileAbsolutePath,
-				displayName: memo.fileName,
+				displayName: memo.displayName,
 				isPinned: true,
 			});
 		} catch (error) {

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/GroupStrip/GroupStrip.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/GroupStrip/GroupStrip.tsx
@@ -1,4 +1,5 @@
 import type { TerminalPreset } from "@superset/local-db";
+import { toast } from "@superset/ui/sonner";
 import { eq, or } from "@tanstack/db";
 import { useLiveQuery } from "@tanstack/react-db";
 import { useNavigate } from "@tanstack/react-router";
@@ -12,6 +13,7 @@ import {
 } from "react";
 import { isTearoffWindow } from "renderer/hooks/useTearoffInit";
 import { electronTrpc } from "renderer/lib/electron-trpc";
+import { createWorkspaceMemo } from "renderer/lib/workspace-memos";
 import { usePresets } from "renderer/react-query/presets";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 import { useWorkspaceId } from "renderer/screens/main/components/WorkspaceView/WorkspaceIdContext";
@@ -41,6 +43,7 @@ export function GroupStrip() {
 	const tabHistoryStacks = useTabsStore((s) => s.tabHistoryStacks);
 	const addChatTab = useTabsStore((s) => s.addChatTab);
 	const addBrowserTab = useTabsStore((s) => s.addBrowserTab);
+	const addFileViewerPane = useTabsStore((s) => s.addFileViewerPane);
 	const renameTab = useTabsStore((s) => s.renameTab);
 	const setTabColor = useTabsStore((s) => s.setTabColor);
 	const setActiveTab = useTabsStore((s) => s.setActiveTab);
@@ -235,6 +238,23 @@ export function GroupStrip() {
 		addBrowserTab(activeWorkspaceId);
 	};
 
+	const handleAddMemo = useCallback(async () => {
+		if (!activeWorkspaceId) return;
+
+		try {
+			const memo = await createWorkspaceMemo(activeWorkspaceId);
+			addFileViewerPane(activeWorkspaceId, {
+				filePath: memo.memoFileAbsolutePath,
+				displayName: memo.fileName,
+				isPinned: true,
+			});
+		} catch (error) {
+			const message =
+				error instanceof Error ? error.message : "Failed to create memo";
+			toast.error(message);
+		}
+	}, [activeWorkspaceId, addFileViewerPane]);
+
 	const handleOpenPreset = useCallback(
 		(preset: TerminalPreset) => {
 			if (!activeWorkspaceId) return;
@@ -327,6 +347,7 @@ export function GroupStrip() {
 			onAddTerminal={handleAddGroup}
 			onAddChat={handleAddChat}
 			onAddBrowser={handleAddBrowser}
+			onAddMemo={handleAddMemo}
 			onOpenPreset={handleOpenPreset}
 			onConfigurePresets={handleOpenPresetsSettings}
 			onToggleShowPresetsBar={(enabled) =>

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/GroupStrip/GroupStrip.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/GroupStrip/GroupStrip.tsx
@@ -245,7 +245,7 @@ export function GroupStrip() {
 			const memo = await createWorkspaceMemo(activeWorkspaceId);
 			addFileViewerPane(activeWorkspaceId, {
 				filePath: memo.memoFileAbsolutePath,
-				displayName: memo.fileName,
+				displayName: memo.displayName,
 				isPinned: true,
 			});
 		} catch (error) {

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/GroupStrip/components/AddTabButton/AddTabButton.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/GroupStrip/components/AddTabButton/AddTabButton.tsx
@@ -10,7 +10,7 @@ import {
 } from "@superset/ui/dropdown-menu";
 import { BsTerminalPlus } from "react-icons/bs";
 import { HiMiniChevronDown } from "react-icons/hi2";
-import { LuPlus } from "react-icons/lu";
+import { LuFileText, LuPlus } from "react-icons/lu";
 import { TbMessageCirclePlus, TbWorld } from "react-icons/tb";
 import { HotkeyMenuShortcut } from "renderer/components/HotkeyMenuShortcut";
 import { NewTabDropZone } from "../../NewTabDropZone";
@@ -25,6 +25,7 @@ interface AddTabButtonProps {
 	onAddTerminal: () => void;
 	onAddChat: () => void;
 	onAddBrowser: () => void;
+	onAddMemo: () => void;
 	onOpenPreset: (preset: TerminalPreset) => void;
 	onConfigurePresets: () => void;
 	onToggleShowPresetsBar: (enabled: boolean) => void;
@@ -40,6 +41,7 @@ export function AddTabButton({
 	onAddTerminal,
 	onAddChat,
 	onAddBrowser,
+	onAddMemo,
 	onOpenPreset,
 	onConfigurePresets,
 	onToggleShowPresetsBar,
@@ -117,6 +119,19 @@ export function AddTabButton({
 								<TbWorld className="size-4" />
 								<span>Browser</span>
 								<HotkeyMenuShortcut hotkeyId="NEW_BROWSER" />
+							</DropdownMenuItem>
+							<DropdownMenuItem onClick={onAddMemo} className="gap-2">
+								<LuFileText className="size-4" />
+								<span>Memo</span>
+							</DropdownMenuItem>
+							<DropdownMenuSeparator />
+						</>
+					)}
+					{showBigAddButton && (
+						<>
+							<DropdownMenuItem onClick={onAddMemo} className="gap-2">
+								<LuFileText className="size-4" />
+								<span>Memo</span>
 							</DropdownMenuItem>
 							<DropdownMenuSeparator />
 						</>

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/FileViewerPane.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/FileViewerPane.tsx
@@ -6,7 +6,10 @@ import type { MosaicBranch } from "react-mosaic-component";
 import { createChatServiceIpcClient } from "renderer/components/Chat/utils/chat-service-client";
 import type { MarkdownEditorAdapter } from "renderer/components/MarkdownRenderer";
 import { electronTrpc } from "renderer/lib/electron-trpc";
-import { getTrustedMemoRootPath } from "renderer/lib/workspace-memos";
+import {
+	deriveMemoDisplayName,
+	getTrustedMemoRootPath,
+} from "renderer/lib/workspace-memos";
 import { electronQueryClient } from "renderer/providers/ElectronTRPCProvider";
 import { FileSaveConflictDialog } from "renderer/screens/main/components/WorkspaceView/components/FileSaveConflictDialog";
 import { useWorkspaceFileEvents } from "renderer/screens/main/components/WorkspaceView/hooks/useWorkspaceFileEvents";
@@ -56,6 +59,7 @@ import { useMarkdownSearch } from "./hooks/useMarkdownSearch";
 import { UnsavedChangesDialog } from "./UnsavedChangesDialog";
 
 const chatServiceIpcClient = createChatServiceIpcClient();
+const MEMO_AUTOSAVE_DELAY_MS = 1000;
 
 interface FileViewerPaneProps {
 	paneId: string;
@@ -142,6 +146,9 @@ export function FileViewerPane({
 	const isFocused = useTabsStore((s) => s.focusedPaneIds[tabId] === paneId);
 	const equalizePaneSplits = useTabsStore((s) => s.equalizePaneSplits);
 	const pinPane = useTabsStore((s) => s.pinPane);
+	const setFileViewerDisplayName = useTabsStore(
+		(s) => s.setFileViewerDisplayName,
+	);
 	const {
 		viewMode: diffViewMode,
 		setViewMode: setDiffViewMode,
@@ -436,21 +443,9 @@ export function FileViewerPane({
 				return;
 			}
 
-			if (isMemoFile) {
-				console.log("[MemoPane] handleContentChange", {
-					filePath: absoluteFilePath,
-					documentKey,
-					valueLength: value.length,
-				});
-			}
-
 			const dirty = updateDocumentDraft(documentKey, value);
 			if (isMemoFile) {
-				console.log("[MemoPane] draftUpdated", {
-					filePath: absoluteFilePath,
-					documentKey,
-					dirty,
-				});
+				setFileViewerDisplayName(paneId, deriveMemoDisplayName(value));
 			}
 			if (dirty && !isPinned) {
 				pinPane(paneId);
@@ -459,7 +454,14 @@ export function FileViewerPane({
 				});
 			}
 		},
-		[absoluteFilePath, documentKey, isMemoFile, isPinned, paneId, pinPane],
+		[
+			documentKey,
+			isMemoFile,
+			isPinned,
+			paneId,
+			pinPane,
+			setFileViewerDisplayName,
+		],
 	);
 
 	useEffect(() => {
@@ -661,27 +663,43 @@ export function FileViewerPane({
 			return;
 		}
 
-		console.log("[MemoPane] renderedContentChanged", {
-			filePath: absoluteFilePath,
-			documentKey,
-			renderedContentLength: renderedContent.length,
-			isDirty,
-			viewMode,
-		});
-	}, [
-		absoluteFilePath,
-		documentKey,
-		isDirty,
-		isMemoFile,
-		renderedContent,
-		viewMode,
-	]);
+		setFileViewerDisplayName(paneId, deriveMemoDisplayName(renderedContent));
+	}, [isMemoFile, paneId, renderedContent, setFileViewerDisplayName]);
+
 	const hasRenderedMode =
 		isMarkdownFile(filePath) || isImageFile(filePath) || isHtmlFile(filePath);
 	const hasDiff = !!diffCategory;
 	const unsavedDialogCopy = getUnsavedDialogCopy(
 		session?.pendingIntent ?? null,
 	);
+
+	useEffect(() => {
+		if (
+			!isMemoFile ||
+			!isDirty ||
+			isSaving ||
+			hasExternalDiskChange ||
+			viewMode === "diff" ||
+			viewMode === "conflict"
+		) {
+			return;
+		}
+
+		const timeoutId = window.setTimeout(() => {
+			void performFileSave();
+		}, MEMO_AUTOSAVE_DELAY_MS);
+
+		return () => {
+			window.clearTimeout(timeoutId);
+		};
+	}, [
+		hasExternalDiskChange,
+		isDirty,
+		isMemoFile,
+		isSaving,
+		performFileSave,
+		viewMode,
+	]);
 
 	if (!fileViewer) {
 		return (

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/FileViewerPane.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/FileViewerPane.tsx
@@ -6,6 +6,7 @@ import type { MosaicBranch } from "react-mosaic-component";
 import { createChatServiceIpcClient } from "renderer/components/Chat/utils/chat-service-client";
 import type { MarkdownEditorAdapter } from "renderer/components/MarkdownRenderer";
 import { electronTrpc } from "renderer/lib/electron-trpc";
+import { getTrustedMemoRootPath } from "renderer/lib/workspace-memos";
 import { electronQueryClient } from "renderer/providers/ElectronTRPCProvider";
 import { FileSaveConflictDialog } from "renderer/screens/main/components/WorkspaceView/components/FileSaveConflictDialog";
 import { useWorkspaceFileEvents } from "renderer/screens/main/components/WorkspaceView/hooks/useWorkspaceFileEvents";
@@ -368,6 +369,7 @@ export function FileViewerPane({
 		() => toAbsoluteWorkspacePath(worktreePath, filePath),
 		[worktreePath, filePath],
 	);
+	const isMemoFile = Boolean(getTrustedMemoRootPath(absoluteFilePath));
 	const baselineContent = getEditorDocumentBaselineContent(documentKey);
 
 	useEffect(() => {
@@ -434,7 +436,22 @@ export function FileViewerPane({
 				return;
 			}
 
+			if (isMemoFile) {
+				console.debug("[MemoPane] handleContentChange", {
+					filePath: absoluteFilePath,
+					documentKey,
+					valueLength: value.length,
+				});
+			}
+
 			const dirty = updateDocumentDraft(documentKey, value);
+			if (isMemoFile) {
+				console.debug("[MemoPane] draftUpdated", {
+					filePath: absoluteFilePath,
+					documentKey,
+					dirty,
+				});
+			}
 			if (dirty && !isPinned) {
 				pinPane(paneId);
 				useEditorSessionsStore.getState().patchSession(paneId, {
@@ -442,7 +459,7 @@ export function FileViewerPane({
 				});
 			}
 		},
-		[documentKey, isPinned, paneId, pinPane],
+		[absoluteFilePath, documentKey, isMemoFile, isPinned, paneId, pinPane],
 	);
 
 	useEffect(() => {
@@ -638,6 +655,27 @@ export function FileViewerPane({
 
 		return "";
 	}, [currentDocumentContent, documentKey, rawFileData]);
+
+	useEffect(() => {
+		if (!isMemoFile) {
+			return;
+		}
+
+		console.debug("[MemoPane] renderedContentChanged", {
+			filePath: absoluteFilePath,
+			documentKey,
+			renderedContentLength: renderedContent.length,
+			isDirty,
+			viewMode,
+		});
+	}, [
+		absoluteFilePath,
+		documentKey,
+		isDirty,
+		isMemoFile,
+		renderedContent,
+		viewMode,
+	]);
 	const hasRenderedMode =
 		isMarkdownFile(filePath) || isImageFile(filePath) || isHtmlFile(filePath);
 	const hasDiff = !!diffCategory;

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/FileViewerPane.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/FileViewerPane.tsx
@@ -437,7 +437,7 @@ export function FileViewerPane({
 			}
 
 			if (isMemoFile) {
-				console.debug("[MemoPane] handleContentChange", {
+				console.log("[MemoPane] handleContentChange", {
 					filePath: absoluteFilePath,
 					documentKey,
 					valueLength: value.length,
@@ -446,7 +446,7 @@ export function FileViewerPane({
 
 			const dirty = updateDocumentDraft(documentKey, value);
 			if (isMemoFile) {
-				console.debug("[MemoPane] draftUpdated", {
+				console.log("[MemoPane] draftUpdated", {
 					filePath: absoluteFilePath,
 					documentKey,
 					dirty,
@@ -661,7 +661,7 @@ export function FileViewerPane({
 			return;
 		}
 
-		console.debug("[MemoPane] renderedContentChanged", {
+		console.log("[MemoPane] renderedContentChanged", {
 			filePath: absoluteFilePath,
 			documentKey,
 			renderedContentLength: renderedContent.length,

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/components/FileViewerContent/FileViewerContent.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/components/FileViewerContent/FileViewerContent.tsx
@@ -12,6 +12,7 @@ import {
 	TipTapMarkdownRenderer,
 } from "renderer/components/MarkdownRenderer";
 import { electronTrpc } from "renderer/lib/electron-trpc";
+import { getTrustedMemoRootPath } from "renderer/lib/workspace-memos";
 import type { CodeEditorAdapter } from "renderer/screens/main/components/WorkspaceView/ContentView/components";
 import { CodeEditor } from "renderer/screens/main/components/WorkspaceView/components/CodeEditor";
 import type { Tab } from "renderer/stores/tabs/types";
@@ -266,6 +267,10 @@ export function FileViewerContent({
 	const absoluteFilePath = useMemo(
 		() => (worktreePath ? toAbsoluteWorkspacePath(worktreePath, filePath) : ""),
 		[worktreePath, filePath],
+	);
+	const trustedImageRootPath = useMemo(
+		() => getTrustedMemoRootPath(absoluteFilePath),
+		[absoluteFilePath],
 	);
 	const { data: workspace } = electronTrpc.workspaces.get.useQuery(
 		{ id: workspaceId ?? "" },
@@ -717,6 +722,9 @@ export function FileViewerContent({
 						editorRef={markdownEditorRef}
 						onChange={onContentChange}
 						onSave={onSaveFile}
+						workspaceId={workspaceId}
+						filePath={absoluteFilePath}
+						trustedImageRootPath={trustedImageRootPath}
 					/>
 				</div>
 			</div>

--- a/apps/desktop/src/renderer/stores/editor-state/editorCoordinator.ts
+++ b/apps/desktop/src/renderer/stores/editor-state/editorCoordinator.ts
@@ -517,23 +517,6 @@ export function requestViewModeChange(
 		return true;
 	}
 
-	const session = useEditorSessionsStore.getState().sessions[paneId];
-	const document = session
-		? useEditorDocumentsStore.getState().documents[session.documentKey]
-		: null;
-
-	if (document?.dirty) {
-		focusPane(paneId);
-		useEditorSessionsStore
-			.getState()
-			.setPendingIntent(
-				paneId,
-				{ type: "change-view-mode", nextMode },
-				"unsaved",
-			);
-		return false;
-	}
-
 	executePendingIntent(paneId, { type: "change-view-mode", nextMode });
 	return true;
 }

--- a/apps/desktop/src/renderer/stores/editor-state/editorCoordinator.ts
+++ b/apps/desktop/src/renderer/stores/editor-state/editorCoordinator.ts
@@ -1,5 +1,6 @@
 import { invalidateFileSaveQueries } from "renderer/lib/invalidate-file-save-queries";
 import { electronTrpcClient } from "renderer/lib/trpc-client";
+import { getTrustedMemoRootPath } from "renderer/lib/workspace-memos";
 import { useTabsStore } from "renderer/stores/tabs/store";
 import type { AddFileViewerPaneOptions } from "renderer/stores/tabs/types";
 import { resolveFileViewerMode } from "renderer/stores/tabs/utils";
@@ -515,6 +516,26 @@ export function requestViewModeChange(
 	const pane = useTabsStore.getState().panes[paneId];
 	if (!pane?.fileViewer || pane.fileViewer.viewMode === nextMode) {
 		return true;
+	}
+
+	const session = useEditorSessionsStore.getState().sessions[paneId];
+	const document = session
+		? useEditorDocumentsStore.getState().documents[session.documentKey]
+		: null;
+	const isMemoFile = Boolean(
+		document?.filePath && getTrustedMemoRootPath(document.filePath),
+	);
+
+	if (document?.dirty && !isMemoFile) {
+		focusPane(paneId);
+		useEditorSessionsStore
+			.getState()
+			.setPendingIntent(
+				paneId,
+				{ type: "change-view-mode", nextMode },
+				"unsaved",
+			);
+		return false;
 	}
 
 	executePendingIntent(paneId, { type: "change-view-mode", nextMode });

--- a/apps/desktop/src/renderer/stores/tabs/store.ts
+++ b/apps/desktop/src/renderer/stores/tabs/store.ts
@@ -1267,6 +1267,40 @@ export const useTabsStore = create<TabsStore>()(
 						),
 					});
 				},
+				setFileViewerDisplayName: (paneId, displayName) => {
+					set((state) => {
+						const pane = state.panes[paneId];
+						if (
+							!pane?.fileViewer ||
+							pane.userTitle?.trim() ||
+							(pane.name === displayName &&
+								pane.fileViewer.displayName === displayName)
+						) {
+							return state;
+						}
+
+						const nextPanes = {
+							...state.panes,
+							[paneId]: {
+								...pane,
+								name: displayName,
+								fileViewer: {
+									...pane.fileViewer,
+									displayName,
+								},
+							},
+						};
+
+						return {
+							panes: nextPanes,
+							tabs: state.tabs.map((tab) =>
+								tab.id === pane.tabId
+									? { ...tab, name: deriveTabName(nextPanes, tab.id) }
+									: tab,
+							),
+						};
+					});
+				},
 				setPaneWorkspaceRun: (paneId, workspaceRun) => {
 					set((state) => {
 						const pane = state.panes[paneId];

--- a/apps/desktop/src/renderer/stores/tabs/types.ts
+++ b/apps/desktop/src/renderer/stores/tabs/types.ts
@@ -142,6 +142,7 @@ export interface TabsStore extends TabsState {
 	markPaneAsUsed: (paneId: string) => void;
 	setPaneStatus: (paneId: string, status: PaneStatus) => void;
 	setPaneName: (paneId: string, name: string) => void;
+	setFileViewerDisplayName: (paneId: string, displayName: string) => void;
 	setPaneWorkspaceRun: (
 		paneId: string,
 		workspaceRun: {


### PR DESCRIPTION
## 概要
- v1 / v2 のプラスメニューと empty state から workspace 配下の `.superset/memos/` に保存される Memo を作成できるようにしました
- memo は実ファイルを `.superset/memos/<memo-id>/memo.md` に固定し、タブ表示名は本文先頭の見出しまたは最初の非空行から自動生成するようにしました
- markdown editor で画像を貼り付けると `.superset/memos/<memo-id>/assets/` に保存し、相対パスの markdown を挿入するようにしました
- `.superset/memos/**` 配下の相対画像だけを trusted context で解決して表示するようにしました
- memo については v1 / v2 ともに自動保存を追加しました

## 確認
- `bun run lint`
  - 既存の `apps/desktop/src/main/lib/vscode-shim/*` と `CodeMirrorDiffViewer.tsx` / `CodeEditor.tsx` の lint 警告で失敗
- `bun run typecheck`
  - 既存の `apps/desktop/src/renderer/routes/_authenticated/settings/models/components/ModelsSettings/ModelsSettings.tsx` の型エラーで失敗

close #124