### PR TITLE
fix(desktop): インライン自動補完の過剰発火を改善

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/components/CodeMirrorDiffViewer/CodeMirrorDiffViewer.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/components/CodeMirrorDiffViewer/CodeMirrorDiffViewer.tsx
@@ -276,8 +276,8 @@ export function CodeMirrorDiffViewer({
 			inlineCompletionCompartmentB.of(
 				inlineCompletionRequestRef.current
 					? createInlineCompletionPlugin(
-							(args) =>
-								inlineCompletionRequestRef.current?.(args) ??
+							(args, signal) =>
+								inlineCompletionRequestRef.current?.(args, signal) ??
 								Promise.resolve(null),
 						)
 					: [],
@@ -404,8 +404,8 @@ export function CodeMirrorDiffViewer({
 			effects: inlineCompletionCompartmentB.reconfigure(
 				hasInlineCompletionRequest
 					? createInlineCompletionPlugin(
-							(args) =>
-								inlineCompletionRequestRef.current?.(args) ??
+							(args, signal) =>
+								inlineCompletionRequestRef.current?.(args, signal) ??
 								Promise.resolve(null),
 						)
 					: [],

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/hooks/useNextEditCompletion.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/hooks/useNextEditCompletion.ts
@@ -267,13 +267,16 @@ export function useNextEditCompletion({
 	);
 
 	const requestInlineCompletion = useCallback(
-		async ({
-			currentFileContent,
-			cursorOffset,
-		}: {
-			currentFileContent: string;
-			cursorOffset: number;
-		}) => {
+		async (
+			{
+				currentFileContent,
+				cursorOffset,
+			}: {
+				currentFileContent: string;
+				cursorOffset: number;
+			},
+			signal: AbortSignal,
+		) => {
 			if (!isAvailable) {
 				logNextEditDebug("request skipped: unavailable", {
 					filePath,
@@ -283,8 +286,13 @@ export function useNextEditCompletion({
 				return null;
 			}
 
+			if (signal.aborted) return null;
+
 			try {
 				flushPendingEditHistory();
+
+				if (signal.aborted) return null;
+
 				const nextSnippet = extractSnippetAtCursor({
 					filePath,
 					content: currentFileContent,
@@ -312,6 +320,8 @@ export function useNextEditCompletion({
 						.map((entry) => entry.slice(0, 160)),
 				});
 
+				if (signal.aborted) return null;
+
 				const result = await completeMutationRef.current.mutateAsync({
 					filePath,
 					currentFileContent,
@@ -322,6 +332,9 @@ export function useNextEditCompletion({
 					})),
 					editHistory: editHistoryRef.current,
 				});
+
+				if (signal.aborted) return null;
+
 				logNextEditDebug("request completed", {
 					filePath,
 					hasInsertText: Boolean(result.insertText),
@@ -331,7 +344,10 @@ export function useNextEditCompletion({
 				});
 				return result.insertText;
 			} catch (error) {
-				console.log("[NextEdit] request failed", {
+				if (signal.aborted) {
+					return null;
+				}
+				console.error("[NextEdit] request failed", {
 					filePath,
 					error,
 				});

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/components/CodeEditor/CodeEditor.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/components/CodeEditor/CodeEditor.tsx
@@ -528,8 +528,8 @@ export function CodeEditor({
 				inlineCompletionCompartment.of(
 					inlineCompletionRequestRef.current
 						? createInlineCompletionPlugin(
-								(args) =>
-									inlineCompletionRequestRef.current?.(args) ??
+								(args, signal) =>
+									inlineCompletionRequestRef.current?.(args, signal) ??
 									Promise.resolve(null),
 							)
 						: [],
@@ -708,8 +708,8 @@ export function CodeEditor({
 			effects: inlineCompletionCompartment.reconfigure(
 				hasInlineCompletionRequest
 					? createInlineCompletionPlugin(
-							(args) =>
-								inlineCompletionRequestRef.current?.(args) ??
+							(args, signal) =>
+								inlineCompletionRequestRef.current?.(args, signal) ??
 								Promise.resolve(null),
 						)
 					: [],

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/components/CodeEditor/createInlineCompletionPlugin.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/components/CodeEditor/createInlineCompletionPlugin.ts
@@ -20,6 +20,7 @@ export interface InlineCompletionRequestArgs {
 
 export type InlineCompletionRequest = (
 	args: InlineCompletionRequestArgs,
+	signal: AbortSignal,
 ) => Promise<string | null>;
 
 function logInlineCompletionDebug(
@@ -120,7 +121,7 @@ export function createInlineCompletionPlugin(
 	request: InlineCompletionRequest,
 	options?: { delayMs?: number },
 ) {
-	const delayMs = options?.delayMs ?? 350;
+	const delayMs = options?.delayMs ?? 600;
 
 	const plugin = ViewPlugin.fromClass(
 		class {
@@ -130,15 +131,44 @@ export function createInlineCompletionPlugin(
 			private lastSnapshotKey: string | null = null;
 			private lastSnapshotSuggestion: string | null = null;
 			private inFlightSnapshotKey: string | null = null;
+			private abortController: AbortController | null = null;
 
 			constructor(private readonly view: EditorView) {
 				this.schedule();
 			}
 
 			update(update: ViewUpdate) {
-				if (update.docChanged || update.selectionSet || update.focusChanged) {
-					this.schedule();
+				if (!update.docChanged) {
+					return;
 				}
+
+				const isUserInput = update.transactions.some(
+					(tr) => tr.isUserEvent("input") || tr.isUserEvent("delete"),
+				);
+				if (!isUserInput) {
+					return;
+				}
+
+				const hasNonWhitespaceChange = update.transactions.some((tr) => {
+					let found = false;
+					tr.changes.iterChanges((_fromA, _toA, _fromB, _toB, inserted) => {
+						if (found) return;
+						if (_toA > _fromA) {
+							found = true;
+							return;
+						}
+						const text = inserted.toString();
+						if (text.length > 0 && text.trim().length > 0) {
+							found = true;
+						}
+					});
+					return found;
+				});
+				if (!hasNonWhitespaceChange) {
+					return;
+				}
+
+				this.schedule();
 			}
 
 			destroy() {
@@ -147,6 +177,7 @@ export function createInlineCompletionPlugin(
 					window.clearTimeout(this.timeoutId);
 					this.timeoutId = null;
 				}
+				this.abortController?.abort();
 			}
 
 			private applySuggestionAfterUpdate(suggestion: string | null) {
@@ -171,6 +202,8 @@ export function createInlineCompletionPlugin(
 					window.clearTimeout(this.timeoutId);
 					this.timeoutId = null;
 				}
+				this.abortController?.abort();
+				this.abortController = null;
 
 				const selection = this.view.state.selection.main;
 				if (
@@ -222,11 +255,17 @@ export function createInlineCompletionPlugin(
 				});
 				this.timeoutId = window.setTimeout(() => {
 					this.timeoutId = null;
+					const controller = new AbortController();
+					this.abortController = controller;
+					const { signal } = controller;
 					this.inFlightSnapshotKey = snapshotKey;
-					void request({
-						currentFileContent: snapshotText,
-						cursorOffset: snapshotCursor,
-					})
+					void request(
+						{
+							currentFileContent: snapshotText,
+							cursorOffset: snapshotCursor,
+						},
+						signal,
+					)
 						.then((suggestion) => {
 							if (this.inFlightSnapshotKey === snapshotKey) {
 								this.inFlightSnapshotKey = null;
@@ -276,10 +315,13 @@ export function createInlineCompletionPlugin(
 							if (this.inFlightSnapshotKey === snapshotKey) {
 								this.inFlightSnapshotKey = null;
 							}
+							if (signal.aborted) {
+								return;
+							}
 							if (this.destroyed || currentRequestId !== this.requestId) {
 								return;
 							}
-							console.log("[InlineCompletion] request failed", {
+							console.error("[InlineCompletion] request failed", {
 								requestId: currentRequestId,
 								error,
 							});

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/components/CodeEditor/createInlineCompletionPlugin.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/components/CodeEditor/createInlineCompletionPlugin.ts
@@ -149,16 +149,21 @@ export function createInlineCompletionPlugin(
 					return;
 				}
 
+				// "significant change" = any deletion (_toA > _fromA) OR non-whitespace insertion.
+				// Whitespace-only insertions (e.g. pressing Space/Enter alone) are skipped
+				// to avoid triggering completion on formatting keystrokes.
 				const hasNonWhitespaceChange = update.transactions.some((tr) => {
 					let found = false;
 					tr.changes.iterChanges((_fromA, _toA, _fromB, _toB, inserted) => {
 						if (found) return;
 						if (_toA > _fromA) {
+							// Any deletion counts as a significant change
 							found = true;
 							return;
 						}
 						const text = inserted.toString();
 						if (text.length > 0 && text.trim().length > 0) {
+							// Non-whitespace insertion
 							found = true;
 						}
 					});


### PR DESCRIPTION
close MocA-Love/superset#126

## 概要

Desktop アプリのインライン自動補完が入力中に過剰発火し、UX が悪い問題を修正。VS Code / Copilot に近い補完体感を実現する。

## 変更内容

- `createInlineCompletionPlugin.ts`
  - 発火条件を `docChanged` + ユーザー入力イベント（typing/delete）のみに絞る（`selectionSet`・`focusChanged` を除去）
  - 空白のみの変更では補完をスキップ（削除または非空白挿入がある場合のみスケジュール）
  - debounce delay を `350ms` → `600ms` に引き上げ
  - `AbortController` を導入し、新しいリクエスト発火時に前のリクエストをキャンセル
- `useNextEditCompletion.ts`
  - `requestInlineCompletion` に `signal: AbortSignal` 引数を追加
  - 各フェーズで `signal.aborted` をチェックし、古い応答を破棄
- `CodeEditor.tsx` / `CodeMirrorDiffViewer.tsx`
  - ラッパー関数に `signal` を追加し、`requestInlineCompletion` に渡すよう更新

## 動作の変化

| 項目 | 修正前 | 修正後 |
|------|--------|--------|
| 発火トリガー | 文字入力・カーソル移動・フォーカス変更すべて | 文字入力（typing/delete）のみ |
| 空白のみ入力 | 補完リクエストを送信 | スキップ |
| debounce | 350ms | 600ms |
| 古いリクエストの扱い | requestId で stale 判定のみ | AbortController でキャンセル + 古い応答を破棄 |

## テスト方法

1. Desktop アプリを起動
2. コードエディタでコードを入力し、補完が自然なタイミングで表示されることを確認
3. カーソル移動のみ、フォーカス変更のみでは補完が発火しないことを確認
4. 高速入力時に古い補完が表示されないことを確認
5. paste（貼り付け）・IME（日本語確定）時は補完が発火することを確認