### PR TITLE
chore(upstream): PR2 - おそらく安全なupstream fix 5件取り込み

### DIFF
--- a/apps/api/MCP_TOOLS.md
+++ b/apps/api/MCP_TOOLS.md
@@ -161,12 +161,10 @@ const listTaskStatusesOutput = z.object({
 These tools write to `agent_commands` table and poll for results.
 
 #### `list_devices`
-List online devices in the organization.
+List registered devices in the organization.
 
 ```typescript
-const listDevicesInput = z.object({
-  includeOffline: z.boolean().default(false).describe("Include recently offline devices"),
-});
+const listDevicesInput = z.object({});
 
 const listDevicesOutput = z.object({
   devices: z.array(z.object({
@@ -176,7 +174,6 @@ const listDevicesOutput = z.object({
     ownerId: z.string().uuid().describe("User who owns this device"),
     ownerName: z.string().describe("Name of device owner"),
     lastSeenAt: z.string().datetime(),
-    isOnline: z.boolean(),
   })),
 });
 ```

--- a/apps/api/src/app/api/integrations/slack/events/utils/run-agent/run-agent.ts
+++ b/apps/api/src/app/api/integrations/slack/events/utils/run-agent/run-agent.ts
@@ -370,7 +370,7 @@ async function fetchAgentContext({
 		mcpClient.callTool({ name: "list_task_statuses", arguments: {} }),
 		mcpClient.callTool({
 			name: "list_devices",
-			arguments: { includeOffline: true },
+			arguments: {},
 		}),
 	]);
 
@@ -409,13 +409,12 @@ async function fetchAgentContext({
 			deviceName: string | null;
 			ownerName: string | null;
 			ownerEmail: string;
-			isOnline: boolean;
 		}[];
 	} | null;
 	if (devicesData?.devices?.length) {
 		const lines = devicesData.devices.map(
 			(d) =>
-				`- ${d.deviceName ?? "Unknown"} (id: ${d.deviceId}, owner: ${d.ownerName ?? d.ownerEmail}, status: ${d.isOnline ? "online" : "offline"})`,
+				`- ${d.deviceName ?? "Unknown"} (id: ${d.deviceId}, owner: ${d.ownerName ?? d.ownerEmail})`,
 		);
 		sections.push(`Devices:\n${lines.join("\n")}`);
 	}

--- a/apps/desktop/src/renderer/lib/terminal/terminal-runtime-registry.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-runtime-registry.ts
@@ -153,6 +153,16 @@ class TerminalRuntimeRegistryImpl {
 	}
 }
 
-export const terminalRuntimeRegistry = new TerminalRuntimeRegistryImpl();
+// In dev, preserve the singleton across Vite HMR so active WebSocket
+// connections and xterm instances aren't orphaned on module re-evaluation.
+// import.meta.hot is undefined in production so this is a plain `new` call.
+export const terminalRuntimeRegistry: TerminalRuntimeRegistryImpl =
+	(import.meta.hot?.data?.registry as
+		| TerminalRuntimeRegistryImpl
+		| undefined) ?? new TerminalRuntimeRegistryImpl();
+
+if (import.meta.hot) {
+	import.meta.hot.data.registry = terminalRuntimeRegistry;
+}
 
 export type { ConnectionState };

--- a/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
@@ -47,6 +47,7 @@ function createTerminal(
 		macOptionIsMeta: false,
 		cursorStyle: "block",
 		cursorInactiveStyle: "outline",
+		vtExtensions: { kittyKeyboard: true },
 		scrollbar: { showScrollbar: false },
 	});
 	terminal.loadAddon(fitAddon);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/DashboardSidebar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/DashboardSidebar.tsx
@@ -1,10 +1,81 @@
+import {
+	closestCenter,
+	DndContext,
+	type DragEndEvent,
+	DragOverlay,
+	KeyboardSensor,
+	MeasuringStrategy,
+	MouseSensor,
+	TouchSensor,
+	useSensor,
+	useSensors,
+} from "@dnd-kit/core";
+import {
+	arrayMove,
+	SortableContext,
+	sortableKeyboardCoordinates,
+	useSortable,
+	verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { createPortal } from "react-dom";
+import { useDashboardSidebarState } from "renderer/routes/_authenticated/hooks/useDashboardSidebarState";
 import { DashboardSidebarHeader } from "./components/DashboardSidebarHeader";
 import { DashboardSidebarProjectSection } from "./components/DashboardSidebarProjectSection";
 import { useDashboardSidebarData } from "./hooks/useDashboardSidebarData";
 import { useDashboardSidebarShortcuts } from "./hooks/useDashboardSidebarShortcuts";
+import type { DashboardSidebarProject } from "./types";
 
 interface DashboardSidebarProps {
 	isCollapsed?: boolean;
+}
+
+function SortableProjectWrapper({
+	project,
+	isCollapsed,
+	isDraggingProject,
+	workspaceShortcutLabels,
+	onWorkspaceHover,
+	onToggleCollapse,
+}: {
+	project: DashboardSidebarProject;
+	isCollapsed: boolean;
+	isDraggingProject: boolean;
+	workspaceShortcutLabels: Map<string, string>;
+	onWorkspaceHover: (workspaceId: string) => void | Promise<void>;
+	onToggleCollapse: (projectId: string) => void;
+}) {
+	const {
+		attributes,
+		listeners,
+		setNodeRef,
+		transform,
+		transition,
+		isDragging,
+	} = useSortable({ id: project.id });
+
+	return (
+		<div
+			ref={setNodeRef}
+			style={{
+				transform: CSS.Translate.toString(transform),
+				transition,
+				opacity: isDragging ? 0.5 : undefined,
+			}}
+		>
+			<DashboardSidebarProjectSection
+				project={project}
+				isSidebarCollapsed={isCollapsed}
+				isDraggingProject={isDraggingProject}
+				workspaceShortcutLabels={workspaceShortcutLabels}
+				onWorkspaceHover={onWorkspaceHover}
+				onToggleCollapse={onToggleCollapse}
+				dragHandleListeners={listeners}
+				dragHandleAttributes={attributes}
+			/>
+		</div>
+	);
 }
 
 export function DashboardSidebar({
@@ -13,22 +84,105 @@ export function DashboardSidebar({
 	const { groups, refreshWorkspacePullRequest, toggleProjectCollapsed } =
 		useDashboardSidebarData();
 	const workspaceShortcutLabels = useDashboardSidebarShortcuts(groups);
+	const { reorderProjects } = useDashboardSidebarState();
+
+	const sensors = useSensors(
+		useSensor(MouseSensor, { activationConstraint: { distance: 8 } }),
+		useSensor(TouchSensor, {
+			activationConstraint: { delay: 200, tolerance: 5 },
+		}),
+		useSensor(KeyboardSensor, {
+			coordinateGetter: sortableKeyboardCoordinates,
+		}),
+	);
+
+	const [activeProject, setActiveProject] =
+		useState<DashboardSidebarProject | null>(null);
+
+	// Local project order — syncs from groups, updated on drag end
+	const [projectOrder, setProjectOrder] = useState(() =>
+		groups.map((p) => p.id),
+	);
+	useEffect(() => {
+		setProjectOrder(groups.map((p) => p.id));
+	}, [groups]);
+
+	const orderedGroups = useMemo(() => {
+		const byId = new Map(groups.map((g) => [g.id, g]));
+		return projectOrder
+			.map((id) => byId.get(id))
+			.filter((g): g is DashboardSidebarProject => g != null);
+	}, [groups, projectOrder]);
+
+	const handleDragEnd = useCallback(
+		({ active, over }: DragEndEvent) => {
+			if (over && active.id !== over.id) {
+				const oldIndex = projectOrder.indexOf(String(active.id));
+				const newIndex = projectOrder.indexOf(String(over.id));
+				if (oldIndex !== -1 && newIndex !== -1) {
+					const reordered = arrayMove(projectOrder, oldIndex, newIndex);
+					setProjectOrder(reordered);
+					reorderProjects(reordered);
+				}
+			}
+			setActiveProject(null);
+		},
+		[projectOrder, reorderProjects],
+	);
 
 	return (
 		<div className="flex h-full flex-col border-r border-border bg-muted/45 dark:bg-muted/35">
 			<DashboardSidebarHeader isCollapsed={isCollapsed} />
 
 			<div className="flex-1 overflow-y-auto hide-scrollbar">
-				{groups.map((project) => (
-					<DashboardSidebarProjectSection
-						key={project.id}
-						project={project}
-						isSidebarCollapsed={isCollapsed}
-						workspaceShortcutLabels={workspaceShortcutLabels}
-						onWorkspaceHover={refreshWorkspacePullRequest}
-						onToggleCollapse={toggleProjectCollapsed}
-					/>
-				))}
+				<DndContext
+					sensors={sensors}
+					collisionDetection={closestCenter}
+					measuring={{
+						droppable: { strategy: MeasuringStrategy.Always },
+					}}
+					onDragStart={({ active }) => {
+						const project = groups.find((p) => p.id === active.id);
+						setActiveProject(project ?? null);
+					}}
+					onDragEnd={handleDragEnd}
+					onDragCancel={() => setActiveProject(null)}
+				>
+					<SortableContext
+						items={projectOrder}
+						strategy={verticalListSortingStrategy}
+					>
+						{orderedGroups.map((project) => (
+							<SortableProjectWrapper
+								key={project.id}
+								project={project}
+								isCollapsed={isCollapsed}
+								isDraggingProject={activeProject != null}
+								workspaceShortcutLabels={workspaceShortcutLabels}
+								onWorkspaceHover={refreshWorkspacePullRequest}
+								onToggleCollapse={toggleProjectCollapsed}
+							/>
+						))}
+					</SortableContext>
+
+					{createPortal(
+						<DragOverlay dropAnimation={null}>
+							{activeProject && (
+								<div className="bg-background shadow-lg border-b border-border">
+									<DashboardSidebarProjectSection
+										project={activeProject}
+										isSidebarCollapsed={isCollapsed}
+										isDraggingProject
+										workspaceShortcutLabels={workspaceShortcutLabels}
+										onWorkspaceHover={() => {}}
+										onToggleCollapse={() => {}}
+									/>
+								</div>
+							)}
+						</DragOverlay>,
+						document.body,
+					)}
+				</DndContext>
 			</div>
 		</div>
 	);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarProjectSection/DashboardSidebarProjectSection.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarProjectSection/DashboardSidebarProjectSection.tsx
@@ -1,10 +1,12 @@
+import type {
+	DraggableAttributes,
+	DraggableSyntheticListeners,
+} from "@dnd-kit/core";
 import { cn } from "@superset/ui/utils";
+import { AnimatePresence, motion } from "framer-motion";
 import { useMemo } from "react";
 import type { DashboardSidebarProject } from "../../types";
-import {
-	getProjectChildrenSections,
-	getProjectChildrenWorkspaces,
-} from "../../utils/projectChildren";
+import { getProjectChildrenWorkspaces } from "../../utils/projectChildren";
 import { DashboardSidebarCollapsedProjectContent } from "./components/DashboardSidebarCollapsedProjectContent";
 import { DashboardSidebarExpandedProjectContent } from "./components/DashboardSidebarExpandedProjectContent";
 import { DashboardSidebarProjectContextMenu } from "./components/DashboardSidebarProjectContextMenu";
@@ -14,23 +16,24 @@ import { useDashboardSidebarProjectSectionActions } from "./hooks/useDashboardSi
 interface DashboardSidebarProjectSectionProps {
 	project: DashboardSidebarProject;
 	isSidebarCollapsed?: boolean;
+	isDraggingProject?: boolean;
 	workspaceShortcutLabels: Map<string, string>;
 	onWorkspaceHover: (workspaceId: string) => void | Promise<void>;
 	onToggleCollapse: (projectId: string) => void;
+	dragHandleListeners?: DraggableSyntheticListeners;
+	dragHandleAttributes?: DraggableAttributes;
 }
 
 export function DashboardSidebarProjectSection({
 	project,
 	isSidebarCollapsed = false,
+	isDraggingProject = false,
 	workspaceShortcutLabels,
 	onWorkspaceHover,
 	onToggleCollapse,
+	dragHandleListeners,
+	dragHandleAttributes,
 }: DashboardSidebarProjectSectionProps) {
-	const allSections = useMemo(
-		() => getProjectChildrenSections(project.children),
-		[project.children],
-	);
-
 	const flattenedCollapsedWorkspaces = useMemo(
 		() => getProjectChildrenWorkspaces(project.children),
 		[project.children],
@@ -104,19 +107,33 @@ export function DashboardSidebarProjectSection({
 					onStartRename={startRename}
 					onToggleCollapse={() => onToggleCollapse(project.id)}
 					onNewWorkspace={handleNewWorkspace}
+					{...(dragHandleAttributes ?? {})}
+					{...(dragHandleListeners ?? {})}
 				/>
 			</DashboardSidebarProjectContextMenu>
 
-			<DashboardSidebarExpandedProjectContent
-				isCollapsed={project.isCollapsed}
-				projectChildren={project.children}
-				allSections={allSections}
-				workspaceShortcutLabels={workspaceShortcutLabels}
-				onWorkspaceHover={onWorkspaceHover}
-				onDeleteSection={deleteSection}
-				onRenameSection={renameSection}
-				onToggleSectionCollapse={toggleSectionCollapsed}
-			/>
+			<AnimatePresence initial={false}>
+				{!isDraggingProject && (
+					<motion.div
+						initial={{ height: 0, opacity: 0 }}
+						animate={{ height: "auto", opacity: 1 }}
+						exit={{ height: 0, opacity: 0 }}
+						transition={{ duration: 0.15, ease: "easeOut" }}
+						className="overflow-hidden"
+					>
+						<DashboardSidebarExpandedProjectContent
+							projectId={project.id}
+							isCollapsed={project.isCollapsed}
+							projectChildren={project.children}
+							workspaceShortcutLabels={workspaceShortcutLabels}
+							onWorkspaceHover={onWorkspaceHover}
+							onDeleteSection={deleteSection}
+							onRenameSection={renameSection}
+							onToggleSectionCollapse={toggleSectionCollapsed}
+						/>
+					</motion.div>
+				)}
+			</AnimatePresence>
 		</div>
 	);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarProjectSection/components/DashboardSidebarExpandedProjectContent/DashboardSidebarExpandedProjectContent.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarProjectSection/components/DashboardSidebarExpandedProjectContent/DashboardSidebarExpandedProjectContent.tsx
@@ -1,12 +1,21 @@
+import { DndContext, DragOverlay } from "@dnd-kit/core";
+import {
+	SortableContext,
+	verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
 import { AnimatePresence, motion } from "framer-motion";
+import { createPortal } from "react-dom";
+import { useSidebarDnd } from "../../../../hooks/useSidebarDnd";
+import { parseId } from "../../../../hooks/useSidebarDnd/useSidebarDnd";
 import type { DashboardSidebarProjectChild } from "../../../../types";
-import { DashboardSidebarSection as DashboardSidebarSectionComponent } from "../../../DashboardSidebarSection";
-import { DashboardSidebarWorkspaceItem } from "../../../DashboardSidebarWorkspaceItem";
+import { SidebarDragOverlay } from "../../../SidebarDragOverlay";
+import { SortableSectionHeader } from "../../../SortableSectionHeader";
+import { SortableWorkspaceItem } from "../../../SortableWorkspaceItem";
 
 interface DashboardSidebarExpandedProjectContentProps {
+	projectId: string;
 	isCollapsed: boolean;
 	projectChildren: DashboardSidebarProjectChild[];
-	allSections: Array<{ id: string; name: string }>;
 	workspaceShortcutLabels: Map<string, string>;
 	onWorkspaceHover: (workspaceId: string) => void | Promise<void>;
 	onDeleteSection: (sectionId: string) => void;
@@ -15,15 +24,32 @@ interface DashboardSidebarExpandedProjectContentProps {
 }
 
 export function DashboardSidebarExpandedProjectContent({
+	projectId,
 	isCollapsed,
 	projectChildren,
-	allSections,
 	workspaceShortcutLabels,
 	onWorkspaceHover,
 	onDeleteSection,
 	onRenameSection,
 	onToggleSectionCollapse,
 }: DashboardSidebarExpandedProjectContentProps) {
+	const {
+		sensors,
+		measuring,
+		collisionDetection,
+		flatItems,
+		sortableItems,
+		activeId,
+		activeType,
+		activeItem,
+		predictedColor,
+		groupInfo,
+		collapsedSectionIds,
+		workspacesById,
+		sectionsById,
+		handlers,
+	} = useSidebarDnd({ projectId, projectChildren });
+
 	return (
 		<AnimatePresence initial={false}>
 			{!isCollapsed && (
@@ -35,30 +61,84 @@ export function DashboardSidebarExpandedProjectContent({
 					className="overflow-hidden"
 				>
 					<div className="pb-1">
-						{projectChildren.map((child) =>
-							child.type === "workspace" ? (
-								<DashboardSidebarWorkspaceItem
-									key={child.workspace.id}
-									workspace={child.workspace}
-									onHoverCardOpen={() => onWorkspaceHover(child.workspace.id)}
-									shortcutLabel={workspaceShortcutLabels.get(
-										child.workspace.id,
-									)}
-								/>
-							) : (
-								<DashboardSidebarSectionComponent
-									key={child.section.id}
-									projectId={child.section.projectId}
-									section={child.section}
-									allSections={allSections}
-									workspaceShortcutLabels={workspaceShortcutLabels}
-									onWorkspaceHover={onWorkspaceHover}
-									onDelete={onDeleteSection}
-									onRename={onRenameSection}
-									onToggleCollapse={onToggleSectionCollapse}
-								/>
-							),
-						)}
+						<DndContext
+							sensors={sensors}
+							collisionDetection={collisionDetection}
+							measuring={measuring}
+							{...handlers}
+						>
+							<SortableContext
+								items={sortableItems}
+								strategy={verticalListSortingStrategy}
+							>
+								{flatItems.map((id) => {
+									const parsed = parseId(id);
+									if (!parsed) return null;
+
+									if (parsed.type === "section") {
+										const section = sectionsById.get(parsed.realId);
+										if (!section) return null;
+										return (
+											<SortableSectionHeader
+												key={String(id)}
+												sortableId={String(id)}
+												section={section}
+												onDelete={onDeleteSection}
+												onRename={onRenameSection}
+												onToggleCollapse={onToggleSectionCollapse}
+											/>
+										);
+									}
+
+									const workspace = workspacesById.get(parsed.realId);
+									if (!workspace) return null;
+									const group = groupInfo.get(parsed.realId);
+									const isInSection = !!group;
+									const isInCollapsedSection =
+										isInSection && collapsedSectionIds.has(group.sectionId);
+									const hidden =
+										isInCollapsedSection ||
+										(activeType === "section" && isInSection);
+
+									return (
+										<AnimatePresence key={String(id)} initial={false}>
+											{!hidden && (
+												<motion.div
+													initial={{ height: 0, opacity: 0 }}
+													animate={{ height: "auto", opacity: 1 }}
+													exit={{ height: 0, opacity: 0 }}
+													transition={{ duration: 0.15, ease: "easeOut" }}
+												>
+													<SortableWorkspaceItem
+														sortableId={String(id)}
+														workspace={workspace}
+														accentColor={
+															activeId === id ? predictedColor : group?.color
+														}
+														isInSection={groupInfo.has(parsed.realId)}
+														onHoverCardOpen={() =>
+															onWorkspaceHover(parsed.realId)
+														}
+														shortcutLabel={workspaceShortcutLabels.get(
+															parsed.realId,
+														)}
+													/>
+												</motion.div>
+											)}
+										</AnimatePresence>
+									);
+								})}
+							</SortableContext>
+
+							{createPortal(
+								<DragOverlay dropAnimation={null}>
+									{activeId ? (
+										<SidebarDragOverlay activeItem={activeItem} />
+									) : null}
+								</DragOverlay>,
+								document.body,
+							)}
+						</DndContext>
 					</div>
 				</motion.div>
 			)}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarSection/components/DashboardSidebarSectionHeader/DashboardSidebarSectionHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarSection/components/DashboardSidebarSectionHeader/DashboardSidebarSectionHeader.tsx
@@ -1,7 +1,7 @@
 import { cn } from "@superset/ui/utils";
 import { type ComponentPropsWithoutRef, forwardRef } from "react";
 import { HiChevronRight } from "react-icons/hi2";
-import { LuPencil } from "react-icons/lu";
+import { LuGripVertical, LuPencil } from "react-icons/lu";
 import { RenameInput } from "renderer/screens/main/components/WorkspaceSidebar/RenameInput";
 import type { DashboardSidebarSection } from "../../../../types";
 
@@ -54,12 +54,16 @@ export const DashboardSidebarSectionHeader = forwardRef<
 							}
 				}
 				className={cn(
-					"group flex min-h-8 w-full items-center pl-2 pr-2 py-1.5 text-[11px] font-medium",
+					"group flex min-h-8 w-full items-center pl-0.5 pr-2 py-1.5 text-[11px] font-medium",
 					"text-muted-foreground hover:bg-muted/50 transition-colors",
 					className,
 				)}
 				{...props}
 			>
+				<div className="flex shrink-0 items-center justify-center w-5 h-5 opacity-0 group-hover:opacity-60 transition-opacity cursor-grab active:cursor-grabbing">
+					<LuGripVertical className="size-3" />
+				</div>
+
 				<div className="flex min-w-0 flex-1 items-center gap-1.5">
 					{isRenaming ? (
 						<RenameInput

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/DashboardSidebarWorkspaceItem.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/DashboardSidebarWorkspaceItem.tsx
@@ -12,6 +12,7 @@ interface DashboardSidebarWorkspaceItemProps {
 	onHoverCardOpen?: () => void;
 	shortcutLabel?: string;
 	isCollapsed?: boolean;
+	isInSection?: boolean;
 }
 
 export function DashboardSidebarWorkspaceItem({
@@ -19,6 +20,7 @@ export function DashboardSidebarWorkspaceItem({
 	onHoverCardOpen,
 	shortcutLabel,
 	isCollapsed = false,
+	isInSection = false,
 }: DashboardSidebarWorkspaceItemProps) {
 	const {
 		id,
@@ -88,6 +90,7 @@ export function DashboardSidebarWorkspaceItem({
 				) : (
 					<DashboardSidebarWorkspaceContextMenu
 						projectId={projectId}
+						isInSection={isInSection}
 						onHoverCardOpen={
 							hostType === "local-device" ? onHoverCardOpen : undefined
 						}
@@ -149,6 +152,7 @@ export function DashboardSidebarWorkspaceItem({
 			) : (
 				<DashboardSidebarWorkspaceContextMenu
 					projectId={projectId}
+					isInSection={isInSection}
 					onHoverCardOpen={
 						hostType === "local-device" ? onHoverCardOpen : undefined
 					}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/DashboardSidebarExpandedWorkspaceRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/DashboardSidebarExpandedWorkspaceRow.tsx
@@ -1,6 +1,12 @@
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { cn } from "@superset/ui/utils";
-import { type ComponentPropsWithoutRef, forwardRef, useMemo } from "react";
+import {
+	type ComponentPropsWithoutRef,
+	forwardRef,
+	useEffect,
+	useMemo,
+	useRef,
+} from "react";
 import { HiMiniXMark } from "react-icons/hi2";
 import { HotkeyLabel } from "renderer/hotkeys";
 import { RenameInput } from "renderer/screens/main/components/WorkspaceSidebar/RenameInput";
@@ -58,9 +64,17 @@ export const DashboardSidebarExpandedWorkspaceRow = forwardRef<
 			pullRequest,
 			creationStatus,
 		} = workspace;
-		const showBranchSubtitle = !!name && name !== branch;
-		const showSubtitle = showBranchSubtitle || !!pullRequest;
 		const showsStandaloneActiveStripe = accentColor == null;
+		const localRef = useRef<HTMLDivElement>(null);
+
+		useEffect(() => {
+			if (isActive) {
+				localRef.current?.scrollIntoView({
+					block: "nearest",
+					behavior: "smooth",
+				});
+			}
+		}, [isActive]);
 
 		const creationStatusText = useMemo(
 			() => getCreationStatusText(creationStatus),
@@ -73,7 +87,11 @@ export const DashboardSidebarExpandedWorkspaceRow = forwardRef<
 				role={onClick ? "button" : undefined}
 				tabIndex={onClick ? 0 : undefined}
 				aria-disabled={creationStatus ? true : undefined}
-				ref={ref}
+				ref={(node) => {
+					localRef.current = node;
+					if (typeof ref === "function") ref(node);
+					else if (ref) ref.current = node;
+				}}
 				onClick={onClick}
 				onKeyDown={(event) => {
 					if (onClick && (event.key === "Enter" || event.key === " ")) {
@@ -85,8 +103,8 @@ export const DashboardSidebarExpandedWorkspaceRow = forwardRef<
 				className={cn(
 					"relative flex w-full items-center pl-3 pr-2 text-left text-sm",
 					onClick && "cursor-pointer hover:bg-muted/50",
-					"transition-colors group",
-					showSubtitle ? "py-1.5" : "py-2",
+					"group",
+					"py-1.5",
 					isActive && "bg-muted",
 					className,
 				)}
@@ -120,160 +138,85 @@ export const DashboardSidebarExpandedWorkspaceRow = forwardRef<
 				</Tooltip>
 
 				<div className="flex min-w-0 flex-1 flex-col justify-center">
-					{showSubtitle ? (
-						<div className="grid min-w-0 grid-cols-[minmax(0,1fr)_auto] grid-rows-2 items-center gap-x-1.5 gap-y-0.5">
-							{isRenaming ? (
-								<RenameInput
-									value={renameValue}
-									onChange={onRenameValueChange}
-									onSubmit={onSubmitRename}
-									onCancel={onCancelRename}
-									className={cn(
-										"h-5 w-full -ml-1 border-none bg-transparent px-1 py-0 text-[13px] leading-tight outline-none",
-										!showBranchSubtitle && "row-span-2 self-center",
-									)}
-								/>
-							) : (
-								<span
-									className={cn(
-										"truncate text-[13px] leading-tight transition-colors",
-										isActive
-											? "text-foreground font-medium"
-											: "text-foreground/80",
-										!showBranchSubtitle && "row-span-2 self-center",
-									)}
-								>
-									{name || branch}
-								</span>
-							)}
-
-							<div className="col-start-2 row-start-1 grid h-5 shrink-0 items-center [&>*]:col-start-1 [&>*]:row-start-1">
-								{creationStatusText ? (
-									<span className="text-[11px] text-muted-foreground">
-										{creationStatusText}
-									</span>
-								) : (
-									<>
-										<DashboardSidebarWorkspaceDiffStats
-											additions={mockData.diffStats.additions}
-											deletions={mockData.diffStats.deletions}
-											isActive={isActive}
-										/>
-										<div className="invisible flex items-center justify-end gap-1.5 opacity-0 transition-[opacity,visibility] group-hover:visible group-hover:opacity-100">
-											{shortcutLabel && (
-												<span className="shrink-0 font-mono text-[10px] tabular-nums text-muted-foreground">
-													{shortcutLabel}
-												</span>
-											)}
-											<Tooltip delayDuration={300}>
-												<TooltipTrigger asChild>
-													<button
-														type="button"
-														onClick={(event) => {
-															event.stopPropagation();
-															onDeleteClick();
-														}}
-														className="flex items-center justify-center text-muted-foreground hover:text-foreground"
-														aria-label="Close workspace"
-													>
-														<HiMiniXMark className="size-3.5" />
-													</button>
-												</TooltipTrigger>
-												<TooltipContent side="top" sideOffset={4}>
-													<HotkeyLabel
-														label="Close workspace"
-														id={isActive ? "CLOSE_WORKSPACE" : undefined}
-													/>
-												</TooltipContent>
-											</Tooltip>
-										</div>
-									</>
+					<div className="grid min-w-0 grid-cols-[minmax(0,1fr)_auto] grid-rows-2 items-center gap-x-1.5 gap-y-0.5">
+						{isRenaming ? (
+							<RenameInput
+								value={renameValue}
+								onChange={onRenameValueChange}
+								onSubmit={onSubmitRename}
+								onCancel={onCancelRename}
+								className={cn(
+									"h-5 w-full -ml-1 border-none bg-transparent px-1 py-0 text-[13px] leading-tight outline-none",
 								)}
-							</div>
+							/>
+						) : (
+							<span
+								className={cn(
+									"truncate text-[13px] leading-tight transition-colors",
+									isActive ? "text-foreground" : "text-foreground/80",
+								)}
+							>
+								{name || branch}
+							</span>
+						)}
 
-							{showBranchSubtitle && (
-								<span className="col-start-1 row-start-2 truncate font-mono text-[11px] leading-tight text-muted-foreground/60">
-									{branch}
+						<div className="col-start-2 row-start-1 grid h-5 shrink-0 items-center [&>*]:col-start-1 [&>*]:row-start-1">
+							{creationStatusText ? (
+								<span className="text-[11px] text-muted-foreground">
+									{creationStatusText}
 								</span>
-							)}
-
-							{pullRequest && (
-								<DashboardSidebarWorkspaceStatusBadge
-									state={pullRequest.state}
-									prNumber={pullRequest.number}
-									prUrl={pullRequest.url}
-									className="col-start-2 row-start-2 justify-self-end"
-								/>
+							) : (
+								<>
+									<DashboardSidebarWorkspaceDiffStats
+										additions={mockData.diffStats.additions}
+										deletions={mockData.diffStats.deletions}
+										isActive={isActive}
+									/>
+									<div className="invisible flex items-center justify-end gap-1.5 opacity-0 transition-[opacity,visibility] group-hover:visible group-hover:opacity-100">
+										{shortcutLabel && (
+											<span className="shrink-0 font-mono text-[10px] tabular-nums text-muted-foreground">
+												{shortcutLabel}
+											</span>
+										)}
+										<Tooltip delayDuration={300}>
+											<TooltipTrigger asChild>
+												<button
+													type="button"
+													onClick={(event) => {
+														event.stopPropagation();
+														onDeleteClick();
+													}}
+													className="flex items-center justify-center text-muted-foreground hover:text-foreground"
+													aria-label="Close workspace"
+												>
+													<HiMiniXMark className="size-3.5" />
+												</button>
+											</TooltipTrigger>
+											<TooltipContent side="top" sideOffset={4}>
+												<HotkeyLabel
+													label="Close workspace"
+													id={isActive ? "CLOSE_WORKSPACE" : undefined}
+												/>
+											</TooltipContent>
+										</Tooltip>
+									</div>
+								</>
 							)}
 						</div>
-					) : (
-						<div className="flex min-h-5 items-center gap-1.5">
-							{isRenaming ? (
-								<RenameInput
-									value={renameValue}
-									onChange={onRenameValueChange}
-									onSubmit={onSubmitRename}
-									onCancel={onCancelRename}
-									className="h-5 w-full flex-1 -ml-1 border-none bg-transparent px-1 py-0 text-[13px] leading-tight outline-none"
-								/>
-							) : (
-								<span
-									className={cn(
-										"truncate text-[13px] leading-tight transition-colors flex-1",
-										isActive
-											? "text-foreground font-medium"
-											: "text-foreground/80",
-									)}
-								>
-									{name || branch}
-								</span>
-							)}
 
-							<div className="grid h-5 shrink-0 items-center [&>*]:col-start-1 [&>*]:row-start-1">
-								{creationStatusText ? (
-									<span className="text-[11px] text-muted-foreground">
-										{creationStatusText}
-									</span>
-								) : (
-									<>
-										<DashboardSidebarWorkspaceDiffStats
-											additions={mockData.diffStats.additions}
-											deletions={mockData.diffStats.deletions}
-											isActive={isActive}
-										/>
-										<div className="invisible flex items-center justify-end gap-1.5 opacity-0 transition-[opacity,visibility] group-hover:visible group-hover:opacity-100">
-											{shortcutLabel && (
-												<span className="shrink-0 font-mono text-[10px] tabular-nums text-muted-foreground">
-													{shortcutLabel}
-												</span>
-											)}
-											<Tooltip delayDuration={300}>
-												<TooltipTrigger asChild>
-													<button
-														type="button"
-														onClick={(event) => {
-															event.stopPropagation();
-															onDeleteClick();
-														}}
-														className="flex items-center justify-center text-muted-foreground hover:text-foreground"
-														aria-label="Close workspace"
-													>
-														<HiMiniXMark className="size-3.5" />
-													</button>
-												</TooltipTrigger>
-												<TooltipContent side="top" sideOffset={4}>
-													<HotkeyLabel
-														label="Close workspace"
-														id={isActive ? "CLOSE_WORKSPACE" : undefined}
-													/>
-												</TooltipContent>
-											</Tooltip>
-										</div>
-									</>
-								)}
-							</div>
-						</div>
-					)}
+						<span className="col-start-1 row-start-2 truncate font-mono text-[11px] leading-tight text-muted-foreground/60">
+							{branch}
+						</span>
+
+						{pullRequest && (
+							<DashboardSidebarWorkspaceStatusBadge
+								state={pullRequest.state}
+								prNumber={pullRequest.number}
+								prUrl={pullRequest.url}
+								className="col-start-2 row-start-2 justify-self-end"
+							/>
+						)}
+					</div>
 				</div>
 			</div>
 		);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceContextMenu/DashboardSidebarWorkspaceContextMenu.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceContextMenu/DashboardSidebarWorkspaceContextMenu.tsx
@@ -18,10 +18,10 @@ import { useLiveQuery } from "@tanstack/react-db";
 import { useState } from "react";
 import {
 	LuArrowRightLeft,
+	LuArrowUp,
 	LuCopy,
 	LuFolderOpen,
 	LuFolderPlus,
-	LuMinus,
 	LuPencil,
 	LuTrash2,
 	LuX,
@@ -31,6 +31,7 @@ import { useCollections } from "renderer/routes/_authenticated/providers/Collect
 interface DashboardSidebarWorkspaceContextMenuProps {
 	hoverCardContent?: React.ReactNode;
 	projectId: string;
+	isInSection?: boolean;
 	onHoverCardOpen?: () => void;
 	onCreateSection: () => void;
 	onMoveToSection: (sectionId: string | null) => void;
@@ -44,6 +45,7 @@ interface DashboardSidebarWorkspaceContextMenuProps {
 
 export function DashboardSidebarWorkspaceContextMenu({
 	projectId,
+	isInSection,
 	onHoverCardOpen,
 	hoverCardContent,
 	onCreateSection,
@@ -68,6 +70,7 @@ export function DashboardSidebarWorkspaceContextMenu({
 				.select(({ sidebarSections }) => ({
 					id: sidebarSections.sectionId,
 					name: sidebarSections.name,
+					color: sidebarSections.color,
 				})),
 		[collections, projectId],
 	);
@@ -98,20 +101,29 @@ export function DashboardSidebarWorkspaceContextMenu({
 						<LuFolderPlus className="size-4 mr-2" />
 						New Section
 					</ContextMenuItem>
-					<ContextMenuItem onSelect={() => onMoveToSection(null)}>
-						<LuMinus className="size-4 mr-2" />
-						Ungrouped
-					</ContextMenuItem>
+					{sections.length > 0 && <ContextMenuSeparator />}
 					{sections.map((section) => (
 						<ContextMenuItem
 							key={section.id}
 							onSelect={() => onMoveToSection(section.id)}
 						>
+							{section.color && (
+								<span
+									className="size-2 shrink-0 rounded-full mr-2"
+									style={{ backgroundColor: section.color }}
+								/>
+							)}
 							{section.name}
 						</ContextMenuItem>
 					))}
 				</ContextMenuSubContent>
 			</ContextMenuSub>
+			{isInSection && (
+				<ContextMenuItem onSelect={() => onMoveToSection(null)}>
+					<LuArrowUp className="size-4 mr-2" />
+					Remove from Group
+				</ContextMenuItem>
+			)}
 			<ContextMenuSeparator />
 			<ContextMenuItem
 				onSelect={onRemoveFromSidebar}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/SidebarDragOverlay/SidebarDragOverlay.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/SidebarDragOverlay/SidebarDragOverlay.tsx
@@ -1,0 +1,52 @@
+import { LuGripVertical } from "react-icons/lu";
+import { PROJECT_COLOR_DEFAULT } from "shared/constants/project-colors";
+import type {
+	DashboardSidebarSection,
+	DashboardSidebarWorkspace,
+} from "../../types";
+import { DashboardSidebarWorkspaceItem } from "../DashboardSidebarWorkspaceItem";
+
+type ActiveItem =
+	| { type: "workspace"; workspace: DashboardSidebarWorkspace }
+	| { type: "section"; section: DashboardSidebarSection };
+
+interface SidebarDragOverlayProps {
+	activeItem: ActiveItem | null;
+}
+
+export function SidebarDragOverlay({ activeItem }: SidebarDragOverlayProps) {
+	if (!activeItem) return null;
+
+	if (activeItem.type === "workspace") {
+		return (
+			<div className="bg-background shadow-lg">
+				<DashboardSidebarWorkspaceItem workspace={activeItem.workspace} />
+			</div>
+		);
+	}
+
+	const { section } = activeItem;
+	const hasColor =
+		section.color != null && section.color !== PROJECT_COLOR_DEFAULT;
+
+	return (
+		<div
+			className="bg-background shadow-lg"
+			style={{
+				borderLeft: hasColor
+					? `2px solid ${section.color}`
+					: "2px solid var(--color-border)",
+			}}
+		>
+			<div className="flex min-h-8 w-full items-center gap-1.5 pl-0.5 pr-2 py-1.5 text-[11px] font-medium text-muted-foreground">
+				<div className="flex shrink-0 items-center justify-center w-5 h-5 opacity-60">
+					<LuGripVertical className="size-3" />
+				</div>
+				<span className="truncate">{section.name}</span>
+				<span className="text-[10px] font-normal tabular-nums shrink-0">
+					({section.workspaces.length})
+				</span>
+			</div>
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/SidebarDragOverlay/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/SidebarDragOverlay/index.ts
@@ -1,0 +1,1 @@
+export { SidebarDragOverlay } from "./SidebarDragOverlay";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/SortableSectionHeader/SortableSectionHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/SortableSectionHeader/SortableSectionHeader.tsx
@@ -1,0 +1,86 @@
+import { useSortable } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { useState } from "react";
+import { useDashboardSidebarState } from "renderer/routes/_authenticated/hooks/useDashboardSidebarState";
+import { PROJECT_COLOR_DEFAULT } from "shared/constants/project-colors";
+import type { DashboardSidebarSection } from "../../types";
+import { DashboardSidebarSectionContextMenu } from "../DashboardSidebarSection/components/DashboardSidebarSectionContextMenu";
+import { DashboardSidebarSectionHeader } from "../DashboardSidebarSection/components/DashboardSidebarSectionHeader";
+
+interface SortableSectionHeaderProps {
+	sortableId: string;
+	section: DashboardSidebarSection;
+	onDelete: (sectionId: string) => void;
+	onRename: (sectionId: string, name: string) => void;
+	onToggleCollapse: (sectionId: string) => void;
+}
+
+export function SortableSectionHeader({
+	sortableId,
+	section,
+	onDelete,
+	onRename,
+	onToggleCollapse,
+}: SortableSectionHeaderProps) {
+	const { setSectionColor } = useDashboardSidebarState();
+	const [isRenaming, setIsRenaming] = useState(false);
+	const [renameValue, setRenameValue] = useState(section.name);
+
+	const {
+		attributes,
+		listeners,
+		setNodeRef,
+		transform,
+		transition,
+		isDragging,
+	} = useSortable({ id: sortableId });
+
+	const hasColor =
+		section.color != null && section.color !== PROJECT_COLOR_DEFAULT;
+
+	const handleSubmitRename = () => {
+		const trimmed = renameValue.trim();
+		if (trimmed) onRename(section.id, trimmed);
+		setIsRenaming(false);
+	};
+
+	return (
+		<div
+			ref={setNodeRef}
+			style={{
+				transform: CSS.Translate.toString(transform),
+				transition,
+				opacity: isDragging ? 0.5 : undefined,
+				borderLeft: hasColor
+					? `2px solid ${section.color}`
+					: "2px solid var(--color-border)",
+			}}
+		>
+			<DashboardSidebarSectionContextMenu
+				color={section.color}
+				onRename={() => setIsRenaming(true)}
+				onSetColor={(color) => setSectionColor(section.id, color)}
+				onDelete={() => onDelete(section.id)}
+			>
+				<DashboardSidebarSectionHeader
+					section={section}
+					isRenaming={isRenaming}
+					renameValue={renameValue}
+					onRenameValueChange={setRenameValue}
+					onSubmitRename={handleSubmitRename}
+					onCancelRename={() => {
+						setRenameValue(section.name);
+						setIsRenaming(false);
+					}}
+					onStartRename={() => {
+						setRenameValue(section.name);
+						setIsRenaming(true);
+					}}
+					onToggleCollapse={() => onToggleCollapse(section.id)}
+					{...attributes}
+					{...listeners}
+				/>
+			</DashboardSidebarSectionContextMenu>
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/SortableSectionHeader/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/SortableSectionHeader/index.ts
@@ -1,0 +1,1 @@
+export { SortableSectionHeader } from "./SortableSectionHeader";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/SortableWorkspaceItem/SortableWorkspaceItem.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/SortableWorkspaceItem/SortableWorkspaceItem.tsx
@@ -1,0 +1,52 @@
+import { useSortable } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import type { DashboardSidebarWorkspace } from "../../types";
+import { DashboardSidebarWorkspaceItem } from "../DashboardSidebarWorkspaceItem";
+
+interface SortableWorkspaceItemProps {
+	sortableId: string;
+	workspace: DashboardSidebarWorkspace;
+	accentColor?: string | null;
+	isInSection?: boolean;
+	onHoverCardOpen?: () => void;
+	shortcutLabel?: string;
+}
+
+export function SortableWorkspaceItem({
+	sortableId,
+	workspace,
+	accentColor,
+	isInSection,
+	onHoverCardOpen,
+	shortcutLabel,
+}: SortableWorkspaceItemProps) {
+	const {
+		setNodeRef,
+		attributes,
+		listeners,
+		isDragging,
+		transform,
+		transition,
+	} = useSortable({ id: sortableId });
+
+	return (
+		<div
+			ref={setNodeRef}
+			style={{
+				transform: CSS.Translate.toString(transform),
+				transition,
+				opacity: isDragging ? 0.5 : undefined,
+				borderLeft: accentColor ? `2px solid ${accentColor}` : undefined,
+			}}
+			{...attributes}
+			{...listeners}
+		>
+			<DashboardSidebarWorkspaceItem
+				workspace={workspace}
+				onHoverCardOpen={onHoverCardOpen}
+				shortcutLabel={shortcutLabel}
+				isInSection={isInSection}
+			/>
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/SortableWorkspaceItem/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/SortableWorkspaceItem/index.ts
@@ -1,0 +1,1 @@
+export { SortableWorkspaceItem } from "./SortableWorkspaceItem";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useSidebarDnd/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useSidebarDnd/index.ts
@@ -1,0 +1,1 @@
+export { useSidebarDnd } from "./useSidebarDnd";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useSidebarDnd/useSidebarDnd.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useSidebarDnd/useSidebarDnd.ts
@@ -1,0 +1,362 @@
+import {
+	closestCenter,
+	type DragEndEvent,
+	type DragOverEvent,
+	type DragStartEvent,
+	KeyboardSensor,
+	MeasuringStrategy,
+	MouseSensor,
+	TouchSensor,
+	type UniqueIdentifier,
+	useSensor,
+	useSensors,
+} from "@dnd-kit/core";
+import { arrayMove, sortableKeyboardCoordinates } from "@dnd-kit/sortable";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useDashboardSidebarState } from "renderer/routes/_authenticated/hooks/useDashboardSidebarState";
+import type {
+	DashboardSidebarProjectChild,
+	DashboardSidebarSection,
+	DashboardSidebarWorkspace,
+} from "../../types";
+
+// ── ID helpers ───────────────────────────────────────────────────────
+
+const WS = "ws::";
+const SEC = "sec::";
+
+export const wsId = (id: string) => `${WS}${id}`;
+export const secId = (id: string) => `${SEC}${id}`;
+export const isSec = (id: UniqueIdentifier) => String(id).startsWith(SEC);
+
+export const parseId = (id: UniqueIdentifier) => {
+	const s = String(id);
+	if (s.startsWith(WS))
+		return { type: "workspace" as const, realId: s.slice(WS.length) };
+	if (s.startsWith(SEC))
+		return { type: "section" as const, realId: s.slice(SEC.length) };
+	return null;
+};
+
+// ── Measuring config ─────────────────────────────────────────────────
+
+export const measuring = {
+	droppable: { strategy: MeasuringStrategy.Always as const },
+};
+
+// ── Build flat list from project children ────────────────────────────
+
+function buildFlatItems(
+	children: DashboardSidebarProjectChild[],
+): UniqueIdentifier[] {
+	const items: UniqueIdentifier[] = [];
+	for (const child of children) {
+		if (child.type === "workspace") {
+			items.push(wsId(child.workspace.id));
+		} else {
+			items.push(secId(child.section.id));
+			// Always include workspaces so AnimatePresence can animate collapse
+			for (const ws of child.section.workspaces) {
+				items.push(wsId(ws.id));
+			}
+		}
+	}
+	return items;
+}
+
+// ── Parse flat list to determine section membership ──────────────────
+
+interface ParsedFlatItems {
+	topLevel: Array<{ type: "workspace" | "section"; id: string }>;
+	sections: Record<string, string[]>;
+}
+
+function parseFlatItems(items: UniqueIdentifier[]): ParsedFlatItems {
+	const result: ParsedFlatItems = { topLevel: [], sections: {} };
+	let currentSection: string | null = null;
+
+	for (const id of items) {
+		const parsed = parseId(id);
+		if (!parsed) continue;
+		if (parsed.type === "section") {
+			currentSection = parsed.realId;
+			result.topLevel.push({ type: "section", id: parsed.realId });
+			result.sections[parsed.realId] = [];
+		} else if (parsed.type === "workspace") {
+			if (currentSection) {
+				result.sections[currentSection].push(parsed.realId);
+			} else {
+				result.topLevel.push({ type: "workspace", id: parsed.realId });
+			}
+		}
+	}
+	return result;
+}
+
+// ── Hook ─────────────────────────────────────────────────────────────
+
+interface UseSidebarDndOptions {
+	projectId: string;
+	projectChildren: DashboardSidebarProjectChild[];
+}
+
+export function useSidebarDnd({
+	projectId,
+	projectChildren,
+}: UseSidebarDndOptions) {
+	const { reorderProjectChildren, moveWorkspaceToSectionAtIndex } =
+		useDashboardSidebarState();
+
+	const sensors = useSensors(
+		useSensor(MouseSensor, { activationConstraint: { distance: 8 } }),
+		useSensor(TouchSensor, {
+			activationConstraint: { delay: 200, tolerance: 5 },
+		}),
+		useSensor(KeyboardSensor, {
+			coordinateGetter: sortableKeyboardCoordinates,
+		}),
+	);
+
+	const [flatItems, setFlatItems] = useState<UniqueIdentifier[]>(() =>
+		buildFlatItems(projectChildren),
+	);
+	const [activeId, setActiveId] = useState<UniqueIdentifier | null>(null);
+	const activeType: "workspace" | "section" | null = activeId
+		? isSec(activeId)
+			? "section"
+			: "workspace"
+		: null;
+	const [overId, setOverId] = useState<UniqueIdentifier | null>(null);
+	const clonedRef = useRef<UniqueIdentifier[] | null>(null);
+
+	// When dragging a section, SortableContext only has section IDs.
+	// When dragging a workspace (or idle), SortableContext has everything.
+	const sortableItems = useMemo(() => {
+		if (activeType === "section") {
+			return flatItems.filter((id) => isSec(id));
+		}
+		return flatItems;
+	}, [flatItems, activeType]);
+
+	// Sync from external data when items or their order/membership changes
+	const prevFingerprintRef = useRef("");
+	useEffect(() => {
+		if (activeId) return; // Don't reset during active drag
+		const fingerprint = projectChildren
+			.map((c) =>
+				c.type === "workspace"
+					? c.workspace.id
+					: `s:${c.section.id}:${c.section.workspaces.map((w) => w.id).join("|")}`,
+			)
+			.join(",");
+		if (fingerprint !== prevFingerprintRef.current) {
+			prevFingerprintRef.current = fingerprint;
+			setFlatItems(buildFlatItems(projectChildren));
+		}
+	}, [projectChildren, activeId]);
+
+	const collapsedSectionIds = useMemo(() => {
+		const set = new Set<string>();
+		for (const child of projectChildren) {
+			if (child.type === "section" && child.section.isCollapsed) {
+				set.add(child.section.id);
+			}
+		}
+		return set;
+	}, [projectChildren]);
+
+	// ── Lookups ──────────────────────────────────────────────────────
+
+	const workspacesById = useMemo(() => {
+		const map = new Map<string, DashboardSidebarWorkspace>();
+		for (const child of projectChildren) {
+			if (child.type === "workspace") {
+				map.set(child.workspace.id, child.workspace);
+			} else {
+				for (const ws of child.section.workspaces) {
+					map.set(ws.id, ws);
+				}
+			}
+		}
+		return map;
+	}, [projectChildren]);
+
+	const sectionsById = useMemo(() => {
+		const map = new Map<string, DashboardSidebarSection>();
+		for (const child of projectChildren) {
+			if (child.type === "section") {
+				map.set(child.section.id, child.section);
+			}
+		}
+		return map;
+	}, [projectChildren]);
+
+	// Which section does each workspace belong to? (for visual grouping)
+	const groupInfo = useMemo(() => {
+		const map = new Map<string, { sectionId: string; color: string | null }>();
+		let currentSection: { id: string; color: string | null } | null = null;
+
+		for (const id of flatItems) {
+			const parsed = parseId(id);
+			if (!parsed) continue;
+			if (parsed.type === "section") {
+				const sec = sectionsById.get(parsed.realId);
+				currentSection = sec ? { id: sec.id, color: sec.color } : null;
+			} else if (parsed.type === "workspace" && currentSection) {
+				map.set(parsed.realId, {
+					sectionId: currentSection.id,
+					color: currentSection.color,
+				});
+			}
+		}
+		return map;
+	}, [flatItems, sectionsById]);
+
+	const activeItem = useMemo(() => {
+		if (!activeId) return null;
+		const parsed = parseId(activeId);
+		if (!parsed) return null;
+		if (parsed.type === "workspace") {
+			const ws = workspacesById.get(parsed.realId);
+			return ws ? { type: "workspace" as const, workspace: ws } : null;
+		}
+		const sec = sectionsById.get(parsed.realId);
+		return sec ? { type: "section" as const, section: sec } : null;
+	}, [activeId, workspacesById, sectionsById]);
+
+	// Color the active workspace's ghost should show based on where it would land
+	const predictedColor = useMemo(() => {
+		if (!activeId || !overId || activeType !== "workspace") return null;
+		const overIndex = flatItems.indexOf(overId);
+		if (overIndex === -1) return null;
+		// If over is a section header, the workspace lands ABOVE it,
+		// so look for the section above the over position (skip the over itself)
+		const startFrom = isSec(overId) ? overIndex - 1 : overIndex;
+		for (let i = startFrom; i >= 0; i--) {
+			const p = parseId(flatItems[i]);
+			if (p?.type === "section") {
+				const sec = sectionsById.get(p.realId);
+				return sec?.color ?? null;
+			}
+		}
+		return null; // ungrouped — no section above
+	}, [activeId, overId, activeType, flatItems, sectionsById]);
+
+	// ── Persistence ──────────────────────────────────────────────────
+
+	const commitToDb = useCallback(
+		(items: UniqueIdentifier[]) => {
+			const parsed = parseFlatItems(items);
+
+			// Top-level order (ungrouped workspaces + sections interleaved)
+			reorderProjectChildren(projectId, parsed.topLevel);
+
+			// Each section's workspace order
+			for (const [sectionId, wsIds] of Object.entries(parsed.sections)) {
+				for (let i = 0; i < wsIds.length; i++) {
+					moveWorkspaceToSectionAtIndex(wsIds[i], projectId, sectionId, i);
+				}
+			}
+		},
+		[projectId, reorderProjectChildren, moveWorkspaceToSectionAtIndex],
+	);
+
+	// ── Handlers ─────────────────────────────────────────────────────
+
+	const onDragStart = useCallback(
+		({ active }: DragStartEvent) => {
+			setActiveId(active.id);
+			clonedRef.current = [...flatItems];
+		},
+		[flatItems],
+	);
+
+	const onDragOver = useCallback(({ over }: DragOverEvent) => {
+		setOverId(over?.id ?? null);
+	}, []);
+
+	const onDragEnd = useCallback(
+		({ active, over }: DragEndEvent) => {
+			setActiveId(null);
+			setOverId(null);
+
+			if (!over || active.id === over.id) return;
+
+			if (isSec(active.id)) {
+				// Section drag: only section IDs were in the SortableContext.
+				// Reorder sections, then rebuild the full flat list with
+				// workspaces in their original positions under each section.
+				const sectionIds = flatItems.filter((id) => isSec(id));
+				const oldIdx = sectionIds.indexOf(active.id);
+				const newIdx = sectionIds.indexOf(over.id);
+				if (oldIdx === -1 || newIdx === -1 || oldIdx === newIdx) return;
+
+				const reorderedSections = arrayMove(sectionIds, oldIdx, newIdx);
+
+				// Rebuild flat list: ungrouped workspaces first, then
+				// each section with its workspaces in new section order
+				const ungrouped: UniqueIdentifier[] = [];
+				const sectionGroups = new Map<string, UniqueIdentifier[]>();
+
+				let currentSec: string | null = null;
+				for (const id of flatItems) {
+					if (isSec(id)) {
+						currentSec = String(id);
+						sectionGroups.set(currentSec, []);
+					} else if (currentSec) {
+						sectionGroups.get(currentSec)?.push(id);
+					} else {
+						ungrouped.push(id);
+					}
+				}
+
+				const newItems: UniqueIdentifier[] = [...ungrouped];
+				for (const secSortId of reorderedSections) {
+					newItems.push(secSortId);
+					const wsInSec = sectionGroups.get(String(secSortId)) ?? [];
+					newItems.push(...wsInSec);
+				}
+
+				setFlatItems(newItems);
+				commitToDb(newItems);
+			} else {
+				// Workspace drag: simple arrayMove in the full flat list
+				const oldIndex = flatItems.indexOf(active.id);
+				const overIndex = flatItems.indexOf(over.id);
+				if (oldIndex === -1 || overIndex === -1 || oldIndex === overIndex)
+					return;
+
+				const newItems = arrayMove(flatItems, oldIndex, overIndex);
+				setFlatItems(newItems);
+				commitToDb(newItems);
+			}
+		},
+		[flatItems, commitToDb],
+	);
+
+	const onDragCancel = useCallback(() => {
+		if (clonedRef.current) {
+			setFlatItems(clonedRef.current);
+		}
+		setActiveId(null);
+		setOverId(null);
+		clonedRef.current = null;
+	}, []);
+
+	return {
+		sensors,
+		measuring,
+		collisionDetection: closestCenter,
+		flatItems,
+		sortableItems,
+		activeId,
+		activeType,
+		activeItem,
+		predictedColor,
+		groupInfo,
+		collapsedSectionIds,
+		workspacesById,
+		sectionsById,
+		handlers: { onDragStart, onDragOver, onDragEnd, onDragCancel },
+	};
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/hooks/useDashboardSidebarState/useDashboardSidebarState.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/hooks/useDashboardSidebarState/useDashboardSidebarState.ts
@@ -2,6 +2,7 @@ import type { WorkspaceState } from "@superset/panes";
 import { useCallback } from "react";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 import type { AppCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider/collections";
+import { PROJECT_CUSTOM_COLORS } from "shared/constants/project-colors";
 
 function getNextTabOrder(items: Array<{ tabOrder: number }>): number {
 	const maxTabOrder = items.reduce(
@@ -123,6 +124,63 @@ export function useDashboardSidebarState() {
 		[collections],
 	);
 
+	const reorderProjectChildren = useCallback(
+		(
+			projectId: string,
+			orderedItems: Array<{ type: "workspace" | "section"; id: string }>,
+		) => {
+			orderedItems.forEach((item, index) => {
+				const tabOrder = index + 1;
+				if (item.type === "workspace") {
+					if (!collections.v2WorkspaceLocalState.get(item.id)) return;
+					collections.v2WorkspaceLocalState.update(item.id, (draft) => {
+						draft.sidebarState.tabOrder = tabOrder;
+						draft.sidebarState.sectionId = null;
+						draft.sidebarState.projectId = projectId;
+					});
+				} else {
+					if (!collections.v2SidebarSections.get(item.id)) return;
+					collections.v2SidebarSections.update(item.id, (draft) => {
+						draft.tabOrder = tabOrder;
+					});
+				}
+			});
+		},
+		[collections],
+	);
+
+	const moveWorkspaceToSectionAtIndex = useCallback(
+		(
+			workspaceId: string,
+			projectId: string,
+			sectionId: string,
+			index: number,
+		) => {
+			const existing = collections.v2WorkspaceLocalState.get(workspaceId);
+			if (!existing) return;
+			const siblings = Array.from(
+				collections.v2WorkspaceLocalState.state.values(),
+			)
+				.filter(
+					(item) =>
+						item.sidebarState.projectId === projectId &&
+						item.workspaceId !== workspaceId &&
+						item.sidebarState.sectionId === sectionId,
+				)
+				.sort((a, b) => a.sidebarState.tabOrder - b.sidebarState.tabOrder);
+			const reordered = [...siblings];
+			reordered.splice(index, 0, existing);
+			reordered.forEach((item, i) => {
+				collections.v2WorkspaceLocalState.update(item.workspaceId, (draft) => {
+					draft.sidebarState.tabOrder = i + 1;
+					draft.sidebarState.sectionId = sectionId;
+					draft.sidebarState.projectId = projectId;
+				});
+			});
+		},
+		[collections],
+	);
+
 	const createSection = useCallback(
 		(projectId: string, name = "New Section") => {
 			ensureSidebarProjectRecord(collections, projectId);
@@ -132,6 +190,11 @@ export function useDashboardSidebarState() {
 				collections.v2SidebarSections.state.values(),
 			).filter((item) => item.projectId === projectId);
 
+			const randomColor =
+				PROJECT_CUSTOM_COLORS[
+					Math.floor(Math.random() * PROJECT_CUSTOM_COLORS.length)
+				].value;
+
 			collections.v2SidebarSections.insert({
 				sectionId,
 				projectId,
@@ -139,7 +202,7 @@ export function useDashboardSidebarState() {
 				createdAt: new Date(),
 				tabOrder: getNextTabOrder(sectionOrders),
 				isCollapsed: false,
-				color: null,
+				color: randomColor,
 			});
 
 			return sectionId;
@@ -181,6 +244,55 @@ export function useDashboardSidebarState() {
 		(workspaceId: string, projectId: string, sectionId: string | null) => {
 			const existing = collections.v2WorkspaceLocalState.get(workspaceId);
 			if (!existing) return;
+
+			if (sectionId === null) {
+				// "Remove from group" — place right above the first section.
+				// Find the lowest section tabOrder, then use tabOrder - 1.
+				// If no sections exist, append to end of ungrouped workspaces.
+				const sectionOrders = Array.from(
+					collections.v2SidebarSections.state.values(),
+				)
+					.filter((s) => s.projectId === projectId)
+					.map((s) => s.tabOrder);
+
+				const firstSectionOrder =
+					sectionOrders.length > 0 ? Math.min(...sectionOrders) : null;
+
+				let newTabOrder: number;
+				if (firstSectionOrder != null) {
+					// Place right before the first section, after existing ungrouped
+					const ungroupedOrders = Array.from(
+						collections.v2WorkspaceLocalState.state.values(),
+					)
+						.filter(
+							(item) =>
+								item.sidebarState.projectId === projectId &&
+								item.workspaceId !== workspaceId &&
+								item.sidebarState.sectionId === null,
+						)
+						.map((item) => ({ tabOrder: item.sidebarState.tabOrder }));
+					newTabOrder = getNextTabOrder(ungroupedOrders);
+				} else {
+					// No sections — append to end
+					const ungroupedOrders = Array.from(
+						collections.v2WorkspaceLocalState.state.values(),
+					)
+						.filter(
+							(item) =>
+								item.sidebarState.projectId === projectId &&
+								item.workspaceId !== workspaceId &&
+								item.sidebarState.sectionId === null,
+						)
+						.map((item) => ({ tabOrder: item.sidebarState.tabOrder }));
+					newTabOrder = getNextTabOrder(ungroupedOrders);
+				}
+
+				collections.v2WorkspaceLocalState.update(workspaceId, (draft) => {
+					draft.sidebarState.sectionId = null;
+					draft.sidebarState.tabOrder = newTabOrder;
+				});
+				return;
+			}
 
 			const siblingRows = Array.from(
 				collections.v2WorkspaceLocalState.state.values(),
@@ -274,7 +386,9 @@ export function useDashboardSidebarState() {
 		ensureProjectInSidebar,
 		ensureWorkspaceInSidebar,
 		moveWorkspaceToSection,
+		moveWorkspaceToSectionAtIndex,
 		removeProjectFromSidebar,
+		reorderProjectChildren,
 		removeWorkspaceFromSidebar,
 		reorderProjects,
 		reorderWorkspaces,

--- a/apps/desktop/src/shared/constants/project-colors.test.ts
+++ b/apps/desktop/src/shared/constants/project-colors.test.ts
@@ -1,9 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import {
-	PROJECT_COLOR_DEFAULT,
-	PROJECT_COLORS,
-	PROJECT_CUSTOM_COLORS,
-} from "./project-colors";
+import { PROJECT_COLORS, PROJECT_CUSTOM_COLORS } from "./project-colors";
 
 function hexToRgb(hex: string) {
 	const normalizedHex = hex.replace("#", "");
@@ -32,7 +28,7 @@ describe("PROJECT_COLORS", () => {
 
 		expect(new Set(colorNames).size).toBe(colorNames.length);
 		expect(new Set(colorValues).size).toBe(colorValues.length);
-		expect(PROJECT_COLORS[0]?.value).toBe(PROJECT_COLOR_DEFAULT);
+		expect(PROJECT_COLORS.length).toBeGreaterThan(0);
 	});
 
 	it("keeps custom swatches visually distinct", () => {

--- a/apps/desktop/src/shared/constants/project-colors.ts
+++ b/apps/desktop/src/shared/constants/project-colors.ts
@@ -2,7 +2,6 @@
 export const PROJECT_COLOR_DEFAULT = "default";
 
 export const PROJECT_COLORS = [
-	{ name: "Default", value: PROJECT_COLOR_DEFAULT },
 	{ name: "Red", value: "#ef4444" },
 	{ name: "Orange", value: "#f97316" },
 	{ name: "Yellow", value: "#eab308" },
@@ -17,9 +16,7 @@ export const PROJECT_COLORS = [
 	{ name: "Slate", value: "#64748b" },
 ] as const;
 
-export const PROJECT_CUSTOM_COLORS = PROJECT_COLORS.filter(
-	(color) => color.value !== PROJECT_COLOR_DEFAULT,
-);
+export const PROJECT_CUSTOM_COLORS = PROJECT_COLORS;
 
 export const PROJECT_COLOR_VALUES: string[] = PROJECT_COLORS.map(
 	(color) => color.value,

--- a/apps/docs/content/docs/mcp.mdx
+++ b/apps/docs/content/docs/mcp.mdx
@@ -248,7 +248,7 @@ API keys grant full access to your organization. Keep them secret and never comm
 
 | Tool | Description |
 |------|-------------|
-| `list_devices` | List online devices in your organization |
+| `list_devices` | List registered devices in your organization |
 | `list_projects` | List all projects on a device |
 | `get_app_context` | Get current app state (active workspace, pathname) |
 | `list_members` | List organization members |

--- a/packages/cli/src/commands/devices/list/command.ts
+++ b/packages/cli/src/commands/devices/list/command.ts
@@ -1,15 +1,12 @@
-import { boolean, CLIError, command, table } from "@superset/cli-framework";
+import { CLIError, command, table } from "@superset/cli-framework";
 
 export default command({
 	description: "List all devices in the org",
-	options: {
-		includeOffline: boolean().desc("Include offline devices"),
-	},
+	options: {},
 	display: (data) =>
 		table(data as Record<string, unknown>[], [
 			"deviceName",
 			"deviceType",
-			"status",
 			"lastSeen",
 		]),
 	run: async () => {

--- a/packages/mcp/src/tools/devices/list-devices/list-devices.test.ts
+++ b/packages/mcp/src/tools/devices/list-devices/list-devices.test.ts
@@ -2,13 +2,10 @@ import { beforeEach, describe, expect, it, mock } from "bun:test";
 import { z } from "zod";
 
 const getMcpContextMock = mock(() => ({ organizationId: "org-1" }));
-const executeOnDeviceMock = mock(
-	async (input: Record<string, unknown>) => input,
-);
 
 let fetchedDevices = [
 	{
-		deviceId: "device-online",
+		deviceId: "device-a",
 		deviceName: "Ada's MacBook",
 		deviceType: "desktop",
 		lastSeenAt: new Date(Date.now() - 30_000),
@@ -17,7 +14,7 @@ let fetchedDevices = [
 		ownerEmail: "ada@example.com",
 	},
 	{
-		deviceId: "device-offline",
+		deviceId: "device-b",
 		deviceName: "Grace's iPhone",
 		deviceType: "mobile",
 		lastSeenAt: new Date(Date.now() - 120_000),
@@ -43,8 +40,12 @@ mock.module("@superset/db/client", () => ({
 	},
 }));
 
+// mock.module is process-global in bun test. Preserve every real export
+// (notably executeOnDevice, which start-agent-session.test.ts imports after
+// this file mounts its mocks) so sibling test files don't break.
+const realUtils = await import("../../utils");
 mock.module("../../utils", () => ({
-	executeOnDevice: executeOnDeviceMock,
+	...realUtils,
 	getMcpContext: getMcpContextMock,
 }));
 
@@ -65,7 +66,6 @@ type RegisteredToolHandler = (
 			ownerId: string;
 			ownerName: string | null;
 			ownerEmail: string;
-			isOnline: boolean;
 		}>;
 	};
 }>;
@@ -106,7 +106,7 @@ describe("list_devices MCP tool", () => {
 	beforeEach(() => {
 		fetchedDevices = [
 			{
-				deviceId: "device-online",
+				deviceId: "device-a",
 				deviceName: "Ada's MacBook",
 				deviceType: "desktop",
 				lastSeenAt: new Date(Date.now() - 30_000),
@@ -115,7 +115,7 @@ describe("list_devices MCP tool", () => {
 				ownerEmail: "ada@example.com",
 			},
 			{
-				deviceId: "device-offline",
+				deviceId: "device-b",
 				deviceName: "Grace's iPhone",
 				deviceType: "mobile",
 				lastSeenAt: new Date(Date.now() - 120_000),
@@ -124,27 +124,20 @@ describe("list_devices MCP tool", () => {
 				ownerEmail: "grace@example.com",
 			},
 		];
-		executeOnDeviceMock.mockClear();
 		getMcpContextMock.mockClear();
 		selectMock.mockClear();
 	});
 
-	it("registers input and output schemas that validate includeOffline and isOnline", async () => {
+	it("registers an output schema that validates the device list", async () => {
 		const { config, handler } = createTool();
-		const inputSchema = z.object(config.inputSchema);
 		const outputSchema = z.object(config.outputSchema);
 
-		expect(inputSchema.parse({})).toEqual({ includeOffline: false });
-		expect(inputSchema.parse({ includeOffline: true })).toEqual({
-			includeOffline: true,
-		});
-
-		const result = await handler({ includeOffline: true }, {});
+		const result = await handler({}, {});
 
 		expect(() => outputSchema.parse(result.structuredContent)).not.toThrow();
 	});
 
-	it("returns only online devices by default", async () => {
+	it("returns every registered device regardless of lastSeenAt", async () => {
 		const { handler } = createTool();
 
 		const result = await handler({}, {});
@@ -153,35 +146,23 @@ describe("list_devices MCP tool", () => {
 		expect(selectMock).toHaveBeenCalledTimes(1);
 		expect(result.structuredContent?.devices).toEqual([
 			{
-				deviceId: "device-online",
+				deviceId: "device-a",
 				deviceName: "Ada's MacBook",
 				deviceType: "desktop",
 				lastSeenAt: expect.any(String),
 				ownerId: "user-1",
 				ownerName: "Ada",
 				ownerEmail: "ada@example.com",
-				isOnline: true,
+			},
+			{
+				deviceId: "device-b",
+				deviceName: "Grace's iPhone",
+				deviceType: "mobile",
+				lastSeenAt: expect.any(String),
+				ownerId: "user-2",
+				ownerName: "Grace",
+				ownerEmail: "grace@example.com",
 			},
 		]);
-	});
-
-	it("includes offline devices when requested and marks them offline", async () => {
-		const { handler } = createTool();
-
-		const result = await handler({ includeOffline: true }, {});
-
-		expect(result.structuredContent?.devices).toHaveLength(2);
-		expect(result.structuredContent?.devices).toEqual(
-			expect.arrayContaining([
-				expect.objectContaining({
-					deviceId: "device-online",
-					isOnline: true,
-				}),
-				expect.objectContaining({
-					deviceId: "device-offline",
-					isOnline: false,
-				}),
-			]),
-		);
 	});
 });

--- a/packages/mcp/src/tools/devices/list-devices/list-devices.ts
+++ b/packages/mcp/src/tools/devices/list-devices/list-devices.ts
@@ -5,20 +5,12 @@ import { desc, eq } from "drizzle-orm";
 import { z } from "zod";
 import { getMcpContext } from "../../utils";
 
-const DEVICE_ONLINE_WINDOW_MS = 60_000;
-
 export function register(server: McpServer) {
 	server.registerTool(
 		"list_devices",
 		{
-			description:
-				"List devices in the organization. By default, only devices seen within the last 60 seconds are returned.",
-			inputSchema: {
-				includeOffline: z
-					.boolean()
-					.default(false)
-					.describe("Include devices that have not checked in recently"),
-			},
+			description: "List registered devices in the organization.",
+			inputSchema: {},
 			outputSchema: {
 				devices: z.array(
 					z.object({
@@ -29,15 +21,12 @@ export function register(server: McpServer) {
 						ownerId: z.string(),
 						ownerName: z.string().nullable(),
 						ownerEmail: z.string(),
-						isOnline: z.boolean(),
 					}),
 				),
 			},
 		},
-		async (args, extra) => {
+		async (_args, extra) => {
 			const ctx = getMcpContext(extra);
-			const includeOffline = args.includeOffline === true;
-			const onlineCutoff = Date.now() - DEVICE_ONLINE_WINDOW_MS;
 
 			const devices = await db
 				.select({
@@ -54,17 +43,10 @@ export function register(server: McpServer) {
 				.where(eq(devicePresence.organizationId, ctx.organizationId))
 				.orderBy(desc(devicePresence.lastSeenAt));
 
-			const result = devices
-				.map((d) => {
-					const isOnline = d.lastSeenAt.getTime() >= onlineCutoff;
-
-					return {
-						...d,
-						lastSeenAt: d.lastSeenAt.toISOString(),
-						isOnline,
-					};
-				})
-				.filter((device) => includeOffline || device.isOnline);
+			const result = devices.map((d) => ({
+				...d,
+				lastSeenAt: d.lastSeenAt.toISOString(),
+			}));
 
 			return {
 				structuredContent: { devices: result },

--- a/packages/panes/src/core/store/store.ts
+++ b/packages/panes/src/core/store/store.ts
@@ -182,7 +182,7 @@ export function createWorkspaceStore<TData>(
 			const tab = buildTab({ ...args, panes: builtPanes });
 			set((s) => ({
 				tabs: [...s.tabs, tab],
-				activeTabId: s.activeTabId ?? tab.id,
+				activeTabId: tab.id,
 			}));
 		},
 


### PR DESCRIPTION
## Summary

upstream (superset-sh/superset) から behind していた25コミットのうち、「おそらく安全」と判定した中から単独取り込み可能な5件を取り込みます。PR分割戦略の第2弾。

## 取り込みコミット

| 元コミット | 内容 | 規模 |
|---|---|---|
| `97031ad01` (#3222) | feat: v2 sidebar DnD並び替え（dnd-kit導入、SortableWorkspaceItem等新設） | 大（18ファイル） |
| `4ceae6c55` ← `ed7fb5624` (#3251) | feat: v2 terminalでKitty keyboardプロトコル有効化 | 極小（1行） |
| `4f8bb1d9c` ← `abdcdc6a2` (#3275) | fix: Vite HMR時にterminal registryを保持（dev環境改善） | 極小 |
| `beeac0ec1` ← `a8f560d01` (#3299) | fix(mcp): list_devicesでデバイスをoffline判定しない（60s窓問題revert） | 小 |
| `91a6b2482` ← `e0b99ef95` (#3301) | fix: v2 workspace新規タブをアクティブ化（pane store 1行） | 極小 |

## スキップしたコミット（当初「おそらく安全」判定だったが要見直し）

- `5ac13afb2` (#3246) v2 sidebar changes tab改善 → `useWorkspaceEvent` hookを使用するが、これは `14de45b09` (unified WS event bus、要検討) で導入されるもので依存関係あり。**PR5で`14de45b09`と一緒に**
- `b12c7105a` (#3304) relay exposure security setting → 設定自体がrelayサービスに依存。`50e609fb7` (relay service) が前提なので単独取り込み不可。**PR5で`50e609fb7`と一緒に**

## コンフリクト解決

### `packages/mcp/src/tools/devices/list-devices/list-devices.test.ts`
フォークの独自コミット `5aaf3528a` (test: fix mcp utils mock leakage) が同じ mock 漏れ問題を `executeOnDeviceMock` 明示で解決していたが、upstream `a8f560d01` は `...realUtils` スプレッドでより包括的に解決している。後者の方が将来のutil追加にも耐えるため upstream 版を採用し、`executeOnDeviceMock` 関連行を削除した。

## 検証

- [x] 5コミットを chronological order で cherry-pick
- [x] `bun run typecheck` → 既存の `ModelsSettings.tsx` エラーのみ（mainと同じ）で本PRとは無関係

## Test plan

- [ ] CI通過確認
- [ ] rv-pr スキルによるレビュー
- [ ] ローカルでdesktopビルドし、以下を確認
  - [ ] v2 sidebar で workspace をDnDで並び替えできる
  - [ ] v2 terminal で Kitty keyboard protocol が機能する
  - [ ] v2 workspaceで新規タブ作成時にアクティブ化される
  - [ ] list_devices MCP tool が devices を offline 扱いしない