### PR TITLE
chore(upstream): PR4 - terminal ensureSession 手動移植 + bundle name sanitize

### DIFF
--- a/apps/desktop/scripts/patch-dev-protocol.ts
+++ b/apps/desktop/scripts/patch-dev-protocol.ts
@@ -151,7 +151,10 @@ export function resolveWorkspaceIdentity(
 		: undefined;
 	const displayWorkspaceName = resolvedDisplayName || workspaceName;
 	const bundleDisplayWorkspaceName =
-		displayWorkspaceName.replaceAll("/", "-").trim() || workspaceName;
+		displayWorkspaceName
+			.replaceAll("/", "-")
+			.replaceAll(/[^a-zA-Z0-9 -]/g, "")
+			.trim() || workspaceName;
 
 	return {
 		workspaceName,

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx
@@ -65,32 +65,58 @@ export function TerminalPane({ ctx, workspaceId }: TerminalPaneProps) {
 	);
 	const initialThemeType = initialThemeTypeRef.current;
 
-	const websocketUrl = useWorkspaceWsUrl(`/terminal/${terminalId}`, {
-		workspaceId,
-		themeType: initialThemeType,
-	});
+	// URL is stable — no workspaceId/themeType in query params.
+	// Session is created via tRPC before WebSocket connects.
+	const websocketUrl = useWorkspaceWsUrl(`/terminal/${terminalId}`);
+
+	const ensureSession = workspaceTrpc.terminal.ensureSession.useMutation();
+	const ensureSessionRef = useRef(ensureSession);
+	ensureSessionRef.current = ensureSession;
 
 	const connectionState = useSyncExternalStore(
 		subscribeToState(terminalId),
 		() => getConnectionState(terminalId),
 	);
 
-	// Appearance read from ref to avoid re-attach on theme/font change.
 	useEffect(() => {
 		const container = containerRef.current;
 		if (!container) return;
 
-		terminalRuntimeRegistry.attach(
-			terminalId,
-			container,
-			websocketUrl,
-			appearanceRef.current,
-		);
+		let cancelled = false;
+
+		// Create session via tRPC, then connect WebSocket as data pipe.
+		ensureSessionRef.current
+			.mutateAsync({
+				terminalId,
+				workspaceId,
+				themeType: initialThemeType,
+			})
+			.then(() => {
+				if (cancelled) return;
+				terminalRuntimeRegistry.attach(
+					terminalId,
+					container,
+					websocketUrl,
+					appearanceRef.current,
+				);
+			})
+			.catch((err) => {
+				if (cancelled) return;
+				console.error("[TerminalPane] ensureSession failed:", err);
+				// Still try to connect — WS handler has fallback for existing sessions
+				terminalRuntimeRegistry.attach(
+					terminalId,
+					container,
+					websocketUrl,
+					appearanceRef.current,
+				);
+			});
 
 		return () => {
+			cancelled = true;
 			terminalRuntimeRegistry.detach(terminalId);
 		};
-	}, [terminalId, websocketUrl]);
+	}, [terminalId, websocketUrl, initialThemeType, workspaceId]);
 
 	useEffect(() => {
 		terminalRuntimeRegistry.updateAppearance(terminalId, appearance);

--- a/packages/host-service/src/terminal/terminal.ts
+++ b/packages/host-service/src/terminal/terminal.ts
@@ -18,7 +18,7 @@ interface RegisterWorkspaceTerminalRouteOptions {
 	upgradeWebSocket: NodeWebSocket["upgradeWebSocket"];
 }
 
-function parseThemeType(
+export function parseThemeType(
 	value: string | null | undefined,
 ): "dark" | "light" | undefined {
 	return value === "dark" || value === "light" ? value : undefined;
@@ -110,7 +110,7 @@ interface CreateTerminalSessionOptions {
 	db: HostDb;
 }
 
-function createTerminalSessionInternal({
+export function createTerminalSessionInternal({
 	terminalId,
 	workspaceId,
 	themeType,
@@ -293,8 +293,6 @@ export function registerWorkspaceTerminalRoute({
 		"/terminal/:terminalId",
 		upgradeWebSocket((c) => {
 			const terminalId = c.req.param("terminalId") ?? "";
-			const workspaceId = c.req.query("workspaceId") ?? null;
-			const themeType = parseThemeType(c.req.query("themeType"));
 
 			return {
 				onOpen: (_event, ws) => {
@@ -304,56 +302,61 @@ export function registerWorkspaceTerminalRoute({
 					}
 
 					const existing = sessions.get(terminalId);
-					if (existing) {
-						if (existing.socket && existing.socket !== ws) {
-							existing.socket.close(4000, "Displaced by new connection");
+					if (!existing) {
+						// Session must be created via tRPC terminal.ensureSession before connecting.
+						// Fall back to query params for backwards compatibility with v1 callers.
+						const workspaceId = c.req.query("workspaceId") ?? null;
+						if (!workspaceId) {
+							sendMessage(ws, {
+								type: "error",
+								message:
+									"Session not found. Call terminal.ensureSession first.",
+							});
+							ws.close(1011, "Session not found");
+							return;
 						}
-						existing.socket = ws;
+
+						const themeType = parseThemeType(c.req.query("themeType"));
+						const result = createTerminalSessionInternal({
+							terminalId,
+							workspaceId,
+							themeType,
+							db,
+						});
+
+						if ("error" in result) {
+							sendMessage(ws, { type: "error", message: result.error });
+							ws.close(1011, result.error);
+							return;
+						}
+
+						result.socket = ws;
 
 						db.update(terminalSessions)
 							.set({ lastAttachedAt: Date.now() })
 							.where(eq(terminalSessions.id, terminalId))
 							.run();
-
-						replayBuffer(existing, ws);
-						if (existing.exited) {
-							sendMessage(ws, {
-								type: "exit",
-								exitCode: existing.exitCode,
-								signal: existing.exitSignal,
-							});
-						}
 						return;
 					}
 
-					if (!workspaceId) {
-						sendMessage(ws, {
-							type: "error",
-							message: "Missing workspaceId for new terminal session",
-						});
-						ws.close(1011, "Missing workspaceId");
-						return;
+					if (existing.socket && existing.socket !== ws) {
+						existing.socket.close(4000, "Displaced by new connection");
 					}
-
-					const result = createTerminalSessionInternal({
-						terminalId,
-						workspaceId,
-						themeType,
-						db,
-					});
-
-					if ("error" in result) {
-						sendMessage(ws, { type: "error", message: result.error });
-						ws.close(1011, result.error);
-						return;
-					}
-
-					result.socket = ws;
+					existing.socket = ws;
 
 					db.update(terminalSessions)
 						.set({ lastAttachedAt: Date.now() })
 						.where(eq(terminalSessions.id, terminalId))
 						.run();
+
+					replayBuffer(existing, ws);
+					if (existing.exited) {
+						sendMessage(ws, {
+							type: "exit",
+							exitCode: existing.exitCode,
+							signal: existing.exitSignal,
+						});
+					}
 				},
 
 				onMessage: (event, ws) => {

--- a/packages/host-service/src/trpc/router/router.ts
+++ b/packages/host-service/src/trpc/router/router.ts
@@ -7,6 +7,7 @@ import { githubRouter } from "./github";
 import { healthRouter } from "./health";
 import { projectRouter } from "./project";
 import { pullRequestsRouter } from "./pull-requests";
+import { terminalRouter } from "./terminal";
 import { workspaceRouter } from "./workspace";
 
 export const appRouter = router({
@@ -18,6 +19,7 @@ export const appRouter = router({
 	cloud: cloudRouter,
 	pullRequests: pullRequestsRouter,
 	project: projectRouter,
+	terminal: terminalRouter,
 	workspace: workspaceRouter,
 });
 

--- a/packages/host-service/src/trpc/router/terminal/index.ts
+++ b/packages/host-service/src/trpc/router/terminal/index.ts
@@ -1,0 +1,1 @@
+export { terminalRouter } from "./terminal";

--- a/packages/host-service/src/trpc/router/terminal/terminal.ts
+++ b/packages/host-service/src/trpc/router/terminal/terminal.ts
@@ -1,0 +1,35 @@
+import { z } from "zod";
+import {
+	createTerminalSessionInternal,
+	parseThemeType,
+} from "../../../terminal/terminal";
+import { protectedProcedure, router } from "../../index";
+
+export const terminalRouter = router({
+	ensureSession: protectedProcedure
+		.input(
+			z.object({
+				terminalId: z.string(),
+				workspaceId: z.string(),
+				themeType: z.string().optional(),
+			}),
+		)
+		.mutation(({ ctx, input }) => {
+			const result = createTerminalSessionInternal({
+				terminalId: input.terminalId,
+				workspaceId: input.workspaceId,
+				themeType: parseThemeType(input.themeType),
+				db: ctx.db,
+			});
+
+			if ("error" in result) {
+				return {
+					terminalId: input.terminalId,
+					status: "error" as const,
+					error: result.error,
+				};
+			}
+
+			return { terminalId: result.terminalId, status: "active" as const };
+		}),
+});


### PR DESCRIPTION
## Summary

当初の計画では「PR4 = auto-updater/quit 系4コミット取り込み」だったが、Codex 事前調査の結果、**fork 独自実装 (`requestQuit(mode)` / `GitHub API ベース auto-updater` / `cleanupMainWindowResources()` / tray 二択メニュー) と 4コミットの大半が直接衝突**することが判明した。

そのため PR4 は方針を縮小し、**実質的に価値があり fork 独自実装を壊さない部分のみ**を手動移植する。

## 取り込み内容

### コミット1: `c3cdd68fa` terminal ensureSession tRPC mutation（upstream #3252 部分）

upstream `54e8a1c88` から terminal 関連部分のみ抽出。quit lifecycle 変更は除外。

**目的**: terminal session 作成を WebSocket query params → tRPC mutation に移行し、WebSocket URL を安定化。workspace 切替時の xterm 描画 garbling を修正。

**取り込んだファイル**:
- `packages/host-service/src/trpc/router/router.ts` (+terminalRouter)
- `packages/host-service/src/trpc/router/terminal/index.ts` (新規)
- `packages/host-service/src/trpc/router/terminal/terminal.ts` (新規 ensureSession mutation)
- `packages/host-service/src/terminal/terminal.ts` (+export, WS handler のフォールバック処理)
- `apps/desktop/src/renderer/.../TerminalPane/TerminalPane.tsx` (ensureSession 呼び出し追加)

**意図的に除外したファイル**:
- `apps/desktop/src/main/index.ts` — upstream が `setSkipQuitConfirmation()` / `quitApp()` を追加しようとするが、fork は `requestQuit(mode: QuitMode)` / `pendingQuitMode` / `prepareQuit('stop'|'release')` を使用
- `apps/desktop/src/main/lib/auto-updater.ts` — fork は `IS_FORK=true` で GitHub API ベース auto-updater に置換済み、`prepareQuit('stop')` で macOS quit ブロック回避

host-service 側の WebSocket handler は query-param フォールバックを残したため、v1 callers との後方互換あり。

### コミット2: `5f83081a6` bundle display name sanitize（upstream #3253 部分）

upstream `146c86d73` から `patch-dev-protocol.ts` の sanitize hunk のみ抽出。quit lifecycle 書き換え本体は除外。

**目的**: workspace 名に特殊文字（例: アポストロフィ）が含まれると PlistBuddy コマンドが壊れるバグ修正。allowlist (英数字・スペース・ハイフン) でサニタイズ。

## スキップ確定コミット（取り込まない）

memory `project_upstream_merge_workflow` に記録する:

| コミット | スキップ理由 |
|---|---|
| `146c86d73` 本体 (#3253) | fork の `QuitMode/requestQuit/prepareQuit/cleanupMainWindowResources/closeLocalDb/shutdownExtensionHost` を丸ごと捨てる方向。tray 二択メニューも消す。fork 独自 cleanup 体系が壊れる |
| `129839219` (#3278) | fork は `IS_FORK=true` で GitHub Releases 外部オープン完結のため、upstream の `quitAndInstall()` 起点修正が現行 runtime に効かない。commit 単体でも import/call が不整合（`quitApp` import しつつ `setSkipQuitConfirmation()` 呼ぶ） |
| `6daee831b` (#3291) | macOS close-to-hide 削除は fork の tray UX（Quit Keep/Stop Services 二択）を前提にしており UX 破壊 |
| `54e8a1c88` (#3252) quit 部分 | 本 PR コミット1 と同様、quit 部分のみ除外 |

## Fork 独自要素（維持必須 - memoryにも記録済み）

- `cleanupMainWindowResources()` @ `main/index.ts`
- `shutdownExtensionHost()`, `closeLocalDb()`
- `IS_FORK=true` GitHub API auto-updater
- `app-command` (マウス戻る/進む) @ `windows/main.ts`
- tray 二択メニュー @ `tray/index.ts`
- `QuitMode = "release" | "stop"`, `prepareQuit('stop')` (macOS quit ブロック回避)

## 検証

- [x] `bun run typecheck` → 既存の `ModelsSettings.tsx` エラーのみ
- [x] 2コミット分離 (terminal feature / unrelated sanitize bug fix)
- [x] fork 独自 auto-updater, quit lifecycle, tray menu は一切触らない

## Test plan

- [ ] CI通過確認
- [ ] rv-pr スキルによるレビュー
- [ ] ローカル検証:
  - [ ] v2 terminal で workspace 切替時に描画が garble しない
  - [ ] terminal.ensureSession が正常に呼ばれる
  - [ ] host-service 再起動なしでも既存の v1 terminal が query-param fallback で動作する
  - [ ] アポストロフィを含む workspace 名で dev 起動できる
  - [ ] auto-updater / quit 挙動に regression なし（fork 独自 prepareQuit フロー維持）