### PR TITLE
fix(desktop): ブラウザペインの背景透過を修正

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/browserRuntimeRegistry.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/browserRuntimeRegistry.ts
@@ -149,6 +149,7 @@ class BrowserRuntimeRegistryImpl {
 		const webview = document.createElement("webview") as Electron.WebviewTag;
 		webview.setAttribute("partition", "persist:superset");
 		webview.setAttribute("allowpopups", "");
+		webview.setAttribute("webpreferences", "transparent=no");
 		webview.style.position = "fixed";
 		webview.style.top = "0";
 		webview.style.left = "0";

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/hooks/usePersistentWebview/usePersistentWebview.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/hooks/usePersistentWebview/usePersistentWebview.ts
@@ -256,6 +256,7 @@ export function usePersistentWebview({
 			clearPersistentWebviewDomReady(paneId);
 			webview.setAttribute("partition", "persist:superset");
 			webview.setAttribute("allowpopups", "");
+			webview.setAttribute("webpreferences", "transparent=no");
 			webview.setAttribute("useragent", chromeLikeUserAgent);
 			webview.style.display = "flex";
 			webview.style.flex = "1";


### PR DESCRIPTION
close #150

## 概要

v2ワークスペースのブラウザペインで、表示されるウェブページの背景がsupersetアプリのダークテーマ背景色と同化するバグを修正。

## 原因

Electronの`<webview>`タグは`WebPreferences.transparent`のデフォルトが`true`のため、guest pageの背景が透過し、親要素のダークテーマ背景が透けて見えていた。

## 変更内容

- v1・v2両方のBrowserPaneのwebview作成時に`webpreferences="transparent=no"`を追加

| | 修正前 | 修正後 |
|---|---|---|
| v2ブラウザペイン | ページ背景がsupersetの背景色と同化（透過） | ページ本来の背景色が正しく表示 |
| v1ブラウザペイン | レイアウト構造の違いで目立ちにくいが同じ問題あり | transparent=noで明示的に透過を無効化 |

## 変更ファイル

- `apps/desktop/.../v2-workspace/.../browserRuntimeRegistry.ts` - 1行追加
- `apps/desktop/.../v1/.../usePersistentWebview.ts` - 1行追加

## テスト方法

- v2ワークスペースでブラウザペインを開き、GitHub等のページを表示して背景が白く表示されることを確認
- ダークスキームのページでも背景が正常に表示されることを確認
- about:blank / 初期表示が正常なこと
- HMR時は既存タブが再生成されないため、タブ作り直しかフルリロードで確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * Webビューの表示透明性に関する問題を修正しました。コンテンツが正しく表示されるように改善されています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->