### PR TITLE
chore(upstream): PR6 - CLI release pipeline 4件取り込み

### DIFF
--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -54,6 +54,8 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/cli-v')
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout code

--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -14,15 +14,13 @@ jobs:
         include:
           - os: macos-14
             target: darwin-arm64
-          - os: macos-13
-            target: darwin-x64
           - os: ubuntu-latest
             target: linux-x64
 
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -30,7 +28,7 @@ jobs:
           bun-version-file: .bun-version
 
       - name: Setup Node.js (for native addon compilation)
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22
 
@@ -45,7 +43,7 @@ jobs:
         run: bun run build:dist --target=${{ matrix.target }}
 
       - name: Upload tarball
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: superset-${{ matrix.target }}
           path: packages/cli/dist/superset-${{ matrix.target }}.tar.gz
@@ -59,10 +57,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           path: release-artifacts
           pattern: superset-*

--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -1,0 +1,79 @@
+name: Build CLI Distribution
+
+on:
+  push:
+    tags: ["cli-v*"]
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build ${{ matrix.target }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-14
+            target: darwin-arm64
+          - os: macos-13
+            target: darwin-x64
+          - os: ubuntu-latest
+            target: linux-x64
+
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version-file: .bun-version
+
+      - name: Setup Node.js (for native addon compilation)
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install dependencies
+        run: bun install --frozen
+
+      - name: Build distribution
+        working-directory: packages/cli
+        env:
+          RELAY_URL: https://relay.superset.sh
+          CLOUD_API_URL: https://api.superset.sh
+        run: bun run build:dist --target=${{ matrix.target }}
+
+      - name: Upload tarball
+        uses: actions/upload-artifact@v4
+        with:
+          name: superset-${{ matrix.target }}
+          path: packages/cli/dist/superset-${{ matrix.target }}.tar.gz
+          if-no-files-found: error
+
+  release:
+    name: Create GitHub Release
+    needs: build
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/cli-v')
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: release-artifacts
+          pattern: superset-*
+          merge-multiple: true
+
+      - name: Create Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${{ github.ref_name }}" \
+            release-artifacts/*.tar.gz \
+            --title "Superset CLI ${{ github.ref_name }}" \
+            --generate-notes \
+            --draft

--- a/.github/workflows/bump-homebrew.yml
+++ b/.github/workflows/bump-homebrew.yml
@@ -1,0 +1,137 @@
+name: Bump Homebrew Formula
+
+# Triggers when a CLI release (tag matching cli-v*) is published, computes
+# SHA256 for each platform tarball, and pushes an updated formula to the
+# superset-sh/homebrew-tap repository.
+
+on:
+  release:
+    types: [published]
+
+# Serialize runs so two concurrent releases can't race and drop a bump.
+concurrency:
+  group: homebrew-tap-formula-bump
+  cancel-in-progress: false
+
+jobs:
+  bump:
+    if: startsWith(github.event.release.tag_name, 'cli-v')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Extract version from tag
+        id: version
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          # Validate tag format: cli-v<semver>. Rejects tags with shell metacharacters.
+          if ! printf '%s' "$TAG" | grep -Eq '^cli-v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.]+)?$'; then
+            echo "::error::Invalid tag format: $TAG"
+            exit 1
+          fi
+          VERSION="${TAG#cli-v}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Compute SHA256 for each tarball
+        id: shas
+        env:
+          TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          set -euo pipefail
+          for target in darwin-arm64 darwin-x64 linux-x64; do
+            url="https://github.com/superset-sh/superset/releases/download/${TAG}/superset-${target}.tar.gz"
+            echo "Fetching SHA for $url"
+            tmp=$(mktemp)
+            if ! curl -fsSL -o "$tmp" "$url"; then
+              echo "::error::Failed to download $url"
+              rm -f "$tmp"
+              exit 1
+            fi
+            sha=$(shasum -a 256 "$tmp" | awk '{print $1}')
+            rm -f "$tmp"
+            echo "${target//-/_}_sha=$sha" >> "$GITHUB_OUTPUT"
+          done
+
+      - name: Checkout homebrew-tap
+        uses: actions/checkout@v4
+        with:
+          repository: superset-sh/homebrew-tap
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          path: homebrew-tap
+
+      - name: Render formula
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          DARWIN_ARM64_SHA: ${{ steps.shas.outputs.darwin_arm64_sha }}
+          DARWIN_X64_SHA: ${{ steps.shas.outputs.darwin_x64_sha }}
+          LINUX_X64_SHA: ${{ steps.shas.outputs.linux_x64_sha }}
+        run: |
+          set -euo pipefail
+          python3 - <<'PYEOF' > homebrew-tap/Formula/superset.rb
+          import os
+          template = '''class Superset < Formula
+            desc "CLI and host-service for Superset"
+            homepage "https://superset.sh"
+            version "{version}"
+            license "MIT"
+
+            on_macos do
+              on_arm do
+                url "https://github.com/superset-sh/superset/releases/download/cli-v#{{version}}/superset-darwin-arm64.tar.gz"
+                sha256 "{darwin_arm64}"
+              end
+              on_intel do
+                url "https://github.com/superset-sh/superset/releases/download/cli-v#{{version}}/superset-darwin-x64.tar.gz"
+                sha256 "{darwin_x64}"
+              end
+            end
+
+            on_linux do
+              on_intel do
+                url "https://github.com/superset-sh/superset/releases/download/cli-v#{{version}}/superset-linux-x64.tar.gz"
+                sha256 "{linux_x64}"
+              end
+            end
+
+            def install
+              libexec.install Dir["*"]
+              bin.install_symlink libexec/"bin/superset"
+              bin.install_symlink libexec/"bin/superset-host"
+            end
+
+            test do
+              assert_match "superset", shell_output("#{{bin}}/superset --version")
+            end
+          end
+          '''
+          print(template.format(
+              version=os.environ["VERSION"],
+              darwin_arm64=os.environ["DARWIN_ARM64_SHA"],
+              darwin_x64=os.environ["DARWIN_X64_SHA"],
+              linux_x64=os.environ["LINUX_X64_SHA"],
+          ), end="")
+          PYEOF
+
+      - name: Commit and push
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          cd homebrew-tap
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add Formula/superset.rb
+          if git diff --cached --quiet; then
+            echo "No changes to formula"
+            exit 0
+          fi
+          git commit -m "superset ${VERSION}"
+
+          # Retry once on non-fast-forward in case the remote moved between
+          # checkout and push (shouldn't happen with the concurrency group,
+          # but belt-and-suspenders).
+          if ! git push; then
+            git pull --rebase
+            git push
+          fi

--- a/.github/workflows/bump-homebrew.yml
+++ b/.github/workflows/bump-homebrew.yml
@@ -39,7 +39,7 @@ jobs:
           TAG: ${{ steps.version.outputs.tag }}
         run: |
           set -euo pipefail
-          for target in darwin-arm64 darwin-x64 linux-x64; do
+          for target in darwin-arm64 linux-x64; do
             url="https://github.com/superset-sh/superset/releases/download/${TAG}/superset-${target}.tar.gz"
             echo "Fetching SHA for $url"
             tmp=$(mktemp)
@@ -54,7 +54,7 @@ jobs:
           done
 
       - name: Checkout homebrew-tap
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: superset-sh/homebrew-tap
           token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
@@ -64,7 +64,6 @@ jobs:
         env:
           VERSION: ${{ steps.version.outputs.version }}
           DARWIN_ARM64_SHA: ${{ steps.shas.outputs.darwin_arm64_sha }}
-          DARWIN_X64_SHA: ${{ steps.shas.outputs.darwin_x64_sha }}
           LINUX_X64_SHA: ${{ steps.shas.outputs.linux_x64_sha }}
         run: |
           set -euo pipefail
@@ -80,10 +79,6 @@ jobs:
               on_arm do
                 url "https://github.com/superset-sh/superset/releases/download/cli-v#{{version}}/superset-darwin-arm64.tar.gz"
                 sha256 "{darwin_arm64}"
-              end
-              on_intel do
-                url "https://github.com/superset-sh/superset/releases/download/cli-v#{{version}}/superset-darwin-x64.tar.gz"
-                sha256 "{darwin_x64}"
               end
             end
 
@@ -108,7 +103,6 @@ jobs:
           print(template.format(
               version=os.environ["VERSION"],
               darwin_arm64=os.environ["DARWIN_ARM64_SHA"],
-              darwin_x64=os.environ["DARWIN_X64_SHA"],
               linux_x64=os.environ["LINUX_X64_SHA"],
           ), end="")
           PYEOF

--- a/apps/marketing/public/cli/install.sh
+++ b/apps/marketing/public/cli/install.sh
@@ -1,0 +1,153 @@
+#!/bin/sh
+# Superset CLI installer
+#
+# Usage:
+#   curl -fsSL https://superset.sh/cli/install.sh | sh
+#
+# Installs the Superset CLI and host-service to ~/superset/.
+# Adds ~/superset/bin to PATH via your shell profile.
+
+set -eu
+
+REPO="superset-sh/superset"
+INSTALL_DIR="${SUPERSET_HOME:-$HOME/superset}"
+TAG="${SUPERSET_VERSION:-latest}"
+
+BOLD='\033[1m'
+GREEN='\033[32m'
+YELLOW='\033[33m'
+RED='\033[31m'
+RESET='\033[0m'
+
+info() { printf "${GREEN}==>${RESET} %s\n" "$1" >&2; }
+warn() { printf "${YELLOW}warning:${RESET} %s\n" "$1" >&2; }
+error() { printf "${RED}error:${RESET} %s\n" "$1" >&2; exit 1; }
+
+detect_target() {
+    os="$(uname -s)"
+    arch="$(uname -m)"
+
+    case "$os" in
+        Darwin)
+            case "$arch" in
+                arm64) echo "darwin-arm64" ;;
+                x86_64) echo "darwin-x64" ;;
+                *) error "Unsupported macOS architecture: $arch" ;;
+            esac
+            ;;
+        Linux)
+            case "$arch" in
+                x86_64) echo "linux-x64" ;;
+                *) error "Unsupported Linux architecture: $arch (only x64 is supported)" ;;
+            esac
+            ;;
+        *)
+            error "Unsupported OS: $os (only macOS and Linux are supported)"
+            ;;
+    esac
+}
+
+download_tarball() {
+    target="$1"
+    tarball="superset-${target}.tar.gz"
+
+    if [ "$TAG" = "latest" ]; then
+        url="https://github.com/${REPO}/releases/latest/download/${tarball}"
+    else
+        url="https://github.com/${REPO}/releases/download/${TAG}/${tarball}"
+    fi
+
+    info "Downloading $url"
+    tmp="$(mktemp -t superset-install.XXXXXX)"
+    if ! curl -fsSL -o "$tmp" "$url"; then
+        rm -f "$tmp"
+        error "Failed to download $url"
+    fi
+    echo "$tmp"
+}
+
+extract_tarball() {
+    tarball="$1"
+    info "Extracting to $INSTALL_DIR"
+    mkdir -p "$INSTALL_DIR"
+    tar -xzf "$tarball" -C "$INSTALL_DIR"
+    rm -f "$tarball"
+}
+
+detect_shell_profile() {
+    case "${SHELL:-}" in
+        */zsh) echo "$HOME/.zshrc" ;;
+        */bash)
+            if [ -f "$HOME/.bash_profile" ]; then
+                echo "$HOME/.bash_profile"
+            else
+                echo "$HOME/.bashrc"
+            fi
+            ;;
+        */fish) echo "$HOME/.config/fish/config.fish" ;;
+        *) echo "" ;;
+    esac
+}
+
+update_path() {
+    bin_dir="$INSTALL_DIR/bin"
+
+    # Check if it's already in PATH
+    case ":$PATH:" in
+        *":$bin_dir:"*)
+            info "$bin_dir is already in PATH"
+            return
+            ;;
+    esac
+
+    profile="$(detect_shell_profile)"
+    if [ -z "$profile" ]; then
+        warn "Could not detect your shell profile. Add this to your shell config:"
+        printf "  export PATH=\"%s:\$PATH\"\n" "$bin_dir"
+        return
+    fi
+
+    export_line="export PATH=\"$bin_dir:\$PATH\""
+    if [ "$profile" = "$HOME/.config/fish/config.fish" ]; then
+        export_line="set -gx PATH $bin_dir \$PATH"
+    fi
+
+    if [ -f "$profile" ] && grep -Fq "$bin_dir" "$profile"; then
+        info "PATH already configured in $profile"
+        return
+    fi
+
+    info "Adding $bin_dir to PATH in $profile"
+    mkdir -p "$(dirname "$profile")"
+    {
+        printf "\n# Superset CLI\n"
+        printf "%s\n" "$export_line"
+    } >> "$profile"
+}
+
+main() {
+    printf "${BOLD}Installing Superset CLI${RESET}\n\n"
+
+    target="$(detect_target)"
+    info "Platform: $target"
+
+    tarball="$(download_tarball "$target")"
+    extract_tarball "$tarball"
+
+    # Verify binaries exist and are executable. Tarball already ships them
+    # with +x, so this is a sanity check, not a chmod fallback.
+    for bin in superset superset-host; do
+        path="$INSTALL_DIR/bin/$bin"
+        if [ ! -f "$path" ] || [ ! -x "$path" ]; then
+            error "Expected executable file not found: $path"
+        fi
+    done
+
+    update_path
+
+    printf "\n${GREEN}${BOLD}Installed!${RESET}\n"
+    printf "Run ${BOLD}superset auth login${RESET} to get started.\n"
+    printf "You may need to restart your shell (or run \`source <your-profile>\`) for the PATH to take effect.\n"
+}
+
+main "$@"

--- a/apps/marketing/public/cli/install.sh
+++ b/apps/marketing/public/cli/install.sh
@@ -31,7 +31,7 @@ detect_target() {
         Darwin)
             case "$arch" in
                 arm64) echo "darwin-arm64" ;;
-                x86_64) echo "darwin-x64" ;;
+                x86_64) error "Intel Macs are not supported. Apple Silicon (arm64) only." ;;
                 *) error "Unsupported macOS architecture: $arch" ;;
             esac
             ;;

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -10,9 +10,8 @@
 		"dev": "dotenv -e ../../.env -- sh -c 'SUPERSET_API_URL=$NEXT_PUBLIC_API_URL bun src/bin.ts $@' --",
 		"build": "bun build --compile src/bin.ts --outfile dist/superset",
 		"build:darwin-arm64": "bun build --compile --target=bun-darwin-arm64 src/bin.ts --outfile dist/superset-darwin-arm64",
-		"build:darwin-x64": "bun build --compile --target=bun-darwin-x64 src/bin.ts --outfile dist/superset-darwin-x64",
 		"build:linux-x64": "bun build --compile --target=bun-linux-x64 src/bin.ts --outfile dist/superset-linux-x64",
-		"build:all": "bun run build:darwin-arm64 && bun run build:darwin-x64 && bun run build:linux-x64",
+		"build:all": "bun run build:darwin-arm64 && bun run build:linux-x64",
 		"build:dist": "bun run scripts/build-dist.ts",
 		"typecheck": "tsc --noEmit"
 	},

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -13,6 +13,7 @@
 		"build:darwin-x64": "bun build --compile --target=bun-darwin-x64 src/bin.ts --outfile dist/superset-darwin-x64",
 		"build:linux-x64": "bun build --compile --target=bun-linux-x64 src/bin.ts --outfile dist/superset-linux-x64",
 		"build:all": "bun run build:darwin-arm64 && bun run build:darwin-x64 && bun run build:linux-x64",
+		"build:dist": "bun run scripts/build-dist.ts",
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {

--- a/packages/cli/scripts/build-dist.ts
+++ b/packages/cli/scripts/build-dist.ts
@@ -277,13 +277,9 @@ async function main(): Promise<void> {
 
 	const tarball = join(cliDir, "dist", `superset-${target}.tar.gz`);
 	console.log(`[build-dist] creating ${tarball}`);
-	await exec("tar", [
-		"-czf",
-		tarball,
-		"-C",
-		dirname(stagingRoot),
-		`superset-${target}`,
-	]);
+	// Tar from inside the staging dir so contents extract directly to the
+	// install target (no top-level superset-<target>/ wrapper).
+	await exec("tar", ["-czf", tarball, "-C", stagingRoot, "."]);
 
 	console.log(`[build-dist] done: ${tarball}`);
 }

--- a/packages/cli/scripts/build-dist.ts
+++ b/packages/cli/scripts/build-dist.ts
@@ -31,9 +31,9 @@ import {
 import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 
-type Target = "darwin-arm64" | "darwin-x64" | "linux-x64";
+type Target = "darwin-arm64" | "linux-x64";
 
-const VALID_TARGETS: Target[] = ["darwin-arm64", "darwin-x64", "linux-x64"];
+const VALID_TARGETS: Target[] = ["darwin-arm64", "linux-x64"];
 const NODE_VERSION = "22.13.0";
 
 /**
@@ -64,7 +64,7 @@ function parseArgs(): { target: Target } {
 
 function nodeArchiveName(target: Target): string {
 	const arch = target === "darwin-arm64" ? "arm64" : "x64";
-	const platform = target.startsWith("darwin") ? "darwin" : "linux";
+	const platform = target === "darwin-arm64" ? "darwin" : "linux";
 	return `node-v${NODE_VERSION}-${platform}-${arch}`;
 }
 

--- a/packages/cli/scripts/build-dist.ts
+++ b/packages/cli/scripts/build-dist.ts
@@ -1,0 +1,291 @@
+/**
+ * Builds a standalone Superset CLI distribution tarball.
+ *
+ * Bundle layout (extracts into ~/superset/):
+ *   bin/superset                 — Bun-compiled CLI binary
+ *   bin/superset-host            — Shell wrapper to run the host-service
+ *   lib/node                     — Standalone Node.js runtime
+ *   lib/host-service.js          — Bundled host-service entry
+ *   lib/node_modules/            — Full native addon packages (JS wrappers + bindings)
+ *     better-sqlite3/
+ *     node-pty/
+ *     @parcel/watcher/
+ *     @parcel/watcher-<target>/
+ *   share/migrations/            — Drizzle migration SQL files
+ *
+ * Usage:
+ *   bun run scripts/build-dist.ts --target=darwin-arm64
+ *   bun run scripts/build-dist.ts --target=darwin-x64
+ *   bun run scripts/build-dist.ts --target=linux-x64
+ */
+import { spawn } from "node:child_process";
+import {
+	chmodSync,
+	cpSync,
+	existsSync,
+	mkdirSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+
+type Target = "darwin-arm64" | "darwin-x64" | "linux-x64";
+
+const VALID_TARGETS: Target[] = ["darwin-arm64", "darwin-x64", "linux-x64"];
+const NODE_VERSION = "22.13.0";
+
+/**
+ * Native addon packages that must be shipped alongside the bundled
+ * host-service because they contain .node files that can't be inlined.
+ */
+const NATIVE_PACKAGES = [
+	"better-sqlite3",
+	"node-pty",
+	"@parcel/watcher",
+] as const;
+
+function parseArgs(): { target: Target } {
+	const targetArg = process.argv.find((a) => a.startsWith("--target="));
+	if (!targetArg) {
+		console.error("Missing required --target=<platform-arch>");
+		console.error(`Valid targets: ${VALID_TARGETS.join(", ")}`);
+		process.exit(1);
+	}
+	const target = targetArg.slice("--target=".length) as Target;
+	if (!VALID_TARGETS.includes(target)) {
+		console.error(`Invalid target: ${target}`);
+		console.error(`Valid targets: ${VALID_TARGETS.join(", ")}`);
+		process.exit(1);
+	}
+	return { target };
+}
+
+function nodeArchiveName(target: Target): string {
+	const arch = target === "darwin-arm64" ? "arm64" : "x64";
+	const platform = target.startsWith("darwin") ? "darwin" : "linux";
+	return `node-v${NODE_VERSION}-${platform}-${arch}`;
+}
+
+function nodeDownloadUrl(target: Target): string {
+	return `https://nodejs.org/dist/v${NODE_VERSION}/${nodeArchiveName(target)}.tar.gz`;
+}
+
+async function exec(cmd: string, args: string[], cwd?: string): Promise<void> {
+	return new Promise((res, rej) => {
+		const child = spawn(cmd, args, {
+			cwd,
+			stdio: "inherit",
+		});
+		child.on("exit", (code) => {
+			if (code === 0) res();
+			else rej(new Error(`${cmd} ${args.join(" ")} exited with ${code}`));
+		});
+		child.on("error", rej);
+	});
+}
+
+async function downloadAndExtractNode(
+	target: Target,
+	destDir: string,
+): Promise<string> {
+	const cacheDir = join(homedir(), ".superset-build-cache");
+	if (!existsSync(cacheDir)) mkdirSync(cacheDir, { recursive: true });
+
+	const archiveName = nodeArchiveName(target);
+	const archivePath = join(cacheDir, `${archiveName}.tar.gz`);
+	const extractedPath = join(cacheDir, archiveName);
+
+	if (!existsSync(archivePath)) {
+		console.log(`[build-dist] downloading ${nodeDownloadUrl(target)}`);
+		await exec("curl", ["-fsSL", "-o", archivePath, nodeDownloadUrl(target)]);
+	}
+
+	if (!existsSync(extractedPath)) {
+		console.log(`[build-dist] extracting Node.js for ${target}`);
+		await exec("tar", ["-xzf", archivePath, "-C", cacheDir]);
+	}
+
+	const sourceBinary = join(extractedPath, "bin", "node");
+	const destBinary = join(destDir, "node");
+	cpSync(sourceBinary, destBinary);
+	chmodSync(destBinary, 0o755);
+	return destBinary;
+}
+
+/**
+ * Read version for a package from the host-service's resolved node_modules.
+ * We use `npm ls` / manual lookup from `package.json` — simplest is to find the
+ * package in bun's `.bun/` store and parse its version from the directory name.
+ */
+function findPackagePath(
+	packageName: string,
+	startDir: string,
+	repoRoot: string,
+): string | null {
+	const { realpathSync } = require("node:fs");
+	// Walk up from startDir looking for node_modules/<packageName>
+	let current = startDir;
+	while (current.startsWith(repoRoot)) {
+		const candidate = join(current, "node_modules", packageName);
+		if (existsSync(candidate)) {
+			return realpathSync(candidate);
+		}
+		const parent = dirname(current);
+		if (parent === current) break;
+		current = parent;
+	}
+	// Fallback: common locations
+	const fallbacks = [
+		join(repoRoot, "packages", "host-service", "node_modules", packageName),
+		join(repoRoot, "packages", "workspace-fs", "node_modules", packageName),
+		join(repoRoot, "node_modules", packageName),
+	];
+	for (const fallback of fallbacks) {
+		if (existsSync(fallback)) {
+			return realpathSync(fallback);
+		}
+	}
+	return null;
+}
+
+function copyPackageWithDeps(
+	packageName: string,
+	startDir: string,
+	repoRoot: string,
+	destModules: string,
+	copied: Set<string>,
+): void {
+	if (copied.has(packageName)) return;
+	copied.add(packageName);
+
+	const sourcePath = findPackagePath(packageName, startDir, repoRoot);
+	if (!sourcePath) {
+		throw new Error(
+			`Package not found: ${packageName}. Run 'bun install' first.`,
+		);
+	}
+
+	const destPath = join(destModules, packageName);
+	mkdirSync(dirname(destPath), { recursive: true });
+	cpSync(sourcePath, destPath, { recursive: true, dereference: true });
+
+	// Recursively copy runtime dependencies
+	const packageJsonPath = join(sourcePath, "package.json");
+	if (existsSync(packageJsonPath)) {
+		const pkg = JSON.parse(readFileSync(packageJsonPath, "utf-8"));
+		const deps = Object.keys(pkg.dependencies ?? {});
+		for (const dep of deps) {
+			copyPackageWithDeps(dep, sourcePath, repoRoot, destModules, copied);
+		}
+	}
+}
+
+function copyNativePackages(libDir: string): void {
+	const repoRoot = resolve(import.meta.dir, "../../..");
+	const destModules = join(libDir, "node_modules");
+	mkdirSync(destModules, { recursive: true });
+	const copied = new Set<string>();
+
+	const hostServiceDir = join(repoRoot, "packages", "host-service");
+	for (const pkg of NATIVE_PACKAGES) {
+		console.log(`[build-dist]   copying ${pkg} (+ deps)`);
+		copyPackageWithDeps(pkg, hostServiceDir, repoRoot, destModules, copied);
+	}
+
+	// better-sqlite3, node-pty, and @parcel/watcher each load their native
+	// binding from build/Release/ as a fallback when the platform-specific
+	// npm sub-package isn't available. Since those sub-packages are optional
+	// and we're shipping the build output, we don't need to copy them.
+}
+
+async function buildCli(target: Target, outputPath: string): Promise<void> {
+	const relayUrl = process.env.RELAY_URL || "https://relay.superset.sh";
+	const cloudApiUrl = process.env.CLOUD_API_URL || "https://api.superset.sh";
+
+	const cliDir = resolve(import.meta.dir, "..");
+	await exec(
+		"bun",
+		[
+			"build",
+			"--compile",
+			`--target=bun-${target}`,
+			"--define",
+			`process.env.RELAY_URL="${relayUrl}"`,
+			"--define",
+			`process.env.CLOUD_API_URL="${cloudApiUrl}"`,
+			"src/bin.ts",
+			"--outfile",
+			outputPath,
+		],
+		cliDir,
+	);
+}
+
+async function buildHostService(): Promise<string> {
+	const hostServiceDir = resolve(import.meta.dir, "../../host-service");
+	await exec("bun", ["run", "build:host"], hostServiceDir);
+	return join(hostServiceDir, "dist", "host-service.js");
+}
+
+function writeHostWrapper(binDir: string): void {
+	const wrapper = `#!/bin/sh
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+export NODE_PATH="$SCRIPT_DIR/../lib/node_modules"
+exec "$SCRIPT_DIR/../lib/node" "$SCRIPT_DIR/../lib/host-service.js" "$@"
+`;
+	const wrapperPath = join(binDir, "superset-host");
+	writeFileSync(wrapperPath, wrapper, { mode: 0o755 });
+	chmodSync(wrapperPath, 0o755);
+}
+
+async function main(): Promise<void> {
+	const { target } = parseArgs();
+	const cliDir = resolve(import.meta.dir, "..");
+	const stagingRoot = join(cliDir, "dist", `superset-${target}`);
+
+	if (existsSync(stagingRoot)) rmSync(stagingRoot, { recursive: true });
+	mkdirSync(join(stagingRoot, "bin"), { recursive: true });
+	mkdirSync(join(stagingRoot, "lib"), { recursive: true });
+	mkdirSync(join(stagingRoot, "share"), { recursive: true });
+
+	console.log(`[build-dist] target: ${target}`);
+	console.log(`[build-dist] staging: ${stagingRoot}`);
+
+	console.log("[build-dist] building CLI binary");
+	await buildCli(target, join(stagingRoot, "bin", "superset"));
+
+	console.log("[build-dist] building host-service bundle");
+	const hostServiceBundle = await buildHostService();
+	cpSync(hostServiceBundle, join(stagingRoot, "lib", "host-service.js"));
+
+	console.log("[build-dist] fetching Node.js");
+	await downloadAndExtractNode(target, join(stagingRoot, "lib"));
+
+	console.log("[build-dist] copying native addon packages");
+	copyNativePackages(join(stagingRoot, "lib"));
+
+	console.log("[build-dist] copying migrations");
+	const migrationsSrc = resolve(import.meta.dir, "../../host-service/drizzle");
+	cpSync(migrationsSrc, join(stagingRoot, "share", "migrations"), {
+		recursive: true,
+	});
+
+	console.log("[build-dist] writing host wrapper");
+	writeHostWrapper(join(stagingRoot, "bin"));
+
+	const tarball = join(cliDir, "dist", `superset-${target}.tar.gz`);
+	console.log(`[build-dist] creating ${tarball}`);
+	await exec("tar", [
+		"-czf",
+		tarball,
+		"-C",
+		dirname(stagingRoot),
+		`superset-${target}`,
+	]);
+
+	console.log(`[build-dist] done: ${tarball}`);
+}
+
+await main();

--- a/packages/cli/src/commands/auth/login/command.ts
+++ b/packages/cli/src/commands/auth/login/command.ts
@@ -29,19 +29,27 @@ export default command({
 
 		s.stop("Authorized!");
 
-		// Show who we logged in as
+		// The user picked an org during the OAuth consent screen — read it back
+		// and cache locally so `host start` and other commands know which org to use.
 		try {
 			const api = createApiClient(config);
 			const user = await api.user.me.query();
 			const org = await api.user.myOrganization.query();
 			p.log.info(`${user.name} (${user.email})`);
-			if (org) p.log.info(`Organization: ${org.name}`);
+
+			if (org) {
+				config.activeOrg = { id: org.id, name: org.name, slug: org.slug };
+				writeConfig(config);
+				p.log.info(`Organization: ${org.name}`);
+			} else {
+				p.log.warn("No organization selected.");
+			}
 		} catch {
 			// Non-fatal — login succeeded even if whoami fails
 		}
 
 		p.outro("Logged in successfully.");
 
-		return { data: { apiUrl } };
+		return { data: { apiUrl, activeOrg: config.activeOrg } };
 	},
 });

--- a/packages/cli/src/commands/host/start/command.ts
+++ b/packages/cli/src/commands/host/start/command.ts
@@ -1,20 +1,82 @@
-import { boolean, command, number } from "@superset/cli-framework";
+import * as p from "@clack/prompts";
+import { boolean, CLIError, command, number } from "@superset/cli-framework";
+import { readConfig } from "../../../lib/config";
+import { isProcessAlive, readManifest } from "../../../lib/host/manifest";
+import { spawnHostService } from "../../../lib/host/spawn";
 
 export default command({
 	description: "Start the host service",
 	options: {
 		daemon: boolean().desc("Run in background"),
-		port: number().default(51741).desc("Port to listen on"),
+		port: number().desc("Port to listen on"),
 	},
 	run: async (opts) => {
-		if (opts.options.daemon) {
-			// TODO: fork to background
+		const config = readConfig();
+
+		if (!config.auth?.accessToken) {
+			throw new CLIError("Not authenticated", "Run: superset auth login");
+		}
+
+		if (!config.activeOrg) {
+			throw new CLIError("No active organization", "Run: superset org switch");
+		}
+
+		const { id: organizationId, name: orgName } = config.activeOrg;
+
+		// Check if already running
+		const existing = readManifest(organizationId);
+		if (existing && isProcessAlive(existing.pid)) {
 			return {
-				data: { pid: 0, port: opts.options.port },
-				message: "Host service started",
+				data: { pid: existing.pid, endpoint: existing.endpoint },
+				message: `Host service already running for ${orgName} (pid ${existing.pid})`,
 			};
 		}
-		// TODO: foreground mode with opts.signal for cleanup
-		return { message: "Not implemented yet" };
+
+		p.intro(`superset host start (${orgName})`);
+		const spinner = p.spinner();
+		spinner.start("Starting host service...");
+
+		try {
+			const result = await spawnHostService({
+				organizationId,
+				sessionToken: config.auth.accessToken,
+				port: opts.options.port,
+				daemon: opts.options.daemon ?? false,
+			});
+
+			spinner.stop(
+				`Host service running on port ${result.port} (pid ${result.pid})`,
+			);
+			p.log.info("Connected to relay — machine is now accessible.");
+
+			if (opts.options.daemon) {
+				p.outro("Running in background.");
+				return {
+					data: {
+						pid: result.pid,
+						port: result.port,
+						organizationId,
+					},
+					message: `Host service started for ${orgName}`,
+				};
+			}
+
+			p.outro("Press Ctrl+C to stop.");
+
+			// Foreground: wait for signal
+			await new Promise<void>((resolve) => {
+				opts.signal.addEventListener("abort", () => resolve(), { once: true });
+			});
+
+			return {
+				data: { pid: result.pid, port: result.port, organizationId },
+				message: "Host service stopped",
+			};
+		} catch (error) {
+			spinner.stop("Failed to start host service");
+			throw new CLIError(
+				error instanceof Error ? error.message : "Unknown error",
+			);
+		}
 	},
 });

--- a/packages/cli/src/commands/host/status/command.ts
+++ b/packages/cli/src/commands/host/status/command.ts
@@ -1,9 +1,73 @@
-import { command } from "@superset/cli-framework";
+import { CLIError, command } from "@superset/cli-framework";
+import { readConfig } from "../../../lib/config";
+import { isProcessAlive, readManifest } from "../../../lib/host/manifest";
+
+async function checkHealth(
+	endpoint: string,
+	authToken: string,
+): Promise<boolean> {
+	try {
+		const controller = new AbortController();
+		const timeout = setTimeout(() => controller.abort(), 2_000);
+		const res = await fetch(`${endpoint}/trpc/health.check`, {
+			signal: controller.signal,
+			headers: { Authorization: `Bearer ${authToken}` },
+		});
+		clearTimeout(timeout);
+		return res.ok;
+	} catch {
+		return false;
+	}
+}
 
 export default command({
 	description: "Check host service status",
 	run: async () => {
-		// TODO: check PID file
-		return { data: { running: false }, message: "Host service is not running" };
+		const config = readConfig();
+
+		if (!config.activeOrg) {
+			throw new CLIError("No active organization", "Run: superset org switch");
+		}
+
+		const { id: organizationId, name: orgName } = config.activeOrg;
+		const manifest = readManifest(organizationId);
+
+		if (!manifest) {
+			return {
+				data: { running: false, organizationId },
+				message: `Not running for ${orgName}`,
+			};
+		}
+
+		const alive = isProcessAlive(manifest.pid);
+		if (!alive) {
+			return {
+				data: {
+					running: false,
+					stale: true,
+					pid: manifest.pid,
+					organizationId,
+				},
+				message: `Stale manifest for ${orgName} (pid ${manifest.pid} is dead)`,
+			};
+		}
+
+		const healthy = await checkHealth(manifest.endpoint, manifest.authToken);
+		const uptimeMs = Date.now() - manifest.startedAt;
+		const uptimeSec = Math.floor(uptimeMs / 1000);
+
+		return {
+			data: {
+				running: true,
+				healthy,
+				pid: manifest.pid,
+				endpoint: manifest.endpoint,
+				organizationId,
+				uptimeSec,
+			},
+			message: `${orgName}: running (pid ${manifest.pid}, ${uptimeSec}s)${
+				healthy ? "" : " — not responding to health check"
+			}`,
+		};
 	},
 });

--- a/packages/cli/src/commands/host/stop/command.ts
+++ b/packages/cli/src/commands/host/stop/command.ts
@@ -1,9 +1,62 @@
-import { command } from "@superset/cli-framework";
+import { CLIError, command } from "@superset/cli-framework";
+import { readConfig } from "../../../lib/config";
+import {
+	isProcessAlive,
+	readManifest,
+	removeManifest,
+} from "../../../lib/host/manifest";
 
 export default command({
 	description: "Stop the host service daemon",
 	run: async () => {
-		// TODO: read PID file, kill process
-		return { message: "Not implemented yet" };
+		const config = readConfig();
+
+		if (!config.activeOrg) {
+			throw new CLIError("No active organization", "Run: superset org switch");
+		}
+
+		const { id: organizationId, name: orgName } = config.activeOrg;
+		const manifest = readManifest(organizationId);
+
+		if (!manifest) {
+			return {
+				data: { running: false },
+				message: `No host service running for ${orgName}`,
+			};
+		}
+
+		if (isProcessAlive(manifest.pid)) {
+			try {
+				process.kill(manifest.pid, "SIGTERM");
+			} catch (error) {
+				throw new CLIError(
+					`Failed to stop host service (pid ${manifest.pid}): ${
+						error instanceof Error ? error.message : "unknown error"
+					}`,
+				);
+			}
+
+			// Wait for the process to actually exit so concurrent `host start`
+			// calls can't race ahead and spawn a duplicate.
+			const deadline = Date.now() + 10_000;
+			while (Date.now() < deadline) {
+				if (!isProcessAlive(manifest.pid)) break;
+				await new Promise((r) => setTimeout(r, 100));
+			}
+
+			if (isProcessAlive(manifest.pid)) {
+				// Escalate to SIGKILL if it refuses to exit
+				try {
+					process.kill(manifest.pid, "SIGKILL");
+				} catch {}
+			}
+		}
+
+		removeManifest(organizationId);
+
+		return {
+			data: { pid: manifest.pid, organizationId },
+			message: `Stopped host service for ${orgName}`,
+		};
 	},
 });

--- a/packages/cli/src/commands/org/switch/command.ts
+++ b/packages/cli/src/commands/org/switch/command.ts
@@ -1,7 +1,7 @@
 import * as p from "@clack/prompts";
 import { CLIError, command, positional } from "@superset/cli-framework";
 import type { ApiClient } from "../../../lib/api-client";
-import { getApiUrl, readConfig } from "../../../lib/config";
+import { getApiUrl, readConfig, writeConfig } from "../../../lib/config";
 
 export default command({
 	description: "Switch active organization",
@@ -12,7 +12,8 @@ export default command({
 		const api = opts.ctx.api as ApiClient;
 		const nameOrId = opts.args.nameOrId as string | undefined;
 		const orgs = await api.user.myOrganizations.query();
-		const currentOrg = await api.user.myOrganization.query();
+		const config = readConfig();
+		const currentOrgId = config.activeOrg?.id;
 
 		let org: (typeof orgs)[number] | undefined;
 
@@ -38,7 +39,7 @@ export default command({
 				options: orgs.map((o) => ({
 					value: o.id,
 					label: o.name,
-					hint: o.id === currentOrg?.id ? "active" : undefined,
+					hint: o.id === currentOrgId ? "active" : undefined,
 				})),
 			});
 
@@ -50,15 +51,18 @@ export default command({
 			if (!org) throw new CLIError("Organization not found");
 		}
 
-		if (org.id === currentOrg?.id) {
+		if (org.id === currentOrgId) {
 			return {
 				data: { id: org.id, name: org.name },
 				message: `Already on ${org.name}`,
 			};
 		}
 
-		// Set active org via Better Auth
-		const config = readConfig();
+		// Persist locally so host commands use this org
+		config.activeOrg = { id: org.id, name: org.name, slug: org.slug };
+		writeConfig(config);
+
+		// Sync server-side active org for tools that read the session
 		const apiUrl = getApiUrl(config);
 		const res = await fetch(`${apiUrl}/api/auth/organization/set-active`, {
 			method: "POST",

--- a/packages/cli/src/lib/config.ts
+++ b/packages/cli/src/lib/config.ts
@@ -2,11 +2,17 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
+export interface ActiveOrg {
+	id: string;
+	name: string;
+	slug: string;
+}
+
 export type SupersetConfig = {
 	auth?: {
 		accessToken: string;
 	};
-	activeOrg?: string;
+	activeOrg?: ActiveOrg;
 	apiUrl?: string;
 	clientIds?: Record<string, string>;
 };
@@ -16,13 +22,13 @@ export type DeviceConfig = {
 	deviceName: string;
 };
 
-const CONFIG_DIR = join(homedir(), ".superset");
-const CONFIG_PATH = join(CONFIG_DIR, "config.json");
-const DEVICE_PATH = join(CONFIG_DIR, "device.json");
+export const SUPERSET_HOME_DIR = join(homedir(), "superset");
+const CONFIG_PATH = join(SUPERSET_HOME_DIR, "config.json");
+const DEVICE_PATH = join(SUPERSET_HOME_DIR, "device.json");
 
 function ensureDir() {
-	if (!existsSync(CONFIG_DIR)) {
-		mkdirSync(CONFIG_DIR, { recursive: true });
+	if (!existsSync(SUPERSET_HOME_DIR)) {
+		mkdirSync(SUPERSET_HOME_DIR, { recursive: true, mode: 0o700 });
 	}
 }
 

--- a/packages/cli/src/lib/env.ts
+++ b/packages/cli/src/lib/env.ts
@@ -1,0 +1,10 @@
+/**
+ * Build-time constants baked into the CLI binary via `bun build --define`.
+ * At runtime (when running `bun src/bin.ts` without compilation), falls back
+ * to actual process.env so local dev can override these.
+ */
+
+export const env = {
+	RELAY_URL: process.env.RELAY_URL || "https://relay.superset.sh",
+	CLOUD_API_URL: process.env.CLOUD_API_URL || "https://api.superset.sh",
+};

--- a/packages/cli/src/lib/host/manifest.ts
+++ b/packages/cli/src/lib/host/manifest.ts
@@ -1,0 +1,77 @@
+import {
+	chmodSync,
+	existsSync,
+	mkdirSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+import { SUPERSET_HOME_DIR } from "../config";
+
+/**
+ * Manifest format matches the desktop app's HostServiceManifest
+ * (apps/desktop/src/main/lib/host-service-manifest.ts) so both clients
+ * can read each other's manifests.
+ */
+export interface HostServiceManifest {
+	pid: number;
+	endpoint: string;
+	authToken: string;
+	startedAt: number;
+	organizationId: string;
+}
+
+function manifestDir(organizationId: string): string {
+	return join(SUPERSET_HOME_DIR, "host", organizationId);
+}
+
+function manifestPath(organizationId: string): string {
+	return join(manifestDir(organizationId), "manifest.json");
+}
+
+export function ensureManifestDir(organizationId: string): string {
+	const dir = manifestDir(organizationId);
+	if (!existsSync(dir)) {
+		mkdirSync(dir, { recursive: true, mode: 0o700 });
+	}
+	return dir;
+}
+
+export function writeManifest(manifest: HostServiceManifest): void {
+	ensureManifestDir(manifest.organizationId);
+	const path = manifestPath(manifest.organizationId);
+	writeFileSync(path, JSON.stringify(manifest, null, 2), { mode: 0o600 });
+	chmodSync(path, 0o600);
+}
+
+export function readManifest(
+	organizationId: string,
+): HostServiceManifest | null {
+	const path = manifestPath(organizationId);
+	if (!existsSync(path)) return null;
+	try {
+		return JSON.parse(readFileSync(path, "utf-8")) as HostServiceManifest;
+	} catch {
+		return null;
+	}
+}
+
+export function removeManifest(organizationId: string): void {
+	const path = manifestPath(organizationId);
+	if (existsSync(path)) rmSync(path);
+}
+
+export function isProcessAlive(pid: number): boolean {
+	if (!pid) return false;
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+export function hostDbPath(organizationId: string): string {
+	return join(manifestDir(organizationId), "host.db");
+}

--- a/packages/cli/src/lib/host/spawn.ts
+++ b/packages/cli/src/lib/host/spawn.ts
@@ -1,0 +1,144 @@
+import { spawn } from "node:child_process";
+import { randomBytes } from "node:crypto";
+import { existsSync } from "node:fs";
+import { createServer } from "node:net";
+import { dirname, join } from "node:path";
+import { env } from "../env";
+import {
+	type HostServiceManifest,
+	hostDbPath,
+	writeManifest,
+} from "./manifest";
+
+const HEALTH_POLL_INTERVAL_MS = 200;
+const HEALTH_POLL_TIMEOUT_MS = 10_000;
+
+export interface SpawnHostOptions {
+	organizationId: string;
+	sessionToken: string;
+	port?: number;
+	daemon: boolean;
+}
+
+export interface SpawnHostResult {
+	pid: number;
+	port: number;
+	secret: string;
+}
+
+async function findFreePort(): Promise<number> {
+	return new Promise((resolve, reject) => {
+		const server = createServer();
+		server.listen(0, "127.0.0.1", () => {
+			const addr = server.address();
+			if (addr && typeof addr === "object") {
+				const { port } = addr;
+				server.close(() => resolve(port));
+			} else {
+				server.close(() => reject(new Error("Could not get port")));
+			}
+		});
+		server.on("error", reject);
+	});
+}
+
+async function pollHealth(port: number, secret: string): Promise<boolean> {
+	const deadline = Date.now() + HEALTH_POLL_TIMEOUT_MS;
+	while (Date.now() < deadline) {
+		try {
+			const controller = new AbortController();
+			const timeout = setTimeout(() => controller.abort(), 2_000);
+			const res = await fetch(`http://127.0.0.1:${port}/trpc/health.check`, {
+				signal: controller.signal,
+				headers: { Authorization: `Bearer ${secret}` },
+			});
+			clearTimeout(timeout);
+			if (res.ok) return true;
+		} catch {
+			// not ready
+		}
+		await new Promise((r) => setTimeout(r, HEALTH_POLL_INTERVAL_MS));
+	}
+	return false;
+}
+
+/**
+ * Resolve the sibling `superset-host` wrapper binary.
+ *
+ * When running as a compiled binary, it's a sibling file in the same bin/
+ * directory as the current executable. When running via `bun src/bin.ts`
+ * in dev, allow override via SUPERSET_HOST_BIN env var.
+ */
+function resolveHostBinary(): string {
+	if (process.env.SUPERSET_HOST_BIN) return process.env.SUPERSET_HOST_BIN;
+	const cliBin = process.execPath;
+	return join(dirname(cliBin), "superset-host");
+}
+
+function resolveMigrationsFolder(): string {
+	if (process.env.HOST_MIGRATIONS_FOLDER) {
+		return process.env.HOST_MIGRATIONS_FOLDER;
+	}
+	// Compiled layout: <bundle>/bin/superset → <bundle>/share/migrations
+	const cliBin = process.execPath;
+	const bundleRoot = dirname(dirname(cliBin));
+	return join(bundleRoot, "share", "migrations");
+}
+
+export async function spawnHostService(
+	options: SpawnHostOptions,
+): Promise<SpawnHostResult> {
+	const hostBin = resolveHostBinary();
+	if (!existsSync(hostBin)) {
+		throw new Error(
+			`superset-host binary not found at ${hostBin}. Set SUPERSET_HOST_BIN to override.`,
+		);
+	}
+
+	const port = options.port ?? (await findFreePort());
+	const secret = randomBytes(32).toString("hex");
+	const migrationsFolder = resolveMigrationsFolder();
+
+	const child = spawn(hostBin, [], {
+		stdio: options.daemon ? "ignore" : "inherit",
+		detached: options.daemon,
+		env: {
+			...process.env,
+			ORGANIZATION_ID: options.organizationId,
+			AUTH_TOKEN: options.sessionToken,
+			CLOUD_API_URL: env.CLOUD_API_URL,
+			RELAY_URL: env.RELAY_URL,
+			HOST_SERVICE_PORT: String(port),
+			HOST_SERVICE_SECRET: secret,
+			HOST_DB_PATH: hostDbPath(options.organizationId),
+			HOST_MIGRATIONS_FOLDER: migrationsFolder,
+		},
+	});
+
+	if (!child.pid) {
+		throw new Error("Failed to spawn host-service");
+	}
+
+	const healthy = await pollHealth(port, secret);
+	if (!healthy) {
+		child.kill("SIGTERM");
+		throw new Error(
+			`Host service failed to start within ${HEALTH_POLL_TIMEOUT_MS}ms`,
+		);
+	}
+
+	const manifest: HostServiceManifest = {
+		pid: child.pid,
+		endpoint: `http://127.0.0.1:${port}`,
+		authToken: secret,
+		startedAt: Date.now(),
+		organizationId: options.organizationId,
+	};
+	writeManifest(manifest);
+
+	if (options.daemon) {
+		child.unref();
+	}
+
+	return { pid: child.pid, port, secret };
+}

--- a/packages/host-service/build.ts
+++ b/packages/host-service/build.ts
@@ -1,0 +1,31 @@
+/**
+ * Bundles the host-service entry point into a single JS file that can be
+ * executed by a standalone Node.js runtime. Native addons (better-sqlite3,
+ * node-pty) are marked external and must be resolved at runtime from
+ * lib/native/ in the distribution bundle.
+ */
+import { existsSync, mkdirSync } from "node:fs";
+
+const outdir = "dist";
+if (!existsSync(outdir)) {
+	mkdirSync(outdir, { recursive: true });
+}
+
+const result = await Bun.build({
+	entrypoints: ["src/serve.ts"],
+	target: "node",
+	outdir,
+	naming: "host-service.js",
+	format: "esm",
+	external: ["better-sqlite3", "node-pty", "@parcel/watcher"],
+});
+
+if (!result.success) {
+	console.error("[host-service] build failed:");
+	for (const log of result.logs) {
+		console.error(log);
+	}
+	process.exit(1);
+}
+
+console.log(`[host-service] bundled to ${outdir}/host-service.js`);

--- a/packages/host-service/package.json
+++ b/packages/host-service/package.json
@@ -32,6 +32,7 @@
 	"scripts": {
 		"clean": "git clean -xdf .cache .turbo dist node_modules",
 		"dev": "bun run src/serve.ts",
+		"build:host": "bun run build.ts",
 		"generate": "drizzle-kit generate",
 		"typecheck": "tsc --noEmit --emitDeclarationOnly false"
 	},


### PR DESCRIPTION
## Summary

upstream から CLI release pipeline 関連4コミットを取り込みます。PR分割戦略の第6弾（最終的に PR5 の大規模 relay/v2Hosts を残すのみ）。

## 取り込みコミット

| 元コミット | 内容 |
|---|---|
| `ceb05da47` ← `7ab64a72d` (#3298) | feat(cli): standalone distribution with embedded host-service（14ファイル、+860行） |
| `09442c18b` ← `a87635488` (#3306) | ci: auto-bump Homebrew formula on CLI release |
| `17840cc19` ← `5e1d432ae` (#3307) | fix(ci): drop darwin-x64, bump actions to v5 |
| `6732f329b` ← `ff57e31d9` (#3308) | fix(ci): grant contents: write to CLI release job |

## 方針について

当初 Codex 事前調査では「fork は DMG のみ配布で CLI 不使用 → 全スキップ推奨」と判定したが、ユーザ判断により **upstream 互換性維持のため全取り込み** に変更。

Fork は現時点で CLI バイナリ配布を実運用しないが、以下の利点がある：
- upstream からのファイル階層・ビルドスクリプトを完全一致させることで今後のマージ衝突を削減
- 将来 CLI 配布を始める時の準備が整う
- `.github/workflows/build-cli.yml` / `bump-homebrew.yml` は fork でも登録されるが、ターゲットのタグ・リポジトリが MocA-Love にならないので実害なし（起動は手動トリガ）

## 新規ファイル（主要なもの）

- `.github/workflows/build-cli.yml` (新規)
- `.github/workflows/bump-homebrew.yml` (新規)
- `apps/marketing/public/cli/install.sh` (新規、CLI インストーラ)
- `packages/cli/scripts/build-dist.ts` (新規)
- `packages/cli/src/lib/env.ts` (新規)
- `packages/cli/src/lib/host/manifest.ts` (新規)
- `packages/cli/src/lib/host/spawn.ts` (新規)
- `packages/host-service/build.ts` (新規)

## 検証

- [x] 4コミット chronological cherry-pick（コンフリクトなし）
- [x] `bun install` → 新規依存なし
- [x] `bun run typecheck` → 既存の `ModelsSettings.tsx` エラーのみ（本PR無関係）

## 注意事項（運用ガイド）

- **`.github/workflows/build-cli.yml`**: `on: release` でトリガされるが fork で CLI release タグを切らない限り発火しない
- **`.github/workflows/bump-homebrew.yml`**: Homebrew tap `MocA-Love/homebrew-tap` が存在しないため、万が一発火しても失敗するだけで実害なし。不要なら後で `.github/workflows/` から削除可
- **CLI パッケージ本体**: 既存の `bun dev` / `bun build` フローには影響しない

## Test plan

- [ ] CI通過確認
- [ ] rv-pr スキルによるレビュー
- [ ] ローカルで `bun dev` が壊れていないか確認