### PR TITLE
chore(upstream): PR7 - 新規upstream 3件取り込み

### DIFF
--- a/apps/desktop/plans/20260409-tui-hotkey-forwarding.md
+++ b/apps/desktop/plans/20260409-tui-hotkey-forwarding.md
@@ -1,0 +1,60 @@
+# TUI hotkey forwarding
+
+## Problem
+
+App-level hotkeys (Cmd+T, Cmd+D, Ctrl+1, etc.) don't fire while focus is in a
+v2 terminal running a TUI. The TUI swallows them — they reach the PTY but
+never bubble to `react-hotkeys-hook`.
+
+## Root cause
+
+v2's `terminal-runtime.ts` never installed a `customKeyEventHandler` on xterm.
+Without one, xterm's `_keyDown` runs to completion for every modifier chord:
+it encodes the key, delivers it to the PTY, then calls `event.preventDefault();
+event.stopPropagation();` (CoreBrowserTerminal.ts:925-928). The event dies at
+target phase and `react-hotkeys-hook`'s document-bubble listener never sees it.
+
+Confirmed via instrumentation: Cmd+D in a Codex TUI produced capture-phase
+logs but zero bubble-phase logs — `stopPropagation` was the culprit.
+
+## Fix (done)
+
+Mirrors VSCode's pattern (terminalInstance.ts:1116-1175): install a
+`customKeyEventHandler` that returns `false` for chords bound to app hotkeys.
+Returning `false` makes xterm bail at the top of `_keyDown` (line 847-849),
+skipping the `stopPropagation` at the bottom. The event bubbles normally and
+`react-hotkeys-hook` fires the app action.
+
+Implementation:
+
+- **`renderer/hotkeys/utils/resolveHotkeyFromEvent.ts`** — reverse-indexes
+  `HOTKEYS_REGISTRY` into a `Map<normalizedChord, HotkeyId>` at module load.
+  Uses the same `event.code` normalization as react-hotkeys-hook's internal
+  `K` function so the index can't drift from the matcher. Returns `HotkeyId |
+  null`.
+- **`renderer/lib/terminal/terminal-runtime.ts`** — one-liner handler:
+  ```ts
+  terminal.attachCustomKeyEventHandler((event) => !isAppHotkey(event));
+  ```
+  Registered chords bubble to the app. Unregistered chords (Ctrl+R, Ctrl+L,
+  Alt+letter, etc.) still reach the TUI.
+
+## Remaining work
+
+### Migrate v1 to the same resolver
+
+v1's handler in `Terminal/helpers.ts:677-679` takes the opposite approach: it
+returns `false` for **all** `ctrl/meta` chords, starving TUIs of unbound
+chords like Ctrl+R. Replacing that catch-all with `resolveHotkeyFromEvent`
+would give v1 the same precision as v2 — only registered app hotkeys bubble,
+everything else reaches the PTY.
+
+### Escape hatches (optional, later)
+
+- **`sendKeybindingsToShell`** user preference (VSCode pattern): disables
+  every non-Meta skip entry so power users running tmux/emacs can forward
+  everything to the shell.
+- **Alt-buffer gate**: use `isAlternateScreenRef` from `useTerminalModes.ts`
+  (or `xterm.buffer.onBufferChange`) to shrink the skip list while a TUI owns
+  the alt screen, so chords like Cmd+F can reach nvim instead of triggering
+  `FIND_IN_TERMINAL`.

--- a/apps/desktop/src/renderer/hotkeys/index.ts
+++ b/apps/desktop/src/renderer/hotkeys/index.ts
@@ -10,4 +10,4 @@ export type {
 	HotkeyDisplay,
 	Platform,
 } from "./types";
-export { isTerminalReservedEvent } from "./utils";
+export { isTerminalReservedEvent, resolveHotkeyFromEvent } from "./utils";

--- a/apps/desktop/src/renderer/hotkeys/utils/index.ts
+++ b/apps/desktop/src/renderer/hotkeys/utils/index.ts
@@ -1,1 +1,2 @@
+export { resolveHotkeyFromEvent } from "./resolveHotkeyFromEvent";
 export { isTerminalReservedEvent } from "./utils";

--- a/apps/desktop/src/renderer/hotkeys/utils/resolveHotkeyFromEvent.ts
+++ b/apps/desktop/src/renderer/hotkeys/utils/resolveHotkeyFromEvent.ts
@@ -1,0 +1,75 @@
+import { HOTKEYS, type HotkeyId } from "../registry";
+
+/**
+ * Resolves a KeyboardEvent to a registered {@link HotkeyId}, or `null` if the
+ * chord is not bound. Uses the same `event.code` normalization as
+ * react-hotkeys-hook (its internal `K` function) so the reverse index
+ * cannot drift from the matcher.
+ */
+export function resolveHotkeyFromEvent(event: KeyboardEvent): HotkeyId | null {
+	if (event.type !== "keydown") return null;
+	const chord = eventToChord(event);
+	if (!chord) return null;
+	return REGISTERED_APP_CHORDS.get(chord) ?? null;
+}
+
+// Mirrors react-hotkeys-hook's alias table (react-hotkeys-hook/dist/index.js:3-19)
+const CODE_ALIASES: Record<string, string> = {
+	esc: "escape",
+	return: "enter",
+	left: "arrowleft",
+	right: "arrowright",
+	up: "arrowup",
+	down: "arrowdown",
+	MetaLeft: "meta",
+	MetaRight: "meta",
+	ShiftLeft: "shift",
+	ShiftRight: "shift",
+	AltLeft: "alt",
+	AltRight: "alt",
+	OSLeft: "meta",
+	OSRight: "meta",
+	ControlLeft: "ctrl",
+	ControlRight: "ctrl",
+};
+
+const MODIFIERS = new Set(["meta", "ctrl", "control", "alt", "shift"]);
+
+function normalizeToken(token: string): string {
+	const aliased = CODE_ALIASES[token.trim()] ?? token.trim();
+	return aliased.toLowerCase().replace(/key|digit|numpad/, "");
+}
+
+function normalizeChord(chord: string): string {
+	const parts = chord.toLowerCase().split("+").map(normalizeToken);
+	const mods: string[] = [];
+	const keys: string[] = [];
+	for (const part of parts) {
+		if (MODIFIERS.has(part)) {
+			mods.push(part === "control" ? "ctrl" : part);
+		} else {
+			keys.push(part);
+		}
+	}
+	mods.sort();
+	return [...mods, ...keys].join("+");
+}
+
+function eventToChord(event: KeyboardEvent): string | null {
+	const key = normalizeToken(event.code);
+	if (!key || MODIFIERS.has(key)) return null;
+	const mods: string[] = [];
+	if (event.metaKey) mods.push("meta");
+	if (event.ctrlKey) mods.push("ctrl");
+	if (event.altKey) mods.push("alt");
+	if (event.shiftKey) mods.push("shift");
+	mods.sort();
+	return [...mods, key].join("+");
+}
+
+const REGISTERED_APP_CHORDS: Map<string, HotkeyId> = new Map(
+	(Object.keys(HOTKEYS) as HotkeyId[]).map((id) => [
+		normalizeChord(HOTKEYS[id].key),
+		id,
+	]),
+);

--- a/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
@@ -3,6 +3,7 @@ import type { ProgressAddon } from "@xterm/addon-progress";
 import type { SearchAddon } from "@xterm/addon-search";
 import { SerializeAddon } from "@xterm/addon-serialize";
 import { Terminal as XTerm } from "@xterm/xterm";
+import { resolveHotkeyFromEvent } from "renderer/hotkeys";
 import { DEFAULT_TERMINAL_SCROLLBACK } from "shared/constants";
 import type { TerminalAppearance } from "./appearance";
 import { loadAddons } from "./terminal-addons";
@@ -12,6 +13,14 @@ const STORAGE_KEY_PREFIX = "terminal-buffer:";
 const DIMS_KEY_PREFIX = "terminal-dims:";
 const DEFAULT_COLS = 120;
 const DEFAULT_ROWS = 32;
+
+// xterm's _keyDown calls stopPropagation after processing, which kills the
+// bubble to react-hotkeys-hook. Returning false from the custom handler makes
+// xterm bail before that, so app hotkeys reach document. (VSCode pattern:
+// terminalInstance.ts:1116-1175)
+function isAppHotkey(event: KeyboardEvent): boolean {
+	return resolveHotkeyFromEvent(event) !== null;
+}
 
 export interface TerminalRuntime {
 	terminalId: string;
@@ -141,6 +150,8 @@ export function createRuntime(
 	wrapper.style.height = "100%";
 	terminal.open(wrapper);
 	restoreBuffer(terminalId, terminal);
+
+	terminal.attachCustomKeyEventHandler((event) => !isAppHotkey(event));
 
 	const addonsResult = loadAddons(terminal);
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarHeader/DashboardSidebarHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarHeader/DashboardSidebarHeader.tsx
@@ -1,6 +1,7 @@
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { cn } from "@superset/ui/utils";
-import { LuFolderPlus, LuPlus } from "react-icons/lu";
+import { useMatchRoute, useNavigate } from "@tanstack/react-router";
+import { LuFolderPlus, LuLayers, LuPlus } from "react-icons/lu";
 import { useHotkeyDisplay } from "renderer/hotkeys";
 import { OrganizationDropdown } from "renderer/routes/_authenticated/_dashboard/components/TopBar/components/OrganizationDropdown";
 import { STROKE_WIDTH_THICK } from "renderer/screens/main/components/WorkspaceSidebar/constants";
@@ -15,11 +16,36 @@ export function DashboardSidebarHeader({
 }: DashboardSidebarHeaderProps) {
 	const openModal = useOpenNewWorkspaceModal();
 	const shortcutText = useHotkeyDisplay("NEW_WORKSPACE").text;
+	const navigate = useNavigate();
+	const matchRoute = useMatchRoute();
+	const isWorkspacesListOpen = !!matchRoute({ to: "/v2-workspaces" });
+
+	const handleWorkspacesClick = () => {
+		navigate({ to: "/v2-workspaces" });
+	};
 
 	if (isCollapsed) {
 		return (
 			<div className="flex flex-col items-center gap-2 border-b border-border py-2">
 				<OrganizationDropdown variant="collapsed" />
+
+				<Tooltip delayDuration={300}>
+					<TooltipTrigger asChild>
+						<button
+							type="button"
+							onClick={handleWorkspacesClick}
+							className={cn(
+								"flex size-8 items-center justify-center rounded-md transition-colors",
+								isWorkspacesListOpen
+									? "bg-accent text-foreground"
+									: "text-muted-foreground hover:bg-accent/50 hover:text-foreground",
+							)}
+						>
+							<LuLayers className="size-4" />
+						</button>
+					</TooltipTrigger>
+					<TooltipContent side="right">Workspaces</TooltipContent>
+				</Tooltip>
 
 				<Tooltip delayDuration={300}>
 					<TooltipTrigger asChild>
@@ -69,6 +95,20 @@ export function DashboardSidebarHeader({
 					<TooltipContent side="right">Add Repository</TooltipContent>
 				</Tooltip>
 			</div>
+
+			<button
+				type="button"
+				onClick={handleWorkspacesClick}
+				className={cn(
+					"flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm font-medium transition-colors",
+					isWorkspacesListOpen
+						? "bg-accent text-foreground"
+						: "text-muted-foreground hover:bg-accent/50 hover:text-foreground",
+				)}
+			>
+				<LuLayers className="size-4 shrink-0" />
+				<span className="flex-1 text-left">Workspaces</span>
+			</button>
 
 			<button
 				type="button"

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/AddTabMenu/AddTabMenu.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/AddTabMenu/AddTabMenu.tsx
@@ -1,8 +1,4 @@
-import {
-	DropdownMenuCheckboxItem,
-	DropdownMenuItem,
-	DropdownMenuSeparator,
-} from "@superset/ui/dropdown-menu";
+import { DropdownMenuItem } from "@superset/ui/dropdown-menu";
 import { BsTerminalPlus } from "react-icons/bs";
 import { LuFileText } from "react-icons/lu";
 import { TbMessageCirclePlus, TbWorld } from "react-icons/tb";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/V2PresetsBar/V2PresetsBar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/V2PresetsBar/V2PresetsBar.tsx
@@ -1,0 +1,407 @@
+import type { WorkspaceStore } from "@superset/panes";
+import {
+	AGENT_PRESET_COMMANDS,
+	AGENT_PRESET_DESCRIPTIONS,
+	AGENT_TYPES,
+} from "@superset/shared/agent-command";
+import { Button } from "@superset/ui/button";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuSeparator,
+	DropdownMenuTrigger,
+} from "@superset/ui/dropdown-menu";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
+import { useLiveQuery } from "@tanstack/react-db";
+import { useNavigate } from "@tanstack/react-router";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { HiMiniCog6Tooth, HiMiniCommandLine } from "react-icons/hi2";
+import { LuCirclePlus, LuPin } from "react-icons/lu";
+import {
+	getPresetIcon,
+	useIsDarkTheme,
+} from "renderer/assets/app-icons/preset-icons";
+import { HotkeyMenuShortcut } from "renderer/components/HotkeyMenuShortcut";
+import type { HotkeyId } from "renderer/hotkeys";
+import { useMigrateV1PresetsToV2 } from "renderer/routes/_authenticated/hooks/useMigrateV1PresetsToV2";
+import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
+import type { V2TerminalPresetRow } from "renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal";
+import { filterMatchingPresetsForProject } from "shared/preset-project-targeting";
+import type { StoreApi } from "zustand/vanilla";
+import type { PaneViewerData, TerminalPaneData } from "../../types";
+import { V2PresetBarItem } from "./components/V2PresetBarItem";
+
+interface V2PresetsBarProps {
+	workspaceId: string;
+	projectId: string;
+	store: StoreApi<WorkspaceStore<PaneViewerData>>;
+}
+
+// Co-located to keep v2 self-contained. Mirrors the v1 array in
+// renderer/hotkeys/registry.ts; order matches the registry OPEN_PRESET_{n}
+// definitions so PRESET_HOTKEY_IDS[i] targets the i-th pinned preset.
+const PRESET_HOTKEY_IDS: HotkeyId[] = [
+	"OPEN_PRESET_1",
+	"OPEN_PRESET_2",
+	"OPEN_PRESET_3",
+	"OPEN_PRESET_4",
+	"OPEN_PRESET_5",
+	"OPEN_PRESET_6",
+	"OPEN_PRESET_7",
+	"OPEN_PRESET_8",
+	"OPEN_PRESET_9",
+];
+
+interface PresetTemplate {
+	name: string;
+	description: string;
+	cwd: string;
+	commands: string[];
+}
+
+const QUICK_ADD_PRESET_TEMPLATES: PresetTemplate[] = AGENT_TYPES.map(
+	(agent) => ({
+		name: agent,
+		description: AGENT_PRESET_DESCRIPTIONS[agent],
+		cwd: "",
+		commands: AGENT_PRESET_COMMANDS[agent],
+	}),
+);
+
+function isPresetPinnedToBar(pinnedToBar: boolean | undefined): boolean {
+	// Backward-compatibility rule mirroring v1: undefined defaults to pinned.
+	return pinnedToBar !== false;
+}
+
+function areStringArraysEqual(left: string[], right: string[]): boolean {
+	if (left.length !== right.length) return false;
+	return left.every((value, index) => value === right[index]);
+}
+
+function getPinnedPresetOrder(
+	presets: ReadonlyArray<{ id: string; pinnedToBar?: boolean }>,
+): string[] {
+	return presets.flatMap((preset) =>
+		isPresetPinnedToBar(preset.pinnedToBar) ? [preset.id] : [],
+	);
+}
+
+export function V2PresetsBar({
+	workspaceId,
+	projectId,
+	store,
+}: V2PresetsBarProps) {
+	const navigate = useNavigate();
+	const isDark = useIsDarkTheme();
+	const collections = useCollections();
+	useMigrateV1PresetsToV2();
+
+	const { data: allPresets = [] } = useLiveQuery(
+		(query) =>
+			query
+				.from({ v2TerminalPresets: collections.v2TerminalPresets })
+				.orderBy(({ v2TerminalPresets }) => v2TerminalPresets.tabOrder),
+		[collections],
+	);
+
+	const matchedPresets = useMemo(
+		() => filterMatchingPresetsForProject(allPresets, projectId),
+		[allPresets, projectId],
+	);
+
+	const [localPinnedPresetIds, setLocalPinnedPresetIds] = useState<string[]>(
+		() => getPinnedPresetOrder(matchedPresets),
+	);
+
+	useEffect(() => {
+		const serverPinnedPresetIds = getPinnedPresetOrder(matchedPresets);
+		setLocalPinnedPresetIds((current) =>
+			areStringArraysEqual(current, serverPinnedPresetIds)
+				? current
+				: serverPinnedPresetIds,
+		);
+	}, [matchedPresets]);
+
+	const presetsByName = useMemo(() => {
+		const map = new Map<string, V2TerminalPresetRow[]>();
+		for (const preset of matchedPresets) {
+			const existing = map.get(preset.name);
+			if (existing) {
+				existing.push(preset);
+				continue;
+			}
+			map.set(preset.name, [preset]);
+		}
+		return map;
+	}, [matchedPresets]);
+
+	const pinnedPresets = useMemo(() => {
+		const presetById = new Map(
+			matchedPresets.map((preset, index) => [preset.id, { preset, index }]),
+		);
+		const orderedPinnedPresets: Array<{
+			preset: V2TerminalPresetRow;
+			index: number;
+		}> = [];
+		const seenIds = new Set<string>();
+
+		for (const presetId of localPinnedPresetIds) {
+			const item = presetById.get(presetId);
+			if (!item) continue;
+			if (!isPresetPinnedToBar(item.preset.pinnedToBar)) continue;
+			orderedPinnedPresets.push(item);
+			seenIds.add(presetId);
+		}
+
+		for (const [index, preset] of matchedPresets.entries()) {
+			if (!isPresetPinnedToBar(preset.pinnedToBar)) continue;
+			if (seenIds.has(preset.id)) continue;
+			orderedPinnedPresets.push({ preset, index });
+		}
+
+		return orderedPinnedPresets;
+	}, [matchedPresets, localPinnedPresetIds]);
+
+	const presetIndexById = useMemo(
+		() => new Map(matchedPresets.map((preset, index) => [preset.id, index])),
+		[matchedPresets],
+	);
+
+	const managedPresets = useMemo(() => {
+		const templateNames = new Set(
+			QUICK_ADD_PRESET_TEMPLATES.map((t) => t.name),
+		);
+		const primaryTemplatePresetIds = new Set(
+			QUICK_ADD_PRESET_TEMPLATES.flatMap((template) => {
+				const match = presetsByName.get(template.name)?.[0];
+				return match ? [match.id] : [];
+			}),
+		);
+		const fromTemplates = QUICK_ADD_PRESET_TEMPLATES.map((template) => ({
+			key: `template:${template.name}`,
+			name: template.name,
+			preset: presetsByName.get(template.name)?.[0],
+			template,
+			iconName: template.name,
+		}));
+		const customExisting = matchedPresets
+			.filter(
+				(preset) =>
+					!templateNames.has(preset.name) ||
+					!primaryTemplatePresetIds.has(preset.id),
+			)
+			.map((preset) => ({
+				key: `preset:${preset.id}`,
+				name: preset.name || "default",
+				preset: preset as V2TerminalPresetRow | undefined,
+				template: null as PresetTemplate | null,
+				iconName: preset.name,
+			}));
+		return [...fromTemplates, ...customExisting];
+	}, [matchedPresets, presetsByName]);
+
+	const openPresetInNewTab = useCallback(
+		(preset: V2TerminalPresetRow) => {
+			if (!workspaceId) return;
+			const initialCommand =
+				preset.commands.length > 0 ? preset.commands.join(" && ") : undefined;
+			store.getState().addTab({
+				titleOverride: preset.name || "Terminal",
+				panes: [
+					{
+						kind: "terminal",
+						data: {
+							terminalId: crypto.randomUUID(),
+							initialCommand,
+						} as TerminalPaneData,
+					},
+				],
+			});
+		},
+		[workspaceId, store],
+	);
+
+	const handleEditPreset = useCallback(
+		(presetId: string) => {
+			navigate({
+				to: "/settings/terminal",
+				search: { editPresetId: presetId },
+			});
+		},
+		[navigate],
+	);
+
+	const handleLocalPinnedReorder = useCallback(
+		(fromIndex: number, toIndex: number) => {
+			setLocalPinnedPresetIds((current) => {
+				if (
+					fromIndex < 0 ||
+					fromIndex >= current.length ||
+					toIndex < 0 ||
+					toIndex >= current.length
+				) {
+					return current;
+				}
+				const next = [...current];
+				const [moved] = next.splice(fromIndex, 1);
+				next.splice(toIndex, 0, moved);
+				return next;
+			});
+		},
+		[],
+	);
+
+	const handlePersistPinnedReorder = useCallback(
+		(presetId: string, targetPinnedIndex: number) => {
+			const reorderedPinnedPresetIds = [...localPinnedPresetIds];
+			const currentPinnedIndex = reorderedPinnedPresetIds.indexOf(presetId);
+			if (currentPinnedIndex === -1) return;
+			const [moved] = reorderedPinnedPresetIds.splice(currentPinnedIndex, 1);
+			reorderedPinnedPresetIds.splice(targetPinnedIndex, 0, moved);
+
+			const pinnedSet = new Set(reorderedPinnedPresetIds);
+			const unpinned = matchedPresets
+				.filter((preset) => !pinnedSet.has(preset.id))
+				.map((preset) => preset.id);
+			const finalOrder = [...reorderedPinnedPresetIds, ...unpinned];
+
+			for (const [index, id] of finalOrder.entries()) {
+				collections.v2TerminalPresets.update(id, (draft) => {
+					draft.tabOrder = index;
+				});
+			}
+		},
+		[collections.v2TerminalPresets, localPinnedPresetIds, matchedPresets],
+	);
+
+	const handleTogglePinned = useCallback(
+		(presetId: string, nextPinned: boolean) => {
+			collections.v2TerminalPresets.update(presetId, (draft) => {
+				draft.pinnedToBar = nextPinned;
+			});
+		},
+		[collections.v2TerminalPresets],
+	);
+
+	const handleCreateFromTemplate = useCallback(
+		(template: PresetTemplate) => {
+			const maxTabOrder = matchedPresets.reduce(
+				(max, preset) => Math.max(max, preset.tabOrder),
+				-1,
+			);
+			collections.v2TerminalPresets.insert({
+				id: crypto.randomUUID(),
+				name: template.name,
+				description: template.description,
+				cwd: template.cwd,
+				commands: template.commands,
+				projectIds: null,
+				pinnedToBar: true,
+				executionMode: "new-tab",
+				tabOrder: maxTabOrder + 1,
+				createdAt: new Date(),
+			});
+		},
+		[collections.v2TerminalPresets, matchedPresets],
+	);
+
+	return (
+		<div
+			className="flex items-center h-8 border-b border-border bg-background px-2 gap-0.5 overflow-x-auto shrink-0"
+			style={{ scrollbarWidth: "none" }}
+		>
+			<DropdownMenu>
+				<Tooltip>
+					<TooltipTrigger asChild>
+						<DropdownMenuTrigger asChild>
+							<Button variant="ghost" size="icon" className="size-6 shrink-0">
+								<HiMiniCog6Tooth className="size-3.5" />
+							</Button>
+						</DropdownMenuTrigger>
+					</TooltipTrigger>
+					<TooltipContent side="bottom" sideOffset={4}>
+						Manage Presets
+					</TooltipContent>
+				</Tooltip>
+				<DropdownMenuContent align="start" className="w-56">
+					{managedPresets.map((item) => {
+						const icon = getPresetIcon(item.iconName, isDark);
+						const isPinned = item.preset
+							? isPresetPinnedToBar(item.preset.pinnedToBar)
+							: false;
+						const hasPreset = !!item.preset;
+						const presetIndex = item.preset
+							? presetIndexById.get(item.preset.id)
+							: undefined;
+						const hotkeyId =
+							typeof presetIndex === "number"
+								? PRESET_HOTKEY_IDS[presetIndex]
+								: undefined;
+						return (
+							<DropdownMenuItem
+								key={item.key}
+								className="gap-2"
+								onSelect={(event) => {
+									event.preventDefault();
+									if (hasPreset && item.preset) {
+										handleTogglePinned(item.preset.id, !isPinned);
+										return;
+									}
+									if (!item.template) return;
+									handleCreateFromTemplate(item.template);
+								}}
+							>
+								{icon ? (
+									<img src={icon} alt="" className="size-4 object-contain" />
+								) : (
+									<HiMiniCommandLine className="size-4" />
+								)}
+								<span className="truncate">{item.name || "default"}</span>
+								<div className="ml-auto flex items-center gap-2">
+									{hotkeyId ? <HotkeyMenuShortcut hotkeyId={hotkeyId} /> : null}
+									{hasPreset ? (
+										<LuPin
+											className={`size-3.5 ${
+												isPinned
+													? "text-foreground"
+													: "text-muted-foreground/60"
+											}`}
+										/>
+									) : (
+										<LuCirclePlus className="size-3.5 text-muted-foreground" />
+									)}
+								</div>
+							</DropdownMenuItem>
+						);
+					})}
+					<DropdownMenuSeparator />
+					<DropdownMenuItem
+						className="gap-2"
+						onClick={() => navigate({ to: "/settings/terminal" })}
+					>
+						<HiMiniCog6Tooth className="size-4" />
+						<span>Manage Presets</span>
+					</DropdownMenuItem>
+				</DropdownMenuContent>
+			</DropdownMenu>
+			<div className="h-4 w-px bg-border mx-1 shrink-0" />
+			{pinnedPresets.map(({ preset, index }, pinnedIndex) => {
+				const hotkeyId = PRESET_HOTKEY_IDS[index];
+				return (
+					<V2PresetBarItem
+						key={preset.id}
+						preset={preset}
+						pinnedIndex={pinnedIndex}
+						hotkeyId={hotkeyId}
+						isDark={isDark}
+						onOpenInNewTab={openPresetInNewTab}
+						onEdit={(presetToEdit) => handleEditPreset(presetToEdit.id)}
+						onLocalReorder={handleLocalPinnedReorder}
+						onPersistReorder={handlePersistPinnedReorder}
+					/>
+				);
+			})}
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/V2PresetsBar/components/V2PresetBarItem/V2PresetBarItem.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/V2PresetsBar/components/V2PresetBarItem/V2PresetBarItem.tsx
@@ -1,0 +1,122 @@
+import { Button } from "@superset/ui/button";
+import {
+	ContextMenu,
+	ContextMenuContent,
+	ContextMenuItem,
+	ContextMenuSeparator,
+	ContextMenuTrigger,
+} from "@superset/ui/context-menu";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
+import { useEffect, useRef } from "react";
+import { useDrag, useDrop } from "react-dnd";
+import { HiMiniCommandLine } from "react-icons/hi2";
+import { getPresetIcon } from "renderer/assets/app-icons/preset-icons";
+import type { HotkeyId } from "renderer/hotkeys";
+import { HotkeyLabel } from "renderer/hotkeys";
+import type { V2TerminalPresetRow } from "renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal";
+
+const V2_PRESET_BAR_ITEM_TYPE = "V2_PRESET_BAR_ITEM";
+
+interface V2PresetBarItemProps {
+	preset: V2TerminalPresetRow;
+	pinnedIndex: number;
+	hotkeyId?: HotkeyId;
+	isDark: boolean;
+	onOpenInNewTab: (preset: V2TerminalPresetRow) => void;
+	onEdit: (preset: V2TerminalPresetRow) => void;
+	onLocalReorder: (fromIndex: number, toIndex: number) => void;
+	onPersistReorder: (presetId: string, targetPinnedIndex: number) => void;
+}
+
+export function V2PresetBarItem({
+	preset,
+	pinnedIndex,
+	hotkeyId,
+	isDark,
+	onOpenInNewTab,
+	onEdit,
+	onLocalReorder,
+	onPersistReorder,
+}: V2PresetBarItemProps) {
+	const containerRef = useRef<HTMLDivElement>(null);
+	const icon = getPresetIcon(preset.name, isDark);
+	const label = preset.description || preset.name || "default";
+
+	const [{ isDragging }, drag] = useDrag(
+		() => ({
+			type: V2_PRESET_BAR_ITEM_TYPE,
+			item: {
+				id: preset.id,
+				index: pinnedIndex,
+				originalIndex: pinnedIndex,
+			},
+			collect: (monitor) => ({
+				isDragging: monitor.isDragging(),
+			}),
+		}),
+		[preset.id, pinnedIndex],
+	);
+
+	const [, drop] = useDrop({
+		accept: V2_PRESET_BAR_ITEM_TYPE,
+		hover: (item: { id: string; index: number; originalIndex: number }) => {
+			if (item.index !== pinnedIndex) {
+				onLocalReorder(item.index, pinnedIndex);
+				item.index = pinnedIndex;
+			}
+		},
+		drop: (item: { id: string; index: number; originalIndex: number }) => {
+			if (item.originalIndex !== item.index) {
+				onPersistReorder(item.id, item.index);
+			}
+		},
+	});
+
+	useEffect(() => {
+		drag(drop(containerRef));
+	}, [drag, drop]);
+
+	return (
+		<ContextMenu>
+			<ContextMenuTrigger asChild>
+				<div
+					ref={containerRef}
+					className={isDragging ? "opacity-40" : undefined}
+					style={{ cursor: isDragging ? "grabbing" : "grab" }}
+				>
+					<Tooltip>
+						<TooltipTrigger asChild>
+							<Button
+								variant="ghost"
+								size="sm"
+								className="h-6 px-2 gap-1.5 text-xs shrink-0"
+								onClick={() => onOpenInNewTab(preset)}
+							>
+								{icon ? (
+									<img src={icon} alt="" className="size-3.5 object-contain" />
+								) : (
+									<HiMiniCommandLine className="size-3.5" />
+								)}
+								<span className="truncate max-w-[120px]">
+									{preset.name || "default"}
+								</span>
+							</Button>
+						</TooltipTrigger>
+						<TooltipContent side="bottom" sideOffset={4}>
+							<HotkeyLabel label={label} id={hotkeyId} />
+						</TooltipContent>
+					</Tooltip>
+				</div>
+			</ContextMenuTrigger>
+			<ContextMenuContent>
+				<ContextMenuItem onSelect={() => onOpenInNewTab(preset)}>
+					Open in new tab
+				</ContextMenuItem>
+				<ContextMenuSeparator />
+				<ContextMenuItem onSelect={() => onEdit(preset)}>
+					Edit preset
+				</ContextMenuItem>
+			</ContextMenuContent>
+		</ContextMenu>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/V2PresetsBar/components/V2PresetBarItem/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/V2PresetsBar/components/V2PresetBarItem/index.ts
@@ -1,0 +1,1 @@
+export { V2PresetBarItem } from "./V2PresetBarItem";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/V2PresetsBar/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/V2PresetsBar/index.ts
@@ -1,0 +1,1 @@
+export { V2PresetsBar } from "./V2PresetsBar";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
@@ -31,8 +31,11 @@ import {
 	useCommandPalette,
 } from "renderer/screens/main/components/CommandPalette";
 import { PresetsBar } from "renderer/screens/main/components/WorkspaceView/ContentView/components/PresetsBar";
+import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
+import { CommandPalette } from "renderer/screens/main/components/CommandPalette";
 import { useStore } from "zustand";
 import { AddTabMenu } from "./components/AddTabMenu";
+import { V2PresetsBar } from "./components/V2PresetsBar";
 import { WorkspaceEmptyState } from "./components/WorkspaceEmptyState";
 import { WorkspaceNotFoundState } from "./components/WorkspaceNotFoundState";
 import { WorkspaceSidebar } from "./components/WorkspaceSidebar";
@@ -136,28 +139,6 @@ function WorkspaceContent({
 	const paneRegistry = usePaneRegistry(workspaceId);
 	const defaultContextMenuActions = useDefaultContextMenuActions();
 	const rightSidebarOpenViewWidth = useRightSidebarOpenViewWidth();
-
-	const utils = electronTrpc.useUtils();
-	const { data: showPresetsBar, isLoading: isLoadingPresetsBar } =
-		electronTrpc.settings.getShowPresetsBar.useQuery();
-	const setShowPresetsBar = electronTrpc.settings.setShowPresetsBar.useMutation(
-		{
-			onMutate: async ({ enabled }) => {
-				await utils.settings.getShowPresetsBar.cancel();
-				const previous = utils.settings.getShowPresetsBar.getData();
-				utils.settings.getShowPresetsBar.setData(undefined, enabled);
-				return { previous };
-			},
-			onError: (_error, _variables, context) => {
-				if (context?.previous !== undefined) {
-					utils.settings.getShowPresetsBar.setData(undefined, context.previous);
-				}
-			},
-			onSettled: () => {
-				utils.settings.getShowPresetsBar.invalidate();
-			},
-		},
-	);
 
 	const selectedFilePath = useStore(store, (s) => {
 		const tab = s.tabs.find((t) => t.id === s.activeTabId);
@@ -409,11 +390,17 @@ function WorkspaceContent({
 						className="flex min-h-0 min-w-0 h-full flex-col overflow-hidden"
 						data-workspace-id={workspaceId}
 					>
-						{!isLoadingPresetsBar && showPresetsBar ? <PresetsBar /> : null}
 						<Workspace<PaneViewerData>
 							registry={paneRegistry}
 							paneActions={defaultPaneActions}
 							contextMenuActions={defaultContextMenuActions}
+							renderBelowTabBar={() => (
+								<V2PresetsBar
+									workspaceId={workspaceId}
+									projectId={projectId}
+									store={store}
+								/>
+							)}
 							renderAddTabMenu={() => (
 								<AddTabMenu
 									onAddTerminal={addTerminalTab}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesHeader/V2WorkspacesHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesHeader/V2WorkspacesHeader.tsx
@@ -1,0 +1,110 @@
+import {
+	InputGroup,
+	InputGroupAddon,
+	InputGroupInput,
+} from "@superset/ui/input-group";
+import { ToggleGroup, ToggleGroupItem } from "@superset/ui/toggle-group";
+import {
+	LuCloud,
+	LuLaptop,
+	LuLayers,
+	LuMonitor,
+	LuSearch,
+} from "react-icons/lu";
+import type { V2WorkspaceDeviceCounts } from "renderer/routes/_authenticated/_dashboard/v2-workspaces/hooks/useAccessibleV2Workspaces";
+import {
+	useV2WorkspacesFilterStore,
+	type V2WorkspacesDeviceFilter,
+} from "renderer/routes/_authenticated/_dashboard/v2-workspaces/stores/v2WorkspacesFilterStore";
+
+interface V2WorkspacesHeaderProps {
+	counts: V2WorkspaceDeviceCounts;
+}
+
+const DEVICE_FILTER_OPTIONS: Array<{
+	value: V2WorkspacesDeviceFilter;
+	label: string;
+	Icon: typeof LuLayers | null;
+}> = [
+	{ value: "all", label: "All", Icon: LuLayers },
+	{ value: "this-device", label: "This device", Icon: LuLaptop },
+	{ value: "other-devices", label: "Other devices", Icon: LuMonitor },
+	{ value: "cloud", label: "Cloud", Icon: LuCloud },
+];
+
+export function V2WorkspacesHeader({ counts }: V2WorkspacesHeaderProps) {
+	const searchQuery = useV2WorkspacesFilterStore((state) => state.searchQuery);
+	const setSearchQuery = useV2WorkspacesFilterStore(
+		(state) => state.setSearchQuery,
+	);
+	const deviceFilter = useV2WorkspacesFilterStore(
+		(state) => state.deviceFilter,
+	);
+	const setDeviceFilter = useV2WorkspacesFilterStore(
+		(state) => state.setDeviceFilter,
+	);
+
+	const countForFilter = (value: V2WorkspacesDeviceFilter): number => {
+		switch (value) {
+			case "all":
+				return counts.all;
+			case "this-device":
+				return counts.thisDevice;
+			case "other-devices":
+				return counts.otherDevices;
+			case "cloud":
+				return counts.cloud;
+		}
+	};
+
+	return (
+		<div className="flex flex-col gap-3 border-b border-border px-6 pt-5 pb-4">
+			<div className="flex flex-col gap-0.5">
+				<h1 className="text-lg font-semibold tracking-tight">Workspaces</h1>
+				<p className="text-sm text-muted-foreground">
+					Every workspace you can access across your devices. Open one to jump
+					in, or add it to your sidebar.
+				</p>
+			</div>
+
+			<div className="flex flex-wrap items-center gap-3">
+				<InputGroup className="w-full max-w-sm">
+					<InputGroupAddon align="inline-start">
+						<LuSearch className="size-4" />
+					</InputGroupAddon>
+					<InputGroupInput
+						type="search"
+						placeholder="Search workspace, project, branch, or device..."
+						value={searchQuery}
+						onChange={(event) => setSearchQuery(event.target.value)}
+					/>
+				</InputGroup>
+
+				<ToggleGroup
+					type="single"
+					variant="outline"
+					size="sm"
+					value={deviceFilter}
+					onValueChange={(value) => {
+						if (value) setDeviceFilter(value as V2WorkspacesDeviceFilter);
+					}}
+				>
+					{DEVICE_FILTER_OPTIONS.map(({ value, label, Icon }) => (
+						<ToggleGroupItem
+							key={value}
+							value={value}
+							aria-label={label}
+							className="gap-1.5"
+						>
+							{Icon ? <Icon className="size-3.5" /> : null}
+							<span>{label}</span>
+							<span className="tabular-nums text-muted-foreground">
+								{countForFilter(value)}
+							</span>
+						</ToggleGroupItem>
+					))}
+				</ToggleGroup>
+			</div>
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesHeader/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesHeader/index.ts
@@ -1,0 +1,1 @@
+export { V2WorkspacesHeader } from "./V2WorkspacesHeader";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesList/V2WorkspacesList.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesList/V2WorkspacesList.tsx
@@ -1,0 +1,229 @@
+import { Button } from "@superset/ui/button";
+import {
+	Empty,
+	EmptyContent,
+	EmptyDescription,
+	EmptyHeader,
+	EmptyMedia,
+	EmptyTitle,
+} from "@superset/ui/empty";
+import { ItemGroup } from "@superset/ui/item";
+import { ScrollArea } from "@superset/ui/scroll-area";
+import { useMatchRoute } from "@tanstack/react-router";
+import { useMemo } from "react";
+import { LuLayers, LuSearchX } from "react-icons/lu";
+import type {
+	AccessibleV2Workspace,
+	V2WorkspaceHostType,
+} from "renderer/routes/_authenticated/_dashboard/v2-workspaces/hooks/useAccessibleV2Workspaces";
+import {
+	useV2WorkspacesFilterStore,
+	type V2WorkspacesDeviceFilter,
+} from "renderer/routes/_authenticated/_dashboard/v2-workspaces/stores/v2WorkspacesFilterStore";
+import { V2WorkspaceRow } from "./components/V2WorkspaceRow";
+
+interface V2WorkspacesListProps {
+	pinned: AccessibleV2Workspace[];
+	others: AccessibleV2Workspace[];
+	hasAnyAccessible: boolean;
+}
+
+interface ProjectGroup {
+	projectId: string;
+	projectName: string;
+	workspaces: AccessibleV2Workspace[];
+}
+
+function matchesDeviceFilter(
+	hostType: V2WorkspaceHostType,
+	deviceFilter: V2WorkspacesDeviceFilter,
+): boolean {
+	switch (deviceFilter) {
+		case "all":
+			return true;
+		case "this-device":
+			return hostType === "local-device";
+		case "other-devices":
+			return hostType === "remote-device";
+		case "cloud":
+			return hostType === "cloud";
+	}
+}
+
+function groupByProject(workspaces: AccessibleV2Workspace[]): ProjectGroup[] {
+	const groupsById = new Map<string, ProjectGroup>();
+	for (const workspace of workspaces) {
+		const existing = groupsById.get(workspace.projectId);
+		if (existing) {
+			existing.workspaces.push(workspace);
+		} else {
+			groupsById.set(workspace.projectId, {
+				projectId: workspace.projectId,
+				projectName: workspace.projectName,
+				workspaces: [workspace],
+			});
+		}
+	}
+	return Array.from(groupsById.values()).sort((a, b) => {
+		const aLatest = Math.max(
+			...a.workspaces.map((workspace) => workspace.createdAt.getTime()),
+		);
+		const bLatest = Math.max(
+			...b.workspaces.map((workspace) => workspace.createdAt.getTime()),
+		);
+		return bLatest - aLatest;
+	});
+}
+
+export function V2WorkspacesList({
+	pinned,
+	others,
+	hasAnyAccessible,
+}: V2WorkspacesListProps) {
+	const matchRoute = useMatchRoute();
+	const currentWorkspaceMatch = matchRoute({
+		to: "/v2-workspace/$workspaceId",
+	});
+	const currentWorkspaceId =
+		currentWorkspaceMatch !== false ? currentWorkspaceMatch.workspaceId : null;
+
+	const searchQuery = useV2WorkspacesFilterStore((state) => state.searchQuery);
+	const deviceFilter = useV2WorkspacesFilterStore(
+		(state) => state.deviceFilter,
+	);
+	const resetFilters = useV2WorkspacesFilterStore((state) => state.reset);
+
+	// `pinned` / `others` already have the search filter applied upstream in
+	// useAccessibleV2Workspaces, so here we only narrow by device filter.
+	const filteredPinnedGroups = useMemo(() => {
+		const filtered = pinned.filter((workspace) =>
+			matchesDeviceFilter(workspace.hostType, deviceFilter),
+		);
+		return groupByProject(filtered);
+	}, [pinned, deviceFilter]);
+
+	const filteredOtherGroups = useMemo(() => {
+		const filtered = others.filter((workspace) =>
+			matchesDeviceFilter(workspace.hostType, deviceFilter),
+		);
+		return groupByProject(filtered);
+	}, [others, deviceFilter]);
+
+	const pinnedCount = filteredPinnedGroups.reduce(
+		(total, group) => total + group.workspaces.length,
+		0,
+	);
+	const othersCount = filteredOtherGroups.reduce(
+		(total, group) => total + group.workspaces.length,
+		0,
+	);
+	const hasAnyMatches = pinnedCount > 0 || othersCount > 0;
+	const hasActiveFilters = searchQuery.trim() !== "" || deviceFilter !== "all";
+
+	if (!hasAnyAccessible) {
+		return (
+			<Empty className="flex-1 border-0">
+				<EmptyHeader>
+					<EmptyMedia
+						variant="icon"
+						className="size-14 [&_svg:not([class*='size-'])]:size-7"
+					>
+						<LuLayers />
+					</EmptyMedia>
+					<EmptyTitle>No workspaces yet</EmptyTitle>
+					<EmptyDescription>
+						Create a workspace from the sidebar to get started. Workspaces you
+						have access to across all your devices will show up here.
+					</EmptyDescription>
+				</EmptyHeader>
+			</Empty>
+		);
+	}
+
+	if (!hasAnyMatches) {
+		return (
+			<Empty className="flex-1 border-0">
+				<EmptyHeader>
+					<EmptyMedia
+						variant="icon"
+						className="size-14 [&_svg:not([class*='size-'])]:size-7"
+					>
+						<LuSearchX />
+					</EmptyMedia>
+					<EmptyTitle>No workspaces match your filters</EmptyTitle>
+					<EmptyDescription>
+						Try a different search term or clear the device filter.
+					</EmptyDescription>
+				</EmptyHeader>
+				{hasActiveFilters ? (
+					<EmptyContent>
+						<Button variant="outline" size="sm" onClick={() => resetFilters()}>
+							Clear filters
+						</Button>
+					</EmptyContent>
+				) : null}
+			</Empty>
+		);
+	}
+
+	const renderProjectGroups = (groups: ProjectGroup[]) => (
+		<div className="flex flex-col gap-5">
+			{groups.map((group) => (
+				<div key={group.projectId} className="flex flex-col gap-2">
+					<div className="flex items-baseline gap-2 px-1">
+						<h3 className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+							{group.projectName}
+						</h3>
+						<span className="text-xs text-muted-foreground/70">
+							{group.workspaces.length}
+						</span>
+					</div>
+					<ItemGroup className="gap-2">
+						{group.workspaces.map((workspace) => (
+							<V2WorkspaceRow
+								key={workspace.id}
+								workspace={workspace}
+								showProjectName={false}
+								isCurrentRoute={workspace.id === currentWorkspaceId}
+							/>
+						))}
+					</ItemGroup>
+				</div>
+			))}
+		</div>
+	);
+
+	return (
+		<ScrollArea className="flex-1">
+			<div className="flex flex-col gap-8 px-6 py-6">
+				{pinnedCount > 0 ? (
+					<section className="flex flex-col gap-3">
+						<div className="flex items-baseline gap-2">
+							<h2 className="text-sm font-semibold text-foreground">
+								In your sidebar
+							</h2>
+							<span className="text-xs text-muted-foreground">
+								{pinnedCount}
+							</span>
+						</div>
+						{renderProjectGroups(filteredPinnedGroups)}
+					</section>
+				) : null}
+
+				{othersCount > 0 ? (
+					<section className="flex flex-col gap-3">
+						<div className="flex items-baseline gap-2">
+							<h2 className="text-sm font-semibold text-foreground">
+								Other workspaces
+							</h2>
+							<span className="text-xs text-muted-foreground">
+								{othersCount}
+							</span>
+						</div>
+						{renderProjectGroups(filteredOtherGroups)}
+					</section>
+				) : null}
+			</div>
+		</ScrollArea>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesList/components/V2WorkspaceRow/V2WorkspaceRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesList/components/V2WorkspaceRow/V2WorkspaceRow.tsx
@@ -1,0 +1,151 @@
+import { Badge } from "@superset/ui/badge";
+import { Button } from "@superset/ui/button";
+import {
+	Item,
+	ItemActions,
+	ItemContent,
+	ItemDescription,
+	ItemMedia,
+	ItemTitle,
+} from "@superset/ui/item";
+import { useNavigate } from "@tanstack/react-router";
+import { useCallback } from "react";
+import {
+	LuCloud,
+	LuGitBranch,
+	LuLaptop,
+	LuMinus,
+	LuMonitor,
+	LuPlus,
+} from "react-icons/lu";
+import { navigateToV2Workspace } from "renderer/routes/_authenticated/_dashboard/utils/workspace-navigation";
+import type { AccessibleV2Workspace } from "renderer/routes/_authenticated/_dashboard/v2-workspaces/hooks/useAccessibleV2Workspaces";
+import { useDashboardSidebarState } from "renderer/routes/_authenticated/hooks/useDashboardSidebarState";
+import { getRelativeTime } from "renderer/screens/main/components/WorkspacesListView/utils";
+import { V2WorkspaceDeviceBadge } from "./components/V2WorkspaceDeviceBadge";
+
+interface V2WorkspaceRowProps {
+	workspace: AccessibleV2Workspace;
+	showProjectName: boolean;
+	isCurrentRoute: boolean;
+}
+
+export function V2WorkspaceRow({
+	workspace,
+	showProjectName,
+	isCurrentRoute,
+}: V2WorkspaceRowProps) {
+	const navigate = useNavigate();
+	const { ensureWorkspaceInSidebar, removeWorkspaceFromSidebar } =
+		useDashboardSidebarState();
+
+	const HostIcon =
+		workspace.hostType === "cloud"
+			? LuCloud
+			: workspace.hostType === "local-device"
+				? LuLaptop
+				: LuMonitor;
+
+	const handleOpen = useCallback(() => {
+		navigateToV2Workspace(workspace.id, navigate);
+	}, [navigate, workspace.id]);
+
+	const handleAddToSidebar = useCallback(
+		(event: React.MouseEvent) => {
+			event.stopPropagation();
+			ensureWorkspaceInSidebar(workspace.id, workspace.projectId);
+		},
+		[ensureWorkspaceInSidebar, workspace.id, workspace.projectId],
+	);
+
+	const handleRemoveFromSidebar = useCallback(
+		(event: React.MouseEvent) => {
+			event.stopPropagation();
+			removeWorkspaceFromSidebar(workspace.id);
+		},
+		[removeWorkspaceFromSidebar, workspace.id],
+	);
+
+	const creatorLabel = workspace.isCreatedByCurrentUser
+		? "you"
+		: (workspace.createdByName ?? "unknown");
+
+	const handleRowKeyDown = useCallback(
+		(event: React.KeyboardEvent<HTMLDivElement>) => {
+			if (event.key === "Enter" || event.key === " ") {
+				event.preventDefault();
+				handleOpen();
+			}
+		},
+		[handleOpen],
+	);
+
+	return (
+		<Item
+			variant="outline"
+			size="sm"
+			role="button"
+			tabIndex={0}
+			onClick={handleOpen}
+			onKeyDown={handleRowKeyDown}
+			className="cursor-pointer border-border/60 outline-none hover:bg-accent/50 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50"
+		>
+			<ItemMedia variant="icon">
+				<HostIcon className="size-4" />
+			</ItemMedia>
+
+			<ItemContent>
+				<ItemTitle>
+					<span className="truncate">{workspace.name}</span>
+				</ItemTitle>
+				<ItemDescription className="flex flex-wrap items-center gap-2">
+					{showProjectName ? (
+						<span className="font-medium text-foreground/70">
+							{workspace.projectName}
+						</span>
+					) : null}
+					<Badge variant="secondary" className="gap-1 font-normal">
+						<LuGitBranch className="size-3" />
+						<span className="max-w-[16rem] truncate">{workspace.branch}</span>
+					</Badge>
+					<V2WorkspaceDeviceBadge
+						hostType={workspace.hostType}
+						hostName={workspace.hostName}
+						isOnline={workspace.hostIsOnline}
+					/>
+					<span className="text-xs text-muted-foreground">
+						{getRelativeTime(workspace.createdAt.getTime(), {
+							format: "compact",
+						})}{" "}
+						by {creatorLabel}
+					</span>
+				</ItemDescription>
+			</ItemContent>
+
+			<ItemActions>
+				{workspace.isInSidebar ? (
+					<Button
+						size="sm"
+						variant="outline"
+						onClick={handleRemoveFromSidebar}
+						disabled={isCurrentRoute}
+						className="gap-1.5"
+					>
+						<LuMinus className="size-3.5" />
+						Remove from sidebar
+					</Button>
+				) : (
+					<Button
+						size="sm"
+						variant="default"
+						onClick={handleAddToSidebar}
+						className="gap-1.5"
+					>
+						<LuPlus className="size-3.5" />
+						Add to sidebar
+					</Button>
+				)}
+			</ItemActions>
+		</Item>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesList/components/V2WorkspaceRow/components/V2WorkspaceDeviceBadge/V2WorkspaceDeviceBadge.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesList/components/V2WorkspaceRow/components/V2WorkspaceDeviceBadge/V2WorkspaceDeviceBadge.tsx
@@ -1,0 +1,58 @@
+import { Badge } from "@superset/ui/badge";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
+import { cn } from "@superset/ui/utils";
+import { LuCloud, LuLaptop, LuMonitor } from "react-icons/lu";
+import type { V2WorkspaceHostType } from "renderer/routes/_authenticated/_dashboard/v2-workspaces/hooks/useAccessibleV2Workspaces";
+
+interface V2WorkspaceDeviceBadgeProps {
+	hostType: V2WorkspaceHostType;
+	hostName: string;
+	isOnline: boolean;
+}
+
+export function V2WorkspaceDeviceBadge({
+	hostType,
+	hostName,
+	isOnline,
+}: V2WorkspaceDeviceBadgeProps) {
+	const Icon =
+		hostType === "cloud"
+			? LuCloud
+			: hostType === "local-device"
+				? LuLaptop
+				: LuMonitor;
+
+	// The local device is always reachable from here — ignore any stale
+	// isOnline flag on that row.
+	const treatAsOffline = !isOnline && hostType !== "local-device";
+
+	const badge = (
+		<Badge
+			variant="outline"
+			className={cn(
+				"gap-1 font-normal",
+				treatAsOffline && "text-muted-foreground/70",
+			)}
+		>
+			<Icon className="size-3" />
+			<span className="max-w-[12rem] truncate">{hostName}</span>
+			{treatAsOffline ? (
+				<span
+					aria-hidden
+					className="ml-0.5 inline-block size-1.5 rounded-full bg-muted-foreground/50"
+				/>
+			) : null}
+		</Badge>
+	);
+
+	if (!treatAsOffline) {
+		return badge;
+	}
+
+	return (
+		<Tooltip delayDuration={300}>
+			<TooltipTrigger asChild>{badge}</TooltipTrigger>
+			<TooltipContent side="top">Host is offline</TooltipContent>
+		</Tooltip>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesList/components/V2WorkspaceRow/components/V2WorkspaceDeviceBadge/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesList/components/V2WorkspaceRow/components/V2WorkspaceDeviceBadge/index.ts
@@ -1,0 +1,1 @@
+export { V2WorkspaceDeviceBadge } from "./V2WorkspaceDeviceBadge";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesList/components/V2WorkspaceRow/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesList/components/V2WorkspaceRow/index.ts
@@ -1,0 +1,1 @@
+export { V2WorkspaceRow } from "./V2WorkspaceRow";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesList/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesList/index.ts
@@ -1,0 +1,1 @@
+export { V2WorkspacesList } from "./V2WorkspacesList";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/hooks/useAccessibleV2Workspaces/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/hooks/useAccessibleV2Workspaces/index.ts
@@ -1,0 +1,8 @@
+export {
+	type AccessibleV2Workspace,
+	type UseAccessibleV2WorkspacesResult,
+	useAccessibleV2Workspaces,
+	type V2WorkspaceDeviceCounts,
+	type V2WorkspaceHostType,
+	type V2WorkspaceProjectGroup,
+} from "./useAccessibleV2Workspaces";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/hooks/useAccessibleV2Workspaces/useAccessibleV2Workspaces.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/hooks/useAccessibleV2Workspaces/useAccessibleV2Workspaces.ts
@@ -1,0 +1,207 @@
+import { and, eq } from "@tanstack/db";
+import { useLiveQuery } from "@tanstack/react-db";
+import { useMemo } from "react";
+import { env } from "renderer/env.renderer";
+import { authClient } from "renderer/lib/auth-client";
+import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
+import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
+import { MOCK_ORG_ID } from "shared/constants";
+
+export type V2WorkspaceHostType = "local-device" | "remote-device" | "cloud";
+
+export interface AccessibleV2Workspace {
+	id: string;
+	name: string;
+	branch: string;
+	createdAt: Date;
+	createdByUserId: string | null;
+	createdByName: string | null;
+	createdByImage: string | null;
+	isCreatedByCurrentUser: boolean;
+	projectId: string;
+	projectName: string;
+	hostId: string;
+	hostName: string;
+	hostMachineId: string | null;
+	hostIsOnline: boolean;
+	hostType: V2WorkspaceHostType;
+	isInSidebar: boolean;
+}
+
+export interface V2WorkspaceProjectGroup {
+	projectId: string;
+	projectName: string;
+	workspaces: AccessibleV2Workspace[];
+}
+
+export interface V2WorkspaceDeviceCounts {
+	all: number;
+	thisDevice: number;
+	otherDevices: number;
+	cloud: number;
+}
+
+export interface UseAccessibleV2WorkspacesResult {
+	all: AccessibleV2Workspace[];
+	pinned: AccessibleV2Workspace[];
+	others: AccessibleV2Workspace[];
+	counts: V2WorkspaceDeviceCounts;
+}
+
+interface UseAccessibleV2WorkspacesOptions {
+	searchQuery?: string;
+}
+
+function workspaceMatchesSearch(
+	workspace: AccessibleV2Workspace,
+	searchQuery: string,
+): boolean {
+	if (!searchQuery.trim()) return true;
+	const query = searchQuery.trim().toLowerCase();
+	return (
+		workspace.name.toLowerCase().includes(query) ||
+		workspace.projectName.toLowerCase().includes(query) ||
+		workspace.branch.toLowerCase().includes(query) ||
+		workspace.hostName.toLowerCase().includes(query) ||
+		(workspace.createdByName ?? "").toLowerCase().includes(query)
+	);
+}
+
+export function useAccessibleV2Workspaces(
+	options: UseAccessibleV2WorkspacesOptions = {},
+): UseAccessibleV2WorkspacesResult {
+	const searchQuery = options.searchQuery ?? "";
+	const { data: session } = authClient.useSession();
+	const collections = useCollections();
+	const { machineId } = useLocalHostService();
+
+	const activeOrganizationId = env.SKIP_ENV_VALIDATION
+		? MOCK_ORG_ID
+		: (session?.session?.activeOrganizationId ?? null);
+	const currentUserId = session?.user?.id ?? null;
+
+	const { data: rows = [] } = useLiveQuery(
+		(q) =>
+			q
+				.from({ workspaces: collections.v2Workspaces })
+				.innerJoin({ hosts: collections.v2Hosts }, ({ workspaces, hosts }) =>
+					eq(workspaces.hostId, hosts.id),
+				)
+				.innerJoin(
+					{ userHosts: collections.v2UsersHosts },
+					({ hosts, userHosts }) => eq(userHosts.hostId, hosts.id),
+				)
+				.innerJoin(
+					{ projects: collections.v2Projects },
+					({ workspaces, projects }) => eq(workspaces.projectId, projects.id),
+				)
+				.leftJoin(
+					{ sidebarState: collections.v2WorkspaceLocalState },
+					({ workspaces, sidebarState }) =>
+						eq(sidebarState.workspaceId, workspaces.id),
+				)
+				.leftJoin({ creators: collections.users }, ({ workspaces, creators }) =>
+					eq(workspaces.createdByUserId, creators.id),
+				)
+				.where(({ workspaces, userHosts }) =>
+					and(
+						eq(workspaces.organizationId, activeOrganizationId ?? ""),
+						eq(userHosts.userId, currentUserId ?? ""),
+					),
+				)
+				.select(({ workspaces, hosts, projects, sidebarState, creators }) => ({
+					id: workspaces.id,
+					name: workspaces.name,
+					branch: workspaces.branch,
+					createdAt: workspaces.createdAt,
+					createdByUserId: workspaces.createdByUserId,
+					createdByName: creators?.name ?? null,
+					createdByImage: creators?.image ?? null,
+					projectId: projects.id,
+					projectName: projects.name,
+					hostId: hosts.id,
+					hostName: hosts.name,
+					hostMachineId: hosts.machineId,
+					hostIsOnline: hosts.isOnline,
+					sidebarWorkspaceId: sidebarState?.workspaceId ?? null,
+				})),
+		[activeOrganizationId, collections, currentUserId],
+	);
+
+	const enriched = useMemo<AccessibleV2Workspace[]>(() => {
+		const deduped = new Map<string, AccessibleV2Workspace>();
+		for (const row of rows) {
+			if (deduped.has(row.id)) continue;
+			const hostType: V2WorkspaceHostType =
+				row.hostMachineId == null
+					? "cloud"
+					: row.hostMachineId === machineId
+						? "local-device"
+						: "remote-device";
+			deduped.set(row.id, {
+				id: row.id,
+				name: row.name,
+				branch: row.branch,
+				createdAt: new Date(row.createdAt),
+				createdByUserId: row.createdByUserId,
+				createdByName: row.createdByName ?? null,
+				createdByImage: row.createdByImage ?? null,
+				isCreatedByCurrentUser:
+					currentUserId != null && row.createdByUserId === currentUserId,
+				projectId: row.projectId,
+				projectName: row.projectName,
+				hostId: row.hostId,
+				hostName: row.hostName,
+				hostMachineId: row.hostMachineId,
+				hostIsOnline: row.hostIsOnline,
+				hostType,
+				isInSidebar: row.sidebarWorkspaceId != null,
+			});
+		}
+		return Array.from(deduped.values()).sort(
+			(a, b) => b.createdAt.getTime() - a.createdAt.getTime(),
+		);
+	}, [rows, machineId, currentUserId]);
+
+	const searchFiltered = useMemo(
+		() =>
+			enriched.filter((workspace) =>
+				workspaceMatchesSearch(workspace, searchQuery),
+			),
+		[enriched, searchQuery],
+	);
+
+	const pinned = useMemo(
+		() => searchFiltered.filter((workspace) => workspace.isInSidebar),
+		[searchFiltered],
+	);
+
+	const others = useMemo(
+		() => searchFiltered.filter((workspace) => !workspace.isInSidebar),
+		[searchFiltered],
+	);
+
+	const counts = useMemo<V2WorkspaceDeviceCounts>(() => {
+		let thisDevice = 0;
+		let otherDevices = 0;
+		let cloud = 0;
+		for (const workspace of searchFiltered) {
+			if (workspace.hostType === "local-device") thisDevice += 1;
+			else if (workspace.hostType === "remote-device") otherDevices += 1;
+			else cloud += 1;
+		}
+		return {
+			all: searchFiltered.length,
+			thisDevice,
+			otherDevices,
+			cloud,
+		};
+	}, [searchFiltered]);
+
+	return {
+		all: searchFiltered,
+		pinned,
+		others,
+		counts,
+	};
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/page.tsx
@@ -1,4 +1,9 @@
 import { createFileRoute } from "@tanstack/react-router";
+import { useEffect } from "react";
+import { V2WorkspacesHeader } from "./components/V2WorkspacesHeader";
+import { V2WorkspacesList } from "./components/V2WorkspacesList";
+import { useAccessibleV2Workspaces } from "./hooks/useAccessibleV2Workspaces";
+import { useV2WorkspacesFilterStore } from "./stores/v2WorkspacesFilterStore";
 
 export const Route = createFileRoute(
 	"/_authenticated/_dashboard/v2-workspaces/",
@@ -7,26 +12,27 @@ export const Route = createFileRoute(
 });
 
 function V2WorkspacesPage() {
-	return (
-		<div className="flex h-full flex-col overflow-y-auto p-6">
-			<div className="mx-auto flex w-full max-w-4xl flex-col gap-6">
-				<div className="space-y-2">
-					<h1 className="text-2xl font-semibold tracking-tight">Workspaces</h1>
-					<p className="max-w-2xl text-sm text-muted-foreground">
-						This page will become the browse surface for all accessible V2
-						workspaces, with sidebar workspaces prioritized first.
-					</p>
-				</div>
+	const searchQuery = useV2WorkspacesFilterStore((state) => state.searchQuery);
+	const resetFilters = useV2WorkspacesFilterStore((state) => state.reset);
 
-				<div className="rounded-xl border border-border bg-card p-5">
-					<h2 className="text-sm font-medium">WIP</h2>
-					<p className="mt-2 text-sm text-muted-foreground">
-						Next up is splitting local sidebar workspaces from the full set of
-						accessible shared workspaces and giving this page proper search,
-						filtering, and recents.
-					</p>
-				</div>
-			</div>
+	// Start with a fresh view every time the discovery page mounts — otherwise
+	// the zustand singleton would carry over a stale search/device filter from a
+	// previous visit with no visible indication that a filter is active.
+	useEffect(() => {
+		resetFilters();
+	}, [resetFilters]);
+
+	const { pinned, others, counts } = useAccessibleV2Workspaces({ searchQuery });
+	const hasAnyAccessible = pinned.length > 0 || others.length > 0;
+
+	return (
+		<div className="flex h-full w-full flex-1 flex-col overflow-hidden">
+			<V2WorkspacesHeader counts={counts} />
+			<V2WorkspacesList
+				pinned={pinned}
+				others={others}
+				hasAnyAccessible={hasAnyAccessible}
+			/>
 		</div>
 	);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/stores/v2WorkspacesFilterStore/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/stores/v2WorkspacesFilterStore/index.ts
@@ -1,0 +1,4 @@
+export {
+	useV2WorkspacesFilterStore,
+	type V2WorkspacesDeviceFilter,
+} from "./v2WorkspacesFilterStore";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/stores/v2WorkspacesFilterStore/v2WorkspacesFilterStore.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/stores/v2WorkspacesFilterStore/v2WorkspacesFilterStore.ts
@@ -1,0 +1,25 @@
+import { create } from "zustand";
+
+export type V2WorkspacesDeviceFilter =
+	| "all"
+	| "this-device"
+	| "other-devices"
+	| "cloud";
+
+interface V2WorkspacesFilterState {
+	searchQuery: string;
+	deviceFilter: V2WorkspacesDeviceFilter;
+	setSearchQuery: (searchQuery: string) => void;
+	setDeviceFilter: (deviceFilter: V2WorkspacesDeviceFilter) => void;
+	reset: () => void;
+}
+
+export const useV2WorkspacesFilterStore = create<V2WorkspacesFilterState>()(
+	(set) => ({
+		searchQuery: "",
+		deviceFilter: "all",
+		setSearchQuery: (searchQuery) => set({ searchQuery }),
+		setDeviceFilter: (deviceFilter) => set({ deviceFilter }),
+		reset: () => set({ searchQuery: "", deviceFilter: "all" }),
+	}),
+);

--- a/apps/desktop/src/renderer/routes/_authenticated/hooks/useMigrateV1PresetsToV2/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/hooks/useMigrateV1PresetsToV2/index.ts
@@ -1,0 +1,1 @@
+export { useMigrateV1PresetsToV2 } from "./useMigrateV1PresetsToV2";

--- a/apps/desktop/src/renderer/routes/_authenticated/hooks/useMigrateV1PresetsToV2/useMigrateV1PresetsToV2.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/hooks/useMigrateV1PresetsToV2/useMigrateV1PresetsToV2.ts
@@ -1,0 +1,71 @@
+import { useEffect, useRef } from "react";
+import { env } from "renderer/env.renderer";
+import { authClient } from "renderer/lib/auth-client";
+import { electronTrpcClient } from "renderer/lib/trpc-client";
+import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
+import { MOCK_ORG_ID } from "shared/constants";
+
+function getMigrationMarkerKey(organizationId: string): string {
+	return `v2-terminal-presets-migrated-${organizationId}`;
+}
+
+/**
+ * Copies v1 main-process terminal presets into the v2TerminalPresets
+ * collection on first run per organization. v1's `getTerminalPresets`
+ * auto-initializes default agent presets on first call, so fresh users
+ * get a populated bar and users who customized v1 keep their presets.
+ *
+ * Uses the vanilla electronTrpcClient (ipcLink) instead of the React
+ * hook because V2PresetsBar is mounted inside WorkspaceTrpcProvider,
+ * which would route the request to the workspace HTTP server (404).
+ */
+export function useMigrateV1PresetsToV2() {
+	const collections = useCollections();
+	const { data: session } = authClient.useSession();
+	const organizationId = env.SKIP_ENV_VALIDATION
+		? MOCK_ORG_ID
+		: session?.session?.activeOrganizationId;
+	const migratedOrgRef = useRef<string | null>(null);
+
+	useEffect(() => {
+		if (!organizationId) return;
+		if (migratedOrgRef.current === organizationId) return;
+
+		const markerKey = getMigrationMarkerKey(organizationId);
+		if (localStorage.getItem(markerKey) === "1") {
+			migratedOrgRef.current = organizationId;
+			return;
+		}
+
+		migratedOrgRef.current = organizationId;
+
+		void (async () => {
+			try {
+				const v1Presets =
+					await electronTrpcClient.settings.getTerminalPresets.query();
+
+				const now = new Date();
+				collections.v2TerminalPresets.insert(
+					v1Presets.map((v1Preset, index) => ({
+						id: crypto.randomUUID(),
+						name: v1Preset.name,
+						description: v1Preset.description,
+						cwd: v1Preset.cwd,
+						commands: v1Preset.commands,
+						projectIds: v1Preset.projectIds ?? null,
+						pinnedToBar: v1Preset.pinnedToBar,
+						applyOnWorkspaceCreated: v1Preset.applyOnWorkspaceCreated,
+						applyOnNewTab: v1Preset.applyOnNewTab,
+						executionMode: v1Preset.executionMode ?? "new-tab",
+						tabOrder: index,
+						createdAt: now,
+					})),
+				);
+
+				localStorage.setItem(markerKey, "1");
+			} catch {
+				migratedOrgRef.current = null;
+			}
+		})();
+	}, [collections.v2TerminalPresets, organizationId]);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/collections.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/collections.ts
@@ -41,6 +41,8 @@ import {
 	type DashboardSidebarSectionRow,
 	dashboardSidebarProjectSchema,
 	dashboardSidebarSectionSchema,
+	type V2TerminalPresetRow,
+	v2TerminalPresetSchema,
 	type WorkspaceLocalStateRow,
 	workspaceLocalStateSchema,
 } from "./dashboardSidebarLocal";
@@ -105,6 +107,13 @@ export interface OrgCollections {
 		LocalStorageCollectionUtils,
 		typeof dashboardSidebarSectionSchema,
 		z.input<typeof dashboardSidebarSectionSchema>
+	>;
+	v2TerminalPresets: Collection<
+		V2TerminalPresetRow,
+		string,
+		LocalStorageCollectionUtils,
+		typeof v2TerminalPresetSchema,
+		z.input<typeof v2TerminalPresetSchema>
 	>;
 }
 
@@ -523,6 +532,15 @@ function createOrgCollections(organizationId: string): OrgCollections {
 		}),
 	);
 
+	const v2TerminalPresets = createCollection(
+		localStorageCollectionOptions({
+			id: `v2_terminal_presets-${organizationId}`,
+			storageKey: `v2-terminal-presets-${organizationId}`,
+			schema: v2TerminalPresetSchema,
+			getKey: (item) => item.id,
+		}),
+	);
+
 	return {
 		tasks,
 		taskStatuses,
@@ -547,6 +565,7 @@ function createOrgCollections(organizationId: string): OrgCollections {
 		v2SidebarProjects,
 		v2WorkspaceLocalState,
 		v2SidebarSections,
+		v2TerminalPresets,
 	};
 }
 

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema.ts
@@ -52,6 +52,29 @@ export const dashboardSidebarSectionSchema = z.object({
 	color: z.string().nullable().default(null),
 });
 
+const v2ExecutionModeSchema = z.enum([
+	"split-pane",
+	"new-tab",
+	"new-tab-split-pane",
+]);
+
+// projectIds uses plain z.string() (not uuid) because v1 accepts arbitrary
+// string IDs and the migration copies them verbatim.
+export const v2TerminalPresetSchema = z.object({
+	id: z.string().uuid(),
+	name: z.string(),
+	description: z.string().optional(),
+	cwd: z.string().default(""),
+	commands: z.array(z.string()).default([]),
+	projectIds: z.array(z.string()).nullable().default(null),
+	pinnedToBar: z.boolean().optional(),
+	applyOnWorkspaceCreated: z.boolean().optional(),
+	applyOnNewTab: z.boolean().optional(),
+	executionMode: v2ExecutionModeSchema.default("new-tab"),
+	tabOrder: z.number().int().default(0),
+	createdAt: persistedDateSchema,
+});
+
 export type DashboardSidebarProjectRow = z.infer<
 	typeof dashboardSidebarProjectSchema
 >;
@@ -59,3 +82,4 @@ export type WorkspaceLocalStateRow = z.infer<typeof workspaceLocalStateSchema>;
 export type DashboardSidebarSectionRow = z.infer<
 	typeof dashboardSidebarSectionSchema
 >;
+export type V2TerminalPresetRow = z.infer<typeof v2TerminalPresetSchema>;

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/TerminalSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/TerminalSettings.tsx
@@ -1,3 +1,5 @@
+import { FEATURE_FLAGS } from "@superset/shared/constants";
+import { useFeatureFlagEnabled } from "posthog-js/react";
 import type { ReactNode } from "react";
 import {
 	isItemVisible,
@@ -8,6 +10,7 @@ import { LinkBehaviorSetting } from "./components/LinkBehaviorSetting";
 import { PresetsSection } from "./components/PresetsSection";
 import { SessionsSection } from "./components/SessionsSection";
 import { SuggestionsSetting } from "./components/SuggestionsSetting";
+import { V2PresetsSection } from "./components/V2PresetsSection";
 
 interface TerminalSettingsProps {
 	visibleItems?: SettingItemId[] | null;
@@ -45,6 +48,8 @@ export function TerminalSettings({
 	pendingCreateProjectId,
 	onPendingCreateProjectIdChange,
 }: TerminalSettingsProps) {
+	const isV2CloudEnabled =
+		useFeatureFlagEnabled(FEATURE_FLAGS.V2_CLOUD) ?? false;
 	const showPresets = isItemVisible(
 		SETTING_ITEM_ID.TERMINAL_PRESETS,
 		visibleItems,
@@ -88,6 +93,28 @@ export function TerminalSettings({
 					/>
 				)}
 				{showSuggestions && <SuggestionsSetting key="suggestions" />}
+				{(showPresets || showQuickAdd) &&
+					(isV2CloudEnabled ? (
+						<V2PresetsSection
+							key="presets"
+							showPresets={showPresets}
+							showQuickAdd={showQuickAdd}
+							editingPresetId={editingPresetId}
+							onEditingPresetIdChange={onEditingPresetIdChange}
+							pendingCreateProjectId={pendingCreateProjectId}
+							onPendingCreateProjectIdChange={onPendingCreateProjectIdChange}
+						/>
+					) : (
+						<PresetsSection
+							key="presets"
+							showPresets={showPresets}
+							showQuickAdd={showQuickAdd}
+							editingPresetId={editingPresetId}
+							onEditingPresetIdChange={onEditingPresetIdChange}
+							pendingCreateProjectId={pendingCreateProjectId}
+							onPendingCreateProjectIdChange={onPendingCreateProjectIdChange}
+						/>
+					))}
 				{showLinkBehavior && <LinkBehaviorSetting key="link-behavior" />}
 				{showSessions && <SessionsSection key="sessions" />}
 			</SectionList>

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/V2PresetsSection/V2PresetsSection.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/V2PresetsSection/V2PresetsSection.tsx
@@ -1,0 +1,589 @@
+import {
+	type ExecutionMode,
+	normalizeExecutionMode,
+	type TerminalPreset,
+} from "@superset/local-db";
+import { Button } from "@superset/ui/button";
+import { Label } from "@superset/ui/label";
+import { useLiveQuery } from "@tanstack/react-db";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { HiOutlinePlus } from "react-icons/hi2";
+import { useIsDarkTheme } from "renderer/assets/app-icons/preset-icons";
+import { useMigrateV1PresetsToV2 } from "renderer/routes/_authenticated/hooks/useMigrateV1PresetsToV2";
+import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
+import type { V2TerminalPresetRow } from "renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal";
+import type { PresetColumnKey } from "renderer/routes/_authenticated/settings/presets/types";
+import { PresetEditorSheet } from "../PresetsSection/components/PresetEditorSheet";
+import { PresetsTable } from "../PresetsSection/components/PresetsTable";
+import { QuickAddPresets } from "../PresetsSection/components/QuickAddPresets";
+import {
+	type AutoApplyField,
+	PRESET_TEMPLATES,
+	type PresetTemplate,
+} from "../PresetsSection/constants";
+import type { PresetProjectOption } from "../PresetsSection/preset-project-options";
+
+interface V2PresetsSectionProps {
+	showPresets: boolean;
+	showQuickAdd: boolean;
+	editingPresetId?: string | null;
+	onEditingPresetIdChange?: (presetId: string | null) => void;
+	pendingCreateProjectId?: string | null;
+	onPendingCreateProjectIdChange?: (projectId: string | null) => void;
+}
+
+/**
+ * V2 clone of PresetsSection wired to the renderer-side v2TerminalPresets
+ * collection. Reuses PresetsTable / PresetEditorSheet / QuickAddPresets from
+ * the v1 directory (they're prop-driven renderers). When v1 is deprecated,
+ * delete PresetsSection and move the shared sub-components here.
+ */
+export function V2PresetsSection({
+	showPresets,
+	showQuickAdd,
+	editingPresetId: editingPresetIdFromRoute,
+	onEditingPresetIdChange,
+	pendingCreateProjectId,
+	onPendingCreateProjectIdChange,
+}: V2PresetsSectionProps) {
+	const isDark = useIsDarkTheme();
+	const collections = useCollections();
+	useMigrateV1PresetsToV2();
+
+	const { data: v2Presets = [] } = useLiveQuery(
+		(query) =>
+			query
+				.from({ v2TerminalPresets: collections.v2TerminalPresets })
+				.orderBy(({ v2TerminalPresets }) => v2TerminalPresets.tabOrder),
+		[collections],
+	);
+
+	const { data: v2Projects = [] } = useLiveQuery(
+		(query) =>
+			query
+				.from({ v2Projects: collections.v2Projects })
+				.orderBy(({ v2Projects }) => v2Projects.name),
+		[collections],
+	);
+
+	// V2TerminalPresetRow is a superset of TerminalPreset — safe to cast
+	// for the prop-driven sub-components.
+	const serverPresets = useMemo<TerminalPreset[]>(
+		() => v2Presets as unknown as TerminalPreset[],
+		[v2Presets],
+	);
+
+	const [localPresets, setLocalPresets] =
+		useState<TerminalPreset[]>(serverPresets);
+	const [editingPresetId, setEditingPresetId] = useState<string | null>(
+		editingPresetIdFromRoute ?? null,
+	);
+	const presetsContainerRef = useRef<HTMLDivElement>(null);
+	const prevPresetsCountRef = useRef(serverPresets.length);
+	const serverPresetsRef = useRef(serverPresets);
+	const previousServerPresetIdsRef = useRef<Set<string>>(
+		new Set(serverPresets.map((preset) => preset.id)),
+	);
+	const shouldOpenNewPresetEditorRef = useRef(false);
+	const lastHandledCreateProjectIdRef = useRef<string | null>(null);
+
+	const projectOptions = useMemo<PresetProjectOption[]>(
+		() =>
+			v2Projects.map((project) => ({
+				id: project.id,
+				name: project.name,
+				// v2 project schema has no color/mainRepoPath; degrade gracefully.
+				color: "",
+				mainRepoPath: "",
+			})),
+		[v2Projects],
+	);
+	const projectOptionsById = useMemo(
+		() => new Map(projectOptions.map((project) => [project.id, project])),
+		[projectOptions],
+	);
+
+	useEffect(() => {
+		serverPresetsRef.current = serverPresets;
+	}, [serverPresets]);
+
+	const setEditingPreset = useCallback(
+		(presetId: string | null) => {
+			setEditingPresetId(presetId);
+			onEditingPresetIdChange?.(presetId);
+		},
+		[onEditingPresetIdChange],
+	);
+
+	useEffect(() => {
+		setEditingPresetId(editingPresetIdFromRoute ?? null);
+	}, [editingPresetIdFromRoute]);
+
+	useEffect(() => {
+		setLocalPresets(serverPresets);
+
+		const previousIds = previousServerPresetIdsRef.current;
+		if (shouldOpenNewPresetEditorRef.current) {
+			const addedPreset = serverPresets.find(
+				(preset) => !previousIds.has(preset.id),
+			);
+			if (addedPreset) {
+				setEditingPreset(addedPreset.id);
+				shouldOpenNewPresetEditorRef.current = false;
+			}
+		}
+
+		if (serverPresets.length > prevPresetsCountRef.current) {
+			requestAnimationFrame(() => {
+				presetsContainerRef.current?.scrollTo({
+					top: presetsContainerRef.current.scrollHeight,
+					behavior: "smooth",
+				});
+			});
+		}
+		prevPresetsCountRef.current = serverPresets.length;
+		previousServerPresetIdsRef.current = new Set(
+			serverPresets.map((preset) => preset.id),
+		);
+	}, [serverPresets, setEditingPreset]);
+
+	const editingRowIndex = useMemo(() => {
+		if (!editingPresetId) return -1;
+		return localPresets.findIndex((preset) => preset.id === editingPresetId);
+	}, [editingPresetId, localPresets]);
+
+	const editingPreset = useMemo(
+		() => (editingRowIndex >= 0 ? localPresets[editingRowIndex] : null),
+		[editingRowIndex, localPresets],
+	);
+
+	useEffect(() => {
+		if (
+			editingPresetId &&
+			!localPresets.some((preset) => preset.id === editingPresetId)
+		) {
+			setEditingPreset(null);
+		}
+	}, [editingPresetId, localPresets, setEditingPreset]);
+
+	const existingPresetNames = useMemo(
+		() => new Set(serverPresets.map((preset) => preset.name)),
+		[serverPresets],
+	);
+
+	const isTemplateAdded = useCallback(
+		(template: PresetTemplate) => existingPresetNames.has(template.preset.name),
+		[existingPresetNames],
+	);
+
+	const insertV2Preset = useCallback(
+		(input: {
+			name: string;
+			description?: string;
+			cwd: string;
+			commands: string[];
+			projectIds?: string[] | null;
+			pinnedToBar?: boolean;
+			executionMode?: ExecutionMode;
+		}) => {
+			const maxTabOrder = v2Presets.reduce(
+				(max, preset) => Math.max(max, preset.tabOrder),
+				-1,
+			);
+			collections.v2TerminalPresets.insert({
+				id: crypto.randomUUID(),
+				name: input.name,
+				description: input.description,
+				cwd: input.cwd,
+				commands: input.commands,
+				projectIds: input.projectIds ?? null,
+				pinnedToBar: input.pinnedToBar,
+				executionMode: input.executionMode ?? "new-tab",
+				tabOrder: maxTabOrder + 1,
+				createdAt: new Date(),
+			});
+		},
+		[collections.v2TerminalPresets, v2Presets],
+	);
+
+	const updateV2Preset = useCallback(
+		(id: string, patch: Partial<V2TerminalPresetRow>) => {
+			collections.v2TerminalPresets.update(id, (draft) => {
+				for (const [key, value] of Object.entries(patch) as Array<
+					[keyof V2TerminalPresetRow, unknown]
+				>) {
+					// biome-ignore lint/suspicious/noExplicitAny: narrow assignment across union
+					(draft as any)[key] = value;
+				}
+			});
+		},
+		[collections.v2TerminalPresets],
+	);
+
+	const deleteV2Preset = useCallback(
+		(id: string) => {
+			collections.v2TerminalPresets.delete(id);
+		},
+		[collections.v2TerminalPresets],
+	);
+
+	const reorderV2Presets = useCallback(
+		(presetId: string, targetIndex: number) => {
+			const orderedIds = v2Presets.map((preset) => preset.id);
+			const currentIndex = orderedIds.indexOf(presetId);
+			if (currentIndex === -1) return;
+			if (targetIndex < 0 || targetIndex >= orderedIds.length) return;
+
+			const [moved] = orderedIds.splice(currentIndex, 1);
+			orderedIds.splice(targetIndex, 0, moved);
+
+			for (const [index, id] of orderedIds.entries()) {
+				collections.v2TerminalPresets.update(id, (draft) => {
+					draft.tabOrder = index;
+				});
+			}
+		},
+		[collections.v2TerminalPresets, v2Presets],
+	);
+
+	const handleCellChange = useCallback(
+		(rowIndex: number, column: PresetColumnKey, value: string) => {
+			setLocalPresets((prev) =>
+				prev.map((preset, index) =>
+					index === rowIndex ? { ...preset, [column]: value } : preset,
+				),
+			);
+		},
+		[],
+	);
+
+	const handleCellBlur = useCallback(
+		(rowIndex: number, column: PresetColumnKey) => {
+			setLocalPresets((currentLocal) => {
+				const preset = currentLocal[rowIndex];
+				if (!preset) return currentLocal;
+				const serverPreset = serverPresetsRef.current.find(
+					(serverPresetItem) => serverPresetItem.id === preset.id,
+				);
+				if (!serverPreset) return currentLocal;
+				if (preset[column] === serverPreset[column]) return currentLocal;
+
+				updateV2Preset(preset.id, { [column]: preset[column] });
+				return currentLocal;
+			});
+		},
+		[updateV2Preset],
+	);
+
+	const handleCommandsChange = useCallback(
+		(rowIndex: number, commands: string[]) => {
+			setLocalPresets((prev) => {
+				const preset = prev[rowIndex];
+				const isDelete = preset && commands.length < preset.commands.length;
+				const newPresets = prev.map((presetItem, index) =>
+					index === rowIndex ? { ...presetItem, commands } : presetItem,
+				);
+
+				if (isDelete && preset) {
+					updateV2Preset(preset.id, { commands });
+				}
+				return newPresets;
+			});
+		},
+		[updateV2Preset],
+	);
+
+	const handleCommandsBlur = useCallback(
+		(rowIndex: number) => {
+			setLocalPresets((currentLocal) => {
+				const preset = currentLocal[rowIndex];
+				if (!preset) return currentLocal;
+				const serverPreset = serverPresetsRef.current.find(
+					(serverPresetItem) => serverPresetItem.id === preset.id,
+				);
+				if (!serverPreset) return currentLocal;
+				if (
+					JSON.stringify(preset.commands) ===
+					JSON.stringify(serverPreset.commands)
+				) {
+					return currentLocal;
+				}
+
+				updateV2Preset(preset.id, { commands: preset.commands });
+				return currentLocal;
+			});
+		},
+		[updateV2Preset],
+	);
+
+	const handleExecutionModeChange = useCallback(
+		(rowIndex: number, mode: ExecutionMode) => {
+			setLocalPresets((currentLocal) => {
+				const preset = currentLocal[rowIndex];
+				if (!preset) return currentLocal;
+
+				const newPresets = currentLocal.map((presetItem, index) =>
+					index === rowIndex
+						? { ...presetItem, executionMode: mode }
+						: presetItem,
+				);
+
+				updateV2Preset(preset.id, { executionMode: mode });
+
+				return newPresets;
+			});
+		},
+		[updateV2Preset],
+	);
+
+	const handleAddRow = useCallback(
+		(projectIds?: string[] | null) => {
+			shouldOpenNewPresetEditorRef.current = true;
+			insertV2Preset({
+				name: "",
+				cwd: "",
+				commands: [""],
+				projectIds,
+				executionMode: "new-tab",
+			});
+		},
+		[insertV2Preset],
+	);
+
+	const handleAddTemplate = useCallback(
+		(template: PresetTemplate) => {
+			if (existingPresetNames.has(template.preset.name)) return;
+			insertV2Preset(template.preset);
+		},
+		[existingPresetNames, insertV2Preset],
+	);
+
+	useEffect(() => {
+		if (!pendingCreateProjectId) {
+			lastHandledCreateProjectIdRef.current = null;
+			return;
+		}
+
+		if (lastHandledCreateProjectIdRef.current === pendingCreateProjectId) {
+			return;
+		}
+
+		lastHandledCreateProjectIdRef.current = pendingCreateProjectId;
+		handleAddRow([pendingCreateProjectId]);
+		onPendingCreateProjectIdChange?.(null);
+	}, [handleAddRow, onPendingCreateProjectIdChange, pendingCreateProjectId]);
+
+	const handleDeleteRow = useCallback(
+		(rowIndex: number) => {
+			setLocalPresets((currentLocal) => {
+				const preset = currentLocal[rowIndex];
+				if (preset) {
+					deleteV2Preset(preset.id);
+				}
+				return currentLocal;
+			});
+		},
+		[deleteV2Preset],
+	);
+
+	const handleToggleAutoApply = useCallback(
+		(presetId: string, field: AutoApplyField, enabled: boolean) => {
+			updateV2Preset(presetId, { [field]: enabled ? true : undefined });
+		},
+		[updateV2Preset],
+	);
+
+	const handleTogglePin = useCallback(
+		(presetId: string, pinned: boolean) => {
+			updateV2Preset(presetId, { pinnedToBar: pinned });
+		},
+		[updateV2Preset],
+	);
+
+	const handleLocalReorder = useCallback(
+		(fromIndex: number, toIndex: number) => {
+			setLocalPresets((prev) => {
+				const newPresets = [...prev];
+				const [removed] = newPresets.splice(fromIndex, 1);
+				newPresets.splice(toIndex, 0, removed);
+				return newPresets;
+			});
+		},
+		[],
+	);
+
+	const handlePersistReorder = useCallback(
+		(presetId: string, targetIndex: number) => {
+			reorderV2Presets(presetId, targetIndex);
+		},
+		[reorderV2Presets],
+	);
+
+	const handleCloseEditor = useCallback(() => {
+		setEditingPreset(null);
+	}, [setEditingPreset]);
+
+	const handleDeleteEditingPreset = useCallback(() => {
+		if (editingRowIndex < 0) return;
+		handleDeleteRow(editingRowIndex);
+		setEditingPreset(null);
+	}, [editingRowIndex, handleDeleteRow, setEditingPreset]);
+
+	const isWorkspaceCreation = !!editingPreset?.applyOnWorkspaceCreated;
+	const isNewTab = !!editingPreset?.applyOnNewTab;
+	const hasMultipleCommands = (editingPreset?.commands.length ?? 0) > 1;
+	const normalizedMode = normalizeExecutionMode(editingPreset?.executionMode);
+	const modeValue: ExecutionMode = hasMultipleCommands
+		? normalizedMode
+		: normalizedMode === "split-pane"
+			? "split-pane"
+			: "new-tab";
+
+	const handleEditorFieldChange = useCallback(
+		(column: PresetColumnKey, value: string) => {
+			if (editingRowIndex < 0) return;
+			handleCellChange(editingRowIndex, column, value);
+		},
+		[editingRowIndex, handleCellChange],
+	);
+
+	const handleEditorFieldBlur = useCallback(
+		(column: PresetColumnKey) => {
+			if (editingRowIndex < 0) return;
+			handleCellBlur(editingRowIndex, column);
+		},
+		[editingRowIndex, handleCellBlur],
+	);
+
+	const handleEditorDirectorySelect = useCallback(
+		(value: string) => {
+			if (!editingPreset || editingRowIndex < 0) return;
+
+			setLocalPresets((prev) =>
+				prev.map((preset, index) =>
+					index === editingRowIndex ? { ...preset, cwd: value } : preset,
+				),
+			);
+
+			updateV2Preset(editingPreset.id, { cwd: value });
+		},
+		[editingPreset, editingRowIndex, updateV2Preset],
+	);
+
+	const handleEditorProjectIdsChange = useCallback(
+		(projectIds: string[] | null) => {
+			if (!editingPreset || editingRowIndex < 0) return;
+
+			setLocalPresets((prev) =>
+				prev.map((preset, index) =>
+					index === editingRowIndex ? { ...preset, projectIds } : preset,
+				),
+			);
+
+			updateV2Preset(editingPreset.id, { projectIds });
+		},
+		[editingPreset, editingRowIndex, updateV2Preset],
+	);
+
+	const handleEditorCommandsChange = useCallback(
+		(commands: string[]) => {
+			if (editingRowIndex < 0) return;
+			handleCommandsChange(editingRowIndex, commands);
+		},
+		[editingRowIndex, handleCommandsChange],
+	);
+
+	const handleEditorCommandsBlur = useCallback(() => {
+		if (editingRowIndex < 0) return;
+		handleCommandsBlur(editingRowIndex);
+	}, [editingRowIndex, handleCommandsBlur]);
+
+	const handleEditorModeChange = useCallback(
+		(mode: ExecutionMode) => {
+			if (editingRowIndex < 0) return;
+			handleExecutionModeChange(editingRowIndex, mode);
+		},
+		[editingRowIndex, handleExecutionModeChange],
+	);
+
+	const handleEditorAutoApplyToggle = useCallback(
+		(field: AutoApplyField, enabled: boolean) => {
+			if (!editingPreset) return;
+			handleToggleAutoApply(editingPreset.id, field, enabled);
+		},
+		[editingPreset, handleToggleAutoApply],
+	);
+
+	return (
+		<div className="space-y-4">
+			<div className="flex items-center justify-between">
+				<div className="space-y-0.5">
+					<Label className="text-sm font-medium">Terminal Presets</Label>
+					<p className="text-xs text-muted-foreground">
+						Presets let you quickly launch terminals with pre-configured
+						commands.
+					</p>
+				</div>
+				{showPresets && (
+					<Button
+						variant="default"
+						size="sm"
+						className="gap-2"
+						onClick={() => handleAddRow()}
+					>
+						<HiOutlinePlus className="h-4 w-4" />
+						Add Preset
+					</Button>
+				)}
+			</div>
+
+			{showQuickAdd && (
+				<QuickAddPresets
+					templates={PRESET_TEMPLATES}
+					isDark={isDark}
+					isCreatePending={false}
+					isTemplateAdded={isTemplateAdded}
+					onAddTemplate={handleAddTemplate}
+				/>
+			)}
+
+			{showPresets && (
+				<>
+					<PresetsTable
+						presets={localPresets}
+						isLoading={false}
+						projectOptionsById={projectOptionsById}
+						presetsContainerRef={presetsContainerRef}
+						onEdit={setEditingPreset}
+						onLocalReorder={handleLocalReorder}
+						onPersistReorder={handlePersistReorder}
+						onTogglePin={handleTogglePin}
+					/>
+					<p className="text-xs text-muted-foreground">
+						Click a preset row to edit details.
+					</p>
+				</>
+			)}
+
+			<PresetEditorSheet
+				preset={editingPreset}
+				projects={projectOptions}
+				open={!!editingPreset}
+				onOpenChange={(open) => !open && handleCloseEditor()}
+				onDeletePreset={handleDeleteEditingPreset}
+				onFieldChange={handleEditorFieldChange}
+				onFieldBlur={handleEditorFieldBlur}
+				onProjectIdsChange={handleEditorProjectIdsChange}
+				onDirectorySelect={handleEditorDirectorySelect}
+				onCommandsChange={handleEditorCommandsChange}
+				onCommandsBlur={handleEditorCommandsBlur}
+				onModeChange={handleEditorModeChange}
+				onToggleAutoApply={handleEditorAutoApplyToggle}
+				modeValue={modeValue}
+				hasMultipleCommands={hasMultipleCommands}
+				isWorkspaceCreation={isWorkspaceCreation}
+				isNewTab={isNewTab}
+			/>
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/V2PresetsSection/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/V2PresetsSection/index.ts
@@ -1,0 +1,1 @@
+export { V2PresetsSection } from "./V2PresetsSection";

--- a/packages/panes/src/react/components/Workspace/Workspace.tsx
+++ b/packages/panes/src/react/components/Workspace/Workspace.tsx
@@ -11,6 +11,7 @@ export function Workspace<TData>({
 	renderTabAccessory,
 	renderEmptyState,
 	renderAddTabMenu,
+	renderBelowTabBar,
 	onBeforeCloseTab,
 	paneActions,
 	contextMenuActions,
@@ -61,6 +62,7 @@ export function Workspace<TData>({
 				renderAddTabMenu={renderAddTabMenu}
 				renderTabAccessory={renderTabAccessory}
 			/>
+			{renderBelowTabBar?.()}
 			{activeTab ? (
 				<Tab
 					store={store}

--- a/packages/panes/src/react/types.ts
+++ b/packages/panes/src/react/types.ts
@@ -88,6 +88,7 @@ export interface WorkspaceProps<TData> {
 	renderTabAccessory?: (tab: Tab<TData>) => ReactNode;
 	renderEmptyState?: () => ReactNode;
 	renderAddTabMenu?: () => ReactNode;
+	renderBelowTabBar?: () => ReactNode;
 	onBeforeClosePane?: (
 		pane: Pane<TData>,
 		tab: Tab<TData>,


### PR DESCRIPTION
## Summary

upstream merge 作業の最終PR。作業開始後に upstream に追加された新規3コミットを取り込みます。

## 取り込みコミット

| 元コミット | 内容 |
|---|---|
| `cd25beea0` (#3317) | feat: v2 workspace discovery page（14ファイル +862行） |
| `fa861c4fc` (#3316) | fix: v2 tui hotkey forwarding（5ファイル +148行） |
| `5b1477189` (#3274) | fix: always show preset bar in v2 workspace（15ファイル +1275行） |

## コンフリクト解決

全て「両方追加」型の衝突で、fork 独自機能と upstream 新機能を両方保持:
- `AddTabMenu.tsx`: fork 独自タブ追加オプション + upstream preset 関連追加
- `page.tsx` (v2-workspace): fork 独自コード + upstream PresetsBar 追加
- `TerminalSettings.tsx`: fork 独自設定 + upstream V2PresetsSection 追加

## 検証

- [x] 3コミット cherry-pick + コンフリクト解決
- [x] `bun run typecheck` → 新規エラーなし

## 次のステップ

このPRマージ後、`git merge -s ours` で cherry-pick 済みコミットと意図的スキップ（quit lifecycle 4件）を git 履歴上マージ済みにし、behind を 0 にします。