### PR TITLE
fix(desktop): add refresh button and auto-reload for HTML rendered mode

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/FileViewerPane.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/FileViewerPane.tsx
@@ -49,7 +49,10 @@ import { isHtmlFile, isImageFile, isMarkdownFile } from "shared/file-types";
 import type { FileViewerMode } from "shared/tabs-types";
 import type { CodeEditorAdapter } from "../../../components";
 import { BasePaneWindow } from "../components";
-import { FileViewerContent } from "./components/FileViewerContent";
+import {
+	FileViewerContent,
+	type HtmlPreviewHandle,
+} from "./components/FileViewerContent";
 import { FileViewerToolbar } from "./components/FileViewerToolbar";
 import { ExternalChangeDialog } from "./ExternalChangeDialog";
 import { useDiffSearch } from "./hooks/useDiffSearch";
@@ -165,6 +168,7 @@ export function FileViewerPane({
 	const [isResolvingIntent, setIsResolvingIntent] = useState(false);
 
 	const [htmlZoomLevel, setHtmlZoomLevel] = useState(0);
+	const htmlPreviewRef = useRef<HtmlPreviewHandle | null>(null);
 
 	const filePath = fileViewer?.filePath ?? "";
 	const viewMode = fileViewer?.viewMode ?? "raw";
@@ -505,6 +509,7 @@ export function FileViewerPane({
 			}
 
 			invalidateCurrentFile();
+			htmlPreviewRef.current?.reload();
 		},
 		Boolean(workspaceId && worktreePath && absoluteFilePath),
 	);
@@ -755,6 +760,7 @@ export function FileViewerPane({
 							onPopOut={handlers.onPopOut}
 							htmlZoomLevel={htmlZoomLevel}
 							onHtmlZoomChange={setHtmlZoomLevel}
+							onHtmlRefresh={() => htmlPreviewRef.current?.reload()}
 						/>
 					</div>
 				)}
@@ -837,6 +843,7 @@ export function FileViewerPane({
 							markdownContainerRef={markdownContainerRef}
 							markdownSearch={markdownSearch}
 							htmlZoomLevel={htmlZoomLevel}
+							htmlPreviewRef={htmlPreviewRef}
 						/>
 					</div>
 				</div>

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/components/FileViewerContent/FileViewerContent.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/components/FileViewerContent/FileViewerContent.tsx
@@ -36,17 +36,24 @@ import {
 	mapDiffLocationToRawPosition,
 } from "./utils/diff-location";
 
+export interface HtmlPreviewHandle {
+	reload: () => void;
+}
+
 function HtmlPreviewWebview({
 	absolutePath,
 	zoomLevel,
+	handleRef,
 }: {
 	absolutePath: string;
 	zoomLevel: number;
+	handleRef?: MutableRefObject<HtmlPreviewHandle | null>;
 }) {
 	const containerRef = useRef<HTMLDivElement>(null);
 	const webviewRef = useRef<Electron.WebviewTag | null>(null);
 	const zoomLevelRef = useRef(zoomLevel);
 	zoomLevelRef.current = zoomLevel;
+	const pendingReloadRef = useRef(false);
 
 	useEffect(() => {
 		const container = containerRef.current;
@@ -66,14 +73,34 @@ function HtmlPreviewWebview({
 			e.preventDefault();
 		});
 
+		if (handleRef) {
+			handleRef.current = {
+				reload: () => {
+					if (webviewRef.current) {
+						webviewRef.current.reload();
+					} else {
+						pendingReloadRef.current = true;
+					}
+				},
+			};
+		}
+
 		webview.addEventListener("dom-ready", () => {
 			webviewRef.current = webview;
 			webview.setZoomLevel(zoomLevelRef.current);
+			if (pendingReloadRef.current) {
+				pendingReloadRef.current = false;
+				webview.reload();
+			}
 		});
 
 		container.appendChild(webview);
 
 		return () => {
+			if (handleRef) {
+				handleRef.current = null;
+			}
+			pendingReloadRef.current = false;
 			webviewRef.current = null;
 			try {
 				if (webview.isConnected) {
@@ -84,7 +111,7 @@ function HtmlPreviewWebview({
 				// already removed
 			}
 		};
-	}, [absolutePath]);
+	}, [absolutePath, handleRef]);
 
 	useEffect(() => {
 		if (webviewRef.current) {
@@ -204,6 +231,7 @@ interface FileViewerContentProps {
 	markdownContainerRef: RefObject<HTMLDivElement | null>;
 	markdownSearch: TextSearchState;
 	htmlZoomLevel?: number;
+	htmlPreviewRef?: MutableRefObject<HtmlPreviewHandle | null>;
 }
 
 export function FileViewerContent({
@@ -245,6 +273,7 @@ export function FileViewerContent({
 	markdownContainerRef,
 	markdownSearch,
 	htmlZoomLevel = 0,
+	htmlPreviewRef,
 }: FileViewerContentProps) {
 	const isImage = isImageFile(filePath);
 	const isHtml = isHtmlFile(filePath);
@@ -617,6 +646,7 @@ export function FileViewerContent({
 				key={filePath}
 				absolutePath={absoluteFilePath}
 				zoomLevel={htmlZoomLevel}
+				handleRef={htmlPreviewRef}
 			/>
 		);
 	}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/components/FileViewerContent/index.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/components/FileViewerContent/index.ts
@@ -1,1 +1,1 @@
-export { FileViewerContent } from "./FileViewerContent";
+export { FileViewerContent, type HtmlPreviewHandle } from "./FileViewerContent";

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/components/FileViewerToolbar/FileViewerToolbar.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/components/FileViewerToolbar/FileViewerToolbar.tsx
@@ -2,7 +2,7 @@ import { ToggleGroup, ToggleGroupItem } from "@superset/ui/toggle-group";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { cn } from "@superset/ui/utils";
 import { useCallback, useMemo } from "react";
-import { LuMinus, LuPlus } from "react-icons/lu";
+import { LuMinus, LuPlus, LuRefreshCw } from "react-icons/lu";
 import {
 	TbFold,
 	TbLayoutSidebarRightFilled,
@@ -40,6 +40,7 @@ interface FileViewerToolbarProps {
 	onPopOut?: (e: React.MouseEvent) => void;
 	htmlZoomLevel?: number;
 	onHtmlZoomChange?: (level: number) => void;
+	onHtmlRefresh?: () => void;
 }
 
 export function FileViewerToolbar({
@@ -62,6 +63,7 @@ export function FileViewerToolbar({
 	onPopOut,
 	htmlZoomLevel = 0,
 	onHtmlZoomChange,
+	onHtmlRefresh,
 }: FileViewerToolbarProps) {
 	const { copyToClipboard, copied } = useCopyToClipboard(1500);
 
@@ -189,6 +191,22 @@ export function FileViewerToolbar({
 							</TooltipContent>
 						</Tooltip>
 					</>
+				)}
+				{showHtmlZoom && onHtmlRefresh && (
+					<Tooltip>
+						<TooltipTrigger asChild>
+							<button
+								type="button"
+								onClick={onHtmlRefresh}
+								className="rounded p-0.5 text-muted-foreground/60 transition-colors hover:text-muted-foreground"
+							>
+								<LuRefreshCw className="size-3.5" />
+							</button>
+						</TooltipTrigger>
+						<TooltipContent side="bottom" showArrow={false}>
+							Refresh Preview
+						</TooltipContent>
+					</Tooltip>
 				)}
 				{showHtmlZoom && (
 					<div className="flex items-center gap-0.5">

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/components/FileViewerToolbar/FileViewerToolbar.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/components/FileViewerToolbar/FileViewerToolbar.tsx
@@ -198,6 +198,7 @@ export function FileViewerToolbar({
 							<button
 								type="button"
 								onClick={onHtmlRefresh}
+								aria-label="Refresh Preview"
 								className="rounded p-0.5 text-muted-foreground/60 transition-colors hover:text-muted-foreground"
 							>
 								<LuRefreshCw className="size-3.5" />


### PR DESCRIPTION
## Summary
- HTMLファイルのRenderedモードにリフレッシュボタンを追加(ツールバーにLuRefreshCwアイコン)
- ファイルシステム変更イベント検知時にwebviewを自動リロード
- dom-ready前にファイル変更が来た場合のpending reloadフラグによる競合状態対処

Closes #142

## Test plan
- [ ] HTMLファイルをRenderedモードで開き、リフレッシュボタンが表示されることを確認
- [ ] リフレッシュボタンクリックでプレビューが更新されることを確認
- [ ] 別エディタでHTMLファイルを編集し、Renderedモードが自動的に更新されることを確認
- [ ] ズーム機能が引き続き正常に動作することを確認
- [ ] RawモードやDiffモードに影響がないことを確認