### PR TITLE
chore(upstream): PR3 - terminal系upstream fix 3件取り込み

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -143,6 +143,7 @@
 		"@xterm/addon-fit": "0.12.0-beta.195",
 		"@xterm/addon-image": "0.10.0-beta.195",
 		"@xterm/addon-ligatures": "0.11.0-beta.195",
+		"@xterm/addon-progress": "0.3.0-beta.195",
 		"@xterm/addon-search": "0.17.0-beta.195",
 		"@xterm/addon-serialize": "0.15.0-beta.195",
 		"@xterm/addon-unicode11": "0.10.0-beta.195",

--- a/apps/desktop/src/renderer/lib/terminal/links/buffer-helpers.test.ts
+++ b/apps/desktop/src/renderer/lib/terminal/links/buffer-helpers.test.ts
@@ -1,0 +1,534 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *
+ *  Adapted from VSCode's terminalLinkHelpers.test.ts
+ *  https://github.com/microsoft/vscode/blob/main/src/vs/workbench/contrib/terminalContrib/links/test/browser/terminalLinkHelpers.test.ts
+ *--------------------------------------------------------------------------------------------*/
+
+import { describe, expect, it } from "bun:test";
+import type { IBufferLine } from "@xterm/xterm";
+import {
+	convertLinkRangeToBuffer,
+	getXtermLineContent,
+} from "./buffer-helpers";
+
+/**
+ * Create a mock IBufferLine from a descriptor.
+ * `text` is the logical string content; `width` is the number of terminal
+ * columns the line occupies (may differ from text.length when wide/emoji chars
+ * are present).
+ */
+function createMockBufferLine(descriptor: {
+	text: string;
+	width: number;
+}): IBufferLine {
+	const { text, width } = descriptor;
+
+	// Pre-compute per-cell data: iterate the text once.
+	// Wide characters occupy 2 cells; the second cell has an empty char and
+	// width 0. Multi-codepoint characters (e.g. emoji composed of several
+	// code-units) report their full string as `getChars()`.
+	const cells: { chars: string; width: number }[] = [];
+	for (const char of text) {
+		const codePoint = char.codePointAt(0) ?? 0;
+		// Simple wide-char heuristic: CJK Unified Ideographs + some common ranges
+		const isWide =
+			(codePoint >= 0x1100 &&
+				(codePoint <= 0x115f || // Hangul Jamo
+					codePoint === 0x2329 ||
+					codePoint === 0x232a ||
+					(codePoint >= 0x2e80 && codePoint <= 0x3247) ||
+					(codePoint >= 0x3250 && codePoint <= 0x4dbf) ||
+					(codePoint >= 0x4e00 && codePoint <= 0xa4c6) ||
+					(codePoint >= 0xa960 && codePoint <= 0xa97c) ||
+					(codePoint >= 0xac00 && codePoint <= 0xd7a3) ||
+					(codePoint >= 0xf900 && codePoint <= 0xfaff) ||
+					(codePoint >= 0xfe10 && codePoint <= 0xfe19) ||
+					(codePoint >= 0xfe30 && codePoint <= 0xfe6b) ||
+					(codePoint >= 0xff01 && codePoint <= 0xff60) ||
+					(codePoint >= 0xffe0 && codePoint <= 0xffe6) ||
+					(codePoint >= 0x1f000 && codePoint <= 0x1fbff) ||
+					(codePoint >= 0x20000 && codePoint <= 0x2fffd) ||
+					(codePoint >= 0x30000 && codePoint <= 0x3fffd))) ||
+			// Emoji modifiers and common emoji ranges
+			(codePoint >= 0x1f300 && codePoint <= 0x1f9ff);
+
+		if (isWide) {
+			cells.push({ chars: char, width: 2 });
+			// Wide chars occupy a second cell with empty content
+			cells.push({ chars: "", width: 0 });
+		} else {
+			cells.push({ chars: char, width: 1 });
+		}
+	}
+
+	// Pad remaining cells to `width` with empty space cells
+	while (cells.length < width) {
+		cells.push({ chars: " ", width: 1 });
+	}
+
+	return {
+		length: width,
+		isWrapped: false,
+		getCell(x: number) {
+			const cell = cells[x];
+			if (!cell) return undefined as never;
+			return {
+				getChars: () => cell.chars,
+				getWidth: () => cell.width,
+				getCode: () => cell.chars.codePointAt(0) ?? 0,
+				isBold: () => 0,
+				isDim: () => 0,
+				isInverse: () => 0,
+				isItalic: () => 0,
+				isStrikethrough: () => 0,
+				isUnderline: () => 0,
+				isBlink: () => 0,
+				isInvisible: () => 0,
+				isOverline: () => 0,
+				isAttributeDefault: () => false,
+				getFgColorMode: () => 0,
+				getBgColorMode: () => 0,
+				getFgColor: () => 0,
+				getBgColor: () => 0,
+			} as never;
+		},
+		translateToString(
+			trimRight?: boolean,
+			startColumn?: number,
+			endColumn?: number,
+		) {
+			const start = startColumn ?? 0;
+			const end = endColumn ?? width;
+			let result = "";
+			for (let i = start; i < end && i < cells.length; i++) {
+				const c = cells[i];
+				if (c?.chars) {
+					result += c.chars;
+				}
+			}
+			if (trimRight) {
+				result = result.replace(/\s+$/, "");
+			}
+			return result;
+		},
+	} as unknown as IBufferLine;
+}
+
+function createBufferLineArray(
+	descriptors: { text: string; width: number }[],
+): IBufferLine[] {
+	return descriptors.map(createMockBufferLine);
+}
+
+describe("buffer-helpers", () => {
+	describe("convertLinkRangeToBuffer", () => {
+		it("should convert ranges for ascii characters", () => {
+			const lines = createBufferLineArray([
+				{ text: "AA http://t", width: 11 },
+				{ text: ".com/f/", width: 8 },
+			]);
+			const result = convertLinkRangeToBuffer(
+				lines,
+				11,
+				{
+					startColumn: 4,
+					startLineNumber: 1,
+					endColumn: 19,
+					endLineNumber: 1,
+				},
+				0,
+			);
+			expect(result).toEqual({
+				start: { x: 4, y: 1 },
+				end: { x: 7, y: 2 },
+			});
+		});
+
+		it("should convert ranges for wide characters before the link", () => {
+			const lines = createBufferLineArray([
+				{ text: "A文 http://", width: 11 },
+				{ text: "t.com/f/", width: 9 },
+			]);
+			const result = convertLinkRangeToBuffer(
+				lines,
+				11,
+				{
+					startColumn: 4,
+					startLineNumber: 1,
+					endColumn: 19,
+					endLineNumber: 1,
+				},
+				0,
+			);
+			expect(result).toEqual({
+				start: { x: 4 + 1, y: 1 },
+				end: { x: 7 + 1, y: 2 },
+			});
+		});
+
+		it("should give correct range for links containing multi-character emoji", () => {
+			const lines = createBufferLineArray([{ text: "A🙂 http://", width: 11 }]);
+			const result = convertLinkRangeToBuffer(
+				lines,
+				11,
+				{
+					startColumn: 0 + 1,
+					startLineNumber: 1,
+					endColumn: 2 + 1,
+					endLineNumber: 1,
+				},
+				0,
+			);
+			expect(result).toEqual({
+				start: { x: 1, y: 1 },
+				end: { x: 2, y: 1 },
+			});
+		});
+
+		// Note: In a real xterm buffer, 🙂 (U+1F642) is a supplementary character
+		// that takes 2 JS string positions (surrogate pair) AND 2 buffer cells.
+		// The algorithm correctly nets to 0 offset for emoji (width +1, chars.length -1).
+		// This differs from CJK (BMP) chars which take 1 JS position but 2 cells (+1 offset).
+		it("should convert ranges for emoji characters before the link", () => {
+			const lines = createBufferLineArray([
+				{ text: "A🙂 http://", width: 11 },
+				{ text: "t.com/f/", width: 9 },
+			]);
+			const result = convertLinkRangeToBuffer(
+				lines,
+				11,
+				{
+					startColumn: 4 + 1,
+					startLineNumber: 1,
+					endColumn: 19 + 1,
+					endLineNumber: 1,
+				},
+				0,
+			);
+			// Emoji offset is 0: the surrogate pair occupies 2 text positions
+			// matching the 2 buffer cells, so no adjustment needed.
+			expect(result).toEqual({
+				start: { x: 5, y: 1 },
+				end: { x: 8, y: 2 },
+			});
+		});
+
+		it("should convert ranges for wide characters inside the link", () => {
+			const lines = createBufferLineArray([
+				{ text: "AA http://t", width: 11 },
+				{ text: ".com/文/", width: 8 },
+			]);
+			const result = convertLinkRangeToBuffer(
+				lines,
+				11,
+				{
+					startColumn: 4,
+					startLineNumber: 1,
+					endColumn: 19,
+					endLineNumber: 1,
+				},
+				0,
+			);
+			expect(result).toEqual({
+				start: { x: 4, y: 1 },
+				end: { x: 7 + 1, y: 2 },
+			});
+		});
+
+		it("should convert ranges for wide characters before and inside the link", () => {
+			const lines = createBufferLineArray([
+				{ text: "A文 http://", width: 11 },
+				{ text: "t.com/文/", width: 9 },
+			]);
+			const result = convertLinkRangeToBuffer(
+				lines,
+				11,
+				{
+					startColumn: 4,
+					startLineNumber: 1,
+					endColumn: 19,
+					endLineNumber: 1,
+				},
+				0,
+			);
+			expect(result).toEqual({
+				start: { x: 4 + 1, y: 1 },
+				end: { x: 7 + 2, y: 2 },
+			});
+		});
+
+		it("should convert ranges for emoji before and wide inside the link", () => {
+			const lines = createBufferLineArray([
+				{ text: "A🙂 http://", width: 11 },
+				{ text: "t.com/文/", width: 9 },
+			]);
+			const result = convertLinkRangeToBuffer(
+				lines,
+				11,
+				{
+					startColumn: 4 + 1,
+					startLineNumber: 1,
+					endColumn: 19 + 1,
+					endLineNumber: 1,
+				},
+				0,
+			);
+			// Emoji before: 0 offset. CJK inside link: +1 offset.
+			expect(result).toEqual({
+				start: { x: 5, y: 1 },
+				end: { x: 9, y: 2 },
+			});
+		});
+
+		it("should convert ranges for ascii characters (link starts on wrapped line)", () => {
+			const lines = createBufferLineArray([
+				{ text: "AAAAAAAAAAA", width: 11 },
+				{ text: "AA http://t", width: 11 },
+				{ text: ".com/f/", width: 8 },
+			]);
+			const result = convertLinkRangeToBuffer(
+				lines,
+				11,
+				{
+					startColumn: 15,
+					startLineNumber: 1,
+					endColumn: 30,
+					endLineNumber: 1,
+				},
+				0,
+			);
+			expect(result).toEqual({
+				start: { x: 4, y: 2 },
+				end: { x: 7, y: 3 },
+			});
+		});
+
+		it("should convert ranges for wide characters before the link (link starts on wrapped line)", () => {
+			const lines = createBufferLineArray([
+				{ text: "AAAAAAAAAAA", width: 11 },
+				{ text: "A文 http://", width: 11 },
+				{ text: "t.com/f/", width: 9 },
+			]);
+			const result = convertLinkRangeToBuffer(
+				lines,
+				11,
+				{
+					startColumn: 15,
+					startLineNumber: 1,
+					endColumn: 30,
+					endLineNumber: 1,
+				},
+				0,
+			);
+			expect(result).toEqual({
+				start: { x: 4 + 1, y: 2 },
+				end: { x: 7 + 1, y: 3 },
+			});
+		});
+
+		it("regression test #147619: CJK text with numbers", () => {
+			const lines = createBufferLineArray([
+				{ text: "获取模板 25235168 的预览图失败", width: 30 },
+			]);
+			expect(
+				convertLinkRangeToBuffer(
+					lines,
+					30,
+					{
+						startColumn: 1,
+						startLineNumber: 1,
+						endColumn: 5,
+						endLineNumber: 1,
+					},
+					0,
+				),
+			).toEqual({
+				start: { x: 1, y: 1 },
+				end: { x: 8, y: 1 },
+			});
+			expect(
+				convertLinkRangeToBuffer(
+					lines,
+					30,
+					{
+						startColumn: 6,
+						startLineNumber: 1,
+						endColumn: 14,
+						endLineNumber: 1,
+					},
+					0,
+				),
+			).toEqual({
+				start: { x: 10, y: 1 },
+				end: { x: 17, y: 1 },
+			});
+			expect(
+				convertLinkRangeToBuffer(
+					lines,
+					30,
+					{
+						startColumn: 15,
+						startLineNumber: 1,
+						endColumn: 21,
+						endLineNumber: 1,
+					},
+					0,
+				),
+			).toEqual({
+				start: { x: 19, y: 1 },
+				end: { x: 30, y: 1 },
+			});
+		});
+
+		it("should convert ranges for wide characters inside the link (link starts on wrapped line)", () => {
+			const lines = createBufferLineArray([
+				{ text: "AAAAAAAAAAA", width: 11 },
+				{ text: "AA http://t", width: 11 },
+				{ text: ".com/文/", width: 8 },
+			]);
+			const result = convertLinkRangeToBuffer(
+				lines,
+				11,
+				{
+					startColumn: 15,
+					startLineNumber: 1,
+					endColumn: 30,
+					endLineNumber: 1,
+				},
+				0,
+			);
+			expect(result).toEqual({
+				start: { x: 4, y: 2 },
+				end: { x: 7 + 1, y: 3 },
+			});
+		});
+
+		it("should convert ranges for wide characters before and inside the link #2", () => {
+			const lines = createBufferLineArray([
+				{ text: "AAAAAAAAAAA", width: 11 },
+				{ text: "A文 http://", width: 11 },
+				{ text: "t.com/文/", width: 9 },
+			]);
+			const result = convertLinkRangeToBuffer(
+				lines,
+				11,
+				{
+					startColumn: 15,
+					startLineNumber: 1,
+					endColumn: 30,
+					endLineNumber: 1,
+				},
+				0,
+			);
+			expect(result).toEqual({
+				start: { x: 4 + 1, y: 2 },
+				end: { x: 7 + 2, y: 3 },
+			});
+		});
+
+		it("should convert ranges for several wide characters before the link", () => {
+			const lines = createBufferLineArray([
+				{ text: "A文文AAAAAA", width: 11 },
+				{ text: "AA文文 http", width: 11 },
+				{ text: "://t.com/f/", width: 11 },
+			]);
+			const result = convertLinkRangeToBuffer(
+				lines,
+				11,
+				{
+					startColumn: 15,
+					startLineNumber: 1,
+					endColumn: 30,
+					endLineNumber: 1,
+				},
+				0,
+			);
+			expect(result).toEqual({
+				start: { x: 3 + 4, y: 2 },
+				end: { x: 6 + 4, y: 3 },
+			});
+		});
+
+		it("should convert ranges for several wide characters before and inside the link", () => {
+			const lines = createBufferLineArray([
+				{ text: "A文文AAAAAA", width: 11 },
+				{ text: "AA文文 http", width: 11 },
+				{ text: "://t.com/文", width: 11 },
+				{ text: "文/", width: 3 },
+			]);
+			// Text "A文文AAAAAAA文文 http://t.com/文文/" = 28 chars
+			// Line 0: A(1)+文(2+pad)+文(2+pad)+A(1)*6 = 11 cells. Text offset +2 (2 CJK)
+			// Line 1: A(1)*2+文(2+pad)+文(2+pad)+space(1)+h(1)+t(1)+t(1)+p(1) = 11 cells. Text offset +2 (2 CJK)
+			// Line 2: :(1)+/(1)+/(1)+t(1)+.(1)+c(1)+o(1)+m(1)+/(1)+文(2) = 11 cells. Text offset +1 (1 CJK)
+			// Line 3: 文(2)+/(1) = 3 cells. Text offset +1 (1 CJK)
+			const result = convertLinkRangeToBuffer(
+				lines,
+				11,
+				{
+					startColumn: 14,
+					startLineNumber: 1,
+					endColumn: 31,
+					endLineNumber: 1,
+				},
+				0,
+			);
+			expect(result).toEqual({
+				start: { x: 5, y: 2 },
+				end: { x: 1, y: 4 },
+			});
+		});
+	});
+
+	describe("getXtermLineContent", () => {
+		it("should extract text from a single line", () => {
+			const line = createMockBufferLine({ text: "hello world", width: 80 });
+			const buffer = {
+				getLine: (i: number) => (i === 0 ? line : undefined),
+			};
+			const result = getXtermLineContent(buffer as never, 0, 0, 80);
+			expect(result).toBe("hello world");
+		});
+
+		it("should concatenate multiple wrapped lines", () => {
+			// Note: translateToString(true) trims trailing whitespace, so the
+			// first line's text must fill the width to preserve the trailing space.
+			const line0 = createMockBufferLine({ text: "hello wor!", width: 10 });
+			const line1 = createMockBufferLine({ text: "ld", width: 10 });
+			const buffer = {
+				getLine: (i: number) => {
+					if (i === 0) return line0;
+					if (i === 1) return line1;
+					return undefined;
+				},
+			};
+			const result = getXtermLineContent(buffer as never, 0, 1, 10);
+			expect(result).toBe("hello wor!ld");
+		});
+
+		it("should cap lines to prevent excessive reads", () => {
+			// With cols=10, maxLineLength = max(2048, 20) = 2048
+			// lineEnd is capped to lineStart + 2048
+			const lines = new Map<number, IBufferLine>();
+			for (let i = 0; i < 300; i++) {
+				lines.set(i, createMockBufferLine({ text: "a".repeat(10), width: 10 }));
+			}
+			const buffer = {
+				getLine: (i: number) => lines.get(i),
+			};
+			// Even if we request 300 lines (3000 chars), it should cap
+			const result = getXtermLineContent(buffer as never, 0, 299, 10);
+			// With the cap, we should get at most ~2048 lines * cols worth of text
+			expect(result.length).toBeLessThanOrEqual(2048 * 10);
+		});
+
+		it("should handle missing lines gracefully", () => {
+			const buffer = {
+				getLine: () => undefined,
+			};
+			const result = getXtermLineContent(buffer as never, 0, 0, 80);
+			expect(result).toBe("");
+		});
+	});
+});

--- a/apps/desktop/src/renderer/lib/terminal/links/buffer-helpers.ts
+++ b/apps/desktop/src/renderer/lib/terminal/links/buffer-helpers.ts
@@ -1,0 +1,224 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *
+ *  Adapted from VSCode's terminalLinkHelpers.ts
+ *  https://github.com/microsoft/vscode/blob/main/src/vs/workbench/contrib/terminalContrib/links/browser/terminalLinkHelpers.ts
+ *--------------------------------------------------------------------------------------------*/
+
+import type { IBuffer, IBufferLine, IBufferRange } from "@xterm/xterm";
+
+/**
+ * A simplified IRange representation (1-based columns, 1-based lines) matching
+ * the shape VSCode feeds into convertLinkRangeToBuffer.
+ */
+export interface IRange {
+	startColumn: number;
+	startLineNumber: number;
+	endColumn: number;
+	endLineNumber: number;
+}
+
+/**
+ * Convert a text-offset range (IRange) into a buffer-cell range (IBufferRange),
+ * correctly accounting for wide characters (CJK, emoji) that occupy 2 cells but
+ * only 1 logical character position.
+ *
+ * This is ported directly from VSCode to fix a class of bugs where the
+ * highlighted link range is shifted when wide characters appear on the same
+ * line.
+ */
+export function convertLinkRangeToBuffer(
+	lines: IBufferLine[],
+	bufferWidth: number,
+	range: IRange,
+	startLine: number,
+): IBufferRange {
+	const bufferRange: IBufferRange = {
+		start: {
+			x: range.startColumn,
+			y: range.startLineNumber + startLine,
+		},
+		end: {
+			x: range.endColumn - 1,
+			y: range.endLineNumber + startLine,
+		},
+	};
+
+	// Calculate start offset caused by wide chars before the start column
+	let startOffset = 0;
+	const startWrappedLineCount = Math.ceil(range.startColumn / bufferWidth);
+	for (let y = 0; y < Math.min(startWrappedLineCount); y++) {
+		const lineLength = Math.min(
+			bufferWidth,
+			range.startColumn - 1 - y * bufferWidth,
+		);
+		let lineOffset = 0;
+		const line = lines[y];
+		if (!line) {
+			break;
+		}
+		for (let x = 0; x < Math.min(bufferWidth, lineLength + lineOffset); x++) {
+			const cell = line.getCell(x);
+			if (!cell) {
+				break;
+			}
+			const width = cell.getWidth();
+			if (width === 2) {
+				lineOffset++;
+			}
+			const char = cell.getChars();
+			if (char.length > 1) {
+				lineOffset -= char.length - 1;
+			}
+		}
+		startOffset += lineOffset;
+	}
+
+	// Calculate end offset caused by wide chars between start and end columns
+	let endOffset = 0;
+	const endWrappedLineCount = Math.ceil(range.endColumn / bufferWidth);
+	for (
+		let y = Math.max(0, startWrappedLineCount - 1);
+		y < endWrappedLineCount;
+		y++
+	) {
+		const start =
+			y === startWrappedLineCount - 1
+				? (range.startColumn - 1 + startOffset) % bufferWidth
+				: 0;
+		const lineLength = Math.min(
+			bufferWidth,
+			range.endColumn + startOffset - y * bufferWidth,
+		);
+		let lineOffset = 0;
+		const line = lines[y];
+		if (!line) {
+			break;
+		}
+		for (
+			let x = start;
+			x < Math.min(bufferWidth, lineLength + lineOffset);
+			x++
+		) {
+			const cell = line.getCell(x);
+			if (!cell) {
+				break;
+			}
+			const width = cell.getWidth();
+			const chars = cell.getChars();
+			if (width === 2) {
+				lineOffset++;
+			}
+			// A wide character that can't fit at the last column causes xterm to
+			// place an empty marker cell (width=1, chars="") there and wrap the
+			// char to the next line. A normal padding cell (the 2nd half of a
+			// wide char that DID fit) has width=0 and should NOT trigger an
+			// extra offset. VSCode's original code only checks `chars === ""`
+			// which is overly broad; we add a width check to avoid false
+			// positives when a wide char's padding cell lands on the last column.
+			if (x === bufferWidth - 1 && chars === "" && cell.getWidth() !== 0) {
+				lineOffset++;
+			}
+			if (chars.length > 1) {
+				lineOffset -= chars.length - 1;
+			}
+		}
+		endOffset += lineOffset;
+	}
+
+	bufferRange.start.x += startOffset;
+	bufferRange.end.x += startOffset + endOffset;
+
+	// Wrap x values that overflow a line into the next line
+	while (bufferRange.start.x > bufferWidth) {
+		bufferRange.start.x -= bufferWidth;
+		bufferRange.start.y++;
+	}
+	while (bufferRange.end.x > bufferWidth) {
+		bufferRange.end.x -= bufferWidth;
+		bufferRange.end.y++;
+	}
+
+	return bufferRange;
+}
+
+/**
+ * Split terminal lines by text attributes (bold, underline, italic, etc.).
+ * Returns buffer ranges where each range has consistent styling.
+ *
+ * Used as a last-resort fallback for link detection: if a filename is printed
+ * with different styling (e.g. bold or underlined) than surrounding text,
+ * each styled segment can be tested as a potential file path.
+ *
+ * Vendored from VSCode's terminalLinkHelpers.ts.
+ */
+export function getXtermRangesByAttr(
+	buffer: IBuffer,
+	lineStart: number,
+	lineEnd: number,
+	cols: number,
+): IBufferRange[] {
+	let bufferRangeStart: { x: number; y: number } | undefined;
+	let lastFgAttr = -1;
+	let lastBgAttr = -1;
+	const ranges: IBufferRange[] = [];
+	for (let y = lineStart; y <= lineEnd; y++) {
+		const line = buffer.getLine(y);
+		if (!line) {
+			continue;
+		}
+		for (let x = 0; x < cols; x++) {
+			const cell = line.getCell(x);
+			if (!cell) {
+				break;
+			}
+			// Re-construct the attributes from fg and bg. This relies on
+			// xterm's internal buffer bit layout (same approach as VSCode).
+			const thisFgAttr =
+				cell.isBold() |
+				cell.isInverse() |
+				cell.isStrikethrough() |
+				cell.isUnderline();
+			const thisBgAttr = cell.isDim() | cell.isItalic();
+			if (lastFgAttr === -1 || lastBgAttr === -1) {
+				bufferRangeStart = { x, y };
+			} else {
+				if (lastFgAttr !== thisFgAttr || lastBgAttr !== thisBgAttr) {
+					if (bufferRangeStart) {
+						ranges.push({
+							start: bufferRangeStart,
+							end: { x, y },
+						});
+					}
+					bufferRangeStart = { x, y };
+				}
+			}
+			lastFgAttr = thisFgAttr;
+			lastBgAttr = thisBgAttr;
+		}
+	}
+	return ranges;
+}
+
+/**
+ * Extract the text content from a range of terminal buffer lines.
+ * Caps the maximum read length to prevent excessive reads on very long output.
+ */
+export function getXtermLineContent(
+	buffer: IBuffer,
+	lineStart: number,
+	lineEnd: number,
+	cols: number,
+): string {
+	const maxLineLength = Math.max(2048, cols * 2);
+	const cappedEnd = Math.min(lineEnd, lineStart + maxLineLength);
+	let content = "";
+	for (let i = lineStart; i <= cappedEnd; i++) {
+		const line = buffer.getLine(i);
+		if (line) {
+			content += line.translateToString(true, 0, cols);
+		}
+	}
+	return content;
+}

--- a/apps/desktop/src/renderer/lib/terminal/links/index.ts
+++ b/apps/desktop/src/renderer/lib/terminal/links/index.ts
@@ -1,0 +1,20 @@
+export type { IRange } from "./buffer-helpers";
+export {
+	convertLinkRangeToBuffer,
+	getXtermLineContent,
+} from "./buffer-helpers";
+
+export { LinkDetectorAdapter } from "./link-detector-adapter";
+
+export {
+	type ResolvedLink,
+	type StatCallback,
+	TerminalLinkResolver,
+} from "./link-resolver";
+
+export {
+	type DetectedLink,
+	LocalLinkDetector,
+} from "./local-link-detector";
+
+export { WordLinkDetector } from "./word-link-detector";

--- a/apps/desktop/src/renderer/lib/terminal/links/link-detector-adapter.test.ts
+++ b/apps/desktop/src/renderer/lib/terminal/links/link-detector-adapter.test.ts
@@ -1,0 +1,204 @@
+/*---------------------------------------------------------------------------------------------
+ *  Tests for LinkDetectorAdapter — the bridge between LocalLinkDetector
+ *  and xterm's ILinkProvider interface.
+ *--------------------------------------------------------------------------------------------*/
+
+import { describe, expect, it } from "bun:test";
+import type { ILink } from "@xterm/xterm";
+import { LinkDetectorAdapter } from "./link-detector-adapter";
+import type { StatCallback } from "./link-resolver";
+import { TerminalLinkResolver } from "./link-resolver";
+import { LocalLinkDetector } from "./local-link-detector";
+
+// ---------------------------------------------------------------------------
+// Mock terminal buffer
+// ---------------------------------------------------------------------------
+
+function createMockTerminal(
+	lineDescriptors: { text: string; isWrapped?: boolean }[],
+	cols = 80,
+) {
+	const lines = lineDescriptors.map((desc) => ({
+		translateToString: (
+			_trim?: boolean,
+			startColumn?: number,
+			endColumn?: number,
+		) => {
+			const start = startColumn ?? 0;
+			const end = endColumn ?? cols;
+			let result = desc.text;
+			// Pad to cols width for consistency
+			result = result.padEnd(cols);
+			result = result.substring(start, end);
+			if (_trim) result = result.replace(/\s+$/, "");
+			return result;
+		},
+		isWrapped: desc.isWrapped ?? false,
+		length: cols,
+		getCell: (x: number) =>
+			({
+				getChars: () => (x < desc.text.length ? desc.text[x] : " "),
+				getWidth: () => 1,
+			}) as never,
+	}));
+
+	return {
+		cols,
+		buffer: {
+			active: {
+				length: lines.length,
+				getLine: (i: number) => lines[i] ?? null,
+				viewportY: 0,
+			},
+		},
+	} as never;
+}
+
+function createAdapter(
+	lineDescriptors: (string | { text: string; isWrapped?: boolean })[],
+	validPaths: string[],
+	opts?: { initialCwd?: string; userHome?: string; cols?: number },
+) {
+	const descriptors = lineDescriptors.map((d) =>
+		typeof d === "string" ? { text: d } : d,
+	);
+	const statMock: StatCallback = async (path) => {
+		if (validPaths.includes(path)) {
+			return { isDirectory: false };
+		}
+		return null;
+	};
+	const resolver = new TerminalLinkResolver(statMock);
+	const cols = opts?.cols ?? 80;
+	const terminal = createMockTerminal(descriptors, cols);
+	const detector = new LocalLinkDetector(resolver);
+
+	const adapter = new LinkDetectorAdapter(terminal, detector);
+	return { adapter, terminal };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("LinkDetectorAdapter", () => {
+	it("should implement ILinkProvider.provideLinks", async () => {
+		const { adapter } = createAdapter(
+			["see /foo/bar.ts for details"],
+			["/foo/bar.ts"],
+		);
+
+		const links = await new Promise<ILink[] | undefined>((resolve) => {
+			adapter.provideLinks(1, resolve);
+		});
+
+		expect(links).toBeDefined();
+		expect(links).toHaveLength(1);
+		expect(links?.[0]?.text).toBe("/foo/bar.ts");
+	});
+
+	it("should return undefined when no links found", async () => {
+		const { adapter } = createAdapter(["just regular text"], []);
+
+		const links = await new Promise<ILink[] | undefined>((resolve) => {
+			adapter.provideLinks(1, resolve);
+		});
+
+		expect(links).toBeUndefined();
+	});
+
+	it("should set correct buffer ranges", async () => {
+		const { adapter } = createAdapter(
+			["see /foo/bar.ts for details"],
+			["/foo/bar.ts"],
+		);
+
+		const links = await new Promise<ILink[] | undefined>((resolve) => {
+			adapter.provideLinks(1, resolve);
+		});
+
+		const range = links?.[0]?.range;
+		expect(range).toBeDefined();
+		// "/foo/bar.ts" starts at index 4 in "see /foo/bar.ts for details"
+		expect(range?.start.y).toBe(1);
+		expect(range?.start.x).toBe(5); // 1-based: index 4 + 1
+		expect(range?.end.x).toBe(15); // 1-based: index 4 + 11
+	});
+
+	it("should detect multiple links", async () => {
+		const { adapter } = createAdapter(
+			["error in /foo/a.ts and /foo/b.ts"],
+			["/foo/a.ts", "/foo/b.ts"],
+		);
+
+		const links = await new Promise<ILink[] | undefined>((resolve) => {
+			adapter.provideLinks(1, resolve);
+		});
+
+		expect(links).toHaveLength(2);
+	});
+
+	it("should handle multi-line buffer (only detect for requested line)", async () => {
+		const { adapter } = createAdapter(
+			["line one", "see /foo/bar.ts", "line three"],
+			["/foo/bar.ts"],
+		);
+
+		// Request line 2 (1-based)
+		const links = await new Promise<ILink[] | undefined>((resolve) => {
+			adapter.provideLinks(2, resolve);
+		});
+
+		expect(links).toHaveLength(1);
+		expect(links?.[0]?.text).toBe("/foo/bar.ts");
+	});
+
+	it("should return undefined for out-of-range lines", async () => {
+		const { adapter } = createAdapter(["hello"], ["/foo/bar.ts"]);
+
+		const links = await new Promise<ILink[] | undefined>((resolve) => {
+			adapter.provideLinks(99, resolve);
+		});
+
+		expect(links).toBeUndefined();
+	});
+
+	it("should include line/col suffix in range but call activate with path info", async () => {
+		const { adapter } = createAdapter(["/foo/bar.ts:42:10"], ["/foo/bar.ts"]);
+
+		const links = await new Promise<ILink[] | undefined>((resolve) => {
+			adapter.provideLinks(1, resolve);
+		});
+
+		expect(links).toHaveLength(1);
+		// The full text includes the suffix
+		expect(links?.[0]?.text).toBe("/foo/bar.ts:42:10");
+	});
+
+	it("should detect paths spanning wrapped lines", async () => {
+		// Simulate a 30-col terminal where a long path wraps
+		const { adapter } = createAdapter(
+			[
+				// Line 1: "see /parent/cwd/apps/web/sr" (30 chars)
+				{ text: "see /parent/cwd/apps/web/sr" },
+				// Line 2 (wrapped): "c/app/page.tsx:1 for info" (continues from line 1)
+				{ text: "c/app/page.tsx:1 for info", isWrapped: true },
+			],
+			["/parent/cwd/apps/web/src/app/page.tsx"],
+			{ cols: 30, initialCwd: "/parent/cwd" },
+		);
+
+		// Request line 1 (the start of the wrapped path)
+		const links = await new Promise<ILink[] | undefined>((resolve) => {
+			adapter.provideLinks(1, resolve);
+		});
+
+		expect(links).toBeDefined();
+		expect(links?.length).toBeGreaterThanOrEqual(1);
+		// The detected text should be the full path including suffix
+		const pathLink = links?.find((l) =>
+			l.text.includes("apps/web/src/app/page.tsx"),
+		);
+		expect(pathLink).toBeDefined();
+	});
+});

--- a/apps/desktop/src/renderer/lib/terminal/links/link-detector-adapter.ts
+++ b/apps/desktop/src/renderer/lib/terminal/links/link-detector-adapter.ts
@@ -1,0 +1,241 @@
+/*---------------------------------------------------------------------------------------------
+ *  Adapted from VSCode's terminalLinkDetectorAdapter.ts
+ *  https://github.com/microsoft/vscode/blob/main/src/vs/workbench/contrib/terminalContrib/links/browser/terminalLinkDetectorAdapter.ts
+ *
+ *  Bridges LocalLinkDetector to xterm's ILinkProvider interface.
+ *  Handles multi-line wrapped paths by gathering context lines.
+ *  Deduplicates in-flight requests per buffer line (VSCode pattern).
+ *--------------------------------------------------------------------------------------------*/
+
+import type { IBufferLine, ILink, ILinkProvider, Terminal } from "@xterm/xterm";
+import {
+	convertLinkRangeToBuffer,
+	getXtermLineContent,
+	getXtermRangesByAttr,
+} from "./buffer-helpers";
+import type { DetectedLink, LocalLinkDetector } from "./local-link-detector";
+
+/** Maximum characters of context to gather around the hovered line. */
+const MAX_LINK_LENGTH = 500;
+
+/**
+ * Adapts a LocalLinkDetector into xterm's ILinkProvider.
+ *
+ * When xterm calls `provideLinks(bufferLineNumber)`, this adapter:
+ * 1. Deduplicates in-flight requests for the same line
+ * 2. Gathers wrapped context lines (previous + current + next)
+ * 3. Concatenates them into a single text block
+ * 4. Delegates to LocalLinkDetector.detect()
+ * 5. If no links found, tries styled-text detection (getXtermRangesByAttr)
+ * 6. Maps detected ranges back to buffer coordinates using
+ *    convertLinkRangeToBuffer (handles wide chars correctly)
+ */
+export class LinkDetectorAdapter implements ILinkProvider {
+	/**
+	 * Cache of in-flight link detection requests per buffer line.
+	 * Prevents duplicate async work when xterm requests the same line
+	 * multiple times during rapid mouse movement (VSCode pattern).
+	 */
+	private _activeRequests = new Map<number, Promise<ILink[]>>();
+
+	constructor(
+		private readonly _terminal: Terminal,
+		private readonly _detector: LocalLinkDetector,
+		private readonly _onActivate?: (
+			event: MouseEvent,
+			link: DetectedLink,
+		) => void,
+	) {}
+
+	provideLinks(
+		bufferLineNumber: number,
+		callback: (links: ILink[] | undefined) => void,
+	): void {
+		// Reuse in-flight request for this line if one exists
+		let request = this._activeRequests.get(bufferLineNumber);
+		if (!request) {
+			request = this._provideLinks(bufferLineNumber);
+			this._activeRequests.set(bufferLineNumber, request);
+		}
+		request.then(
+			(links) => {
+				this._activeRequests.delete(bufferLineNumber);
+				callback(links.length > 0 ? links : undefined);
+			},
+			() => {
+				this._activeRequests.delete(bufferLineNumber);
+				callback(undefined);
+			},
+		);
+	}
+
+	private async _provideLinks(bufferLineNumber: number): Promise<ILink[]> {
+		const buffer = this._terminal.buffer.active;
+		const cols = this._terminal.cols;
+
+		// Gather wrapped context lines around the target line.
+		// VSCode caps context to maxLinkLength chars on either side.
+		let startLine = bufferLineNumber - 1;
+		let endLine = startLine;
+
+		const lines: IBufferLine[] = [];
+		const currentLine = buffer.getLine(startLine);
+		if (!currentLine) return [];
+		lines.push(currentLine);
+
+		const maxCharacterContext = Math.max(MAX_LINK_LENGTH, cols);
+		const maxLineContext = Math.ceil(maxCharacterContext / cols);
+		const minStartLine = Math.max(startLine - maxLineContext, 0);
+		const maxEndLine = Math.min(endLine + maxLineContext, buffer.length);
+
+		// Walk backward through wrapped lines
+		while (startLine >= minStartLine && buffer.getLine(startLine)?.isWrapped) {
+			const prevLine = buffer.getLine(startLine - 1);
+			if (!prevLine) break;
+			lines.unshift(prevLine);
+			startLine--;
+		}
+
+		// Walk forward through wrapped lines
+		while (endLine < maxEndLine && buffer.getLine(endLine + 1)?.isWrapped) {
+			const nextLine = buffer.getLine(endLine + 1);
+			if (!nextLine) break;
+			lines.push(nextLine);
+			endLine++;
+		}
+
+		// Concatenate all gathered lines into one text block
+		const text = getXtermLineContent(buffer, startLine, endLine, cols);
+		if (!text) return [];
+
+		const detectedLinks = await this._detector.detect(text);
+		let result = this._mapDetectedLinks(
+			detectedLinks,
+			lines,
+			cols,
+			startLine,
+			bufferLineNumber,
+		);
+
+		// VENDORED FROM VSCODE (terminalLocalLinkDetector.ts lines 220-252):
+		// Styled-text fallback — if no links found, split lines by terminal
+		// attributes (bold/underline/italic) and try each styled segment as
+		// a file path. Catches filenames that the app printed with styling.
+		// To disable: remove or comment out this block.
+		if (result.length === 0) {
+			result = await this._detectStyledTextLinks(
+				startLine,
+				endLine,
+				bufferLineNumber,
+			);
+		}
+
+		return result;
+	}
+
+	/**
+	 * Styled-text fallback: split lines by terminal attributes and try each
+	 * segment as a file path. Vendored from VSCode's TerminalLocalLinkDetector.
+	 */
+	private async _detectStyledTextLinks(
+		startLine: number,
+		endLine: number,
+		bufferLineNumber: number,
+	): Promise<ILink[]> {
+		const buffer = this._terminal.buffer.active;
+		const cols = this._terminal.cols;
+		const result: ILink[] = [];
+
+		const rangeCandidates = getXtermRangesByAttr(
+			buffer,
+			startLine,
+			endLine,
+			cols,
+		);
+
+		for (const rangeCandidate of rangeCandidates) {
+			let text = "";
+			for (let y = rangeCandidate.start.y; y <= rangeCandidate.end.y; y++) {
+				const line = buffer.getLine(y);
+				if (!line) break;
+				const lineStartX =
+					y === rangeCandidate.start.y ? rangeCandidate.start.x : 0;
+				const lineEndX =
+					y === rangeCandidate.end.y ? rangeCandidate.end.x : cols - 1;
+				text += line.translateToString(false, lineStartX, lineEndX);
+			}
+
+			if (!text.trim()) continue;
+
+			// Adjust to 1-based for xterm link API (matches VSCode's HACK comment)
+			const range = {
+				start: {
+					x: rangeCandidate.start.x + 1,
+					y: rangeCandidate.start.y + 1,
+				},
+				end: {
+					x: rangeCandidate.end.x,
+					y: rangeCandidate.end.y + 1,
+				},
+			};
+
+			// Only include if overlaps with requested line
+			if (range.end.y < bufferLineNumber || range.start.y > bufferLineNumber) {
+				continue;
+			}
+
+			const detectedLinks = await this._detector.detect(text.trim());
+			for (const detected of detectedLinks) {
+				result.push({
+					range,
+					text: detected.text,
+					activate: (event: MouseEvent) => {
+						this._onActivate?.(event, detected);
+					},
+				});
+			}
+		}
+
+		return result;
+	}
+
+	private _mapDetectedLinks(
+		detectedLinks: DetectedLink[],
+		lines: IBufferLine[],
+		cols: number,
+		startLine: number,
+		bufferLineNumber: number,
+	): ILink[] {
+		const result: ILink[] = [];
+
+		for (const detected of detectedLinks) {
+			// Convert text offsets to buffer range, accounting for wide chars
+			const range = convertLinkRangeToBuffer(
+				lines,
+				cols,
+				{
+					startColumn: detected.startIndex + 1, // 1-based
+					startLineNumber: 1,
+					endColumn: detected.endIndex + 1,
+					endLineNumber: 1,
+				},
+				startLine,
+			);
+
+			// Only include links that overlap with the requested line
+			if (range.end.y < bufferLineNumber || range.start.y > bufferLineNumber) {
+				continue;
+			}
+
+			result.push({
+				range,
+				text: detected.text,
+				activate: (event: MouseEvent) => {
+					this._onActivate?.(event, detected);
+				},
+			});
+		}
+
+		return result;
+	}
+}

--- a/apps/desktop/src/renderer/lib/terminal/links/link-resolver.test.ts
+++ b/apps/desktop/src/renderer/lib/terminal/links/link-resolver.test.ts
@@ -1,0 +1,203 @@
+/*---------------------------------------------------------------------------------------------
+ *  Link resolver tests
+ *--------------------------------------------------------------------------------------------*/
+
+import { afterEach, beforeEach, describe, expect, it, jest } from "bun:test";
+import { TerminalLinkResolver } from "./link-resolver";
+
+describe("TerminalLinkResolver", () => {
+	let resolver: TerminalLinkResolver;
+	let statMock: jest.Mock<
+		(path: string) => Promise<{
+			isDirectory: boolean;
+			resolvedPath?: string;
+		} | null>
+	>;
+
+	beforeEach(() => {
+		statMock = jest.fn();
+		resolver = new TerminalLinkResolver(statMock);
+	});
+
+	afterEach(() => {
+		jest.restoreAllMocks();
+	});
+
+	describe("resolveLink", () => {
+		it("should pass path to stat callback", async () => {
+			statMock.mockResolvedValue({ isDirectory: false });
+			const result = await resolver.resolveLink("/foo/bar.ts");
+			expect(result).toEqual({
+				path: "/foo/bar.ts",
+				isDirectory: false,
+			});
+			expect(statMock).toHaveBeenCalledWith("/foo/bar.ts");
+		});
+
+		it("should pass relative paths through to stat (host resolves)", async () => {
+			statMock.mockResolvedValue({
+				isDirectory: false,
+				resolvedPath: "/workspace/src/file.ts",
+			});
+			const result = await resolver.resolveLink("src/file.ts");
+			expect(result).toEqual({
+				path: "/workspace/src/file.ts",
+				isDirectory: false,
+			});
+			expect(statMock).toHaveBeenCalledWith("src/file.ts");
+		});
+
+		it("should pass tilde paths through to stat (host resolves)", async () => {
+			statMock.mockResolvedValue({
+				isDirectory: false,
+				resolvedPath: "/home/user/foo.ts",
+			});
+			const result = await resolver.resolveLink("~/foo.ts");
+			expect(result).toEqual({
+				path: "/home/user/foo.ts",
+				isDirectory: false,
+			});
+			expect(statMock).toHaveBeenCalledWith("~/foo.ts");
+		});
+
+		it("should prefer resolvedPath from stat over input path", async () => {
+			statMock.mockResolvedValue({
+				isDirectory: false,
+				resolvedPath: "/absolute/resolved/file.ts",
+			});
+			const result = await resolver.resolveLink("file.ts");
+			expect(result?.path).toBe("/absolute/resolved/file.ts");
+		});
+
+		it("should fall back to input path when resolvedPath not provided", async () => {
+			statMock.mockResolvedValue({ isDirectory: false });
+			const result = await resolver.resolveLink("/foo/bar.ts");
+			expect(result?.path).toBe("/foo/bar.ts");
+		});
+
+		it("should return null for paths that don't exist", async () => {
+			statMock.mockResolvedValue(null);
+			const result = await resolver.resolveLink("/nonexistent.ts");
+			expect(result).toBeNull();
+		});
+
+		it("should return null for stat errors", async () => {
+			statMock.mockRejectedValue(new Error("ENOENT"));
+			const result = await resolver.resolveLink("/nonexistent.ts");
+			expect(result).toBeNull();
+		});
+
+		it("should detect directories", async () => {
+			statMock.mockResolvedValue({ isDirectory: true });
+			const result = await resolver.resolveLink("/some/dir");
+			expect(result).toEqual({
+				path: "/some/dir",
+				isDirectory: true,
+			});
+		});
+
+		it("should strip file:// URI scheme before calling stat", async () => {
+			statMock.mockResolvedValue({ isDirectory: false });
+			await resolver.resolveLink("file:///foo/bar.ts");
+			expect(statMock).toHaveBeenCalledWith("/foo/bar.ts");
+		});
+
+		it("should decode URL-encoded file:// paths", async () => {
+			statMock.mockResolvedValue({ isDirectory: false });
+			await resolver.resolveLink("file:///foo/bar%20baz.ts");
+			expect(statMock).toHaveBeenCalledWith("/foo/bar baz.ts");
+		});
+
+		it("should strip line/column suffix before calling stat", async () => {
+			statMock.mockResolvedValue({ isDirectory: false });
+			await resolver.resolveLink("/foo/bar.ts:42:10");
+			expect(statMock).toHaveBeenCalledWith("/foo/bar.ts");
+		});
+
+		it("should return null for empty paths", async () => {
+			const result = await resolver.resolveLink("");
+			expect(result).toBeNull();
+		});
+
+		it("should return null for whitespace-only paths", async () => {
+			const result = await resolver.resolveLink("   ");
+			expect(result).toBeNull();
+		});
+	});
+
+	describe("caching", () => {
+		it("should cache resolved results", async () => {
+			statMock.mockResolvedValue({ isDirectory: false });
+			await resolver.resolveLink("/foo/bar.ts");
+			await resolver.resolveLink("/foo/bar.ts");
+			expect(statMock).toHaveBeenCalledTimes(1);
+		});
+
+		it("should cache null results", async () => {
+			statMock.mockResolvedValue(null);
+			await resolver.resolveLink("/nonexistent.ts");
+			await resolver.resolveLink("/nonexistent.ts");
+			expect(statMock).toHaveBeenCalledTimes(1);
+		});
+
+		it("should expire cache after TTL", async () => {
+			statMock.mockResolvedValue({ isDirectory: false });
+			resolver = new TerminalLinkResolver(statMock, { cacheTtlMs: 50 });
+			await resolver.resolveLink("/foo/bar.ts");
+			expect(statMock).toHaveBeenCalledTimes(1);
+
+			await new Promise((r) => setTimeout(r, 60));
+
+			await resolver.resolveLink("/foo/bar.ts");
+			expect(statMock).toHaveBeenCalledTimes(2);
+		});
+
+		it("should cache different paths independently", async () => {
+			statMock.mockImplementation(async (path) => {
+				if (path === "/foo.ts") return { isDirectory: false };
+				return null;
+			});
+
+			const r1 = await resolver.resolveLink("/foo.ts");
+			const r2 = await resolver.resolveLink("/bar.ts");
+
+			expect(r1).not.toBeNull();
+			expect(r2).toBeNull();
+			expect(statMock).toHaveBeenCalledTimes(2);
+		});
+	});
+
+	describe("resolveMultipleCandidates", () => {
+		it("should return the first candidate that exists", async () => {
+			statMock.mockImplementation(async (path) => {
+				if (path === "bar.ts")
+					return { isDirectory: false, resolvedPath: "/workspace/bar.ts" };
+				return null;
+			});
+
+			const result = await resolver.resolveMultipleCandidates([
+				"foo.ts",
+				"bar.ts",
+				"baz.ts",
+			]);
+			expect(result).toEqual({
+				path: "/workspace/bar.ts",
+				isDirectory: false,
+			});
+		});
+
+		it("should return null when no candidates exist", async () => {
+			statMock.mockResolvedValue(null);
+			const result = await resolver.resolveMultipleCandidates([
+				"foo.ts",
+				"bar.ts",
+			]);
+			expect(result).toBeNull();
+		});
+
+		it("should return null for empty candidate list", async () => {
+			const result = await resolver.resolveMultipleCandidates([]);
+			expect(result).toBeNull();
+		});
+	});
+});

--- a/apps/desktop/src/renderer/lib/terminal/links/link-resolver.ts
+++ b/apps/desktop/src/renderer/lib/terminal/links/link-resolver.ts
@@ -1,0 +1,169 @@
+/*---------------------------------------------------------------------------------------------
+ *  Adapted from VSCode's terminalLinkResolver.ts
+ *  https://github.com/microsoft/vscode/blob/main/src/vs/workbench/contrib/terminalContrib/links/browser/terminalLinkResolver.ts
+ *
+ *  Resolves terminal link paths against the filesystem with TTL caching.
+ *
+ *  Unlike VSCode (which resolves paths in the renderer then routes stat via
+ *  URI scheme), we delegate all path resolution to the host service's statPath
+ *  endpoint. The renderer only strips suffixes/query strings and handles
+ *  file:// URIs before passing the raw path to the stat callback.
+ *--------------------------------------------------------------------------------------------*/
+
+import {
+	removeLinkQueryString,
+	removeLinkSuffix,
+} from "@superset/shared/terminal-link-parsing";
+
+/**
+ * The result of resolving a link path against the filesystem.
+ */
+export interface ResolvedLink {
+	/** The absolute, resolved path. */
+	path: string;
+	/** Whether the path points to a directory. */
+	isDirectory: boolean;
+}
+
+/**
+ * Callback that checks whether a path exists on disk.
+ *
+ * The callback receives a path that may be absolute or relative. The host
+ * service resolves relative paths against the workspace root, tilde paths
+ * against $HOME, etc. — all resolution happens server-side.
+ *
+ * Return `{ isDirectory, resolvedPath? }` if the path exists, or `null` if
+ * it doesn't. `resolvedPath` allows the host to report the final absolute
+ * path after server-side resolution.
+ */
+export type StatCallback = (
+	path: string,
+) => Promise<{ isDirectory: boolean; resolvedPath?: string } | null>;
+
+interface CacheEntry {
+	value: ResolvedLink | null;
+}
+
+const DEFAULT_CACHE_TTL_MS = 10_000;
+
+export interface TerminalLinkResolverConfig {
+	cacheTtlMs?: number;
+}
+
+/**
+ * Validates terminal link paths against the filesystem via a stat callback.
+ * Results are cached with a configurable TTL (default 10 seconds) following
+ * VSCode's pattern.
+ *
+ * Path resolution (relative, tilde, etc.) is handled by the stat callback
+ * (host service), not the renderer. The resolver only strips link suffixes
+ * and handles file:// URI decoding.
+ */
+export class TerminalLinkResolver {
+	private readonly _cache = new Map<string, CacheEntry>();
+	private _cacheTtl: ReturnType<typeof setTimeout> | null = null;
+	private readonly _ttlMs: number;
+
+	constructor(
+		private readonly _stat: StatCallback,
+		config?: TerminalLinkResolverConfig,
+	) {
+		this._ttlMs = config?.cacheTtlMs ?? DEFAULT_CACHE_TTL_MS;
+	}
+
+	/**
+	 * Resolve a single link string, checking if it exists via the stat callback.
+	 */
+	async resolveLink(link: string): Promise<ResolvedLink | null> {
+		if (!link || !link.trim()) {
+			return null;
+		}
+
+		// Check cache first
+		const cached = this._cache.get(link);
+		if (cached !== undefined) {
+			return cached.value;
+		}
+
+		// Strip line/column suffix and query string for path resolution
+		let linkPath = removeLinkSuffix(link);
+		linkPath = removeLinkQueryString(linkPath);
+
+		if (!linkPath) {
+			this._cacheSet(link, null);
+			return null;
+		}
+
+		// Handle file:// URIs (decode to plain path)
+		if (linkPath.startsWith("file://")) {
+			try {
+				const url = new URL(linkPath);
+				linkPath = decodeURIComponent(url.pathname);
+			} catch {
+				try {
+					linkPath = decodeURIComponent(linkPath.replace(/^file:\/\//, ""));
+				} catch {
+					// Malformed URI — use as-is with scheme stripped
+					linkPath = linkPath.replace(/^file:\/\//, "");
+				}
+			}
+		}
+
+		// Pass the path to the stat callback. The host service handles all
+		// resolution (relative → workspace root, ~ → $HOME, etc.)
+		try {
+			const stat = await this._stat(linkPath);
+			if (stat) {
+				const result: ResolvedLink = {
+					path: stat.resolvedPath ?? linkPath,
+					isDirectory: stat.isDirectory,
+				};
+				this._cacheSet(link, result);
+				return result;
+			}
+			this._cacheSet(link, null);
+			return null;
+		} catch {
+			this._cacheSet(link, null);
+			return null;
+		}
+	}
+
+	/**
+	 * Try multiple path candidates in order, returning the first one that exists.
+	 */
+	async resolveMultipleCandidates(
+		candidates: string[],
+	): Promise<ResolvedLink | null> {
+		for (const candidate of candidates) {
+			const result = await this.resolveLink(candidate);
+			if (result) {
+				return result;
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Clear the cache (for testing or when the terminal CWD changes).
+	 */
+	clearCache(): void {
+		this._cache.clear();
+		if (this._cacheTtl !== null) {
+			clearTimeout(this._cacheTtl);
+			this._cacheTtl = null;
+		}
+	}
+
+	private _cacheSet(key: string, value: ResolvedLink | null): void {
+		if (this._cacheTtl !== null) {
+			clearTimeout(this._cacheTtl);
+		}
+		this._cacheTtl = setTimeout(() => {
+			this._cache.clear();
+			this._cacheTtl = null;
+		}, this._ttlMs);
+
+		this._cache.set(key, { value });
+	}
+}

--- a/apps/desktop/src/renderer/lib/terminal/links/local-link-detector.test.ts
+++ b/apps/desktop/src/renderer/lib/terminal/links/local-link-detector.test.ts
@@ -1,0 +1,290 @@
+/*---------------------------------------------------------------------------------------------
+ *  Adapted from VSCode's terminalLocalLinkDetector.test.ts
+ *  https://github.com/microsoft/vscode/blob/main/src/vs/workbench/contrib/terminalContrib/links/test/browser/terminalLocalLinkDetector.test.ts
+ *--------------------------------------------------------------------------------------------*/
+
+import { describe, expect, it } from "bun:test";
+import type { StatCallback } from "./link-resolver";
+import { TerminalLinkResolver } from "./link-resolver";
+import { LocalLinkDetector } from "./local-link-detector";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a detector with a mock stat callback. The stat callback simulates
+ * the host service's statPath: it checks if the path (or the path resolved
+ * against a workspace root) matches any of the valid paths.
+ */
+function createDetector(validPaths: string[], workspaceRoot = "/parent/cwd") {
+	const statMock: StatCallback = async (path) => {
+		// Simulate host-side resolution: try raw path, then resolved against root
+		if (validPaths.includes(path)) {
+			return { isDirectory: false, resolvedPath: path };
+		}
+		// Simulate host resolving relative paths against workspace root
+		// (mirrors what the host service's statPath does with path.resolve)
+		if (!path.startsWith("/") && !path.startsWith("~")) {
+			const parts = `${workspaceRoot}/${path}`.split("/").filter(Boolean);
+			const normalized: string[] = [];
+			for (const p of parts) {
+				if (p === ".") continue;
+				if (p === ".." && normalized.length > 0) {
+					normalized.pop();
+				} else {
+					normalized.push(p);
+				}
+			}
+			const resolved = `/${normalized.join("/")}`;
+			if (validPaths.includes(resolved)) {
+				return { isDirectory: false, resolvedPath: resolved };
+			}
+		}
+		// Simulate host resolving tilde
+		if (path.startsWith("~/")) {
+			const resolved = `/home${path.substring(1)}`;
+			if (validPaths.includes(resolved)) {
+				return { isDirectory: false, resolvedPath: resolved };
+			}
+		}
+		return null;
+	};
+	const resolver = new TerminalLinkResolver(statMock);
+	return new LocalLinkDetector(resolver);
+}
+
+function formatLink(
+	fmt: string,
+	path: string,
+	line?: string,
+	col?: string,
+): string {
+	return fmt
+		.replace("{0}", path)
+		.replace("{1}", line ?? "")
+		.replace("{2}", col ?? "");
+}
+
+// ---------------------------------------------------------------------------
+// Unix link paths
+// ---------------------------------------------------------------------------
+
+const unixLinks: { link: string; resolved: string }[] = [
+	// Absolute
+	{ link: "/foo", resolved: "/foo" },
+	{ link: "/foo/bar", resolved: "/foo/bar" },
+	{ link: "/foo/bar+more", resolved: "/foo/bar+more" },
+	// User home
+	{ link: "~/foo", resolved: "/home/foo" },
+	// Relative
+	{ link: "./foo", resolved: "/parent/cwd/foo" },
+	{ link: "../foo", resolved: "/parent/foo" },
+	{ link: "foo/bar", resolved: "/parent/cwd/foo/bar" },
+	{ link: "foo/bar+more", resolved: "/parent/cwd/foo/bar+more" },
+];
+
+// Line/column suffix formats (from VSCode's test suite)
+const suffixFormats: { fmt: string; line?: string; col?: string }[] = [
+	{ fmt: "{0}" },
+	{ fmt: '{0}" on line {1}', line: "5" },
+	{ fmt: '{0}" on line {1}, column {2}', line: "5", col: "3" },
+	{ fmt: "{0}({1})", line: "5" },
+	{ fmt: "{0} ({1})", line: "5" },
+	{ fmt: "{0}({1},{2})", line: "5", col: "3" },
+	{ fmt: "{0} ({1},{2})", line: "5", col: "3" },
+	{ fmt: "{0}({1}, {2})", line: "5", col: "3" },
+	{ fmt: "{0}:{1}", line: "5" },
+	{ fmt: "{0}:{1}:{2}", line: "5", col: "3" },
+	{ fmt: "{0}[{1}]", line: "5" },
+	{ fmt: "{0}[{1},{2}]", line: "5", col: "3" },
+	{ fmt: "{0}#{1}", line: "5" },
+];
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("LocalLinkDetector", () => {
+	describe("detect", () => {
+		it("should return empty for empty text", async () => {
+			const detector = createDetector([]);
+			const result = await detector.detect("");
+			expect(result).toEqual([]);
+		});
+
+		it("should return empty when text exceeds max length", async () => {
+			const detector = createDetector([`/${"a".repeat(100)}`]);
+			const result = await detector.detect("a".repeat(2001));
+			expect(result).toEqual([]);
+		});
+
+		it("should detect absolute paths", async () => {
+			const detector = createDetector(["/foo/bar.ts"]);
+			const result = await detector.detect("see /foo/bar.ts for details");
+			expect(result).toHaveLength(1);
+			expect(result[0]?.resolvedPath).toBe("/foo/bar.ts");
+		});
+
+		it("should detect relative paths resolved against cwd", async () => {
+			const detector = createDetector(["/parent/cwd/src/file.ts"]);
+			const result = await detector.detect("error in ./src/file.ts");
+			expect(result).toHaveLength(1);
+			expect(result[0]?.resolvedPath).toBe("/parent/cwd/src/file.ts");
+		});
+
+		it("should detect tilde paths", async () => {
+			const detector = createDetector(["/home/.config/foo"]);
+			const result = await detector.detect("see ~/.config/foo");
+			expect(result).toHaveLength(1);
+			expect(result[0]?.resolvedPath).toBe("/home/.config/foo");
+		});
+
+		it("should NOT detect paths that don't exist", async () => {
+			const detector = createDetector([]); // nothing exists
+			const result = await detector.detect("see /nonexistent/file.ts");
+			expect(result).toEqual([]);
+		});
+
+		it("should detect multiple links on one line", async () => {
+			const detector = createDetector(["/parent/cwd/foo", "/parent/cwd/bar"]);
+			const result = await detector.detect("./foo ./bar");
+			expect(result).toHaveLength(2);
+			expect(result[0]?.resolvedPath).toBe("/parent/cwd/foo");
+			expect(result[1]?.resolvedPath).toBe("/parent/cwd/bar");
+		});
+
+		it("should preserve line/column suffix info", async () => {
+			const detector = createDetector(["/parent/cwd/file.ts"]);
+			const result = await detector.detect("./file.ts:42:10");
+			expect(result).toHaveLength(1);
+			expect(result[0]?.resolvedPath).toBe("/parent/cwd/file.ts");
+			expect(result[0]?.row).toBe(42);
+			expect(result[0]?.col).toBe(10);
+		});
+
+		it("should handle parenthetical line/col format", async () => {
+			const detector = createDetector(["/parent/cwd/file.ts"]);
+			const result = await detector.detect("./file.ts(5, 3)");
+			expect(result).toHaveLength(1);
+			expect(result[0]?.row).toBe(5);
+			expect(result[0]?.col).toBe(3);
+		});
+
+		it("should skip URLs (http/https)", async () => {
+			const detector = createDetector([]);
+			const result = await detector.detect("visit https://example.com/foo/bar");
+			expect(result).toEqual([]);
+		});
+
+		it("should limit resolved links per line", async () => {
+			// Create 15 valid paths — detector should stop at MAX_RESOLVED_LINKS (10)
+			const paths = Array.from({ length: 15 }, (_, i) => `/parent/cwd/f${i}`);
+			const detector = createDetector(paths);
+			const text = paths.map((_, i) => `./f${i}`).join(" ");
+			const result = await detector.detect(text);
+			expect(result.length).toBeLessThanOrEqual(10);
+		});
+
+		it("should skip links exceeding max link length", async () => {
+			const longPath = `/foo/${"a".repeat(1025)}`;
+			const detector = createDetector([longPath]);
+			const result = await detector.detect(longPath);
+			expect(result).toEqual([]);
+		});
+
+		it("should detect git diff paths", async () => {
+			const detector = createDetector(["/parent/cwd/foo/bar"]);
+			const result = await detector.detect("--- a/foo/bar");
+			expect(result).toHaveLength(1);
+			expect(result[0]?.resolvedPath).toBe("/parent/cwd/foo/bar");
+		});
+
+		it("should detect git diff --git paths", async () => {
+			const detector = createDetector(["/parent/cwd/foo/bar"]);
+			const result = await detector.detect("diff --git a/foo/bar b/foo/bar");
+			expect(result).toHaveLength(2);
+		});
+	});
+
+	describe("Unix path formats with suffixes", () => {
+		for (const { link, resolved } of unixLinks) {
+			for (const { fmt, line, col } of suffixFormats) {
+				const formatted = formatLink(fmt, link, line, col);
+				it(`should detect "${formatted}"`, async () => {
+					const detector = createDetector([resolved]);
+					const result = await detector.detect(formatted);
+					expect(result.length).toBeGreaterThanOrEqual(1);
+					expect(result[0]?.resolvedPath).toBe(resolved);
+					if (line) {
+						expect(result[0]?.row).toBe(Number.parseInt(line, 10));
+					}
+					if (col) {
+						expect(result[0]?.col).toBe(Number.parseInt(col, 10));
+					}
+				});
+			}
+		}
+	});
+
+	describe("fallback matchers", () => {
+		it("should detect Python-style errors", async () => {
+			const detector = createDetector(["/path/to/file.py"]);
+			const result = await detector.detect(
+				'  File "/path/to/file.py", line 42',
+			);
+			expect(result).toHaveLength(1);
+			expect(result[0]?.resolvedPath).toBe("/path/to/file.py");
+			expect(result[0]?.row).toBe(42);
+		});
+
+		it("should detect Rust-style errors", async () => {
+			const detector = createDetector(["/parent/cwd/src/main.rs"]);
+			const result = await detector.detect("   --> src/main.rs:10:5");
+			expect(result).toHaveLength(1);
+			expect(result[0]?.row).toBe(10);
+			expect(result[0]?.col).toBe(5);
+		});
+
+		it("should detect C++ compile errors", async () => {
+			const detector = createDetector(["/path/to/file.cpp"]);
+			const result = await detector.detect(
+				"/path/to/file.cpp(339): error C2065",
+			);
+			expect(result).toHaveLength(1);
+			expect(result[0]?.resolvedPath).toBe("/path/to/file.cpp");
+			expect(result[0]?.row).toBe(339);
+		});
+
+		it("should detect Node.js stack traces", async () => {
+			const detector = createDetector(["/path/to/file.js"]);
+			const result = await detector.detect(
+				"    at Object.<anonymous> (/path/to/file.js:10:5)",
+			);
+			expect(result).toHaveLength(1);
+			expect(result[0]?.resolvedPath).toBe("/path/to/file.js");
+			expect(result[0]?.row).toBe(10);
+		});
+
+		it("should not use fallback if primary detection found links", async () => {
+			// Primary detection should find /path/to/file.ts:10:5
+			// Fallback should not run since primary succeeded
+			const detector = createDetector(["/path/to/file.ts"]);
+			const result = await detector.detect("/path/to/file.ts:10:5");
+			expect(result).toHaveLength(1);
+			// Should have line info from primary suffix detection
+			expect(result[0]?.row).toBe(10);
+		});
+	});
+
+	describe("trimmed candidates", () => {
+		it("should try trimmed path when original has trailing punctuation", async () => {
+			// Path followed by a bracket that gets included in the match —
+			// generateTrimmedCandidates strips it so the stat succeeds.
+			const detector = createDetector(["/foo/bar"]);
+			const result = await detector.detect("see /foo/bar.");
+			expect(result).toHaveLength(1);
+			expect(result[0]?.resolvedPath).toBe("/foo/bar");
+		});
+	});
+});

--- a/apps/desktop/src/renderer/lib/terminal/links/local-link-detector.ts
+++ b/apps/desktop/src/renderer/lib/terminal/links/local-link-detector.ts
@@ -1,0 +1,215 @@
+/*---------------------------------------------------------------------------------------------
+ *  Adapted from VSCode's terminalLocalLinkDetector.ts
+ *  https://github.com/microsoft/vscode/blob/main/src/vs/workbench/contrib/terminalContrib/links/browser/terminalLocalLinkDetector.ts
+ *
+ *  Detects local file-path links in terminal text, validating each candidate
+ *  path against the filesystem before returning it as a link.
+ *--------------------------------------------------------------------------------------------*/
+
+import {
+	detectFallbackLinks,
+	detectLinks,
+	generateTrimmedCandidates,
+	getCurrentOS,
+	type IParsedLink,
+	removeLinkSuffix,
+} from "@superset/shared/terminal-link-parsing";
+import type { TerminalLinkResolver } from "./link-resolver";
+
+const MAX_LINE_LENGTH = 2000;
+const MAX_RESOLVED_LINKS_IN_LINE = 10;
+const MAX_RESOLVED_LINK_LENGTH = 1024;
+
+/**
+ * A detected and validated local file link.
+ */
+export interface DetectedLink {
+	/** The full matched text in the terminal line (including suffix). */
+	text: string;
+	/** The start column in the line (0-based). */
+	startIndex: number;
+	/** The end column in the line (0-based, exclusive). */
+	endIndex: number;
+	/** The validated absolute path on disk. */
+	resolvedPath: string;
+	/** Whether the path is a directory. */
+	isDirectory: boolean;
+	/** Line number from the suffix, if any. */
+	row: number | undefined;
+	/** Column number from the suffix, if any. */
+	col: number | undefined;
+	/** End line number from the suffix, if any. */
+	rowEnd: number | undefined;
+	/** End column number from the suffix, if any. */
+	colEnd: number | undefined;
+	/** The original parsed link data (for debugging). */
+	parsedLink?: IParsedLink;
+}
+
+/**
+ * Detects local file-system links in a line of terminal text.
+ *
+ * The flow:
+ * 1. Parse the line with `detectLinks()` (vendored from VSCode)
+ * 2. For each parsed link, build candidate paths (raw, trimmed variants)
+ * 3. Validate each candidate via the resolver (which delegates to the host)
+ * 4. Only return links that point to real files/directories
+ * 5. If no primary links found, try fallback matchers (Python, Rust, C++, etc.)
+ *
+ * All path resolution (relative → workspace root, ~ → $HOME) happens on the
+ * host service, not in the renderer.
+ */
+export class LocalLinkDetector {
+	constructor(private readonly _resolver: TerminalLinkResolver) {}
+
+	async detect(text: string): Promise<DetectedLink[]> {
+		if (!text || text.length > MAX_LINE_LENGTH) {
+			return [];
+		}
+
+		const links: DetectedLink[] = [];
+		let resolvedCount = 0;
+
+		const os = getCurrentOS();
+		const parsedLinks = detectLinks(text, os);
+
+		for (const parsedLink of parsedLinks) {
+			if (parsedLink.path.text.length > MAX_RESOLVED_LINK_LENGTH) {
+				continue;
+			}
+
+			// Skip URLs — they're handled by the URL link provider
+			if (this._isUrl(parsedLink.path.text)) {
+				continue;
+			}
+
+			// Build candidate paths to try
+			const candidates = this._buildCandidates(parsedLink.path.text);
+
+			// Also generate trimmed candidates (strip trailing punctuation)
+			const trimmedCandidates: string[] = [];
+			for (const candidate of candidates) {
+				for (const trimmed of generateTrimmedCandidates(candidate)) {
+					trimmedCandidates.push(trimmed.path);
+				}
+			}
+			const allCandidates = [...candidates, ...trimmedCandidates];
+
+			const resolved =
+				await this._resolver.resolveMultipleCandidates(allCandidates);
+
+			if (resolved) {
+				const linkStart = parsedLink.prefix?.index ?? parsedLink.path.index;
+				const linkEnd = parsedLink.suffix
+					? parsedLink.suffix.suffix.index +
+						parsedLink.suffix.suffix.text.length
+					: parsedLink.path.index + parsedLink.path.text.length;
+
+				links.push({
+					text: text.substring(linkStart, linkEnd),
+					startIndex: linkStart,
+					endIndex: linkEnd,
+					resolvedPath: resolved.path,
+					isDirectory: resolved.isDirectory,
+					row: parsedLink.suffix?.row,
+					col: parsedLink.suffix?.col,
+					rowEnd: parsedLink.suffix?.rowEnd,
+					colEnd: parsedLink.suffix?.colEnd,
+					parsedLink,
+				});
+			}
+
+			if (++resolvedCount >= MAX_RESOLVED_LINKS_IN_LINE) {
+				break;
+			}
+		}
+
+		// If no primary links found, try fallback matchers
+		if (links.length === 0) {
+			const fallbacks = detectFallbackLinks(text);
+			for (const fallback of fallbacks) {
+				if (fallback.link.length > MAX_RESOLVED_LINK_LENGTH) {
+					continue;
+				}
+
+				const resolved = await this._resolver.resolveLink(fallback.path);
+				if (resolved) {
+					links.push({
+						text: fallback.link,
+						startIndex: fallback.index,
+						endIndex: fallback.index + fallback.link.length,
+						resolvedPath: resolved.path,
+						isDirectory: resolved.isDirectory,
+						row: fallback.line,
+						col: fallback.col,
+						rowEnd: undefined,
+						colEnd: undefined,
+					});
+				}
+			}
+		}
+
+		// SUPERSET ADDITION (not in VSCode's shared fallback matchers):
+		// Last resort — treat the whole trimmed line as a path candidate.
+		// Safe because we validate via stat (false positives are filtered out).
+		// Matches VSCode's `/^ *(?<link>(?<path>.+))/` whole-line fallback in
+		// terminalLocalLinkDetector.ts. Kept here (not in shared fallback
+		// matchers) because unvalidated consumers like v1 FilePathLinkProvider
+		// would get false positives from URLs, version strings, etc.
+		//
+		// To disable: remove or comment out this block. The word link detector
+		// (WordLinkDetector) provides similar coverage for bare filenames.
+		if (links.length === 0 && text.trim().length <= MAX_RESOLVED_LINK_LENGTH) {
+			const trimmed = text.trim();
+			const resolved = await this._resolver.resolveLink(trimmed);
+			if (resolved) {
+				const startIndex = text.indexOf(trimmed);
+				links.push({
+					text: trimmed,
+					startIndex,
+					endIndex: startIndex + trimmed.length,
+					resolvedPath: resolved.path,
+					isDirectory: resolved.isDirectory,
+					row: undefined,
+					col: undefined,
+					rowEnd: undefined,
+					colEnd: undefined,
+				});
+			}
+		}
+
+		return links;
+	}
+
+	private _isUrl(text: string): boolean {
+		return (
+			text.startsWith("http://") ||
+			text.startsWith("https://") ||
+			text.startsWith("ftp://")
+		);
+	}
+
+	/**
+	 * Build candidate paths from the raw link text.
+	 * The raw path is sent to the host for resolution — we only strip
+	 * the line/column suffix here.
+	 */
+	private _buildCandidates(pathText: string): string[] {
+		const candidates: string[] = [];
+
+		const cleanPath = removeLinkSuffix(pathText);
+		if (!cleanPath) {
+			return candidates;
+		}
+
+		candidates.push(cleanPath);
+
+		// For relative paths with leading ../, also try without the ../ prefix
+		const parentPrefixMatch = cleanPath.match(/^(\.\.[/\\])+/);
+		if (parentPrefixMatch) {
+			candidates.push(cleanPath.replace(/^(\.\.[/\\])+/, ""));
+		}
+
+		return candidates;
+	}
+}

--- a/apps/desktop/src/renderer/lib/terminal/links/word-link-detector.ts
+++ b/apps/desktop/src/renderer/lib/terminal/links/word-link-detector.ts
@@ -1,0 +1,131 @@
+/*---------------------------------------------------------------------------------------------
+ *  Adapted from VSCode's terminalWordLinkDetector.ts
+ *  https://github.com/microsoft/vscode/blob/main/src/vs/workbench/contrib/terminalContrib/links/browser/terminalWordLinkDetector.ts
+ *
+ *  Lowest-priority link detector: splits terminal text into words and
+ *  validates each against the filesystem. Unlike VSCode (which opens a
+ *  workspace search), we directly open the file if it exists.
+ *--------------------------------------------------------------------------------------------*/
+
+import type { ILink, ILinkProvider, Terminal } from "@xterm/xterm";
+import type { TerminalLinkResolver } from "./link-resolver";
+
+const MAX_LINE_LENGTH = 2000;
+const MAX_WORD_LINK_LENGTH = 100;
+
+/**
+ * Default word separators (matches VSCode's terminal.integrated.wordSeparators).
+ * Includes powerline symbols (U+E0B0 to U+E0BF).
+ */
+const DEFAULT_WORD_SEPARATORS = " ()[]{}',\"`─''|";
+
+function buildSeparatorRegex(separators: string): RegExp {
+	let powerlineSymbols = "";
+	for (let i = 0xe0b0; i <= 0xe0bf; i++) {
+		powerlineSymbols += String.fromCharCode(i);
+	}
+	const escaped = separators.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+	return new RegExp(`[${escaped}${powerlineSymbols}]`, "g");
+}
+
+interface WordLink {
+	text: string;
+	startIndex: number;
+	endIndex: number;
+}
+
+/**
+ * Word-based link detector. Splits terminal lines by word separators and
+ * validates each word against the filesystem. Only words that resolve to
+ * actual files become links.
+ *
+ * Registered as lowest priority — only runs if the primary file-path
+ * and URL detectors found nothing for the line.
+ */
+export class WordLinkDetector implements ILinkProvider {
+	private readonly _separatorRegex: RegExp;
+
+	constructor(
+		private readonly _terminal: Terminal,
+		private readonly _resolver: TerminalLinkResolver,
+		private readonly _onActivate?: (
+			event: MouseEvent,
+			resolvedPath: string,
+		) => void,
+	) {
+		this._separatorRegex = buildSeparatorRegex(DEFAULT_WORD_SEPARATORS);
+	}
+
+	provideLinks(
+		bufferLineNumber: number,
+		callback: (links: ILink[] | undefined) => void,
+	): void {
+		this._provideLinks(bufferLineNumber).then(
+			(links) => callback(links.length > 0 ? links : undefined),
+			() => callback(undefined),
+		);
+	}
+
+	private async _provideLinks(bufferLineNumber: number): Promise<ILink[]> {
+		const buffer = this._terminal.buffer.active;
+		const line = buffer.getLine(bufferLineNumber - 1);
+		if (!line) return [];
+
+		const text = line.translateToString(true);
+		if (!text || text.length > MAX_LINE_LENGTH) return [];
+
+		const words = this._parseWords(text);
+		const links: ILink[] = [];
+
+		for (const word of words) {
+			if (!word.text || word.text.length > MAX_WORD_LINK_LENGTH) continue;
+
+			// Strip trailing colon (common in "file.txt: error")
+			let wordText = word.text;
+			if (wordText.endsWith(":")) {
+				wordText = wordText.slice(0, -1);
+			}
+
+			// Skip words that don't look like filenames (must contain a dot)
+			if (!wordText.includes(".")) continue;
+
+			// Skip URLs
+			if (wordText.startsWith("http://") || wordText.startsWith("https://"))
+				continue;
+
+			const resolved = await this._resolver.resolveLink(wordText);
+			if (!resolved) continue;
+
+			links.push({
+				range: {
+					start: { x: word.startIndex + 1, y: bufferLineNumber },
+					end: {
+						x: word.startIndex + wordText.length + 1,
+						y: bufferLineNumber,
+					},
+				},
+				text: wordText,
+				activate: (event: MouseEvent) => {
+					this._onActivate?.(event, resolved.path);
+				},
+			});
+		}
+
+		return links;
+	}
+
+	private _parseWords(text: string): WordLink[] {
+		const words: WordLink[] = [];
+		const splitWords = text.split(this._separatorRegex);
+		let runningIndex = 0;
+		for (const word of splitWords) {
+			words.push({
+				text: word,
+				startIndex: runningIndex,
+				endIndex: runningIndex + word.length,
+			});
+			runningIndex += word.length + 1;
+		}
+		return words;
+	}
+}

--- a/apps/desktop/src/renderer/lib/terminal/terminal-addons.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-addons.ts
@@ -1,22 +1,24 @@
 import { ClipboardAddon } from "@xterm/addon-clipboard";
 import { ImageAddon } from "@xterm/addon-image";
 import { LigaturesAddon } from "@xterm/addon-ligatures";
+import { ProgressAddon } from "@xterm/addon-progress";
 import { SearchAddon } from "@xterm/addon-search";
 import { Unicode11Addon } from "@xterm/addon-unicode11";
 import { WebglAddon } from "@xterm/addon-webgl";
 import type { Terminal as XTerm } from "@xterm/xterm";
 
-// Once WebGL fails, skip it for all subsequent runtimes (VS Code pattern).
-let suggestedRendererType: "webgl" | "dom" | undefined;
-
 export interface LoadAddonsResult {
 	searchAddon: SearchAddon;
+	progressAddon: ProgressAddon;
 	dispose: () => void;
 }
 
+// Once WebGL fails, skip it for all subsequent runtimes (VS Code pattern).
+let suggestedRendererType: "webgl" | "dom" | undefined;
+
 /**
  * Load optional addons onto an already-opened terminal. Returns a cleanup
- * function and the SearchAddon instance. WebGL is deferred to rAF to avoid
+ * function and addon instances. WebGL is deferred to rAF to avoid
  * racing with xterm's post-open viewport sync.
  */
 export function loadAddons(terminal: XTerm): LoadAddonsResult {
@@ -33,6 +35,9 @@ export function loadAddons(terminal: XTerm): LoadAddonsResult {
 
 	const searchAddon = new SearchAddon();
 	terminal.loadAddon(searchAddon);
+
+	const progressAddon = new ProgressAddon();
+	terminal.loadAddon(progressAddon);
 
 	try {
 		terminal.loadAddon(new LigaturesAddon());
@@ -57,6 +62,7 @@ export function loadAddons(terminal: XTerm): LoadAddonsResult {
 
 	return {
 		searchAddon,
+		progressAddon,
 		dispose: () => {
 			disposed = true;
 			cancelAnimationFrame(rafId);

--- a/apps/desktop/src/renderer/lib/terminal/terminal-addons.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-addons.ts
@@ -1,6 +1,7 @@
 import { ClipboardAddon } from "@xterm/addon-clipboard";
 import { ImageAddon } from "@xterm/addon-image";
 import { LigaturesAddon } from "@xterm/addon-ligatures";
+import { SearchAddon } from "@xterm/addon-search";
 import { Unicode11Addon } from "@xterm/addon-unicode11";
 import { WebglAddon } from "@xterm/addon-webgl";
 import type { Terminal as XTerm } from "@xterm/xterm";
@@ -8,12 +9,17 @@ import type { Terminal as XTerm } from "@xterm/xterm";
 // Once WebGL fails, skip it for all subsequent runtimes (VS Code pattern).
 let suggestedRendererType: "webgl" | "dom" | undefined;
 
+export interface LoadAddonsResult {
+	searchAddon: SearchAddon;
+	dispose: () => void;
+}
+
 /**
  * Load optional addons onto an already-opened terminal. Returns a cleanup
- * function. WebGL is deferred to rAF to avoid racing with xterm's post-open
- * viewport sync.
+ * function and the SearchAddon instance. WebGL is deferred to rAF to avoid
+ * racing with xterm's post-open viewport sync.
  */
-export function loadAddons(terminal: XTerm): () => void {
+export function loadAddons(terminal: XTerm): LoadAddonsResult {
 	let disposed = false;
 	let webglAddon: WebglAddon | null = null;
 
@@ -24,6 +30,9 @@ export function loadAddons(terminal: XTerm): () => void {
 	terminal.unicode.activeVersion = "11";
 
 	terminal.loadAddon(new ImageAddon());
+
+	const searchAddon = new SearchAddon();
+	terminal.loadAddon(searchAddon);
 
 	try {
 		terminal.loadAddon(new LigaturesAddon());
@@ -46,12 +55,15 @@ export function loadAddons(terminal: XTerm): () => void {
 		}
 	});
 
-	return () => {
-		disposed = true;
-		cancelAnimationFrame(rafId);
-		try {
-			webglAddon?.dispose();
-		} catch {}
-		webglAddon = null;
+	return {
+		searchAddon,
+		dispose: () => {
+			disposed = true;
+			cancelAnimationFrame(rafId);
+			try {
+				webglAddon?.dispose();
+			} catch {}
+			webglAddon = null;
+		},
 	};
 }

--- a/apps/desktop/src/renderer/lib/terminal/terminal-link-manager.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-link-manager.ts
@@ -1,0 +1,142 @@
+/*---------------------------------------------------------------------------------------------
+ *  Adapted from VSCode's terminalLinkManager.ts
+ *  https://github.com/microsoft/vscode/blob/main/src/vs/workbench/contrib/terminalContrib/links/browser/terminalLinkManager.ts
+ *
+ *  Manages link provider registration for a terminal instance.
+ *  Handles lifecycle (dispose old providers before re-registering),
+ *  resolver caching, and priority ordering.
+ *--------------------------------------------------------------------------------------------*/
+
+import type { Terminal as XTerm } from "@xterm/xterm";
+import { UrlLinkProvider } from "../../screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/link-providers";
+import type { DetectedLink } from "./links";
+import {
+	LinkDetectorAdapter,
+	LocalLinkDetector,
+	type StatCallback,
+	TerminalLinkResolver,
+	WordLinkDetector,
+} from "./links";
+
+/**
+ * Link handler callbacks for the v2 terminal.
+ */
+export interface TerminalLinkHandlers {
+	/** Called when a file path link is activated (Cmd/Ctrl+click). */
+	onFileLinkClick?: (event: MouseEvent, link: DetectedLink) => void;
+	/** Called when a URL link is activated. */
+	onUrlClick?: (url: string) => void;
+	/**
+	 * Stat callback to validate file paths exist. Called via the host service
+	 * which handles all path resolution (relative, tilde, etc.) server-side.
+	 */
+	stat?: StatCallback;
+}
+
+interface LinkProviderDisposable {
+	dispose(): void;
+}
+
+/**
+ * Manages all link providers for a single terminal instance.
+ *
+ * Providers are registered in priority order (xterm uses first match):
+ * 1. LocalLinkDetector (file paths with validation) + styled-text fallback
+ * 2. UrlLinkProvider (hard-wrapped URL detection)
+ * 3. WordLinkDetector (bare filenames like "AGENTS.md")
+ */
+export class TerminalLinkManager {
+	private _disposables: LinkProviderDisposable[] = [];
+	private _resolver: TerminalLinkResolver | null = null;
+	private _handlers: TerminalLinkHandlers | null = null;
+
+	constructor(private readonly _terminal: XTerm) {}
+
+	/**
+	 * Set link handlers and register providers. Safe to call multiple times —
+	 * old providers are disposed before new ones are registered. The resolver
+	 * is reused to preserve the stat cache.
+	 */
+	setHandlers(handlers: TerminalLinkHandlers): void {
+		this._handlers = handlers;
+		this._register();
+	}
+
+	/**
+	 * Re-register providers (e.g. after terminal is created).
+	 * No-op if handlers haven't been set yet.
+	 */
+	ensureRegistered(): void {
+		if (this._handlers) {
+			this._register();
+		}
+	}
+
+	dispose(): void {
+		for (const d of this._disposables) d.dispose();
+		this._disposables = [];
+		this._resolver?.clearCache();
+		this._resolver = null;
+		this._handlers = null;
+	}
+
+	private _register(): void {
+		const handlers = this._handlers;
+		if (!handlers?.stat) return;
+
+		// Dispose old providers to prevent duplicates
+		for (const d of this._disposables) d.dispose();
+		this._disposables = [];
+
+		// Reuse resolver to preserve stat cache across re-registrations.
+		if (!this._resolver) {
+			this._resolver = new TerminalLinkResolver(handlers.stat);
+		}
+
+		// 1. File path detector (highest priority)
+		const detector = new LocalLinkDetector(this._resolver);
+		const adapter = new LinkDetectorAdapter(
+			this._terminal,
+			detector,
+			handlers.onFileLinkClick,
+		);
+		this._disposables.push(this._terminal.registerLinkProvider(adapter));
+
+		// 2. URL link provider (handles hard-wrapped URLs)
+		if (handlers.onUrlClick) {
+			const onUrlClick = handlers.onUrlClick;
+			const urlProvider = new UrlLinkProvider(this._terminal, (_event, uri) => {
+				onUrlClick(uri);
+			});
+			this._disposables.push(this._terminal.registerLinkProvider(urlProvider));
+		}
+
+		// 3. SUPERSET ADDITION: Word link detector (lowest priority).
+		// Adapted from VSCode's TerminalWordLinkDetector. VSCode opens a
+		// workspace search on click; ours opens the file directly if it
+		// exists (validated via stat). Catches bare filenames like
+		// "AGENTS.md" that have no path separator or line suffix.
+		// To disable: remove or comment out this block.
+		if (handlers.onFileLinkClick) {
+			const onFileClick = handlers.onFileLinkClick;
+			const wordDetector = new WordLinkDetector(
+				this._terminal,
+				this._resolver,
+				(event, resolvedPath) => {
+					onFileClick(event, {
+						text: resolvedPath,
+						startIndex: 0,
+						endIndex: 0,
+						resolvedPath,
+						isDirectory: false,
+						row: undefined,
+						col: undefined,
+						rowEnd: undefined,
+						colEnd: undefined,
+					});
+				},
+			);
+			this._disposables.push(this._terminal.registerLinkProvider(wordDetector));
+		}
+	}
+}

--- a/apps/desktop/src/renderer/lib/terminal/terminal-runtime-registry.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-runtime-registry.ts
@@ -1,3 +1,5 @@
+import type { ProgressAddon } from "@xterm/addon-progress";
+import type { SearchAddon } from "@xterm/addon-search";
 import type { TerminalAppearance } from "./appearance";
 import {
 	type TerminalLinkHandlers,
@@ -169,6 +171,14 @@ class TerminalRuntimeRegistryImpl {
 
 	getTerminal(terminalId: string) {
 		return this.entries.get(terminalId)?.runtime?.terminal ?? null;
+	}
+
+	getSearchAddon(terminalId: string): SearchAddon | null {
+		return this.entries.get(terminalId)?.runtime?.searchAddon ?? null;
+	}
+
+	getProgressAddon(terminalId: string): ProgressAddon | null {
+		return this.entries.get(terminalId)?.runtime?.progressAddon ?? null;
 	}
 
 	getAllTerminalIds(): Set<string> {

--- a/apps/desktop/src/renderer/lib/terminal/terminal-runtime-registry.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-runtime-registry.ts
@@ -1,5 +1,9 @@
 import type { TerminalAppearance } from "./appearance";
 import {
+	type TerminalLinkHandlers,
+	TerminalLinkManager,
+} from "./terminal-link-manager";
+import {
 	attachToContainer,
 	createRuntime,
 	detachFromContainer,
@@ -21,6 +25,9 @@ import {
 interface RegistryEntry {
 	runtime: TerminalRuntime | null;
 	transport: TerminalTransport;
+	linkManager: TerminalLinkManager | null;
+	/** Stored until linkManager is created (attach called after setLinkHandlers). */
+	pendingLinkHandlers: TerminalLinkHandlers | null;
 }
 
 class TerminalRuntimeRegistryImpl {
@@ -33,6 +40,8 @@ class TerminalRuntimeRegistryImpl {
 		entry = {
 			runtime: null,
 			transport: createTransport(),
+			linkManager: null,
+			pendingLinkHandlers: null,
 		};
 
 		this.entries.set(terminalId, entry);
@@ -49,9 +58,13 @@ class TerminalRuntimeRegistryImpl {
 
 		if (!entry.runtime) {
 			entry.runtime = createRuntime(terminalId, appearance);
+			entry.linkManager = new TerminalLinkManager(entry.runtime.terminal);
+			// Apply pending handlers if setLinkHandlers was called before attach
+			if (entry.pendingLinkHandlers) {
+				entry.linkManager.setHandlers(entry.pendingLinkHandlers);
+				entry.pendingLinkHandlers = null;
+			}
 		} else {
-			// Runtime already exists (reattach) — apply current appearance so
-			// the first fit uses up-to-date font metrics.
 			updateRuntimeAppearance(entry.runtime, appearance);
 		}
 
@@ -71,6 +84,19 @@ class TerminalRuntimeRegistryImpl {
 		connect(transport, runtime.terminal, wsUrl);
 	}
 
+	/**
+	 * Set link handler callbacks for a terminal. Safe to call before or after
+	 * attach(). If the runtime already exists, link providers are re-registered.
+	 */
+	setLinkHandlers(terminalId: string, handlers: TerminalLinkHandlers) {
+		const entry = this.getOrCreateEntry(terminalId);
+		if (entry.linkManager) {
+			entry.linkManager.setHandlers(handlers);
+		} else {
+			entry.pendingLinkHandlers = handlers;
+		}
+	}
+
 	detach(terminalId: string) {
 		const entry = this.entries.get(terminalId);
 		if (!entry?.runtime) return;
@@ -87,8 +113,6 @@ class TerminalRuntimeRegistryImpl {
 
 		updateRuntimeAppearance(entry.runtime, appearance);
 
-		// Font changes can alter the grid size — forward to the PTY so the
-		// backend shell and TUIs see the correct cols/rows.
 		const { cols, rows } = entry.runtime.terminal;
 		if (cols !== prevCols || rows !== prevRows) {
 			sendResize(entry.transport, cols, rows);
@@ -98,6 +122,8 @@ class TerminalRuntimeRegistryImpl {
 	dispose(terminalId: string) {
 		const entry = this.entries.get(terminalId);
 		if (!entry) return;
+
+		entry.linkManager?.dispose();
 
 		sendDispose(entry.transport);
 		disposeTransport(entry.transport);
@@ -124,6 +150,21 @@ class TerminalRuntimeRegistryImpl {
 	paste(terminalId: string, text: string): void {
 		const entry = this.entries.get(terminalId);
 		entry?.runtime?.terminal.paste(text);
+	}
+
+	findNext(terminalId: string, query: string): boolean {
+		const entry = this.entries.get(terminalId);
+		return entry?.runtime?.searchAddon?.findNext(query) ?? false;
+	}
+
+	findPrevious(terminalId: string, query: string): boolean {
+		const entry = this.entries.get(terminalId);
+		return entry?.runtime?.searchAddon?.findPrevious(query) ?? false;
+	}
+
+	clearSearch(terminalId: string): void {
+		const entry = this.entries.get(terminalId);
+		entry?.runtime?.searchAddon?.clearDecorations();
 	}
 
 	getTerminal(terminalId: string) {
@@ -165,4 +206,4 @@ if (import.meta.hot) {
 	import.meta.hot.data.registry = terminalRuntimeRegistry;
 }
 
-export type { ConnectionState };
+export type { ConnectionState, TerminalLinkHandlers };

--- a/apps/desktop/src/renderer/lib/terminal/terminal-runtime-registry.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-runtime-registry.ts
@@ -20,6 +20,7 @@ import {
 	disposeTransport,
 	resetReconnectBackoff,
 	sendDispose,
+	sendInput,
 	sendResize,
 	type TerminalTransport,
 } from "./terminal-ws-transport";
@@ -152,6 +153,13 @@ class TerminalRuntimeRegistryImpl {
 	paste(terminalId: string, text: string): void {
 		const entry = this.entries.get(terminalId);
 		entry?.runtime?.terminal.paste(text);
+	}
+
+	/** Send raw input to the terminal via the WebSocket transport (bypasses xterm). */
+	writeInput(terminalId: string, data: string): void {
+		const entry = this.entries.get(terminalId);
+		if (!entry) return;
+		sendInput(entry.transport, data);
 	}
 
 	findNext(terminalId: string, query: string): boolean {

--- a/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
@@ -1,4 +1,5 @@
 import { FitAddon } from "@xterm/addon-fit";
+import type { ProgressAddon } from "@xterm/addon-progress";
 import type { SearchAddon } from "@xterm/addon-search";
 import { SerializeAddon } from "@xterm/addon-serialize";
 import { Terminal as XTerm } from "@xterm/xterm";
@@ -18,6 +19,7 @@ export interface TerminalRuntime {
 	fitAddon: FitAddon;
 	serializeAddon: SerializeAddon;
 	searchAddon: SearchAddon | null;
+	progressAddon: ProgressAddon | null;
 	wrapper: HTMLDivElement;
 	container: HTMLDivElement | null;
 	resizeObserver: ResizeObserver | null;
@@ -148,6 +150,7 @@ export function createRuntime(
 		fitAddon,
 		serializeAddon,
 		searchAddon: addonsResult.searchAddon,
+		progressAddon: addonsResult.progressAddon,
 		wrapper,
 		container: null,
 		resizeObserver: null,

--- a/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
@@ -1,4 +1,5 @@
 import { FitAddon } from "@xterm/addon-fit";
+import type { SearchAddon } from "@xterm/addon-search";
 import { SerializeAddon } from "@xterm/addon-serialize";
 import { Terminal as XTerm } from "@xterm/xterm";
 import { DEFAULT_TERMINAL_SCROLLBACK } from "shared/constants";
@@ -16,6 +17,7 @@ export interface TerminalRuntime {
 	terminal: XTerm;
 	fitAddon: FitAddon;
 	serializeAddon: SerializeAddon;
+	searchAddon: SearchAddon | null;
 	wrapper: HTMLDivElement;
 	container: HTMLDivElement | null;
 	resizeObserver: ResizeObserver | null;
@@ -138,19 +140,20 @@ export function createRuntime(
 	terminal.open(wrapper);
 	restoreBuffer(terminalId, terminal);
 
-	const disposeAddons = loadAddons(terminal);
+	const addonsResult = loadAddons(terminal);
 
 	return {
 		terminalId,
 		terminal,
 		fitAddon,
 		serializeAddon,
+		searchAddon: addonsResult.searchAddon,
 		wrapper,
 		container: null,
 		resizeObserver: null,
 		lastCols: cols,
 		lastRows: rows,
-		_disposeAddons: disposeAddons,
+		_disposeAddons: addonsResult.dispose,
 	};
 }
 

--- a/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.ts
@@ -197,6 +197,12 @@ export function sendResize(
 	transport.socket.send(JSON.stringify({ type: "resize", cols, rows }));
 }
 
+export function sendInput(transport: TerminalTransport, data: string) {
+	if (!transport.socket || transport.socket.readyState !== WebSocket.OPEN)
+		return;
+	transport.socket.send(JSON.stringify({ type: "input", data }));
+}
+
 export function sendDispose(transport: TerminalTransport) {
 	if (transport.socket?.readyState === WebSocket.OPEN) {
 		transport.socket.send(JSON.stringify({ type: "dispose" }));

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx
@@ -1,4 +1,6 @@
 import type { RendererContext } from "@superset/panes";
+import { toast } from "@superset/ui/sonner";
+import { workspaceTrpc } from "@superset/workspace-client";
 import "@xterm/xterm/css/xterm.css";
 import { useEffect, useMemo, useRef, useSyncExternalStore } from "react";
 import { useHotkey } from "renderer/hotkeys";
@@ -6,6 +8,7 @@ import {
 	type ConnectionState,
 	terminalRuntimeRegistry,
 } from "renderer/lib/terminal/terminal-runtime-registry";
+import { electronTrpcClient } from "renderer/lib/trpc-client";
 import type {
 	PaneViewerData,
 	TerminalPaneData,
@@ -84,6 +87,53 @@ export function TerminalPane({ ctx, workspaceId }: TerminalPaneProps) {
 	useEffect(() => {
 		terminalRuntimeRegistry.updateAppearance(terminalId, appearance);
 	}, [terminalId, appearance]);
+
+	// --- Link handlers ---
+	// All filesystem operations go through the host service.
+	// statPath is a mutation (POST) to avoid tRPC GET URL encoding issues
+	// with paths containing special characters like ().
+	const statPathMutation = workspaceTrpc.filesystem.statPath.useMutation();
+	const statPathRef = useRef(statPathMutation.mutateAsync);
+	statPathRef.current = statPathMutation.mutateAsync;
+
+	useEffect(() => {
+		terminalRuntimeRegistry.setLinkHandlers(terminalId, {
+			stat: async (path) => {
+				try {
+					const result = await statPathRef.current({
+						workspaceId,
+						path,
+					});
+					if (!result) return null;
+					return {
+						isDirectory: result.isDirectory,
+						resolvedPath: result.resolvedPath,
+					};
+				} catch {
+					return null;
+				}
+			},
+			onFileLinkClick: (_event, link) => {
+				if (!_event.metaKey && !_event.ctrlKey) return;
+				_event.preventDefault();
+				electronTrpcClient.external.openFileInEditor
+					.mutate({
+						path: link.resolvedPath,
+						line: link.row,
+						column: link.col,
+					})
+					.catch((error) => {
+						console.error("[v2 Terminal] Failed to open file:", error);
+						toast.error("Failed to open file in editor");
+					});
+			},
+			onUrlClick: (url) => {
+				electronTrpcClient.external.openUrl.mutate(url).catch((error) => {
+					console.error("[v2 Terminal] Failed to open URL:", url, error);
+				});
+			},
+		});
+	}, [terminalId, workspaceId]);
 
 	useHotkey("CLEAR_TERMINAL", () => {
 		terminalRuntimeRegistry.clear(terminalId);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx
@@ -2,7 +2,13 @@ import type { RendererContext } from "@superset/panes";
 import { toast } from "@superset/ui/sonner";
 import { workspaceTrpc } from "@superset/workspace-client";
 import "@xterm/xterm/css/xterm.css";
-import { useEffect, useMemo, useRef, useSyncExternalStore } from "react";
+import {
+	useEffect,
+	useMemo,
+	useRef,
+	useState,
+	useSyncExternalStore,
+} from "react";
 import { useHotkey } from "renderer/hotkeys";
 import {
 	type ConnectionState,
@@ -15,6 +21,7 @@ import type {
 } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/types";
 import { useWorkspaceWsUrl } from "renderer/routes/_authenticated/_dashboard/v2-workspace/providers/WorkspaceTrpcProvider/WorkspaceTrpcProvider";
 import { ScrollToBottomButton } from "renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/ScrollToBottomButton";
+import { TerminalSearch } from "renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/TerminalSearch";
 import { useTheme } from "renderer/stores/theme";
 import { resolveTerminalThemeType } from "renderer/stores/theme/utils";
 import { useTerminalAppearance } from "./hooks/useTerminalAppearance";
@@ -44,6 +51,7 @@ export function TerminalPane({ ctx, workspaceId }: TerminalPaneProps) {
 	);
 	const containerRef = useRef<HTMLDivElement | null>(null);
 	const activeTheme = useTheme();
+	const [isSearchOpen, setIsSearchOpen] = useState(false);
 
 	const appearance = useTerminalAppearance();
 	const appearanceRef = useRef(appearance);
@@ -135,12 +143,25 @@ export function TerminalPane({ ctx, workspaceId }: TerminalPaneProps) {
 		});
 	}, [terminalId, workspaceId]);
 
-	useHotkey("CLEAR_TERMINAL", () => {
-		terminalRuntimeRegistry.clear(terminalId);
-	});
+	useHotkey(
+		"CLEAR_TERMINAL",
+		() => {
+			terminalRuntimeRegistry.clear(terminalId);
+		},
+		{ enabled: ctx.isActive },
+	);
 
-	useHotkey("SCROLL_TO_BOTTOM", () => {
-		terminalRuntimeRegistry.scrollToBottom(terminalId);
+	useHotkey(
+		"SCROLL_TO_BOTTOM",
+		() => {
+			terminalRuntimeRegistry.scrollToBottom(terminalId);
+		},
+		{ enabled: ctx.isActive },
+	);
+
+	useHotkey("FIND_IN_TERMINAL", () => setIsSearchOpen((prev) => !prev), {
+		enabled: ctx.isActive,
+		preventDefault: true,
 	});
 
 	// connectionState in deps ensures terminal ref re-derives after connect/disconnect
@@ -150,9 +171,20 @@ export function TerminalPane({ ctx, workspaceId }: TerminalPaneProps) {
 		[terminalId, connectionState],
 	);
 
+	// biome-ignore lint/correctness/useExhaustiveDependencies: connectionState is intentionally included to trigger re-derive
+	const searchAddon = useMemo(
+		() => terminalRuntimeRegistry.getSearchAddon(terminalId),
+		[terminalId, connectionState],
+	);
+
 	return (
 		<div className="flex h-full w-full flex-col p-2">
 			<div className="relative min-h-0 flex-1 overflow-hidden">
+				<TerminalSearch
+					searchAddon={searchAddon}
+					isOpen={isSearchOpen}
+					onClose={() => setIsSearchOpen(false)}
+				/>
 				<div
 					ref={containerRef}
 					className="h-full w-full"

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx
@@ -41,13 +41,13 @@ function getConnectionState(terminalId: string): ConnectionState {
 }
 
 export function TerminalPane({ ctx, workspaceId }: TerminalPaneProps) {
-	const data = ctx.pane.data as TerminalPaneData;
-	// Guard against legacy pane data format {sessionKey, cwd, launchMode}
+	const paneData = ctx.pane.data as TerminalPaneData;
+	// FORK NOTE: Guard against legacy pane data format {sessionKey, cwd, launchMode}
 	// saved in local DB before the terminalId migration.
 	// useMemo ensures a stable ID across re-renders.
 	const terminalId = useMemo(
-		() => data.terminalId ?? crypto.randomUUID(),
-		[data.terminalId],
+		() => paneData.terminalId ?? crypto.randomUUID(),
+		[paneData.terminalId],
 	);
 	const containerRef = useRef<HTMLDivElement | null>(null);
 	const activeTheme = useTheme();
@@ -95,6 +95,22 @@ export function TerminalPane({ ctx, workspaceId }: TerminalPaneProps) {
 	useEffect(() => {
 		terminalRuntimeRegistry.updateAppearance(terminalId, appearance);
 	}, [terminalId, appearance]);
+
+	// --- Initial command delivery ---
+	// When initialCommand is set on pane data, send it once the WebSocket is
+	// open and immediately clear the field. Clearing prevents re-send on
+	// reconnect, and allows a new initialCommand to be set later (e.g. "run
+	// in current terminal").
+	useEffect(() => {
+		if (connectionState !== "open") return;
+		if (!paneData.initialCommand) return;
+
+		const command = paneData.initialCommand.endsWith("\n")
+			? paneData.initialCommand
+			: `${paneData.initialCommand}\n`;
+		terminalRuntimeRegistry.writeInput(terminalId, command);
+		ctx.actions.updateData({ ...paneData, initialCommand: undefined });
+	}, [connectionState, terminalId, paneData, ctx.actions]);
 
 	// --- Link handlers ---
 	// All filesystem operations go through the host service.

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/types.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/types.ts
@@ -8,6 +8,7 @@ export interface FilePaneData {
 
 export interface TerminalPaneData {
 	terminalId: string;
+	initialCommand?: string;
 }
 
 export interface ChatPaneData {

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/config.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/config.ts
@@ -33,6 +33,7 @@ export const TERMINAL_OPTIONS: ITerminalOptions = {
 	macOptionIsMeta: false,
 	cursorStyle: "block",
 	cursorInactiveStyle: "outline",
+	vtExtensions: { kittyKeyboard: true },
 	screenReaderMode: false,
 	// xterm's fit addon permanently reserves scrollbar width from usable columns.
 	// Hide the built-in scrollbar so terminal content can use the full pane width.

--- a/bun.lock
+++ b/bun.lock
@@ -220,6 +220,7 @@
         "@xterm/addon-fit": "0.12.0-beta.195",
         "@xterm/addon-image": "0.10.0-beta.195",
         "@xterm/addon-ligatures": "0.11.0-beta.195",
+        "@xterm/addon-progress": "0.3.0-beta.195",
         "@xterm/addon-search": "0.17.0-beta.195",
         "@xterm/addon-serialize": "0.15.0-beta.195",
         "@xterm/addon-unicode11": "0.10.0-beta.195",
@@ -3030,6 +3031,8 @@
     "@xterm/addon-image": ["@xterm/addon-image@0.10.0-beta.195", "", { "peerDependencies": { "@xterm/xterm": "^6.1.0-beta.195" } }, "sha512-jm6uzMpfXXut+Yfza/GNCUw2pOw3Bpsn4QEHvh5KCc8dfEuyoLeqmn026Y2kXY2BGoxj+DEHlmlPnL54ihCb2Q=="],
 
     "@xterm/addon-ligatures": ["@xterm/addon-ligatures@0.11.0-beta.195", "", { "dependencies": { "lru-cache": "^6.0.0", "opentype.js": "^0.8.0" }, "peerDependencies": { "@xterm/xterm": "^6.1.0-beta.195" } }, "sha512-sGVuanoIVynj01vRlV8nT9cCPHGJU4zzlju0g37KiKn8C+W8sAQ7TlC+XUqAZTwClWMyrozRxETWOnKlfRsZKw=="],
+
+    "@xterm/addon-progress": ["@xterm/addon-progress@0.3.0-beta.195", "", { "peerDependencies": { "@xterm/xterm": "^6.1.0-beta.195" } }, "sha512-Y+sPNUPEKXwESizWCq+/rLMmj1uO/jPbcktoZMJlYLb0QeRTwDxAFKyz9EY7scJVitCjtZOlQz377sH8IK2o2w=="],
 
     "@xterm/addon-search": ["@xterm/addon-search@0.17.0-beta.195", "", { "peerDependencies": { "@xterm/xterm": "^6.1.0-beta.195" } }, "sha512-n7sQ3u1e1gSfKJvhKCz3W/Ov7KLAOB8auC9m+7sSaFgPCuFfi2/bP4I/TswPUDF5YpkYs9leBzeVdo08/+Cglg=="],
 

--- a/packages/host-service/src/trpc/router/filesystem/filesystem.ts
+++ b/packages/host-service/src/trpc/router/filesystem/filesystem.ts
@@ -1,3 +1,5 @@
+import { stat } from "node:fs/promises";
+import { isAbsolute, join, normalize, resolve } from "node:path";
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
 import type { HostServiceContext } from "../../../types";
@@ -102,6 +104,62 @@ export const filesystemRouter = router({
 			const service = getFilesystemService(ctx, workspaceId);
 			return await service.getMetadata(serviceInput);
 		}),
+
+	/**
+	 * Resolve a path (absolute or relative) against the workspace root and
+	 * check if it exists. Used by the terminal link detector to validate
+	 * file paths before showing them as clickable links.
+	 *
+	 * Accepts:
+	 * - Absolute paths: /foo/bar → stat directly (must be within workspace)
+	 * - Relative paths: src/file.ts → resolved against workspace root
+	 * - Tilde paths: ~/foo → resolved against $HOME
+	 */
+	statPath: protectedProcedure
+		.input(
+			z.object({
+				workspaceId: z.string(),
+				path: z.string(),
+			}),
+		)
+		.mutation(
+			async ({
+				ctx,
+				input,
+			}): Promise<{
+				resolvedPath: string;
+				isDirectory: boolean;
+			} | null> => {
+				const resolvedRoot = ctx.runtime.filesystem.resolveWorkspaceRoot(
+					input.workspaceId,
+				);
+
+				let targetPath: string;
+				if (input.path.startsWith("~")) {
+					const home = process.env.HOME ?? process.env.USERPROFILE;
+					if (!home) return null;
+					targetPath = join(home, input.path.substring(1));
+				} else if (isAbsolute(input.path)) {
+					// Absolute paths are intentionally not confined to the workspace
+					// root — terminal output can reference files anywhere on the host
+					// (e.g. /usr/local/bin/node, stack traces). This endpoint is
+					// behind protectedProcedure so only authenticated clients can call it.
+					targetPath = normalize(input.path);
+				} else {
+					targetPath = resolve(resolvedRoot, input.path);
+				}
+
+				try {
+					const stats = await stat(targetPath);
+					return {
+						resolvedPath: targetPath,
+						isDirectory: stats.isDirectory(),
+					};
+				} catch {
+					return null;
+				}
+			},
+		),
 
 	writeFile: protectedProcedure
 		.input(

--- a/packages/shared/src/terminal-link-parsing/fallback-matchers.ts
+++ b/packages/shared/src/terminal-link-parsing/fallback-matchers.ts
@@ -30,7 +30,7 @@ const fallbackMatchers: RegExp[] = [
 
 	// Unknown tool format: FILE  <path>:<line>:<col>
 	// Example:  FILE  /path/to/file.ts:10:5
-	/^ +FILE +(?<link>(?<path>.+?)(?::(?<line>\d+)(?::(?<col>\d+))?)?)\s*$/,
+	/^ +FILE +(?<link>(?<path>.+)(?::(?<line>\d+)(?::(?<col>\d+))?)?)/,
 
 	// C++ compile error formats (Visual Studio CL/NVIDIA CUDA compiler):
 	// Example: C:\foo\bar baz(339) : error C2065

--- a/packages/shared/src/terminal-link-parsing/link-parsing.ts
+++ b/packages/shared/src/terminal-link-parsing/link-parsing.ts
@@ -149,7 +149,7 @@ function generateLinkSuffixRegex(eolOnly: boolean) {
 		// foo: (339, 12)
 		// foo(339:12)                             [#229842]
 		// foo (339:12)                            [#229842]
-		`:? ?[[(]${r()}(?:(?:, ?|:)${c()})?[\\])]${eolSuffix}`,
+		`:? ?[\\[\\(]${r()}(?:(?:, ?|:)${c()})?[\\]\\)]${eolSuffix}`,
 	];
 
 	const suffixClause = lineAndColumnRegexClauses
@@ -415,7 +415,7 @@ function detectLinksViaSuffix(line: string): IParsedLink[] {
 
 			// If the path contains an opening bracket, provide the path starting immediately after
 			// the opening bracket as an additional result
-			const openingBracketMatch = path.matchAll(/(?<bracket>[[({])(?![\])])/g);
+			const openingBracketMatch = path.matchAll(/(?<bracket>[[(])(?![\])])/g);
 			for (const match of openingBracketMatch) {
 				const bracket = match.groups?.bracket;
 				if (bracket) {


### PR DESCRIPTION
## Summary

upstream から behind していた terminal 関連4コミットのうち、auto-updater/quit lifecycle に侵食しない3件を取り込みます。PR分割戦略の第3弾。

## 取り込みコミット

| 元コミット | 内容 | 規模 |
|---|---|---|
| `56f1f13d1` ← `d98533cbd` (#3245) | feat: VSCode terminal link detection 移植（clickable file paths、stat validation） | 極大（+2558行） |
| `732f25a44` ← `89d79037e` (#3289) | feat: xterm addons追加（progress/unicode/ligatures）+ Kitty keyboard protocol | 中 |
| `6495b2d8e` ← `d1ea876bc` (#3297) | feat: v2 terminalに initial command 配信機能 | 小 |

## スキップしたコミット

### `54e8a1c88` (#3252) fix: prevent xterm garbling via tRPC-first terminal sessions
**理由**: このコミットが `setSkipQuitConfirmation()` / `quitApp()` を追加しているが、forkは独自の `requestQuit(mode: QuitMode)` / `pendingQuitMode` パターン（「release」「stop」モード分岐）を使っており、\`apps/desktop/src/main/index.ts\` と \`auto-updater.ts\` で直接衝突する。

memory `project_upstream_merge_workflow` に記録のとおり、quit lifecycle + auto-updater は fork 独自領域 (`prepareQuit("stop")` 等) との手動統合が必要なため、**PR4（auto-updater/quit系）で手動マージ**する。

## コンフリクト解決

### `apps/desktop/src/main/lib/auto-updater.ts`
upstream `d98533cbd` が `BrowserWindow`/`quitApp` の未使用 import を削除しているが、fork にはそもそもそれらの import がなく、代わりに `prepareQuit`, `gt`, `valid` を import している（fork独自の GitHub API ベース更新チェック）。fork 側（HEAD）をそのまま維持。

### `apps/desktop/src/renderer/.../TerminalPane/TerminalPane.tsx`
fork は legacy pane data 形式（`{sessionKey, cwd, launchMode}`）からの移行ガードとして `useMemo(() => data.terminalId ?? crypto.randomUUID(), ...)` を実装済み。
upstream `d1ea876bc` が `paneData` 変数として分割代入しつつ `initialCommand` 配信の useEffect を追加している。

**解決**: 変数名を upstream の `paneData` に合わせつつ、fork の `useMemo` 後方互換ガードを維持。`FORK NOTE` コメントを追加して設計意図を明示。

## 依存関係

- 新規依存: `@xterm/addon-progress@0.3.0-beta.195`（`89d79037e` に含まれる）→ `bun install` 済み
- terminal links 向け新規モジュール群 `renderer/lib/terminal/links/` （VSCode 由来）
- host-service に `filesystem.statPath` エンドポイント追加

## 検証

- [x] 3コミット cherry-pick + コンフリクト手動解決
- [x] `bun install` で新規 deps 導入
- [x] `bun run typecheck` → 既存の `ModelsSettings.tsx` エラーのみ（mainと同じ）

## Test plan

- [ ] CI通過確認
- [ ] rv-pr スキルによるレビュー
- [ ] ローカルでdesktopビルドし、以下を確認
  - [ ] v2 terminal でファイルパス（`apps/web/page.tsx:42` 等）がクリック可能になる
  - [ ] URL が自動検出される
  - [ ] Kitty keyboard protocol が動作する
  - [ ] v2 preset → terminal の initial command が実行される
  - [ ] 既存の terminal 接続フローがリグレッションしていない