### PR TITLE
fix(desktop): instant auth for tearoff windows via sync IPC token injection

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/tab-tearoff.ts
+++ b/apps/desktop/src/lib/trpc/routers/tab-tearoff.ts
@@ -1,6 +1,7 @@
 import type { WindowManager } from "main/lib/window-manager";
 import { z } from "zod";
 import { publicProcedure, router } from "..";
+import { loadToken } from "./auth/utils/auth-functions";
 
 export const createTabTearoffRouter = (wm: WindowManager) => {
 	return router({
@@ -14,7 +15,7 @@ export const createTabTearoffRouter = (wm: WindowManager) => {
 					screenY: z.number(),
 				}),
 			)
-			.mutation(({ input }) => {
+			.mutation(async ({ input }) => {
 				const windowId = `tearoff-${Date.now()}`;
 
 				// Store data FIRST so it's available when preload requests it
@@ -23,6 +24,13 @@ export const createTabTearoffRouter = (wm: WindowManager) => {
 					panes: input.panes,
 					workspaceId: input.workspaceId,
 				});
+
+				// Pre-load auth token so tearoff window can skip async auth hydration
+				const { token, expiresAt } = await loadToken();
+				wm.setPendingAuthToken(
+					windowId,
+					token && expiresAt ? { token, expiresAt } : null,
+				);
 
 				wm.createTearoffWindow({
 					windowId,

--- a/apps/desktop/src/main/lib/window-manager/index.ts
+++ b/apps/desktop/src/main/lib/window-manager/index.ts
@@ -16,6 +16,11 @@ interface TearoffTabData {
 	workspaceId: string;
 }
 
+interface PendingAuthToken {
+	token: string;
+	expiresAt: string;
+}
+
 type IpcHandler = {
 	attachWindow: (window: BrowserWindow) => void;
 	detachWindow: (window: BrowserWindow) => void;
@@ -26,6 +31,7 @@ export class WindowManager {
 	private ipcHandler: IpcHandler | null = null;
 	private ipcRegistered = false;
 	private pendingTearoffData = new Map<string, TearoffTabData>();
+	private pendingAuthTokens = new Map<string, PendingAuthToken | null>();
 
 	setIpcHandler(handler: IpcHandler): void {
 		this.ipcHandler = handler;
@@ -41,6 +47,13 @@ export class WindowManager {
 			const data = this.pendingTearoffData.get(windowId);
 			if (data) this.pendingTearoffData.delete(windowId);
 			event.returnValue = data ?? null;
+		});
+
+		// Synchronous IPC: preload fetches auth token for tearoff windows
+		ipcMain.on("get-tearoff-auth-token", (event, windowId: string) => {
+			const token = this.pendingAuthTokens.get(windowId);
+			if (token !== undefined) this.pendingAuthTokens.delete(windowId);
+			event.returnValue = token ?? null;
 		});
 
 		// Tearoff window closing: return all tabs to main window (single message)
@@ -66,6 +79,14 @@ export class WindowManager {
 	setPendingTearoffData(windowId: string, data: TearoffTabData): void {
 		this.pendingTearoffData.set(windowId, data);
 		setTimeout(() => this.pendingTearoffData.delete(windowId), 30_000);
+	}
+
+	setPendingAuthToken(
+		windowId: string,
+		token: PendingAuthToken | null,
+	): void {
+		this.pendingAuthTokens.set(windowId, token);
+		setTimeout(() => this.pendingAuthTokens.delete(windowId), 30_000);
 	}
 
 	register(windowId: string, window: BrowserWindow): void {

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -25,12 +25,19 @@ const tearoffData: any = tearoffWindowId
 	? ipcRenderer.sendSync("get-tearoff-data", tearoffWindowId)
 	: null;
 
+// Synchronously fetch auth token for tearoff windows (skips async hydration)
+const tearoffAuthToken: { token: string; expiresAt: string } | null =
+	tearoffWindowId
+		? ipcRenderer.sendSync("get-tearoff-auth-token", tearoffWindowId)
+		: null;
+
 const API = {
 	sayHelloFromBridge: () => console.log("\nHello from bridgeAPI! 👋\n\n"),
 	username: process.env.USER,
 	appVersion: __APP_VERSION__,
 	tearoffWindowId,
 	tearoffData,
+	tearoffAuthToken,
 };
 
 // Store mapping of user listeners to wrapped listeners for proper cleanup

--- a/apps/desktop/src/renderer/providers/AuthProvider/AuthProvider.tsx
+++ b/apps/desktop/src/renderer/providers/AuthProvider/AuthProvider.tsx
@@ -5,14 +5,54 @@ import { SupersetLogo } from "renderer/routes/sign-in/components/SupersetLogo/Su
 import { electronTrpc } from "../../lib/electron-trpc";
 
 export function AuthProvider({ children }: { children: ReactNode }) {
-	const [isHydrated, setIsHydrated] = useState(false);
+	// Tearoff windows get their auth token synchronously via preload
+	const syncAuthToken = window.App?.tearoffAuthToken ?? null;
+
+	const [isHydrated, setIsHydrated] = useState(() => {
+		// If we have a sync token, apply it immediately and mark as hydrated
+		if (syncAuthToken?.token && syncAuthToken?.expiresAt) {
+			const isExpired = new Date(syncAuthToken.expiresAt) < new Date();
+			if (!isExpired) {
+				setAuthToken(syncAuthToken.token);
+				return true;
+			}
+		}
+		return false;
+	});
 	const { refetch: refetchSession } = authClient.useSession();
 
 	const { data: storedToken, isSuccess } =
 		electronTrpc.auth.getStoredToken.useQuery(undefined, {
+			enabled: !syncAuthToken,
 			refetchOnWindowFocus: false,
 			refetchOnReconnect: false,
 		});
+
+	// For tearoff windows with sync token, fetch session/JWT in background (non-blocking)
+	useEffect(() => {
+		if (!syncAuthToken?.token) return;
+		let cancelled = false;
+		async function backgroundHydrate() {
+			try {
+				await refetchSession();
+			} catch (err) {
+				console.warn("[AuthProvider] tearoff session refetch failed", err);
+			}
+			if (cancelled) return;
+			try {
+				const res = await authClient.token();
+				if (res.data?.token) {
+					setJwt(res.data.token);
+				}
+			} catch (err) {
+				console.warn("[AuthProvider] tearoff JWT fetch failed", err);
+			}
+		}
+		backgroundHydrate();
+		return () => {
+			cancelled = true;
+		};
+	}, [syncAuthToken, refetchSession]);
 
 	useEffect(() => {
 		if (!isSuccess || isHydrated) return;

--- a/apps/desktop/src/renderer/routes/_authenticated/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/layout.tsx
@@ -50,8 +50,7 @@ function AuthenticatedLayout() {
 		isRefetching,
 		refetch,
 	} = authClient.useSession();
-	const hasLocalToken =
-		!!getAuthToken() || !!window.App?.tearoffAuthToken?.token;
+	const hasLocalToken = !!getAuthToken();
 	const isOnline = useOnlineStatus();
 	const navigate = useNavigate();
 	const location = useLocation();

--- a/apps/desktop/src/renderer/routes/_authenticated/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/layout.tsx
@@ -50,7 +50,8 @@ function AuthenticatedLayout() {
 		isRefetching,
 		refetch,
 	} = authClient.useSession();
-	const hasLocalToken = !!getAuthToken();
+	const hasLocalToken =
+		!!getAuthToken() || !!window.App?.tearoffAuthToken?.token;
 	const isOnline = useOnlineStatus();
 	const navigate = useNavigate();
 	const location = useLocation();


### PR DESCRIPTION
## Summary
- Tearoff(pop-out)ウィンドウでログイン画面が表示される問題を修正
- 親ウィンドウのauth tokenをpreloadの同期IPCで子ウィンドウに渡し、async hydrationを待たずに即座に認証済み状態で起動するように変更
- tearoffDataと同じパターン(pendingData + sendSync)を利用

## Changes
- `window-manager`: `pendingAuthTokens` Map + `get-tearoff-auth-token` IPCハンドラ追加
- `tab-tearoff.ts`: ウィンドウ作成前に`loadToken()`でtoken取得・保存
- `preload/index.ts`: sync IPCでauthToken取得、`window.App.tearoffAuthToken`に公開
- `AuthProvider.tsx`: sync tokenがあれば即`setAuthToken` + hydrated、async queryは無効化
- `_authenticated/layout.tsx`: `hasLocalToken`にsync tokenも含める

## Test plan
- [ ] タブをドラッグして別ウィンドウにtearoff → ログイン画面が出ないこと
- [ ] tearoffウィンドウでワークスペースが即座に表示されること
- [ ] 通常のアプリ起動フローに影響がないこと
- [ ] 未ログイン状態での起動でsign-inリダイレクトが正常に動くこと