### PR TITLE
Add configurable right sidebar open view width

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/settings/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/settings/index.ts
@@ -26,10 +26,13 @@ import {
 	DEFAULT_FILE_OPEN_MODE,
 	DEFAULT_OPEN_LINKS_IN_APP,
 	DEFAULT_PREVENT_AGENT_SLEEP,
+	DEFAULT_RIGHT_SIDEBAR_OPEN_VIEW_WIDTH,
 	DEFAULT_SHOW_PRESETS_BAR,
 	DEFAULT_SHOW_RESOURCE_MONITOR,
 	DEFAULT_TERMINAL_LINK_BEHAVIOR,
 	DEFAULT_USE_COMPACT_TERMINAL_ADD_BUTTON,
+	MAX_RIGHT_SIDEBAR_OPEN_VIEW_WIDTH,
+	MIN_RIGHT_SIDEBAR_OPEN_VIEW_WIDTH,
 } from "shared/constants";
 import { normalizePresetProjectIds } from "shared/preset-project-targeting";
 import {
@@ -689,6 +692,36 @@ export const createSettingsRouter = () => {
 					.onConflictDoUpdate({
 						target: settings.id,
 						set: { fileOpenMode: input.mode },
+					})
+					.run();
+
+				return { success: true };
+			}),
+
+		getRightSidebarOpenViewWidth: publicProcedure.query(() => {
+			const row = getSettings();
+			return (
+				row.rightSidebarOpenViewWidth ?? DEFAULT_RIGHT_SIDEBAR_OPEN_VIEW_WIDTH
+			);
+		}),
+
+		setRightSidebarOpenViewWidth: publicProcedure
+			.input(
+				z.object({
+					width: z
+						.number()
+						.int()
+						.min(MIN_RIGHT_SIDEBAR_OPEN_VIEW_WIDTH)
+						.max(MAX_RIGHT_SIDEBAR_OPEN_VIEW_WIDTH),
+				}),
+			)
+			.mutation(({ input }) => {
+				localDb
+					.insert(settings)
+					.values({ id: 1, rightSidebarOpenViewWidth: input.width })
+					.onConflictDoUpdate({
+						target: settings.id,
+						set: { rightSidebarOpenViewWidth: input.width },
 					})
 					.run();
 

--- a/apps/desktop/src/renderer/hooks/useRightSidebarOpenViewWidth/index.ts
+++ b/apps/desktop/src/renderer/hooks/useRightSidebarOpenViewWidth/index.ts
@@ -1,0 +1,4 @@
+export {
+	getRightSidebarOpenViewWidth,
+	useRightSidebarOpenViewWidth,
+} from "./useRightSidebarOpenViewWidth";

--- a/apps/desktop/src/renderer/hooks/useRightSidebarOpenViewWidth/useRightSidebarOpenViewWidth.ts
+++ b/apps/desktop/src/renderer/hooks/useRightSidebarOpenViewWidth/useRightSidebarOpenViewWidth.ts
@@ -1,0 +1,22 @@
+import { electronTrpc } from "renderer/lib/electron-trpc";
+import {
+	clampRightSidebarOpenViewWidth,
+	DEFAULT_RIGHT_SIDEBAR_OPEN_VIEW_WIDTH,
+} from "shared/constants";
+
+let cachedRightSidebarOpenViewWidth = DEFAULT_RIGHT_SIDEBAR_OPEN_VIEW_WIDTH;
+
+/** Non-React getter, kept in sync by useRightSidebarOpenViewWidth(). */
+export function getRightSidebarOpenViewWidth(): number {
+	return cachedRightSidebarOpenViewWidth;
+}
+
+export function useRightSidebarOpenViewWidth(): number {
+	const { data } =
+		electronTrpc.settings.getRightSidebarOpenViewWidth.useQuery();
+	const width = clampRightSidebarOpenViewWidth(
+		data ?? DEFAULT_RIGHT_SIDEBAR_OPEN_VIEW_WIDTH,
+	);
+	cachedRightSidebarOpenViewWidth = width;
+	return width;
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
@@ -1,4 +1,9 @@
-import { type PaneActionConfig, Workspace } from "@superset/panes";
+import {
+	type LayoutNode,
+	type PaneActionConfig,
+	type SplitPath,
+	Workspace,
+} from "@superset/panes";
 import { alert } from "@superset/ui/atoms/Alert";
 import {
 	ResizableHandle,
@@ -11,6 +16,7 @@ import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { useCallback, useEffect, useMemo } from "react";
 import { HiMiniXMark } from "react-icons/hi2";
 import { TbLayoutColumns, TbLayoutRows } from "react-icons/tb";
+import { useRightSidebarOpenViewWidth } from "renderer/hooks/useRightSidebarOpenViewWidth";
 import { HotkeyLabel, useHotkey } from "renderer/hotkeys";
 import {
 	addBrowserShortcutListener,
@@ -45,6 +51,41 @@ export const Route = createFileRoute(
 )({
 	component: V2WorkspacePage,
 });
+
+function findPanePathInLayout(
+	node: LayoutNode,
+	paneId: string,
+	currentPath: SplitPath = [],
+): SplitPath | null {
+	if (node.type === "pane") {
+		return node.paneId === paneId ? currentPath : null;
+	}
+
+	const firstPath = findPanePathInLayout(node.first, paneId, [
+		...currentPath,
+		"first",
+	]);
+	if (firstPath) return firstPath;
+
+	const secondPath = findPanePathInLayout(node.second, paneId, [
+		...currentPath,
+		"second",
+	]);
+	if (secondPath) return secondPath;
+
+	return null;
+}
+
+function getNodeAtPathInLayout(
+	node: LayoutNode,
+	path: SplitPath,
+): LayoutNode | null {
+	if (path.length === 0) return node;
+	if (node.type === "pane") return null;
+
+	const [branch, ...rest] = path;
+	return getNodeAtPathInLayout(node[branch], rest);
+}
 
 function V2WorkspacePage() {
 	const { workspaceId } = Route.useParams();
@@ -92,6 +133,7 @@ function WorkspaceContent({
 	});
 	const paneRegistry = usePaneRegistry(workspaceId);
 	const defaultContextMenuActions = useDefaultContextMenuActions();
+	const rightSidebarOpenViewWidth = useRightSidebarOpenViewWidth();
 
 	const utils = electronTrpc.useUtils();
 	const { data: showPresetsBar, isLoading: isLoadingPresetsBar } =
@@ -147,6 +189,64 @@ function WorkspaceContent({
 			});
 		},
 		[store],
+	);
+
+	const openSidebarFilePane = useCallback(
+		(filePath: string) => {
+			const state = store.getState();
+			const active = state.getActivePane();
+			const activeTab = active
+				? (state.tabs.find((tab) => tab.id === active.tabId) ?? null)
+				: null;
+			if (
+				active?.pane.kind === "file" &&
+				(active.pane.data as FilePaneData).filePath === filePath
+			) {
+				state.setPanePinned({ paneId: active.pane.id, pinned: true });
+				return;
+			}
+
+			const activeTabId = state.activeTabId;
+			const activePaneId = active?.pane.id ?? null;
+			const activePanePath =
+				activeTab?.layout && activePaneId
+					? findPanePathInLayout(activeTab.layout, activePaneId)
+					: null;
+
+			state.openPane({
+				pane: {
+					kind: "file",
+					data: {
+						filePath,
+						mode: "editor",
+						hasChanges: false,
+					} as FilePaneData,
+				},
+				tabTitle: "Files",
+			});
+
+			if (!activeTabId || !activePanePath) {
+				return;
+			}
+
+			const nextState = store.getState();
+			const nextTab = nextState.tabs.find((tab) => tab.id === activeTabId);
+			if (!nextTab) {
+				return;
+			}
+
+			const splitNode = getNodeAtPathInLayout(nextTab.layout, activePanePath);
+			if (splitNode?.type !== "split" || splitNode.direction !== "horizontal") {
+				return;
+			}
+
+			nextState.resizeSplit({
+				tabId: activeTabId,
+				path: activePanePath,
+				splitPercentage: 100 - rightSidebarOpenViewWidth,
+			});
+		},
+		[rightSidebarOpenViewWidth, store],
 	);
 
 	const addTerminalTab = useCallback(() => {
@@ -354,7 +454,7 @@ function WorkspaceContent({
 							<WorkspaceSidebar
 								workspaceId={workspaceId}
 								workspaceName={workspaceName}
-								onSelectFile={openFilePane}
+								onSelectFile={openSidebarFilePane}
 								onSearch={handleQuickOpen}
 								selectedFilePath={selectedFilePath}
 							/>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/workspace/$workspaceId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/workspace/$workspaceId/page.tsx
@@ -9,6 +9,7 @@ import {
 import { useCallback, useEffect, useMemo } from "react";
 import { useCopyToClipboard } from "renderer/hooks/useCopyToClipboard";
 import { useFileOpenMode } from "renderer/hooks/useFileOpenMode";
+import { useRightSidebarOpenViewWidth } from "renderer/hooks/useRightSidebarOpenViewWidth";
 import { useHotkey } from "renderer/hotkeys";
 import {
 	addBrowserShortcutListener,
@@ -182,6 +183,7 @@ export function WorkspacePage({
 
 	// Keep the file open mode cache warm for addFileViewerPane
 	useFileOpenMode();
+	useRightSidebarOpenViewWidth();
 
 	const addFileViewerPane = useTabsStore((s) => s.addFileViewerPane);
 	const hasTabsHydrated = useTabsStore((s) => s.hasHydrated ?? false);

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/behavior/components/BehaviorSettings/BehaviorSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/behavior/components/BehaviorSettings/BehaviorSettings.tsx
@@ -1,4 +1,5 @@
 import type { FileOpenMode } from "@superset/local-db";
+import { Input } from "@superset/ui/input";
 import { Label } from "@superset/ui/label";
 import {
 	Select,
@@ -8,8 +9,15 @@ import {
 	SelectValue,
 } from "@superset/ui/select";
 import { Switch } from "@superset/ui/switch";
+import { type FocusEvent, useCallback, useEffect, useState } from "react";
 import { electronTrpc } from "renderer/lib/electron-trpc";
-import { SUPPORTS_AGENT_SLEEP_PREVENTION } from "shared/constants";
+import {
+	clampRightSidebarOpenViewWidth,
+	DEFAULT_RIGHT_SIDEBAR_OPEN_VIEW_WIDTH,
+	MAX_RIGHT_SIDEBAR_OPEN_VIEW_WIDTH,
+	MIN_RIGHT_SIDEBAR_OPEN_VIEW_WIDTH,
+	SUPPORTS_AGENT_SLEEP_PREVENTION,
+} from "shared/constants";
 import {
 	isItemVisible,
 	SETTING_ITEM_ID,
@@ -34,6 +42,10 @@ export function BehaviorSettings({ visibleItems }: BehaviorSettingsProps) {
 		isItemVisible(SETTING_ITEM_ID.BEHAVIOR_PREVENT_AGENT_SLEEP, visibleItems);
 	const showFileOpenMode = isItemVisible(
 		SETTING_ITEM_ID.BEHAVIOR_FILE_OPEN_MODE,
+		visibleItems,
+	);
+	const showRightSidebarOpenViewWidth = isItemVisible(
+		SETTING_ITEM_ID.BEHAVIOR_RIGHT_SIDEBAR_OPEN_VIEW_WIDTH,
 		visibleItems,
 	);
 	const showResourceMonitor = isItemVisible(
@@ -140,6 +152,55 @@ export function BehaviorSettings({ visibleItems }: BehaviorSettingsProps) {
 			utils.settings.getFileOpenMode.invalidate();
 		},
 	});
+
+	const {
+		data: rightSidebarOpenViewWidth,
+		isLoading: isRightSidebarOpenViewWidthLoading,
+	} = electronTrpc.settings.getRightSidebarOpenViewWidth.useQuery();
+	const setRightSidebarOpenViewWidth =
+		electronTrpc.settings.setRightSidebarOpenViewWidth.useMutation({
+			onMutate: async ({ width }) => {
+				await utils.settings.getRightSidebarOpenViewWidth.cancel();
+				const previous = utils.settings.getRightSidebarOpenViewWidth.getData();
+				utils.settings.getRightSidebarOpenViewWidth.setData(undefined, width);
+				return { previous };
+			},
+			onError: (_err, _vars, context) => {
+				if (context?.previous !== undefined) {
+					utils.settings.getRightSidebarOpenViewWidth.setData(
+						undefined,
+						context.previous,
+					);
+				}
+			},
+			onSettled: () => {
+				utils.settings.getRightSidebarOpenViewWidth.invalidate();
+			},
+		});
+	const [rightSidebarOpenViewWidthDraft, setRightSidebarOpenViewWidthDraft] =
+		useState<string | null>(null);
+
+	// biome-ignore lint/correctness/useExhaustiveDependencies: sync draft state when setting changes
+	useEffect(() => {
+		setRightSidebarOpenViewWidthDraft(null);
+	}, [rightSidebarOpenViewWidth]);
+
+	const handleRightSidebarOpenViewWidthBlur = useCallback(
+		(event: FocusEvent<HTMLInputElement>) => {
+			const parsedWidth = Number.parseInt(event.target.value, 10);
+			if (Number.isNaN(parsedWidth)) {
+				setRightSidebarOpenViewWidthDraft(null);
+				return;
+			}
+
+			const nextWidth = clampRightSidebarOpenViewWidth(parsedWidth);
+			if (nextWidth !== rightSidebarOpenViewWidth) {
+				setRightSidebarOpenViewWidth.mutate({ width: nextWidth });
+			}
+			setRightSidebarOpenViewWidthDraft(null);
+		},
+		[rightSidebarOpenViewWidth, setRightSidebarOpenViewWidth],
+	);
 
 	const { data: resourceMonitorEnabled, isLoading: isResourceMonitorLoading } =
 		electronTrpc.settings.getShowResourceMonitor.useQuery();
@@ -265,6 +326,48 @@ export function BehaviorSettings({ visibleItems }: BehaviorSettingsProps) {
 								<SelectItem value="new-tab">New tab</SelectItem>
 							</SelectContent>
 						</Select>
+					</div>
+				)}
+
+				{showRightSidebarOpenViewWidth && (
+					<div className="flex items-center justify-between gap-6">
+						<div className="space-y-0.5">
+							<Label
+								htmlFor="right-sidebar-open-view-width"
+								className="text-sm font-medium"
+							>
+								Right sidebar open view width
+							</Label>
+							<p className="text-xs text-muted-foreground">
+								Initial width for new file and diff views opened from the Files
+								or Git sidebar
+							</p>
+						</div>
+						<div className="flex items-center gap-2">
+							<Input
+								id="right-sidebar-open-view-width"
+								type="number"
+								min={MIN_RIGHT_SIDEBAR_OPEN_VIEW_WIDTH}
+								max={MAX_RIGHT_SIDEBAR_OPEN_VIEW_WIDTH}
+								value={
+									rightSidebarOpenViewWidthDraft ??
+									String(
+										rightSidebarOpenViewWidth ??
+											DEFAULT_RIGHT_SIDEBAR_OPEN_VIEW_WIDTH,
+									)
+								}
+								onChange={(event) =>
+									setRightSidebarOpenViewWidthDraft(event.target.value)
+								}
+								onBlur={handleRightSidebarOpenViewWidthBlur}
+								disabled={
+									isRightSidebarOpenViewWidthLoading ||
+									setRightSidebarOpenViewWidth.isPending
+								}
+								className="w-24"
+							/>
+							<span className="text-sm text-muted-foreground">%</span>
+						</div>
 					</div>
 				)}
 

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/utils/settings-search/settings-search.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/utils/settings-search/settings-search.test.ts
@@ -42,6 +42,14 @@ describe("settings search - font settings", () => {
 		expect(ids).toContain(SETTING_ITEM_ID.APPEARANCE_EDITOR_FONT);
 	});
 
+	it('searching "sidebar split width" returns the right sidebar open view width setting', () => {
+		const results = searchSettings("sidebar split width");
+		const ids = getIds(results);
+		expect(ids).toContain(
+			SETTING_ITEM_ID.BEHAVIOR_RIGHT_SIDEBAR_OPEN_VIEW_WIDTH,
+		);
+	});
+
 	it("empty search returns all settings items", () => {
 		const results = searchSettings("");
 		expect(results.length).toBeGreaterThan(0);

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/utils/settings-search/settings-search.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/utils/settings-search/settings-search.ts
@@ -26,6 +26,8 @@ export const SETTING_ITEM_ID = {
 	BEHAVIOR_TELEMETRY: "behavior-telemetry",
 	BEHAVIOR_PREVENT_AGENT_SLEEP: "behavior-prevent-agent-sleep",
 	BEHAVIOR_FILE_OPEN_MODE: "behavior-file-open-mode",
+	BEHAVIOR_RIGHT_SIDEBAR_OPEN_VIEW_WIDTH:
+		"behavior-right-sidebar-open-view-width",
 	BEHAVIOR_RESOURCE_MONITOR: "behavior-resource-monitor",
 	BEHAVIOR_OPEN_LINKS_IN_APP: "behavior-open-links-in-app",
 	BEHAVIOR_LANGUAGE_DIAGNOSTICS: "behavior-language-diagnostics",
@@ -474,6 +476,25 @@ export const SETTINGS_ITEMS: SettingsItem[] = [
 			"split pane",
 			"viewer",
 			"behavior",
+		],
+	},
+	{
+		id: SETTING_ITEM_ID.BEHAVIOR_RIGHT_SIDEBAR_OPEN_VIEW_WIDTH,
+		section: "behavior",
+		title: "Right sidebar open view width",
+		description:
+			"Choose the initial width for new file and diff views opened from the Files or Git sidebar",
+		keywords: [
+			"right sidebar",
+			"files",
+			"git",
+			"diff",
+			"width",
+			"split",
+			"pane",
+			"initial",
+			"viewer",
+			"changes",
 		],
 	},
 	{

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/FilesView.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/FilesView.tsx
@@ -432,6 +432,7 @@ export function FilesView() {
 			addFileViewerPane(workspaceId, {
 				filePath: entry.path,
 				openInNewTab,
+				useRightSidebarOpenViewWidth: true,
 			});
 		},
 		[workspaceId, worktreePath, addFileViewerPane],

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/index.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/index.tsx
@@ -532,6 +532,7 @@ export function RightSidebar({ isActive = true }: { isActive?: boolean }) {
 				oldPath: file.oldPath
 					? toAbsoluteWorkspacePath(worktreePath, file.oldPath)
 					: undefined,
+				useRightSidebarOpenViewWidth: true,
 			});
 			invalidateFileContent(absolutePath);
 		},
@@ -543,6 +544,21 @@ export function RightSidebar({ isActive = true }: { isActive?: boolean }) {
 			scrollToFile(file, category, commitHash, worktreePath);
 		},
 		[scrollToFile, worktreePath],
+	);
+
+	const handleChangesOpenFileAtLine = useCallback(
+		(path: string, line?: number, column?: number) => {
+			if (!workspaceId || !worktreePath) return;
+			const absolutePath = toAbsoluteWorkspacePath(worktreePath, path);
+			addFileViewerPane(workspaceId, {
+				filePath: absolutePath,
+				viewMode: "raw",
+				line,
+				column,
+				useRightSidebarOpenViewWidth: true,
+			});
+		},
+		[workspaceId, worktreePath, addFileViewerPane],
 	);
 
 	const handleOpenFileAtLine = useCallback(
@@ -730,7 +746,7 @@ export function RightSidebar({ isActive = true }: { isActive?: boolean }) {
 				>
 					<ChangesView
 						onFileOpen={handleFileOpen}
-						onOpenFileAtLine={handleOpenFileAtLine}
+						onOpenFileAtLine={handleChangesOpenFileAtLine}
 						isExpandedView={isExpanded}
 						isActive={rightSidebarTab === RightSidebarTab.Changes}
 					/>

--- a/apps/desktop/src/renderer/stores/tabs/store.ts
+++ b/apps/desktop/src/renderer/stores/tabs/store.ts
@@ -1,6 +1,7 @@
 import type { MosaicNode } from "react-mosaic-component";
 import { updateTree } from "react-mosaic-component";
 import { getFileOpenMode } from "renderer/hooks/useFileOpenMode";
+import { getRightSidebarOpenViewWidth } from "renderer/hooks/useRightSidebarOpenViewWidth";
 import { posthog } from "renderer/lib/posthog";
 import { trpcTabsStorage } from "renderer/lib/trpc-storage";
 import { navigatePersistentWebview } from "renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/hooks/usePersistentWebview/runtime";
@@ -59,6 +60,8 @@ import {
 	resolveFileViewerMode,
 } from "./utils";
 import { killTerminalForPane } from "./utils/terminal-cleanup";
+
+const DEFAULT_FILE_VIEWER_SPLIT_PERCENTAGE = 50;
 
 /**
  * Finds the next best tab to activate when closing a tab.
@@ -1094,12 +1097,15 @@ export const useTabsStore = create<TabsStore>()(
 					}
 
 					const newPane = createFileViewerPane(activeTab.id, options);
+					const splitPercentage = options.useRightSidebarOpenViewWidth
+						? 100 - getRightSidebarOpenViewWidth()
+						: DEFAULT_FILE_VIEWER_SPLIT_PERCENTAGE;
 
 					const newLayout: MosaicNode<string> = {
 						direction: "row",
 						first: activeTab.layout,
 						second: newPane.id,
-						splitPercentage: 50,
+						splitPercentage,
 					};
 
 					const newPanes = { ...state.panes, [newPane.id]: newPane };

--- a/apps/desktop/src/renderer/stores/tabs/types.ts
+++ b/apps/desktop/src/renderer/stores/tabs/types.ts
@@ -92,6 +92,8 @@ export interface AddFileViewerPaneOptions {
 	openInNewTab?: boolean;
 	/** Controls whether file-viewer opens may reuse existing panes instead of always opening a fresh pane/tab */
 	reuseExisting?: FileViewerReuseScope;
+	/** If true, use the right sidebar initial split width setting for new split panes */
+	useRightSidebarOpenViewWidth?: boolean;
 }
 
 /**

--- a/apps/desktop/src/shared/constants.ts
+++ b/apps/desktop/src/shared/constants.ts
@@ -44,6 +44,9 @@ export const DEFAULT_TERMINAL_SCROLLBACK = 5000;
 export const DEFAULT_CONFIRM_ON_QUIT = true;
 export const DEFAULT_TERMINAL_LINK_BEHAVIOR = "file-viewer" as const;
 export const DEFAULT_FILE_OPEN_MODE = "split-pane" as const;
+export const DEFAULT_RIGHT_SIDEBAR_OPEN_VIEW_WIDTH = 50;
+export const MIN_RIGHT_SIDEBAR_OPEN_VIEW_WIDTH = 20;
+export const MAX_RIGHT_SIDEBAR_OPEN_VIEW_WIDTH = 80;
 export const DEFAULT_AUTO_APPLY_DEFAULT_PRESET = true;
 export const DEFAULT_SHOW_PRESETS_BAR = true;
 export const DEFAULT_USE_COMPACT_TERMINAL_ADD_BUTTON = true;
@@ -53,6 +56,13 @@ export const DEFAULT_OPEN_LINKS_IN_APP = false;
 export const DEFAULT_PREVENT_AGENT_SLEEP = false;
 export const SUPPORTS_AGENT_SLEEP_PREVENTION =
 	PLATFORM.IS_MAC || PLATFORM.IS_LINUX;
+
+export function clampRightSidebarOpenViewWidth(width: number): number {
+	return Math.max(
+		MIN_RIGHT_SIDEBAR_OPEN_VIEW_WIDTH,
+		Math.min(MAX_RIGHT_SIDEBAR_OPEN_VIEW_WIDTH, width),
+	);
+}
 
 // External links (documentation, help resources, etc.)
 export const EXTERNAL_LINKS = {

--- a/packages/local-db/drizzle/0042_add_right_sidebar_open_view_width_setting.sql
+++ b/packages/local-db/drizzle/0042_add_right_sidebar_open_view_width_setting.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `settings` ADD `right_sidebar_open_view_width` integer;

--- a/packages/local-db/drizzle/meta/0042_snapshot.json
+++ b/packages/local-db/drizzle/meta/0042_snapshot.json
@@ -1,0 +1,1508 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "1d380eb0-0748-4602-9082-2d3f9a28fbce",
+  "prevId": "33a62ad0-724c-4815-a569-2dffe4f1a76d",
+  "tables": {
+    "browser_history": {
+      "name": "browser_history",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "favicon_url": {
+          "name": "favicon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_visited_at": {
+          "name": "last_visited_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "visit_count": {
+          "name": "visit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "browser_history_url_unique": {
+          "name": "browser_history_url_unique",
+          "columns": [
+            "url"
+          ],
+          "isUnique": true
+        },
+        "browser_history_url_idx": {
+          "name": "browser_history_url_idx",
+          "columns": [
+            "url"
+          ],
+          "isUnique": false
+        },
+        "browser_history_last_visited_at_idx": {
+          "name": "browser_history_last_visited_at_idx",
+          "columns": [
+            "last_visited_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "browser_site_permissions": {
+      "name": "browser_site_permissions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "origin": {
+          "name": "origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'ask'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "browser_site_permissions_origin_idx": {
+          "name": "browser_site_permissions_origin_idx",
+          "columns": [
+            "origin"
+          ],
+          "isUnique": false
+        },
+        "browser_site_permissions_origin_kind_unique": {
+          "name": "browser_site_permissions_origin_kind_unique",
+          "columns": [
+            "origin",
+            "kind"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organization_members": {
+      "name": "organization_members",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organization_members_organization_id_idx": {
+          "name": "organization_members_organization_id_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "organization_members_user_id_idx": {
+          "name": "organization_members_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "organization_members_organization_id_organizations_id_fk": {
+          "name": "organization_members_organization_id_organizations_id_fk",
+          "tableFrom": "organization_members",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_members_user_id_users_id_fk": {
+          "name": "organization_members_user_id_users_id_fk",
+          "tableFrom": "organization_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organizations": {
+      "name": "organizations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "clerk_org_id": {
+          "name": "clerk_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "github_org": {
+          "name": "github_org",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organizations_clerk_org_id_unique": {
+          "name": "organizations_clerk_org_id_unique",
+          "columns": [
+            "clerk_org_id"
+          ],
+          "isUnique": true
+        },
+        "organizations_slug_unique": {
+          "name": "organizations_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        },
+        "organizations_slug_idx": {
+          "name": "organizations_slug_idx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": false
+        },
+        "organizations_clerk_org_id_idx": {
+          "name": "organizations_clerk_org_id_idx",
+          "columns": [
+            "clerk_org_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "main_repo_path": {
+          "name": "main_repo_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tab_order": {
+          "name": "tab_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_opened_at": {
+          "name": "last_opened_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config_toast_dismissed": {
+          "name": "config_toast_dismissed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_branch": {
+          "name": "default_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "workspace_base_branch": {
+          "name": "workspace_base_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "github_owner": {
+          "name": "github_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch_prefix_mode": {
+          "name": "branch_prefix_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch_prefix_custom": {
+          "name": "branch_prefix_custom",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "worktree_base_dir": {
+          "name": "worktree_base_dir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "hide_image": {
+          "name": "hide_image",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "icon_url": {
+          "name": "icon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "neon_project_id": {
+          "name": "neon_project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_app": {
+          "name": "default_app",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "projects_main_repo_path_idx": {
+          "name": "projects_main_repo_path_idx",
+          "columns": [
+            "main_repo_path"
+          ],
+          "isUnique": false
+        },
+        "projects_last_opened_at_idx": {
+          "name": "projects_last_opened_at_idx",
+          "columns": [
+            "last_opened_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "settings": {
+      "name": "settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "last_active_workspace_id": {
+          "name": "last_active_workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "terminal_presets": {
+          "name": "terminal_presets",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "terminal_presets_initialized": {
+          "name": "terminal_presets_initialized",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "agent_preset_overrides": {
+          "name": "agent_preset_overrides",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "agent_custom_definitions": {
+          "name": "agent_custom_definitions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "selected_ringtone_id": {
+          "name": "selected_ringtone_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "confirm_on_quit": {
+          "name": "confirm_on_quit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "terminal_link_behavior": {
+          "name": "terminal_link_behavior",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "persist_terminal": {
+          "name": "persist_terminal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "auto_apply_default_preset": {
+          "name": "auto_apply_default_preset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch_prefix_mode": {
+          "name": "branch_prefix_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch_prefix_custom": {
+          "name": "branch_prefix_custom",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notification_sounds_muted": {
+          "name": "notification_sounds_muted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notification_volume": {
+          "name": "notification_volume",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prevent_agent_sleep": {
+          "name": "prevent_agent_sleep",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "delete_local_branch": {
+          "name": "delete_local_branch",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "file_open_mode": {
+          "name": "file_open_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "right_sidebar_open_view_width": {
+          "name": "right_sidebar_open_view_width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "show_presets_bar": {
+          "name": "show_presets_bar",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "use_compact_terminal_add_button": {
+          "name": "use_compact_terminal_add_button",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "terminal_font_family": {
+          "name": "terminal_font_family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "terminal_font_size": {
+          "name": "terminal_font_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "editor_font_family": {
+          "name": "editor_font_family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "editor_font_size": {
+          "name": "editor_font_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "show_resource_monitor": {
+          "name": "show_resource_monitor",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "worktree_base_dir": {
+          "name": "worktree_base_dir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "open_links_in_app": {
+          "name": "open_links_in_app",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_editor": {
+          "name": "default_editor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "indent_rainbow_enabled": {
+          "name": "indent_rainbow_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "indent_rainbow_colors": {
+          "name": "indent_rainbow_colors",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trailing_spaces_enabled": {
+          "name": "trailing_spaces_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trailing_spaces_color": {
+          "name": "trailing_spaces_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tasks": {
+      "name": "tasks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status_color": {
+          "name": "status_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status_type": {
+          "name": "status_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status_position": {
+          "name": "status_position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "assignee_id": {
+          "name": "assignee_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "estimate": {
+          "name": "estimate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "labels": {
+          "name": "labels",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pr_url": {
+          "name": "pr_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_provider": {
+          "name": "external_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_key": {
+          "name": "external_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_url": {
+          "name": "external_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sync_error": {
+          "name": "sync_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tasks_slug_unique": {
+          "name": "tasks_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        },
+        "tasks_slug_idx": {
+          "name": "tasks_slug_idx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": false
+        },
+        "tasks_organization_id_idx": {
+          "name": "tasks_organization_id_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "tasks_assignee_id_idx": {
+          "name": "tasks_assignee_id_idx",
+          "columns": [
+            "assignee_id"
+          ],
+          "isUnique": false
+        },
+        "tasks_status_idx": {
+          "name": "tasks_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "tasks_created_at_idx": {
+          "name": "tasks_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "tasks_organization_id_organizations_id_fk": {
+          "name": "tasks_organization_id_organizations_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tasks_assignee_id_users_id_fk": {
+          "name": "tasks_assignee_id_users_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "assignee_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "tasks_creator_id_users_id_fk": {
+          "name": "tasks_creator_id_users_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "clerk_id": {
+          "name": "clerk_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_clerk_id_unique": {
+          "name": "users_clerk_id_unique",
+          "columns": [
+            "clerk_id"
+          ],
+          "isUnique": true
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        },
+        "users_email_idx": {
+          "name": "users_email_idx",
+          "columns": [
+            "email"
+          ],
+          "isUnique": false
+        },
+        "users_clerk_id_idx": {
+          "name": "users_clerk_id_idx",
+          "columns": [
+            "clerk_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "workspace_sections": {
+      "name": "workspace_sections",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tab_order": {
+          "name": "tab_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_collapsed": {
+          "name": "is_collapsed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "workspace_sections_project_id_idx": {
+          "name": "workspace_sections_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "workspace_sections_project_id_projects_id_fk": {
+          "name": "workspace_sections_project_id_projects_id_fk",
+          "tableFrom": "workspace_sections",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "workspaces": {
+      "name": "workspaces",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "worktree_id": {
+          "name": "worktree_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tab_order": {
+          "name": "tab_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_opened_at": {
+          "name": "last_opened_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_unread": {
+          "name": "is_unread",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_unnamed": {
+          "name": "is_unnamed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "deleting_at": {
+          "name": "deleting_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "port_base": {
+          "name": "port_base",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "section_id": {
+          "name": "section_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "workspaces_project_id_idx": {
+          "name": "workspaces_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "workspaces_worktree_id_idx": {
+          "name": "workspaces_worktree_id_idx",
+          "columns": [
+            "worktree_id"
+          ],
+          "isUnique": false
+        },
+        "workspaces_last_opened_at_idx": {
+          "name": "workspaces_last_opened_at_idx",
+          "columns": [
+            "last_opened_at"
+          ],
+          "isUnique": false
+        },
+        "workspaces_section_id_idx": {
+          "name": "workspaces_section_id_idx",
+          "columns": [
+            "section_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "workspaces_project_id_projects_id_fk": {
+          "name": "workspaces_project_id_projects_id_fk",
+          "tableFrom": "workspaces",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workspaces_worktree_id_worktrees_id_fk": {
+          "name": "workspaces_worktree_id_worktrees_id_fk",
+          "tableFrom": "workspaces",
+          "tableTo": "worktrees",
+          "columnsFrom": [
+            "worktree_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workspaces_section_id_workspace_sections_id_fk": {
+          "name": "workspaces_section_id_workspace_sections_id_fk",
+          "tableFrom": "workspaces",
+          "tableTo": "workspace_sections",
+          "columnsFrom": [
+            "section_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "worktrees": {
+      "name": "worktrees",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "base_branch": {
+          "name": "base_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "git_status": {
+          "name": "git_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "github_status": {
+          "name": "github_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_superset": {
+          "name": "created_by_superset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        }
+      },
+      "indexes": {
+        "worktrees_project_id_idx": {
+          "name": "worktrees_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "worktrees_branch_idx": {
+          "name": "worktrees_branch_idx",
+          "columns": [
+            "branch"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "worktrees_project_id_projects_id_fk": {
+          "name": "worktrees_project_id_projects_id_fk",
+          "tableFrom": "worktrees",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/local-db/drizzle/meta/_journal.json
+++ b/packages/local-db/drizzle/meta/_journal.json
@@ -295,6 +295,13 @@
       "when": 1775489797005,
       "tag": "0041_add_editor_features_and_site_permissions",
       "breakpoints": true
+    },
+    {
+      "idx": 42,
+      "version": "6",
+      "when": 1775708839194,
+      "tag": "0042_add_right_sidebar_open_view_width_setting",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/local-db/src/schema/schema.ts
+++ b/packages/local-db/src/schema/schema.ts
@@ -219,6 +219,7 @@ export const settings = sqliteTable("settings", {
 	preventAgentSleep: integer("prevent_agent_sleep", { mode: "boolean" }),
 	deleteLocalBranch: integer("delete_local_branch", { mode: "boolean" }),
 	fileOpenMode: text("file_open_mode").$type<FileOpenMode>(),
+	rightSidebarOpenViewWidth: integer("right_sidebar_open_view_width"),
 	showPresetsBar: integer("show_presets_bar", { mode: "boolean" }),
 	useCompactTerminalAddButton: integer("use_compact_terminal_add_button", {
 		mode: "boolean",


### PR DESCRIPTION
## Summary
- add a persisted behavior setting for the initial width of new views opened from the right sidebar
- apply the setting to Files and right-sidebar Changes diff opens in legacy workspace tabs
- apply the same setting to Files opens in the v2 workspace layout while leaving GitGraph behavior unchanged

## Verification
- `git diff --name-only -z | xargs -0 bunx @biomejs/biome@2.4.2 check`
- `bun run lint` *(fails due to pre-existing warnings in `apps/desktop/src/main/lib/vscode-shim/*`, `CodeMirrorDiffViewer.tsx`, and `CodeEditor.tsx`)*
- `bun run typecheck` *(fails due to pre-existing errors in `apps/desktop/src/renderer/routes/_authenticated/settings/models/components/ModelsSettings/ModelsSettings.tsx`)*

## Notes
- This addresses the Files / Changes diff viewer path discussed in issue #128.
- `GitGraph` itself is intentionally left on its current open behavior per implementation decision.

Closes #128
