### PR TITLE
fix(desktop): add gitGraph to pane persistence schema

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/ui-state/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/ui-state/index.ts
@@ -120,6 +120,11 @@ const paneSchema = z.object({
 			sessionId: z.string().optional(),
 		})
 		.optional(),
+	gitGraph: z
+		.object({
+			worktreePath: z.string(),
+		})
+		.optional(),
 	workspaceRun: z
 		.object({
 			workspaceId: z.string(),


### PR DESCRIPTION
## Summary
- `paneSchema` (Zod) に `gitGraph` フィールドが未定義だったため、アプリ終了時のバリデーションで `worktreePath` がサイレントに除去されていた
- 再起動時に GitGraph ペインが「No workspace path」と表示されるバグを修正

## Test plan
- [ ] GitGraph を開いた状態でアプリを終了→再起動し、グラフが正しく表示されることを確認

Closes #141