### PR TITLE
feat(desktop): add hover and go-to-definition in editors

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/language-services/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/language-services/index.ts
@@ -14,6 +14,16 @@ const languageServiceDocumentSchema = z.object({
 	version: z.number().int().nonnegative(),
 });
 
+const languageServicePositionSchema = z.object({
+	workspaceId: z.string(),
+	absolutePath: z.string(),
+	languageId: z.string(),
+	line: z.number().int().positive(),
+	column: z.number().int().positive(),
+	content: z.string().optional(),
+	version: z.number().int().nonnegative().optional(),
+});
+
 function resolveWorkspacePath(workspaceId: string): string {
 	const workspace = getWorkspace(workspaceId);
 	if (!workspace) {
@@ -31,6 +41,25 @@ function resolveWorkspacePath(workspaceId: string): string {
 		});
 	}
 
+	return workspacePath;
+}
+
+async function syncLookupDocumentIfNeeded(
+	input: z.infer<typeof languageServicePositionSchema>,
+): Promise<string> {
+	const workspacePath = resolveWorkspacePath(input.workspaceId);
+	if (input.content === undefined || input.version === undefined) {
+		return workspacePath;
+	}
+
+	await languageServiceManager.syncDocument({
+		workspaceId: input.workspaceId,
+		workspacePath,
+		absolutePath: input.absolutePath,
+		languageId: input.languageId,
+		content: input.content,
+		version: input.version,
+	});
 	return workspacePath;
 }
 
@@ -56,6 +85,34 @@ export const createLanguageServicesRouter = () => {
 					workspacePath,
 				});
 				return { ok: true };
+			}),
+
+		getHover: publicProcedure
+			.input(languageServicePositionSchema)
+			.query(async ({ input }) => {
+				const workspacePath = await syncLookupDocumentIfNeeded(input);
+				return await languageServiceManager.getHover({
+					workspaceId: input.workspaceId,
+					workspacePath,
+					absolutePath: input.absolutePath,
+					languageId: input.languageId,
+					line: input.line,
+					column: input.column,
+				});
+			}),
+
+		getDefinition: publicProcedure
+			.input(languageServicePositionSchema)
+			.query(async ({ input }) => {
+				const workspacePath = await syncLookupDocumentIfNeeded(input);
+				return await languageServiceManager.getDefinition({
+					workspaceId: input.workspaceId,
+					workspacePath,
+					absolutePath: input.absolutePath,
+					languageId: input.languageId,
+					line: input.line,
+					column: input.column,
+				});
 			}),
 
 		closeDocument: publicProcedure

--- a/apps/desktop/src/main/lib/language-services/lsp/ExternalLspLanguageProvider.ts
+++ b/apps/desktop/src/main/lib/language-services/lsp/ExternalLspLanguageProvider.ts
@@ -3,10 +3,13 @@ import type {
 	LanguageServiceCallHierarchyItem,
 	LanguageServiceDiagnostic,
 	LanguageServiceDocument,
+	LanguageServiceHover,
 	LanguageServiceIncomingCall,
 	LanguageServiceLocation,
+	LanguageServiceMarkupContent,
 	LanguageServiceProvider,
 	LanguageServiceProviderSummary,
+	LanguageServiceRange,
 	LanguageServiceRelatedInformation,
 } from "../types";
 import {
@@ -45,6 +48,24 @@ type LspDiagnostic = {
 		};
 		message: string;
 	}>;
+};
+
+type LspPosition = { line: number; character: number };
+type LspRange = { start: LspPosition; end: LspPosition };
+type LspLocation = { uri: string; range: LspRange };
+type LspLocationLink = {
+	targetUri: string;
+	targetRange: LspRange;
+	targetSelectionRange?: LspRange;
+};
+type LspMarkupContent = {
+	kind?: string;
+	value?: string;
+};
+type LspMarkedString = string | { language?: string; value?: string };
+type LspHover = {
+	contents?: LspMarkupContent | LspMarkedString | LspMarkedString[];
+	range?: LspRange;
 };
 
 type WorkspaceSession = {
@@ -132,6 +153,108 @@ function getSectionValue(
 	}
 
 	return current;
+}
+
+function lspRangeToLanguageServiceRange(
+	range: LspRange | undefined,
+): LanguageServiceRange | null {
+	if (!range) {
+		return null;
+	}
+
+	return {
+		line: range.start.line + 1,
+		column: range.start.character + 1,
+		endLine: range.end.line + 1,
+		endColumn: range.end.character + 1,
+	};
+}
+
+function lspLocationToLanguageServiceLocation(
+	location: LspLocation | LspLocationLink,
+): LanguageServiceLocation | null {
+	const targetUri = "targetUri" in location ? location.targetUri : location.uri;
+	const targetRange =
+		"targetUri" in location
+			? (location.targetSelectionRange ?? location.targetRange)
+			: location.range;
+	const absolutePath = fileUriToAbsolutePath(targetUri);
+	if (!absolutePath) {
+		return null;
+	}
+
+	return {
+		absolutePath,
+		line: targetRange.start.line + 1,
+		column: targetRange.start.character + 1,
+		endLine: targetRange.end.line + 1,
+		endColumn: targetRange.end.character + 1,
+	};
+}
+
+function normalizeMarkedString(
+	value: LspMarkedString,
+): LanguageServiceMarkupContent | null {
+	if (typeof value === "string") {
+		return value
+			? {
+					kind: "plaintext",
+					value,
+				}
+			: null;
+	}
+
+	if (value.language && value.value) {
+		return {
+			kind: "markdown",
+			value: `\`\`\`${value.language}\n${value.value}\n\`\`\``,
+		};
+	}
+
+	if (value.value) {
+		return {
+			kind: "plaintext",
+			value: value.value,
+		};
+	}
+
+	return null;
+}
+
+function normalizeLspHoverContents(
+	contents: LspHover["contents"],
+): LanguageServiceMarkupContent[] {
+	if (!contents) {
+		return [];
+	}
+
+	if (Array.isArray(contents)) {
+		return contents
+			.map((item) => normalizeMarkedString(item))
+			.filter((item): item is LanguageServiceMarkupContent => item !== null);
+	}
+
+	if (typeof contents === "string") {
+		const normalized = normalizeMarkedString(contents);
+		return normalized ? [normalized] : [];
+	}
+
+	if ("language" in contents) {
+		const normalized = normalizeMarkedString(contents);
+		return normalized ? [normalized] : [];
+	}
+
+	const markup = contents as LspMarkupContent;
+	if (markup.value) {
+		return [
+			{
+				kind: markup.kind === "markdown" ? "markdown" : "plaintext",
+				value: markup.value,
+			},
+		];
+	}
+
+	return [];
 }
 
 export class ExternalLspLanguageProvider implements LanguageServiceProvider {
@@ -381,6 +504,94 @@ export class ExternalLspLanguageProvider implements LanguageServiceProvider {
 					};
 				})
 				.filter((loc): loc is LanguageServiceLocation => loc !== null);
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			session.lastError = message;
+			this.workspaceErrors.set(args.workspaceId, message);
+			return null;
+		}
+	}
+
+	async getHover(args: {
+		workspaceId: string;
+		workspacePath: string;
+		absolutePath: string;
+		line: number;
+		column: number;
+	}): Promise<LanguageServiceHover | null> {
+		const session = this.sessions.get(args.workspaceId);
+		if (!session) return null;
+
+		try {
+			const result = (await session.client.request("textDocument/hover", {
+				textDocument: {
+					uri: absolutePathToFileUri(args.absolutePath),
+				},
+				position: {
+					line: args.line - 1,
+					character: args.column - 1,
+				},
+			})) as LspHover | null;
+
+			const contents = normalizeLspHoverContents(result?.contents);
+			if (contents.length === 0) {
+				return null;
+			}
+
+			session.lastError = null;
+			this.workspaceErrors.delete(args.workspaceId);
+			return {
+				contents,
+				range: lspRangeToLanguageServiceRange(result?.range),
+			};
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			session.lastError = message;
+			this.workspaceErrors.set(args.workspaceId, message);
+			return null;
+		}
+	}
+
+	async getDefinition(args: {
+		workspaceId: string;
+		workspacePath: string;
+		absolutePath: string;
+		line: number;
+		column: number;
+	}): Promise<LanguageServiceLocation[] | null> {
+		const session = this.sessions.get(args.workspaceId);
+		if (!session) return null;
+
+		try {
+			const result = (await session.client.request("textDocument/definition", {
+				textDocument: {
+					uri: absolutePathToFileUri(args.absolutePath),
+				},
+				position: {
+					line: args.line - 1,
+					character: args.column - 1,
+				},
+			})) as
+				| LspLocation
+				| LspLocationLink
+				| Array<LspLocation | LspLocationLink>
+				| null;
+
+			const locations = (
+				Array.isArray(result) ? result : result ? [result] : []
+			)
+				.map((location) => lspLocationToLanguageServiceLocation(location))
+				.filter(
+					(location): location is LanguageServiceLocation => location !== null,
+				);
+
+			if (locations.length === 0) {
+				return null;
+			}
+
+			session.lastError = null;
+			this.workspaceErrors.delete(args.workspaceId);
+			return locations;
 		} catch (error) {
 			const message = error instanceof Error ? error.message : String(error);
 			session.lastError = message;
@@ -648,6 +859,12 @@ export class ExternalLspLanguageProvider implements LanguageServiceProvider {
 					textDocument: {
 						publishDiagnostics: {
 							relatedInformation: true,
+						},
+						hover: {
+							contentFormat: ["markdown", "plaintext"],
+						},
+						definition: {
+							linkSupport: true,
 						},
 						references: {
 							dynamicRegistration: false,

--- a/apps/desktop/src/main/lib/language-services/manager.ts
+++ b/apps/desktop/src/main/lib/language-services/manager.ts
@@ -14,6 +14,7 @@ import { YamlLanguageProvider } from "./providers/yaml/YamlLanguageProvider";
 import type {
 	LanguageServiceCallHierarchyItem,
 	LanguageServiceDocument,
+	LanguageServiceHover,
 	LanguageServiceIncomingCall,
 	LanguageServiceLocation,
 	LanguageServiceProvider,
@@ -193,6 +194,32 @@ export class LanguageServiceManager {
 		const provider = this.resolveProvider(args.languageId);
 		if (!provider || !this.isProviderEnabled(provider.id)) return null;
 		return (await provider.findReferences?.(args)) ?? null;
+	}
+
+	async getHover(args: {
+		workspaceId: string;
+		workspacePath: string;
+		absolutePath: string;
+		languageId: string;
+		line: number;
+		column: number;
+	}): Promise<LanguageServiceHover | null> {
+		const provider = this.resolveProvider(args.languageId);
+		if (!provider || !this.isProviderEnabled(provider.id)) return null;
+		return (await provider.getHover?.(args)) ?? null;
+	}
+
+	async getDefinition(args: {
+		workspaceId: string;
+		workspacePath: string;
+		absolutePath: string;
+		languageId: string;
+		line: number;
+		column: number;
+	}): Promise<LanguageServiceLocation[] | null> {
+		const provider = this.resolveProvider(args.languageId);
+		if (!provider || !this.isProviderEnabled(provider.id)) return null;
+		return (await provider.getDefinition?.(args)) ?? null;
 	}
 
 	async prepareCallHierarchy(args: {

--- a/apps/desktop/src/main/lib/language-services/providers/typescript/TypeScriptLanguageProvider.ts
+++ b/apps/desktop/src/main/lib/language-services/providers/typescript/TypeScriptLanguageProvider.ts
@@ -7,10 +7,13 @@ import type {
 	LanguageServiceCallHierarchyItem,
 	LanguageServiceDiagnostic,
 	LanguageServiceDocument,
+	LanguageServiceHover,
 	LanguageServiceIncomingCall,
 	LanguageServiceLocation,
+	LanguageServiceMarkupContent,
 	LanguageServiceProvider,
 	LanguageServiceProviderSummary,
+	LanguageServiceRange,
 	LanguageServiceRelatedInformation,
 	LanguageServiceSeverity,
 } from "../../types";
@@ -72,6 +75,29 @@ type OpenDocumentEntry = {
 	languageId: string;
 	version: number;
 	content: string;
+};
+
+type TsServerTextPart =
+	| string
+	| {
+			text?: string;
+	  };
+
+type TsServerFileSpan = {
+	file: string;
+	start: { line: number; offset: number };
+	end: { line: number; offset: number };
+};
+
+type TsServerQuickInfoResponse = {
+	displayString?: string;
+	documentation?: TsServerTextPart[] | string;
+	tags?: Array<{
+		name?: string;
+		text?: TsServerTextPart[] | string;
+	}>;
+	start?: { line: number; offset: number };
+	end?: { line: number; offset: number };
 };
 
 type WorkspaceSession = {
@@ -211,6 +237,86 @@ function computeEndPosition(content: string): {
 		endLine: lines.length,
 		endOffset: (lines.at(-1)?.length ?? 0) + 1,
 	};
+}
+
+function normalizeTsTextParts(
+	parts: TsServerTextPart[] | string | undefined,
+): string {
+	if (!parts) {
+		return "";
+	}
+
+	if (typeof parts === "string") {
+		return parts;
+	}
+
+	return parts
+		.map((part) => (typeof part === "string" ? part : (part.text ?? "")))
+		.join("");
+}
+
+function normalizeTsHoverContents(
+	body: TsServerQuickInfoResponse | undefined,
+): LanguageServiceMarkupContent[] {
+	if (!body) {
+		return [];
+	}
+
+	const sections = [
+		body.displayString?.trim() ?? "",
+		normalizeTsTextParts(body.documentation).trim(),
+		...(body.tags ?? [])
+			.map((tag) => {
+				const tagBody = normalizeTsTextParts(tag.text).trim();
+				return tag.name
+					? `@${tag.name}${tagBody ? ` ${tagBody}` : ""}`
+					: tagBody;
+			})
+			.filter(Boolean),
+	].filter(Boolean);
+
+	if (sections.length === 0) {
+		return [];
+	}
+
+	return [
+		{
+			kind: "plaintext",
+			value: sections.join("\n\n"),
+		},
+	];
+}
+
+function normalizeTsRange(
+	start: { line: number; offset: number } | undefined,
+	end: { line: number; offset: number } | undefined,
+): LanguageServiceRange | null {
+	if (!start || !end) {
+		return null;
+	}
+
+	return {
+		line: start.line,
+		column: start.offset,
+		endLine: end.line,
+		endColumn: end.offset,
+	};
+}
+
+function normalizeTsFileSpans(body: unknown): TsServerFileSpan[] {
+	if (Array.isArray(body)) {
+		return body as TsServerFileSpan[];
+	}
+
+	if (!body || typeof body !== "object") {
+		return [];
+	}
+
+	const candidate = body as {
+		definitions?: TsServerFileSpan[];
+		body?: TsServerFileSpan[];
+	};
+	return candidate.definitions ?? candidate.body ?? [];
 }
 
 export class TypeScriptLanguageProvider implements LanguageServiceProvider {
@@ -431,6 +537,74 @@ export class TypeScriptLanguageProvider implements LanguageServiceProvider {
 				column: ref.start.offset,
 				endLine: ref.end.line,
 				endColumn: ref.end.offset,
+			}));
+		} catch {
+			return null;
+		}
+	}
+
+	async getHover(args: {
+		workspaceId: string;
+		workspacePath: string;
+		absolutePath: string;
+		line: number;
+		column: number;
+	}): Promise<LanguageServiceHover | null> {
+		const session = this.sessions.get(args.workspaceId);
+		if (!session) return null;
+
+		try {
+			const response = await this.sendRequest(session, "quickinfo", {
+				file: args.absolutePath,
+				line: args.line,
+				offset: args.column,
+			});
+
+			const body = response.body as TsServerQuickInfoResponse | undefined;
+			const contents = normalizeTsHoverContents(body);
+			if (contents.length === 0) {
+				return null;
+			}
+
+			session.lastError = null;
+			return {
+				contents,
+				range: normalizeTsRange(body?.start, body?.end),
+			};
+		} catch {
+			return null;
+		}
+	}
+
+	async getDefinition(args: {
+		workspaceId: string;
+		workspacePath: string;
+		absolutePath: string;
+		line: number;
+		column: number;
+	}): Promise<LanguageServiceLocation[] | null> {
+		const session = this.sessions.get(args.workspaceId);
+		if (!session) return null;
+
+		try {
+			const response = await this.sendRequest(session, "definition", {
+				file: args.absolutePath,
+				line: args.line,
+				offset: args.column,
+			});
+
+			const definitions = normalizeTsFileSpans(response.body);
+			if (definitions.length === 0) {
+				return null;
+			}
+
+			session.lastError = null;
+			return definitions.map((definition) => ({
+				absolutePath: definition.file,
+				line: definition.start.line,
+				column: definition.start.offset,
+				endLine: definition.end.line,
+				endColumn: definition.end.offset,
 			}));
 		} catch {
 			return null;

--- a/apps/desktop/src/main/lib/language-services/types.ts
+++ b/apps/desktop/src/main/lib/language-services/types.ts
@@ -77,6 +77,23 @@ export interface LanguageServiceLocation {
 	endColumn: number;
 }
 
+export interface LanguageServiceRange {
+	line: number;
+	column: number;
+	endLine: number;
+	endColumn: number;
+}
+
+export interface LanguageServiceMarkupContent {
+	kind: "plaintext" | "markdown";
+	value: string;
+}
+
+export interface LanguageServiceHover {
+	contents: LanguageServiceMarkupContent[];
+	range: LanguageServiceRange | null;
+}
+
 /**
  * A call hierarchy item returned by prepareCallHierarchy.
  */
@@ -140,6 +157,30 @@ export interface LanguageServiceProvider {
 	 * Returns null if the provider does not support this operation.
 	 */
 	findReferences?(args: {
+		workspaceId: string;
+		workspacePath: string;
+		absolutePath: string;
+		line: number;
+		column: number;
+	}): Promise<LanguageServiceLocation[] | null>;
+
+	/**
+	 * Get hover content for a symbol at the given position.
+	 * Returns null if the provider does not support this operation.
+	 */
+	getHover?(args: {
+		workspaceId: string;
+		workspacePath: string;
+		absolutePath: string;
+		line: number;
+		column: number;
+	}): Promise<LanguageServiceHover | null>;
+
+	/**
+	 * Get definitions for a symbol at the given position.
+	 * Returns null if the provider does not support this operation.
+	 */
+	getDefinition?(args: {
 		workspaceId: string;
 		workspacePath: string;
 		absolutePath: string;

--- a/apps/desktop/src/main/lib/vscode-shim/loader.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/loader.ts
@@ -20,6 +20,14 @@ import { createVscodeApi } from "./vscode-api";
 const vscodeApi = createVscodeApi();
 let interceptInstalled = false;
 
+type ResolveFilename = (
+	this: unknown,
+	request: string,
+	parent: unknown,
+	isMain: boolean,
+	options: unknown,
+) => string;
+
 function installRequireIntercept(): void {
 	if (interceptInstalled) return;
 	interceptInstalled = true;
@@ -43,27 +51,21 @@ function installRequireIntercept(): void {
 		isPreloading: false,
 	} as unknown as NodeModule;
 
-	const originalResolveFilename = (
-		Module as unknown as { _resolveFilename: Function }
-	)._resolveFilename;
-	(Module as unknown as { _resolveFilename: Function })._resolveFilename =
-		function (
-			request: string,
-			parent: unknown,
-			isMain: boolean,
-			options: unknown,
-		) {
-			if (request === "vscode") {
-				return VSCODE_CACHE_KEY;
-			}
-			return originalResolveFilename.call(
-				this,
-				request,
-				parent,
-				isMain,
-				options,
-			);
-		};
+	const moduleWithResolver = Module as unknown as {
+		_resolveFilename: ResolveFilename;
+	};
+	const originalResolveFilename = moduleWithResolver._resolveFilename;
+	moduleWithResolver._resolveFilename = function (
+		request: string,
+		parent: unknown,
+		isMain: boolean,
+		options: unknown,
+	) {
+		if (request === "vscode") {
+			return VSCODE_CACHE_KEY;
+		}
+		return originalResolveFilename.call(this, request, parent, isMain, options);
+	};
 }
 
 export function discoverExtensions(extensionsDir: string): ExtensionInfo[] {
@@ -111,8 +113,9 @@ const loadedExtensions = new Map<string, LoadedExtension>();
 export async function loadExtension(
 	info: ExtensionInfo,
 ): Promise<LoadedExtension> {
-	if (loadedExtensions.has(info.id)) {
-		return loadedExtensions.get(info.id)!;
+	const existing = loadedExtensions.get(info.id);
+	if (existing) {
+		return existing;
 	}
 
 	installRequireIntercept();
@@ -128,7 +131,11 @@ export async function loadExtension(
 	);
 
 	// Load the extension's main module
-	const mainPath = path.resolve(info.extensionPath, info.manifest.main!);
+	const manifestMain = info.manifest.main;
+	if (!manifestMain) {
+		throw new Error(`[vscode-shim] Extension ${info.id} has no main entry`);
+	}
+	const mainPath = path.resolve(info.extensionPath, manifestMain);
 	shimLog(`[vscode-shim] Loading extension: ${info.id} from ${mainPath}`);
 
 	let extensionModule: Record<string, unknown>;

--- a/apps/desktop/src/main/lib/vscode-shim/vscode-api.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/vscode-api.ts
@@ -392,20 +392,63 @@ const NotebookCellKind = {
 	Code: 2,
 } as const;
 
-const NotebookEdit = {
-	replaceCells(_range: unknown, _cells: unknown[]) {
-		return {};
-	},
-	insertCells(_index: number, _cells: unknown[]) {
-		return {};
-	},
-	deleteCells(_range: unknown) {
-		return {};
-	},
-	updateCellMetadata(_index: number, _metadata: Record<string, unknown>) {
-		return {};
-	},
-} as const;
+class NotebookEdit {
+	readonly range?: unknown;
+	readonly newCells?: unknown[];
+	readonly index?: number;
+	readonly metadata?: Record<string, unknown>;
+	readonly kind:
+		| "replaceCells"
+		| "insertCells"
+		| "deleteCells"
+		| "updateCellMetadata";
+
+	constructor(
+		range?: unknown,
+		newCells?: unknown[],
+		options?: {
+			index?: number;
+			metadata?: Record<string, unknown>;
+			kind?:
+				| "replaceCells"
+				| "insertCells"
+				| "deleteCells"
+				| "updateCellMetadata";
+		},
+	) {
+		this.range = range;
+		this.newCells = newCells;
+		this.index = options?.index;
+		this.metadata = options?.metadata;
+		this.kind = options?.kind ?? "replaceCells";
+	}
+
+	static replaceCells(range: unknown, newCells: unknown[]): NotebookEdit {
+		return new NotebookEdit(range, newCells, { kind: "replaceCells" });
+	}
+
+	static insertCells(index: number, newCells: unknown[]): NotebookEdit {
+		return new NotebookEdit(undefined, newCells, {
+			index,
+			kind: "insertCells",
+		});
+	}
+
+	static deleteCells(range: unknown): NotebookEdit {
+		return new NotebookEdit(range, undefined, { kind: "deleteCells" });
+	}
+
+	static updateCellMetadata(
+		index: number,
+		metadata: Record<string, unknown>,
+	): NotebookEdit {
+		return new NotebookEdit(undefined, undefined, {
+			index,
+			metadata,
+			kind: "updateCellMetadata",
+		});
+	}
+}
 
 class TabInputTextDiff {
 	readonly original: Uri;

--- a/apps/desktop/src/main/lib/vscode-shim/vscode-api.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/vscode-api.ts
@@ -185,8 +185,11 @@ class Range {
 		endChar?: number,
 	) {
 		if (typeof startLine === "number") {
+			if (typeof endLine !== "number" || typeof endChar !== "number") {
+				throw new TypeError("Range requires endLine and endChar");
+			}
 			this.start = new Position(startLine, startChar as number);
-			this.end = new Position(endLine!, endChar!);
+			this.end = new Position(endLine, endChar);
 		} else {
 			this.start = startLine;
 			this.end = startChar as Position;
@@ -213,9 +216,12 @@ class Selection extends Range {
 		activeChar?: number,
 	) {
 		if (typeof anchorLine === "number") {
-			super(anchorLine, anchorChar as number, activeLine!, activeChar!);
+			if (typeof activeLine !== "number" || typeof activeChar !== "number") {
+				throw new TypeError("Selection requires activeLine and activeChar");
+			}
+			super(anchorLine, anchorChar as number, activeLine, activeChar);
 			this.anchor = new Position(anchorLine, anchorChar as number);
-			this.active = new Position(activeLine!, activeChar!);
+			this.active = new Position(activeLine, activeChar);
 		} else {
 			super(anchorLine, anchorChar as Position);
 			this.anchor = anchorLine;
@@ -381,28 +387,25 @@ class NotebookCellOutput {
 	}
 }
 
-class NotebookCellKind {
-	static readonly Markup = 1;
-	static readonly Code = 2;
-}
+const NotebookCellKind = {
+	Markup: 1,
+	Code: 2,
+} as const;
 
-class NotebookEdit {
-	static replaceCells(_range: unknown, _cells: unknown[]): NotebookEdit {
-		return new NotebookEdit();
-	}
-	static insertCells(_index: number, _cells: unknown[]): NotebookEdit {
-		return new NotebookEdit();
-	}
-	static deleteCells(_range: unknown): NotebookEdit {
-		return new NotebookEdit();
-	}
-	static updateCellMetadata(
-		_index: number,
-		_metadata: Record<string, unknown>,
-	): NotebookEdit {
-		return new NotebookEdit();
-	}
-}
+const NotebookEdit = {
+	replaceCells(_range: unknown, _cells: unknown[]) {
+		return {};
+	},
+	insertCells(_index: number, _cells: unknown[]) {
+		return {};
+	},
+	deleteCells(_range: unknown) {
+		return {};
+	},
+	updateCellMetadata(_index: number, _metadata: Record<string, unknown>) {
+		return {};
+	},
+} as const;
 
 class TabInputTextDiff {
 	readonly original: Uri;

--- a/apps/desktop/src/renderer/lib/language-services.ts
+++ b/apps/desktop/src/renderer/lib/language-services.ts
@@ -1,0 +1,130 @@
+import type { LanguageServiceProviderId } from "renderer/stores/language-service-preferences";
+
+export function resolveLanguageServiceLanguageId(
+	absolutePath: string,
+): string | null {
+	const normalizedPath = absolutePath.toLowerCase().replaceAll("\\", "/");
+	const fileName = normalizedPath.split("/").at(-1) ?? normalizedPath;
+
+	if (normalizedPath.endsWith(".tsx")) {
+		return "typescriptreact";
+	}
+	if (
+		normalizedPath.endsWith(".ts") ||
+		normalizedPath.endsWith(".mts") ||
+		normalizedPath.endsWith(".cts")
+	) {
+		return "typescript";
+	}
+	if (normalizedPath.endsWith(".jsx")) {
+		return "javascriptreact";
+	}
+	if (
+		normalizedPath.endsWith(".js") ||
+		normalizedPath.endsWith(".mjs") ||
+		normalizedPath.endsWith(".cjs")
+	) {
+		return "javascript";
+	}
+	if (
+		normalizedPath.endsWith(".jsonc") ||
+		fileName === "jsconfig.json" ||
+		fileName === "settings.json" ||
+		fileName === "extensions.json" ||
+		fileName === "launch.json" ||
+		fileName === "tasks.json" ||
+		fileName === "keybindings.json" ||
+		/^tsconfig\..+\.json$/.test(fileName) ||
+		fileName === "tsconfig.json"
+	) {
+		return "jsonc";
+	}
+	if (normalizedPath.endsWith(".json")) {
+		return "json";
+	}
+	if (normalizedPath.endsWith(".toml")) {
+		return "toml";
+	}
+	if (normalizedPath.endsWith(".py") || normalizedPath.endsWith(".pyi")) {
+		return "python";
+	}
+	if (normalizedPath.endsWith(".go")) {
+		return "go";
+	}
+	if (normalizedPath.endsWith(".rs")) {
+		return "rust";
+	}
+	if (normalizedPath.endsWith(".dart")) {
+		return "dart";
+	}
+	if (normalizedPath.endsWith(".yaml") || normalizedPath.endsWith(".yml")) {
+		return "yaml";
+	}
+	if (normalizedPath.endsWith(".html") || normalizedPath.endsWith(".htm")) {
+		return "html";
+	}
+	if (normalizedPath.endsWith(".scss")) {
+		return "scss";
+	}
+	if (normalizedPath.endsWith(".less")) {
+		return "less";
+	}
+	if (normalizedPath.endsWith(".css")) {
+		return "css";
+	}
+	if (
+		fileName === "dockerfile" ||
+		fileName === "containerfile" ||
+		normalizedPath.endsWith(".dockerfile")
+	) {
+		return "dockerfile";
+	}
+	if (
+		normalizedPath.endsWith(".graphql") ||
+		normalizedPath.endsWith(".gql") ||
+		normalizedPath.endsWith(".graphqls")
+	) {
+		return "graphql";
+	}
+
+	return null;
+}
+
+export function resolveLanguageServiceProviderId(
+	languageId: string,
+): LanguageServiceProviderId | null {
+	switch (languageId) {
+		case "typescript":
+		case "typescriptreact":
+		case "javascript":
+		case "javascriptreact":
+			return "typescript";
+		case "json":
+		case "jsonc":
+			return "json";
+		case "yaml":
+			return "yaml";
+		case "html":
+			return "html";
+		case "css":
+		case "scss":
+		case "less":
+			return "css";
+		case "toml":
+			return "toml";
+		case "dart":
+			return "dart";
+		case "python":
+			return "python";
+		case "go":
+			return "go";
+		case "rust":
+			return "rust";
+		case "dockerfile":
+			return "dockerfile";
+		case "graphql":
+			return "graphql";
+		default:
+			return null;
+	}
+}

--- a/apps/desktop/src/renderer/providers/LanguageServicesProvider/LanguageServicesProvider.tsx
+++ b/apps/desktop/src/renderer/providers/LanguageServicesProvider/LanguageServicesProvider.tsx
@@ -1,14 +1,15 @@
 import { useEffect, useMemo, useRef, useState } from "react";
+import {
+	resolveLanguageServiceLanguageId,
+	resolveLanguageServiceProviderId,
+} from "renderer/lib/language-services";
 import { electronTrpcClient } from "renderer/lib/trpc-client";
 import {
 	getDocumentCurrentContent,
 	hasInitializedDocumentBuffer,
 } from "renderer/stores/editor-state/editorBufferRegistry";
 import { useEditorDocumentsStore } from "renderer/stores/editor-state/useEditorDocumentsStore";
-import {
-	type LanguageServiceProviderId,
-	useLanguageServicePreferencesStore,
-} from "renderer/stores/language-service-preferences";
+import { useLanguageServicePreferencesStore } from "renderer/stores/language-service-preferences";
 
 type TrackedDocument = {
 	documentKey: string;
@@ -18,131 +19,6 @@ type TrackedDocument = {
 	content: string;
 	version: number;
 };
-
-function resolveLanguageId(absolutePath: string): string | null {
-	const normalizedPath = absolutePath.toLowerCase().replaceAll("\\", "/");
-	const fileName = normalizedPath.split("/").at(-1) ?? normalizedPath;
-	if (normalizedPath.endsWith(".tsx")) {
-		return "typescriptreact";
-	}
-	if (
-		normalizedPath.endsWith(".ts") ||
-		normalizedPath.endsWith(".mts") ||
-		normalizedPath.endsWith(".cts")
-	) {
-		return "typescript";
-	}
-	if (normalizedPath.endsWith(".jsx")) {
-		return "javascriptreact";
-	}
-	if (
-		normalizedPath.endsWith(".js") ||
-		normalizedPath.endsWith(".mjs") ||
-		normalizedPath.endsWith(".cjs")
-	) {
-		return "javascript";
-	}
-	if (
-		normalizedPath.endsWith(".jsonc") ||
-		fileName === "jsconfig.json" ||
-		fileName === "settings.json" ||
-		fileName === "extensions.json" ||
-		fileName === "launch.json" ||
-		fileName === "tasks.json" ||
-		fileName === "keybindings.json" ||
-		/^tsconfig\..+\.json$/.test(fileName) ||
-		fileName === "tsconfig.json"
-	) {
-		return "jsonc";
-	}
-	if (normalizedPath.endsWith(".json")) {
-		return "json";
-	}
-	if (normalizedPath.endsWith(".toml")) {
-		return "toml";
-	}
-	if (normalizedPath.endsWith(".py") || normalizedPath.endsWith(".pyi")) {
-		return "python";
-	}
-	if (normalizedPath.endsWith(".go")) {
-		return "go";
-	}
-	if (normalizedPath.endsWith(".rs")) {
-		return "rust";
-	}
-	if (normalizedPath.endsWith(".dart")) {
-		return "dart";
-	}
-	if (normalizedPath.endsWith(".yaml") || normalizedPath.endsWith(".yml")) {
-		return "yaml";
-	}
-	if (normalizedPath.endsWith(".html") || normalizedPath.endsWith(".htm")) {
-		return "html";
-	}
-	if (normalizedPath.endsWith(".scss")) {
-		return "scss";
-	}
-	if (normalizedPath.endsWith(".less")) {
-		return "less";
-	}
-	if (normalizedPath.endsWith(".css")) {
-		return "css";
-	}
-	if (
-		fileName === "dockerfile" ||
-		fileName === "containerfile" ||
-		normalizedPath.endsWith(".dockerfile")
-	) {
-		return "dockerfile";
-	}
-	if (
-		normalizedPath.endsWith(".graphql") ||
-		normalizedPath.endsWith(".gql") ||
-		normalizedPath.endsWith(".graphqls")
-	) {
-		return "graphql";
-	}
-	return null;
-}
-
-function resolveProviderId(
-	languageId: string,
-): LanguageServiceProviderId | null {
-	switch (languageId) {
-		case "typescript":
-		case "typescriptreact":
-		case "javascript":
-		case "javascriptreact":
-			return "typescript";
-		case "json":
-		case "jsonc":
-			return "json";
-		case "yaml":
-			return "yaml";
-		case "html":
-			return "html";
-		case "css":
-		case "scss":
-		case "less":
-			return "css";
-		case "toml":
-			return "toml";
-		case "dart":
-			return "dart";
-		case "python":
-			return "python";
-		case "go":
-			return "go";
-		case "rust":
-			return "rust";
-		case "dockerfile":
-			return "dockerfile";
-		case "graphql":
-			return "graphql";
-		default:
-			return null;
-	}
-}
 
 export function LanguageServicesProvider() {
 	const documentsByKey = useEditorDocumentsStore((state) => state.documents);
@@ -193,12 +69,12 @@ export function LanguageServicesProvider() {
 				continue;
 			}
 
-			const languageId = resolveLanguageId(document.filePath);
+			const languageId = resolveLanguageServiceLanguageId(document.filePath);
 			if (!languageId) {
 				continue;
 			}
 
-			const providerId = resolveProviderId(languageId);
+			const providerId = resolveLanguageServiceProviderId(languageId);
 			if (providerId && enabledProviders[providerId] === false) {
 				continue;
 			}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/AddTabMenu/AddTabMenu.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/AddTabMenu/AddTabMenu.tsx
@@ -1,4 +1,8 @@
-import { DropdownMenuItem } from "@superset/ui/dropdown-menu";
+import {
+	DropdownMenuCheckboxItem,
+	DropdownMenuItem,
+	DropdownMenuSeparator,
+} from "@superset/ui/dropdown-menu";
 import { BsTerminalPlus } from "react-icons/bs";
 import { LuFileText } from "react-icons/lu";
 import { TbMessageCirclePlus, TbWorld } from "react-icons/tb";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
@@ -152,9 +152,7 @@ function WorkspaceContent({
 				return { previous };
 			},
 			onError: (_error, _variables, context) => {
-				if (context?.previous !== undefined) {
-					utils.settings.getShowPresetsBar.setData(undefined, context.previous);
-				}
+				utils.settings.getShowPresetsBar.setData(undefined, context?.previous);
 			},
 			onSettled: () => {
 				utils.settings.getShowPresetsBar.invalidate();

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
@@ -23,6 +23,7 @@ import {
 	addBrowserShortcutListener,
 	dispatchBrowserShortcutEvent,
 } from "renderer/lib/browser-shortcut-events";
+import { electronTrpc } from "renderer/lib/electron-trpc";
 import { createWorkspaceMemo } from "renderer/lib/workspace-memos";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 import {
@@ -139,6 +140,27 @@ function WorkspaceContent({
 	const paneRegistry = usePaneRegistry(workspaceId);
 	const defaultContextMenuActions = useDefaultContextMenuActions();
 	const rightSidebarOpenViewWidth = useRightSidebarOpenViewWidth();
+	const utils = electronTrpc.useUtils();
+	const { data: showPresetsBar } =
+		electronTrpc.settings.getShowPresetsBar.useQuery();
+	const setShowPresetsBar = electronTrpc.settings.setShowPresetsBar.useMutation(
+		{
+			onMutate: async ({ enabled }) => {
+				await utils.settings.getShowPresetsBar.cancel();
+				const previous = utils.settings.getShowPresetsBar.getData();
+				utils.settings.getShowPresetsBar.setData(undefined, enabled);
+				return { previous };
+			},
+			onError: (_error, _variables, context) => {
+				if (context?.previous !== undefined) {
+					utils.settings.getShowPresetsBar.setData(undefined, context.previous);
+				}
+			},
+			onSettled: () => {
+				utils.settings.getShowPresetsBar.invalidate();
+			},
+		},
+	);
 
 	const selectedFilePath = useStore(store, (s) => {
 		const tab = s.tabs.find((t) => t.id === s.activeTabId);

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/models/components/ModelsSettings/ModelsSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/models/components/ModelsSettings/ModelsSettings.tsx
@@ -820,10 +820,16 @@ export function ModelsSettings({ visibleItems }: ModelsSettingsProps) {
 								</div>
 								<div className="mt-4 grid gap-3 md:grid-cols-3">
 									{[
-										["Today", nextEditUsageSummary?.today],
-										["This month", nextEditUsageSummary?.month],
-										["All time", nextEditUsageSummary?.allTime],
-									].map(([label, bucket]) => (
+										{ label: "Today", bucket: nextEditUsageSummary?.today },
+										{
+											label: "This month",
+											bucket: nextEditUsageSummary?.month,
+										},
+										{
+											label: "All time",
+											bucket: nextEditUsageSummary?.allTime,
+										},
+									].map(({ label, bucket }) => (
 										<div
 											key={label}
 											className="rounded-md border bg-background p-3"
@@ -852,9 +858,15 @@ export function ModelsSettings({ visibleItems }: ModelsSettingsProps) {
 								</div>
 								<div className="mt-4 grid gap-3 md:grid-cols-2">
 									{[
-										["FIM", nextEditUsageSummary?.byEndpoint.fim],
-										["Next Edit", nextEditUsageSummary?.byEndpoint.next_edit],
-									].map(([label, bucket]) => (
+										{
+											label: "FIM",
+											bucket: nextEditUsageSummary?.byEndpoint.fim,
+										},
+										{
+											label: "Next Edit",
+											bucket: nextEditUsageSummary?.byEndpoint.next_edit,
+										},
+									].map(({ label, bucket }) => (
 										<div
 											key={label}
 											className="rounded-md border bg-background p-3"

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/FileViewerPane.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/FileViewerPane.tsx
@@ -839,6 +839,7 @@ export function FileViewerPane({
 							editorRef={editorRef}
 							markdownEditorRef={markdownEditorRef}
 							renderedContent={renderedContent}
+							documentVersion={documentState?.contentVersion}
 							initialLine={initialLine}
 							initialColumn={initialColumn}
 							diffViewMode={diffViewMode}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/components/CodeMirrorDiffViewer/CodeMirrorDiffViewer.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/components/CodeMirrorDiffViewer/CodeMirrorDiffViewer.tsx
@@ -40,6 +40,11 @@ import {
 	createInlineCompletionPlugin,
 	type InlineCompletionRequest,
 } from "renderer/screens/main/components/WorkspaceView/components/CodeEditor/createInlineCompletionPlugin";
+import {
+	createSymbolInteractions,
+	type SymbolHoverResult,
+	type SymbolPosition,
+} from "renderer/screens/main/components/WorkspaceView/components/CodeEditor/createSymbolInteractions";
 import { loadLanguageSupport } from "renderer/screens/main/components/WorkspaceView/components/CodeEditor/loadLanguageSupport";
 import { getCodeSyntaxHighlighting } from "renderer/screens/main/components/WorkspaceView/utils/code-theme";
 import { useResolvedTheme } from "renderer/stores/theme";
@@ -217,6 +222,11 @@ interface CodeMirrorDiffViewerProps {
 		severity: "error" | "warning" | "info" | "hint";
 	}>;
 	inlineCompletionRequest?: InlineCompletionRequest | null;
+	resolveSymbolHover?: (
+		position: SymbolPosition,
+	) => Promise<SymbolHoverResult | null> | SymbolHoverResult | null;
+	onGoToDefinition?: (position: SymbolPosition) => Promise<void> | void;
+	onModifiedCursorChange?: (position: SymbolPosition | null) => void;
 }
 
 function createDiagnosticsTheme(theme: ReturnType<typeof getEditorTheme>) {
@@ -291,6 +301,9 @@ export function CodeMirrorDiffViewer({
 	blameEntries,
 	diagnostics = [],
 	inlineCompletionRequest,
+	resolveSymbolHover,
+	onGoToDefinition,
+	onModifiedCursorChange,
 }: CodeMirrorDiffViewerProps) {
 	const containerRef = useRef<HTMLDivElement>(null);
 	const mergeViewRef = useRef<MergeView | null>(null);
@@ -315,6 +328,9 @@ export function CodeMirrorDiffViewer({
 	const onChangeRef = useRef(onChange);
 	const onSaveRef = useRef(onSave);
 	const inlineCompletionRequestRef = useRef(inlineCompletionRequest);
+	const resolveSymbolHoverRef = useRef(resolveSymbolHover);
+	const onGoToDefinitionRef = useRef(onGoToDefinition);
+	const onModifiedCursorChangeRef = useRef(onModifiedCursorChange);
 	const activeTheme = useResolvedTheme();
 	const { data: fontSettings } = electronTrpc.settings.getFontSettings.useQuery(
 		undefined,
@@ -327,6 +343,9 @@ export function CodeMirrorDiffViewer({
 	onChangeRef.current = onChange;
 	onSaveRef.current = onSave;
 	inlineCompletionRequestRef.current = inlineCompletionRequest;
+	resolveSymbolHoverRef.current = resolveSymbolHover;
+	onGoToDefinitionRef.current = onGoToDefinition;
+	onModifiedCursorChangeRef.current = onModifiedCursorChange;
 
 	const getActiveEditor = (): EditorView | null => {
 		const mv = mergeViewRef.current;
@@ -575,6 +594,13 @@ export function CodeMirrorDiffViewer({
 			}),
 			suppressInsertions,
 			blameCompartmentB.of([]),
+			...createSymbolInteractions({
+				resolveHover: (position) =>
+					resolveSymbolHoverRef.current?.(position) ?? null,
+				onGoToDefinition: (position) => onGoToDefinitionRef.current?.(position),
+				onCursorChange: (position) =>
+					onModifiedCursorChangeRef.current?.(position),
+			}),
 		];
 
 		const themeExts = [

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/components/CodeMirrorDiffViewer/CodeMirrorDiffViewer.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/components/CodeMirrorDiffViewer/CodeMirrorDiffViewer.tsx
@@ -226,7 +226,6 @@ interface CodeMirrorDiffViewerProps {
 		position: SymbolPosition,
 	) => Promise<SymbolHoverResult | null> | SymbolHoverResult | null;
 	onGoToDefinition?: (position: SymbolPosition) => Promise<void> | void;
-	onModifiedCursorChange?: (position: SymbolPosition | null) => void;
 }
 
 function createDiagnosticsTheme(theme: ReturnType<typeof getEditorTheme>) {
@@ -303,7 +302,6 @@ export function CodeMirrorDiffViewer({
 	inlineCompletionRequest,
 	resolveSymbolHover,
 	onGoToDefinition,
-	onModifiedCursorChange,
 }: CodeMirrorDiffViewerProps) {
 	const containerRef = useRef<HTMLDivElement>(null);
 	const mergeViewRef = useRef<MergeView | null>(null);
@@ -330,7 +328,6 @@ export function CodeMirrorDiffViewer({
 	const inlineCompletionRequestRef = useRef(inlineCompletionRequest);
 	const resolveSymbolHoverRef = useRef(resolveSymbolHover);
 	const onGoToDefinitionRef = useRef(onGoToDefinition);
-	const onModifiedCursorChangeRef = useRef(onModifiedCursorChange);
 	const activeTheme = useResolvedTheme();
 	const { data: fontSettings } = electronTrpc.settings.getFontSettings.useQuery(
 		undefined,
@@ -345,7 +342,6 @@ export function CodeMirrorDiffViewer({
 	inlineCompletionRequestRef.current = inlineCompletionRequest;
 	resolveSymbolHoverRef.current = resolveSymbolHover;
 	onGoToDefinitionRef.current = onGoToDefinition;
-	onModifiedCursorChangeRef.current = onModifiedCursorChange;
 
 	const getActiveEditor = (): EditorView | null => {
 		const mv = mergeViewRef.current;
@@ -598,8 +594,6 @@ export function CodeMirrorDiffViewer({
 				resolveHover: (position) =>
 					resolveSymbolHoverRef.current?.(position) ?? null,
 				onGoToDefinition: (position) => onGoToDefinitionRef.current?.(position),
-				onCursorChange: (position) =>
-					onModifiedCursorChangeRef.current?.(position),
 			}),
 		];
 

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/components/DiffViewerContextMenu/DiffViewerContextMenu.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/components/DiffViewerContextMenu/DiffViewerContextMenu.tsx
@@ -30,6 +30,7 @@ interface DiffViewerContextMenuProps {
 	onMoveToTab: (tabId: string) => void;
 	onMoveToNewTab: () => void;
 	onEditAtLocation: () => void;
+	onGoToDefinition?: () => void;
 }
 
 function isSelectionInsideContainer(
@@ -69,6 +70,7 @@ export function DiffViewerContextMenu({
 	onMoveToTab,
 	onMoveToNewTab,
 	onEditAtLocation,
+	onGoToDefinition,
 }: DiffViewerContextMenuProps) {
 	const { copyToClipboard } = useCopyToClipboard();
 	const getEditor = useCallback((): CodeEditorAdapter | null => {
@@ -133,6 +135,7 @@ export function DiffViewerContextMenu({
 			editorActions={{
 				...editorActions,
 				onFind: undefined,
+				onGoToDefinition,
 			}}
 			leadingItems={
 				<ContextMenuItem onSelect={onEditAtLocation}>

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/components/FileEditorContextMenu/FileEditorContextMenu.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/components/FileEditorContextMenu/FileEditorContextMenu.tsx
@@ -24,6 +24,7 @@ interface FileEditorContextMenuProps {
 	availableTabs: Tab[];
 	onMoveToTab: (tabId: string) => void;
 	onMoveToNewTab: () => void;
+	onGoToDefinition?: () => void;
 	onShowReferenceGraph?: () => void;
 }
 
@@ -44,6 +45,7 @@ export function FileEditorContextMenu({
 	availableTabs,
 	onMoveToTab,
 	onMoveToNewTab,
+	onGoToDefinition,
 	onShowReferenceGraph,
 }: FileEditorContextMenuProps) {
 	const getEditor = useCallback(() => editorRef.current, [editorRef]);
@@ -55,6 +57,7 @@ export function FileEditorContextMenu({
 		worktreePath,
 		supersetLinkProject,
 		editable: true,
+		onGoToDefinition,
 		onShowReferenceGraph,
 	});
 

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/components/FileViewerContent/FileViewerContent.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/components/FileViewerContent/FileViewerContent.tsx
@@ -12,6 +12,10 @@ import {
 	TipTapMarkdownRenderer,
 } from "renderer/components/MarkdownRenderer";
 import { electronTrpc } from "renderer/lib/electron-trpc";
+import {
+	resolveLanguageServiceLanguageId,
+	resolveLanguageServiceProviderId,
+} from "renderer/lib/language-services";
 import { electronTrpcClient } from "renderer/lib/trpc-client";
 import { getTrustedMemoRootPath } from "renderer/lib/workspace-memos";
 import type { CodeEditorAdapter } from "renderer/screens/main/components/WorkspaceView/ContentView/components";
@@ -20,6 +24,7 @@ import type {
 	SymbolHoverResult,
 	SymbolPosition,
 } from "renderer/screens/main/components/WorkspaceView/components/CodeEditor/createSymbolInteractions";
+import { useLanguageServicePreferencesStore } from "renderer/stores/language-service-preferences";
 import { useTabsStore } from "renderer/stores/tabs/store";
 import type { Tab } from "renderer/stores/tabs/types";
 import { pathsMatch, toAbsoluteWorkspacePath } from "shared/absolute-paths";
@@ -296,6 +301,9 @@ export function FileViewerContent({
 		filePath,
 	});
 	const addFileViewerPane = useTabsStore((s) => s.addFileViewerPane);
+	const enabledProviders = useLanguageServicePreferencesStore(
+		(state) => state.enabledProviders,
+	);
 
 	useScrollToFirstDiffChange({
 		containerRef: diffContainerRef,
@@ -368,9 +376,20 @@ export function FileViewerContent({
 			),
 		[workspaceDiagnostics?.problems, absoluteFilePath, filePath],
 	);
-	const languageId = useMemo(() => detectLanguage(filePath), [filePath]);
+	const languageId = useMemo(
+		() => resolveLanguageServiceLanguageId(absoluteFilePath),
+		[absoluteFilePath],
+	);
+	const providerId = useMemo(
+		() => (languageId ? resolveLanguageServiceProviderId(languageId) : null),
+		[languageId],
+	);
 	const canResolveSymbols = Boolean(
-		workspaceId && absoluteFilePath && languageId,
+		workspaceId &&
+			absoluteFilePath &&
+			languageId &&
+			providerId &&
+			enabledProviders[providerId] !== false,
 	);
 
 	const { data: blameData } = electronTrpc.changes.getGitBlame.useQuery(
@@ -388,7 +407,6 @@ export function FileViewerContent({
 		  })
 		| null
 	>(null);
-	const lastModifiedCursorRef = useRef<SymbolPosition | null>(null);
 
 	// biome-ignore lint/correctness/useExhaustiveDependencies: Reset on file change only
 	useEffect(() => {
@@ -453,6 +471,30 @@ export function FileViewerContent({
 			endLine: position.lineNumber,
 		};
 	};
+
+	const getDiffLookupPosition = useCallback((): SymbolPosition | null => {
+		if (!diffData) {
+			return null;
+		}
+
+		const location = lastDiffLocationRef.current;
+		if (!location || location.side !== "additions") {
+			return null;
+		}
+
+		const position = mapDiffLocationToRawPosition({
+			contents: diffData,
+			lineNumber: location.lineNumber,
+			side: location.side,
+			lineType: location.lineType,
+			column: location.column,
+		});
+
+		return {
+			line: position.lineNumber,
+			column: position.column,
+		};
+	}, [diffData]);
 
 	const openRawFromDiffLocation = (
 		location: DiffDomLocation & {
@@ -671,10 +713,7 @@ export function FileViewerContent({
 				onGoToDefinition={
 					canResolveSymbols
 						? () => {
-								if (lastDiffLocationRef.current?.side !== "additions") {
-									return;
-								}
-								const position = lastModifiedCursorRef.current;
+								const position = getDiffLookupPosition();
 								if (!position) {
 									return;
 								}
@@ -728,9 +767,6 @@ export function FileViewerContent({
 								canResolveSymbols ? resolveSymbolHover : undefined
 							}
 							onGoToDefinition={canResolveSymbols ? goToDefinition : undefined}
-							onModifiedCursorChange={(position) => {
-								lastModifiedCursorRef.current = position;
-							}}
 						/>
 					</div>
 				</div>

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/components/FileViewerContent/FileViewerContent.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/components/FileViewerContent/FileViewerContent.tsx
@@ -12,9 +12,15 @@ import {
 	TipTapMarkdownRenderer,
 } from "renderer/components/MarkdownRenderer";
 import { electronTrpc } from "renderer/lib/electron-trpc";
+import { electronTrpcClient } from "renderer/lib/trpc-client";
 import { getTrustedMemoRootPath } from "renderer/lib/workspace-memos";
 import type { CodeEditorAdapter } from "renderer/screens/main/components/WorkspaceView/ContentView/components";
 import { CodeEditor } from "renderer/screens/main/components/WorkspaceView/components/CodeEditor";
+import type {
+	SymbolHoverResult,
+	SymbolPosition,
+} from "renderer/screens/main/components/WorkspaceView/components/CodeEditor/createSymbolInteractions";
+import { useTabsStore } from "renderer/stores/tabs/store";
 import type { Tab } from "renderer/stores/tabs/types";
 import { pathsMatch, toAbsoluteWorkspacePath } from "shared/absolute-paths";
 import { type DiffViewMode, isDiffEditable } from "shared/changes-types";
@@ -209,6 +215,7 @@ interface FileViewerContentProps {
 	editorRef: MutableRefObject<CodeEditorAdapter | null>;
 	markdownEditorRef: MutableRefObject<MarkdownEditorAdapter | null>;
 	renderedContent: string;
+	documentVersion?: number;
 	initialLine?: number;
 	initialColumn?: number;
 	diffViewMode: DiffViewMode;
@@ -251,6 +258,7 @@ export function FileViewerContent({
 	editorRef,
 	markdownEditorRef,
 	renderedContent,
+	documentVersion,
 	initialLine,
 	initialColumn,
 	diffViewMode,
@@ -287,6 +295,7 @@ export function FileViewerContent({
 	} = useNextEditCompletion({
 		filePath,
 	});
+	const addFileViewerPane = useTabsStore((s) => s.addFileViewerPane);
 
 	useScrollToFirstDiffChange({
 		containerRef: diffContainerRef,
@@ -359,6 +368,10 @@ export function FileViewerContent({
 			),
 		[workspaceDiagnostics?.problems, absoluteFilePath, filePath],
 	);
+	const languageId = useMemo(() => detectLanguage(filePath), [filePath]);
+	const canResolveSymbols = Boolean(
+		workspaceId && absoluteFilePath && languageId,
+	);
 
 	const { data: blameData } = electronTrpc.changes.getGitBlame.useQuery(
 		{ worktreePath: worktreePath ?? "", absolutePath: absoluteFilePath },
@@ -375,6 +388,7 @@ export function FileViewerContent({
 		  })
 		| null
 	>(null);
+	const lastModifiedCursorRef = useRef<SymbolPosition | null>(null);
 
 	// biome-ignore lint/correctness/useExhaustiveDependencies: Reset on file change only
 	useEffect(() => {
@@ -482,6 +496,82 @@ export function FileViewerContent({
 		[onContentChange, trackDocumentChange],
 	);
 
+	const resolveSymbolHover = useCallback(
+		async (position: SymbolPosition): Promise<SymbolHoverResult | null> => {
+			if (!workspaceId || !absoluteFilePath || !languageId) {
+				return null;
+			}
+
+			return await electronTrpcClient.languageServices.getHover.query({
+				workspaceId,
+				absolutePath: absoluteFilePath,
+				languageId,
+				line: position.line,
+				column: position.column,
+				content: renderedContent,
+				version: documentVersion ?? 0,
+			});
+		},
+		[
+			absoluteFilePath,
+			documentVersion,
+			languageId,
+			renderedContent,
+			workspaceId,
+		],
+	);
+
+	const goToDefinition = useCallback(
+		async (position: SymbolPosition) => {
+			if (!workspaceId || !absoluteFilePath || !languageId) {
+				return;
+			}
+
+			const definitions =
+				await electronTrpcClient.languageServices.getDefinition.query({
+					workspaceId,
+					absolutePath: absoluteFilePath,
+					languageId,
+					line: position.line,
+					column: position.column,
+					content: renderedContent,
+					version: documentVersion ?? 0,
+				});
+			const target = definitions?.[0];
+			if (!target) {
+				return;
+			}
+
+			if (pathsMatch(target.absolutePath, absoluteFilePath)) {
+				if (viewMode === "diff") {
+					onSwitchToRawAtLocation(target.line, target.column);
+					return;
+				}
+
+				editorRef.current?.revealPosition(target.line, target.column);
+				return;
+			}
+
+			addFileViewerPane(workspaceId, {
+				filePath: target.absolutePath,
+				line: target.line,
+				column: target.column,
+				isPinned: false,
+			});
+		},
+		[
+			absoluteFilePath,
+			addFileViewerPane,
+			documentVersion,
+			editorRef,
+			languageId,
+			onSwitchToRawAtLocation,
+			renderedContent,
+			viewMode,
+			workspaceId,
+		],
+	);
+
 	useEffect(() => {
 		if (
 			viewMode !== "raw" ||
@@ -578,6 +668,21 @@ export function FileViewerContent({
 						column: location.column,
 					});
 				}}
+				onGoToDefinition={
+					canResolveSymbols
+						? () => {
+								if (lastDiffLocationRef.current?.side !== "additions") {
+									return;
+								}
+								const position = lastModifiedCursorRef.current;
+								if (!position) {
+									return;
+								}
+
+								void goToDefinition(position);
+							}
+						: undefined
+				}
 			>
 				<div className="relative h-full">
 					<div
@@ -619,6 +724,13 @@ export function FileViewerContent({
 									? requestInlineCompletion
 									: null
 							}
+							resolveSymbolHover={
+								canResolveSymbols ? resolveSymbolHover : undefined
+							}
+							onGoToDefinition={canResolveSymbols ? goToDefinition : undefined}
+							onModifiedCursorChange={(position) => {
+								lastModifiedCursorRef.current = position;
+							}}
 						/>
 					</div>
 				</div>
@@ -781,6 +893,18 @@ export function FileViewerContent({
 			onMoveToTab={onMoveToTab}
 			onMoveToNewTab={onMoveToNewTab}
 			onShowReferenceGraph={onShowReferenceGraph}
+			onGoToDefinition={
+				canResolveSymbols
+					? () => {
+							const position = editorRef.current?.getCursorPosition();
+							if (!position) {
+								return;
+							}
+
+							void goToDefinition(position);
+						}
+					: undefined
+			}
 		>
 			<div className="h-full w-full">
 				<CodeEditor
@@ -798,6 +922,10 @@ export function FileViewerContent({
 					inlineCompletionRequest={
 						isNextEditAvailable ? requestInlineCompletion : null
 					}
+					resolveSymbolHover={
+						canResolveSymbols ? resolveSymbolHover : undefined
+					}
+					onGoToDefinition={canResolveSymbols ? goToDefinition : undefined}
 				/>
 			</div>
 		</FileEditorContextMenu>

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/components/FileViewerContent/FileViewerContent.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/components/FileViewerContent/FileViewerContent.tsx
@@ -550,8 +550,12 @@ export function FileViewerContent({
 				languageId,
 				line: position.line,
 				column: position.column,
-				content: renderedContent,
-				version: documentVersion ?? 0,
+				...(documentVersion !== undefined
+					? {
+							content: renderedContent,
+							version: documentVersion,
+						}
+					: {}),
 			});
 		},
 		[
@@ -576,8 +580,12 @@ export function FileViewerContent({
 					languageId,
 					line: position.line,
 					column: position.column,
-					content: renderedContent,
-					version: documentVersion ?? 0,
+					...(documentVersion !== undefined
+						? {
+								content: renderedContent,
+								version: documentVersion,
+							}
+						: {}),
 				});
 			const target = definitions?.[0];
 			if (!target) {

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/components/EditorContextMenu/EditorContextMenu.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/components/EditorContextMenu/EditorContextMenu.tsx
@@ -33,6 +33,7 @@ export interface EditorActions {
 	onCopySupersetLink?: () => void;
 	onCopySupersetLinkWithLine?: () => void;
 	onFind?: () => void;
+	onGoToDefinition?: () => void;
 	onShowReferenceGraph?: () => void;
 }
 
@@ -65,6 +66,7 @@ export function EditorContextMenu({
 		onCopySupersetLink,
 		onCopySupersetLinkWithLine,
 		onFind,
+		onGoToDefinition,
 		onShowReferenceGraph,
 	} = editorActions;
 	const showCutPaste = !!onCut && !!onPaste;
@@ -139,6 +141,13 @@ export function EditorContextMenu({
 						<LuSearch className="size-4" />
 						Find
 						<ContextMenuShortcut>{cmdKey}+F</ContextMenuShortcut>
+					</ContextMenuItem>
+				)}
+				{onGoToDefinition && (
+					<ContextMenuItem onSelect={onGoToDefinition}>
+						<LuMousePointerClick className="size-4" />
+						Go to Definition
+						<ContextMenuShortcut>F12</ContextMenuShortcut>
 					</ContextMenuItem>
 				)}
 

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/components/EditorContextMenu/useEditorActions.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/components/EditorContextMenu/useEditorActions.ts
@@ -16,6 +16,7 @@ interface UseEditorActionsProps {
 	supersetLinkProject?: SupersetLinkProject | null;
 	/** If true, includes cut/paste actions (for editable editors) */
 	editable?: boolean;
+	onGoToDefinition?: () => void;
 	/** Optional handler for "Show Reference Graph" context menu action */
 	onShowReferenceGraph?: () => void;
 }
@@ -31,6 +32,7 @@ export function useEditorActions({
 	worktreePath,
 	supersetLinkProject,
 	editable = true,
+	onGoToDefinition,
 	onShowReferenceGraph,
 }: UseEditorActionsProps): EditorActions {
 	const { copyToClipboard } = useCopyToClipboard();
@@ -188,6 +190,7 @@ export function useEditorActions({
 				? handleCopySupersetLinkWithLine
 				: undefined,
 		onFind: handleFind,
+		onGoToDefinition,
 		onShowReferenceGraph,
 	};
 }

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/components/CodeEditor/CodeEditor.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/components/CodeEditor/CodeEditor.tsx
@@ -48,6 +48,11 @@ import {
 	createInlineCompletionPlugin,
 	type InlineCompletionRequest,
 } from "./createInlineCompletionPlugin";
+import {
+	createSymbolInteractions,
+	type SymbolHoverResult,
+	type SymbolPosition,
+} from "./createSymbolInteractions";
 import { createTrailingSpacesPlugin } from "./createTrailingSpacesPlugin";
 import { loadLanguageSupport } from "./loadLanguageSupport";
 
@@ -71,6 +76,10 @@ interface CodeEditorProps {
 		severity: "error" | "warning" | "info" | "hint";
 	}>;
 	inlineCompletionRequest?: InlineCompletionRequest | null;
+	resolveSymbolHover?: (
+		position: SymbolPosition,
+	) => Promise<SymbolHoverResult | null> | SymbolHoverResult | null;
+	onGoToDefinition?: (position: SymbolPosition) => Promise<void> | void;
 }
 
 const HIGHLIGHT_CLEAR_DELAY_MS = 1800;
@@ -525,6 +534,8 @@ export function CodeEditor({
 	blameEntries,
 	diagnostics = [],
 	inlineCompletionRequest = null,
+	resolveSymbolHover,
+	onGoToDefinition,
 }: CodeEditorProps) {
 	const [isSearchOpen, setIsSearchOpen] = useState(false);
 	const [searchQuery, setSearchQueryState] = useState("");
@@ -554,6 +565,8 @@ export function CodeEditor({
 	const inlineCompletionRequestRef = useRef<InlineCompletionRequest | null>(
 		inlineCompletionRequest,
 	);
+	const resolveSymbolHoverRef = useRef(resolveSymbolHover);
+	const onGoToDefinitionRef = useRef(onGoToDefinition);
 	// Guards against re-entrant onChange calls triggered by the value-sync effect's own dispatch.
 	const isExternalUpdateRef = useRef(false);
 	const { data: fontSettings } = electronTrpc.settings.getFontSettings.useQuery(
@@ -579,6 +592,8 @@ export function CodeEditor({
 	onChangeRef.current = onChange;
 	onSaveRef.current = onSave;
 	inlineCompletionRequestRef.current = inlineCompletionRequest;
+	resolveSymbolHoverRef.current = resolveSymbolHover;
+	onGoToDefinitionRef.current = onGoToDefinition;
 	searchModeRef.current = searchMode;
 	isSearchOpenRef.current = isSearchOpen;
 
@@ -876,6 +891,12 @@ export function CodeEditor({
 						),
 					),
 				]),
+				...createSymbolInteractions({
+					resolveHover: (position) =>
+						resolveSymbolHoverRef.current?.(position) ?? null,
+					onGoToDefinition: (position) =>
+						onGoToDefinitionRef.current?.(position),
+				}),
 				updateListener,
 				overlaySearchUpdateListener,
 			],

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/components/CodeEditor/createSymbolInteractions.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/components/CodeEditor/createSymbolInteractions.ts
@@ -1,0 +1,234 @@
+import type { Extension, Text } from "@codemirror/state";
+import {
+	EditorView,
+	hoverTooltip,
+	keymap,
+	type Tooltip,
+	ViewPlugin,
+	type ViewUpdate,
+} from "@codemirror/view";
+
+export interface SymbolPosition {
+	line: number;
+	column: number;
+}
+
+export interface SymbolRange {
+	line: number;
+	column: number;
+	endLine: number;
+	endColumn: number;
+}
+
+export interface SymbolMarkupContent {
+	kind: "plaintext" | "markdown";
+	value: string;
+}
+
+export interface SymbolHoverResult {
+	contents: SymbolMarkupContent[];
+	range: SymbolRange | null;
+}
+
+interface CreateSymbolInteractionsOptions {
+	resolveHover?: (
+		position: SymbolPosition,
+	) => Promise<SymbolHoverResult | null> | SymbolHoverResult | null;
+	onGoToDefinition?: (position: SymbolPosition) => Promise<void> | void;
+	onCursorChange?: (position: SymbolPosition | null) => void;
+}
+
+function docOffsetToPosition(doc: Text, offset: number): SymbolPosition {
+	const line = doc.lineAt(offset);
+	return {
+		line: line.number,
+		column: offset - line.from + 1,
+	};
+}
+
+function positionToDocOffset(doc: Text, position: SymbolPosition): number {
+	const safeLine = Math.max(1, Math.min(position.line, doc.lines));
+	const line = doc.line(safeLine);
+	return Math.min(line.from + Math.max(position.column - 1, 0), line.to);
+}
+
+function rangeToOffsets(
+	doc: Text,
+	range: SymbolRange | null,
+	fallbackOffset: number,
+): { from: number; to: number } {
+	if (!range) {
+		return {
+			from: fallbackOffset,
+			to: Math.min(doc.length, fallbackOffset + 1),
+		};
+	}
+
+	const from = positionToDocOffset(doc, {
+		line: range.line,
+		column: range.column,
+	});
+	const rawTo = positionToDocOffset(doc, {
+		line: range.endLine,
+		column: range.endColumn,
+	});
+
+	return {
+		from,
+		to: Math.min(doc.length, Math.max(from + 1, rawTo)),
+	};
+}
+
+function createTooltipDom(contents: SymbolMarkupContent[]): HTMLElement {
+	const dom = document.createElement("div");
+	dom.style.maxWidth = "480px";
+	dom.style.padding = "8px 10px";
+	dom.style.borderRadius = "8px";
+	dom.style.border = "1px solid hsl(var(--border))";
+	dom.style.background = "hsl(var(--popover))";
+	dom.style.color = "hsl(var(--popover-foreground))";
+	dom.style.boxShadow =
+		"0 10px 30px rgba(0, 0, 0, 0.18), 0 2px 8px rgba(0, 0, 0, 0.12)";
+	dom.style.fontSize = "12px";
+	dom.style.lineHeight = "1.5";
+	dom.style.whiteSpace = "pre-wrap";
+	dom.style.wordBreak = "break-word";
+
+	contents.forEach((content, index) => {
+		const section = document.createElement("div");
+		if (index > 0) {
+			section.style.marginTop = "8px";
+			section.style.paddingTop = "8px";
+			section.style.borderTop = "1px solid hsl(var(--border))";
+		}
+
+		if (content.kind === "markdown") {
+			section.style.fontFamily =
+				"ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace";
+		}
+
+		section.textContent = content.value;
+		dom.appendChild(section);
+	});
+
+	return dom;
+}
+
+export function createSymbolInteractions({
+	resolveHover,
+	onGoToDefinition,
+	onCursorChange,
+}: CreateSymbolInteractionsOptions): Extension[] {
+	const extensions: Extension[] = [];
+
+	if (resolveHover) {
+		extensions.push(
+			hoverTooltip(
+				async (view, pos): Promise<Tooltip | null> => {
+					const hover = await resolveHover(
+						docOffsetToPosition(view.state.doc, pos),
+					);
+					if (!hover || hover.contents.length === 0) {
+						return null;
+					}
+
+					const { from, to } = rangeToOffsets(view.state.doc, hover.range, pos);
+					return {
+						pos: from,
+						end: to,
+						above: true,
+						arrow: true,
+						create() {
+							return {
+								dom: createTooltipDom(hover.contents),
+							};
+						},
+					};
+				},
+				{ hoverTime: 250 },
+			),
+		);
+	}
+
+	if (onGoToDefinition) {
+		extensions.push(
+			keymap.of([
+				{
+					key: "F12",
+					run(view) {
+						void onGoToDefinition(
+							docOffsetToPosition(
+								view.state.doc,
+								view.state.selection.main.head,
+							),
+						);
+						return true;
+					},
+				},
+			]),
+		);
+
+		extensions.push(
+			EditorView.domEventHandlers({
+				mousedown(event, view) {
+					if (
+						event.button !== 0 ||
+						(!event.metaKey && !event.ctrlKey) ||
+						event.altKey ||
+						event.shiftKey
+					) {
+						return false;
+					}
+
+					const offset = view.posAtCoords({
+						x: event.clientX,
+						y: event.clientY,
+					});
+					if (offset === null) {
+						return false;
+					}
+
+					event.preventDefault();
+					void onGoToDefinition(docOffsetToPosition(view.state.doc, offset));
+					return true;
+				},
+			}),
+		);
+	}
+
+	if (onCursorChange) {
+		const notifyCursor = (view: EditorView) => {
+			onCursorChange(
+				view.hasFocus
+					? docOffsetToPosition(view.state.doc, view.state.selection.main.head)
+					: null,
+			);
+		};
+
+		extensions.push(
+			ViewPlugin.fromClass(
+				class {
+					constructor(view: EditorView) {
+						notifyCursor(view);
+					}
+
+					update(update: ViewUpdate) {
+						if (
+							update.selectionSet ||
+							update.focusChanged ||
+							update.docChanged
+						) {
+							notifyCursor(update.view);
+						}
+					}
+
+					destroy() {
+						onCursorChange(null);
+					}
+				},
+			),
+		);
+	}
+
+	return extensions;
+}


### PR DESCRIPTION
## Summary
- add `hover` and `definition` queries to the desktop language-service layer and implement them for TypeScript + external LSP providers
- wire raw file viewer and diff viewer's modified pane to show hover info and support `F12`, Cmd/Ctrl-click, and context-menu `Go to Definition`
- include the small existing `apps/desktop` cleanup needed to get lint and typecheck green in this branch

## Scope
- raw file viewer: hover + go-to-definition
- diff viewer: modified/right side only for symbol interactions
- diff original/left side snapshot-backed symbol resolution is still out of scope

## Verification
- `bun run lint`
- `bun run typecheck`
- `cd apps/desktop && bun run typecheck`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  - ホバー機能の追加：コード内の記号にマウスを合わせると、ホバー情報を表示
  - 定義へ移動機能の追加：F12キーまたはコンテキストメニュー「Go to Definition」から定義位置に移動
  - TypeScript/JavaScriptおよびLSP対応言語での記号解析サポート
  - プリセットバーの表示/非表示を切り替え可能

* **改善**
  - エディタの入力値バリデーションを強化
  - ファイルローディング処理を最適化

<!-- end of auto-generated comment: release notes by coderabbit.ai -->