### PR TITLE
fix(desktop): guard WebView getWebContentsId against detached DOM

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/hooks/usePersistentWebview/usePersistentWebview.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/hooks/usePersistentWebview/usePersistentWebview.ts
@@ -280,12 +280,21 @@ export function usePersistentWebview({
 
 		const handleDomReady = () => {
 			markPersistentWebviewDomReady(paneId);
-			const webContentsId = wv.getWebContentsId();
-			const previousId = getRegisteredWebContentsId(paneId);
-			// Register on first load, or re-register if webContentsId changed
-			if (previousId !== webContentsId) {
-				setRegisteredWebContentsId(paneId, webContentsId);
-				registerBrowserRef.current({ paneId, webContentsId });
+
+			if (!wv.isConnected) {
+				return;
+			}
+
+			try {
+				const webContentsId = wv.getWebContentsId();
+				const previousId = getRegisteredWebContentsId(paneId);
+				// Register on first load, or re-register if webContentsId changed
+				if (previousId !== webContentsId) {
+					setRegisteredWebContentsId(paneId, webContentsId);
+					registerBrowserRef.current({ paneId, webContentsId });
+				}
+			} catch {
+				return;
 			}
 
 			const pendingUrl = getPendingPersistentWebviewNavigation(paneId);

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/hooks/usePersistentWebview/usePersistentWebview.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/hooks/usePersistentWebview/usePersistentWebview.ts
@@ -281,20 +281,20 @@ export function usePersistentWebview({
 		const handleDomReady = () => {
 			markPersistentWebviewDomReady(paneId);
 
-			if (!wv.isConnected) {
-				return;
-			}
-
-			try {
-				const webContentsId = wv.getWebContentsId();
-				const previousId = getRegisteredWebContentsId(paneId);
-				// Register on first load, or re-register if webContentsId changed
-				if (previousId !== webContentsId) {
-					setRegisteredWebContentsId(paneId, webContentsId);
-					registerBrowserRef.current({ paneId, webContentsId });
+			if (wv.isConnected) {
+				try {
+					const webContentsId = wv.getWebContentsId();
+					const previousId = getRegisteredWebContentsId(paneId);
+					// Register on first load, or re-register if webContentsId changed
+					if (previousId !== webContentsId) {
+						setRegisteredWebContentsId(paneId, webContentsId);
+						registerBrowserRef.current({ paneId, webContentsId });
+					}
+				} catch {
+					// WebView was detached between the isConnected check and
+					// getWebContentsId call — skip registration but still
+					// attempt to drain the pending navigation below.
 				}
-			} catch {
-				return;
 			}
 
 			const pendingUrl = getPendingPersistentWebviewNavigation(paneId);


### PR DESCRIPTION
## Summary
- WebViewの`dom-ready`イベントがDOM切り離し後に発火した場合に`getWebContentsId()`がクラッシュする問題を修正
- `wv.isConnected`チェックとtry-catchガードを追加

## Sentry Issue
- Fixes ELECTRON-19: "The WebView must be attached to the DOM and the dom-ready event emitted before this method can be called"
- 発生条件: persistent webviewがコンテナ間を移動中にdom-readyが発火(`isTrusted: false`の合成イベント)

## 調査結果
Sentry全66件のissueを調査した結果:
- 修正済み: 31件 (Sentry resolved + コードベースで修正確認)
- Upstream側バグ: ELECTRON-1R/1S, 1P/1N, 1Z, 21, 1Q等 → スキップ
- 外的要因: ネイティブクラッシュ7件, react-dndバグ, ネットワークエラー等
- **フォーク固有バグ: ELECTRON-19 (本PR)**
- ELECTRON-H: 調査の結果worktree内のgit switch挙動の問題でupstream側 → スキップ

## Test plan
- [ ] WebViewを含むBrowserPaneを開き、タブを素早く切り替えてクラッシュしないことを確認
- [ ] ブラウザペインのURL読み込み中にワークスペースを切り替えてもクラッシュしないことを確認