### PR TITLE
fix(desktop): skip auth splash screen for pop-out (tearoff) windows

### DIFF
--- a/apps/desktop/src/renderer/providers/AuthProvider/AuthProvider.tsx
+++ b/apps/desktop/src/renderer/providers/AuthProvider/AuthProvider.tsx
@@ -1,4 +1,5 @@
 import { type ReactNode, useEffect, useState } from "react";
+import { isTearoffWindow } from "renderer/hooks/useTearoffInit";
 import { authClient, setAuthToken, setJwt } from "renderer/lib/auth-client";
 import { SupersetLogo } from "renderer/routes/sign-in/components/SupersetLogo/SupersetLogo";
 import { electronTrpc } from "../../lib/electron-trpc";
@@ -105,7 +106,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 		return () => clearInterval(interval);
 	}, [isHydrated]);
 
-	if (!isHydrated) {
+	if (!isHydrated && !isTearoffWindow()) {
 		return (
 			<div className="flex h-screen w-screen items-center justify-center bg-background">
 				<SupersetLogo className="h-8 w-auto animate-pulse opacity-80" />


### PR DESCRIPTION
## Summary

- pop-outボタンで別ウィンドウを開く際、`AuthProvider` の認証hydration待ちによってsplash画面が表示される問題を修正
- tearoff windowはメインウィンドウと同じ認証セッションを共有しているため、splash待ちをスキップして即座にコンテンツを表示するよう変更
- 認証のhydrate処理自体はバックグラウンドで引き続き実行される

## Changes

- `AuthProvider.tsx`: `isTearoffWindow()` を使い、tearoff windowではsplash表示条件をスキップ

## Test plan

- [ ] メインウィンドウ起動時にsplashが表示されることを確認
- [ ] pop-outボタンで別ウィンドウを開いた際にsplashが表示されず即座に開くことを確認