### PR TITLE
chore(upstream): PR1 - 確実に安全なupstream fix 3件取り込み

### DIFF
--- a/.github/prompts/triage-issue.md
+++ b/.github/prompts/triage-issue.md
@@ -22,8 +22,9 @@ You are triaging GitHub issue `$ISSUE_NUMBER`. Your goal is to:
    - Run any nearby targeted tests needed to validate the fix.
    - If a safe fix is not clear, keep this as reproduction-only and continue to step 6A.
 
-6. **Open exactly one PR** — Run `bun run lint:fix`, then commit, push, and create a PR:
-   - **6A: Reproduction-only PR (reproducible but not solved)**
+6. **Open exactly one PR** — Run `bun run lint:fix`, then commit, push, and create a PR.
+   **Default to draft** (`gh pr create --draft`) unless the issue is high priority (labeled `priority: high` or `priority: critical`, or the issue describes data loss, security, or a production outage) **and** you are highly confident in the fix (clear root cause, minimal scoped change, all relevant tests pass). Only in that case, create as ready for review (omit `--draft`).
+   - **6A: Reproduction-only PR (reproducible but not solved)** — always draft.
      - Title: `test: reproduce #$ISSUE_NUMBER — <short bug description>`
      - Body should include:
        - What the bug is (in your own words, based on the issue)

--- a/.superset/lib/setup/steps.sh
+++ b/.superset/lib/setup/steps.sh
@@ -259,6 +259,7 @@ step_start_electric() {
 
   if ! docker run -d \
       --name "$ELECTRIC_CONTAINER" \
+      --restart unless-stopped \
       $port_flag \
       -e DATABASE_URL="$DIRECT_URL" \
       -e ELECTRIC_SECRET="$ELECTRIC_SECRET" \

--- a/packages/auth/src/server.ts
+++ b/packages/auth/src/server.ts
@@ -329,7 +329,23 @@ export const auth = betterAuth({
 					});
 				},
 
-				beforeAddMember: async ({ organization }) => {
+				beforeAddMember: async ({ organization, user }) => {
+					// Domain-allowlisted users bypass the free-plan member limit.
+					// If an admin put the user's domain in allowedDomains, they've
+					// already explicitly opted in to letting those users join.
+					// (allowedDomains isn't on the hook's organization arg because
+					// it isn't declared as a better-auth additionalField — fetch it.)
+					const userDomain = user.email.split("@")[1]?.toLowerCase();
+					if (userDomain) {
+						const orgRow = await db.query.organizations.findFirst({
+							where: eq(authSchema.organizations.id, organization.id),
+							columns: { allowedDomains: true },
+						});
+						if (orgRow?.allowedDomains?.includes(userDomain)) {
+							return;
+						}
+					}
+
 					const subscription = await db.query.subscriptions.findFirst({
 						where: and(
 							eq(subscriptions.referenceId, organization.id),


### PR DESCRIPTION
## Summary

upstream (superset-sh/superset) から behind していた25コミットのうち、「確実に安全」と判定した3件を取り込みます。PR分割戦略の第1弾です。

## 取り込みコミット

| 元コミット | 内容 |
|---|---|
| `efc736fa2` (#3221) | ci: triage workflow PRsをデフォルトでdraftにする（プロンプト文言のみ） |
| `a57f9fbbb` (#3243) | fix: Electric SQL containers に restart policy 追加（steps.sh 1行） |
| `dfafa5af7` (#3296) | fix(auth): domain allowlist加入時に free-plan メンバー上限をバイパス（packages/auth/server.ts） |

## スキップしたコミット（当初「確実に安全」判定だったが要見直し）

- `ff57e31d9` (#3308) build-cli.yml 権限追加 → `build-cli.yml` は `7ab64a72d` (#3298 standalone CLI) で追加されたファイルでまだforkに存在しない。**PR6（CLI release pipeline）で `7ab64a72d` と一緒に取り込む**
- `dbf83207e` (#3303) v2 host-service jwtProcedure化 → upstream で `device` → `host` へのリネーム/auth モデル変更が前提。**`50e609fb7` (relay) 取り込み時に一括対応が必要**

## 検証

- [x] 3コミットを chronological order で cherry-pick（コンフリクトなし）
- [x] `bun run typecheck` 実行 → `ModelsSettings.tsx` に既存エラーはあるが main にも同様に存在し本PRとは無関係

## Test plan

- [ ] CI通過確認
- [ ] rv-pr スキルによるレビュー