### PR TITLE
fix(desktop): Pane削除後のターミナル上部空白を修正

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/helpers.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/helpers.ts
@@ -797,6 +797,7 @@ export function setupResizeHandlers(
 		const buffer = xterm.buffer.active;
 		const wasAtBottom = buffer.viewportY >= buffer.baseY;
 		fitAddon.fit();
+		xterm.refresh(0, Math.max(0, xterm.rows - 1));
 		onResize(xterm.cols, xterm.rows);
 		if (wasAtBottom) {
 			requestAnimationFrame(() => scrollToBottom(xterm));


### PR DESCRIPTION
close #125

## 概要

複数Paneに分割した状態でPaneを閉じると、残ったターミナル（特にCodex等のTUIアプリ実行中）の上部に巨大な空白が発生する問題を修正する。

## 原因

`setupResizeHandlers` 内で `fitAddon.fit()` の後に `xterm.refresh()` が呼ばれていなかった。

`fitAddon.fit()` はバッファサイズを変更するだけで再描画を行わないため、Paneリサイズ後にレンダラーの描画が古いままになり、上部に空白が発生していた。`runReattachRecovery` では `fitAddon.fit()` の直後に `xterm.refresh()` を呼んでいたが、通常のResizeObserver経路ではこの処理が抜けていた。

## 変更内容

- `helpers.ts`: `setupResizeHandlers` の `fitAddon.fit()` 直後に `xterm.refresh(0, Math.max(0, xterm.rows - 1))` を追加

## 修正前後の比較

| | 修正前 | 修正後 |
|---|---|---|
| Pane削除後の再描画 | fit()のみ（描画は古いまま） | fit() + refresh()（描画を強制更新） |
| 上部の空白 | 発生する | 発生しない |

## テスト方法

1. タブを複数Paneに分割する
2. さらに横にPaneを追加する（3分割以上）
3. 追加したPaneを閉じる
4. 残ったターミナルの上部に空白が発生しないことを確認（特にCodex等のTUIアプリ実行中）