### PR TITLE
fix(desktop): fix browser redirect loops and stale tab titles

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/browserRuntimeRegistry.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/browserRuntimeRegistry.ts
@@ -229,6 +229,7 @@ class BrowserRuntimeRegistryImpl {
 				isLoading: false,
 			});
 			this.refreshNavState(paneId);
+			firePersist();
 		};
 
 		const handleDidNavigateInPage = (e: Electron.DidNavigateInPageEvent) => {
@@ -236,10 +237,12 @@ class BrowserRuntimeRegistryImpl {
 			const title = webview.getTitle() ?? "";
 			this.setState(paneId, { currentUrl: url, pageTitle: title });
 			this.refreshNavState(paneId);
+			firePersist();
 		};
 
 		const handlePageTitleUpdated = (e: Electron.PageTitleUpdatedEvent) => {
 			this.setState(paneId, { pageTitle: e.title ?? "" });
+			firePersist();
 		};
 
 		const handlePageFaviconUpdated = (e: Electron.PageFaviconUpdatedEvent) => {
@@ -340,6 +343,11 @@ class BrowserRuntimeRegistryImpl {
 		entry.onPersist = onPersist;
 		entry.placeholder = placeholder;
 		entry.visible = true;
+		entry.onPersist?.({
+			url: entry.state.currentUrl,
+			pageTitle: entry.state.pageTitle,
+			faviconUrl: entry.state.faviconUrl,
+		});
 
 		entry.resizeObserver?.disconnect();
 		const observer = new ResizeObserver(() => {

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/hooks/usePersistentWebview/usePersistentWebview.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/hooks/usePersistentWebview/usePersistentWebview.ts
@@ -156,11 +156,10 @@ export function usePersistentWebview({
 	splitPaneAuto,
 }: UsePersistentWebviewOptions) {
 	const containerRef = useRef<HTMLDivElement | null>(null);
-	const isHistoryNavigation = useRef(false);
 	const faviconUrlRef = useRef<string | undefined>(undefined);
 	const initialUrlRef = useRef(initialUrl);
+	const lastSyncedUrlRef = useRef<string | null>(null);
 
-	const navigateBrowserHistory = useTabsStore((s) => s.navigateBrowserHistory);
 	const browserState = useTabsStore((s) => s.panes[paneId]?.browser);
 	const historyIndex = browserState?.historyIndex ?? 0;
 	const historyLength = browserState?.history.length ?? 0;
@@ -210,17 +209,26 @@ export function usePersistentWebview({
 			try {
 				const url = webview.getURL();
 				const title = webview.getTitle();
-				if (url) {
-					const store = useTabsStore.getState();
-					const currentUrl = store.panes[paneId]?.browser?.currentUrl;
-					if (url !== currentUrl) {
-						store.updateBrowserUrl(
-							paneId,
-							url,
-							title ?? "",
-							faviconUrlRef.current,
-						);
-					}
+				if (!url) {
+					return;
+				}
+				lastSyncedUrlRef.current = url;
+				const store = useTabsStore.getState();
+				const browser = store.panes[paneId]?.browser;
+				const currentUrl = browser?.currentUrl;
+				const currentTitle =
+					browser?.history[browser.historyIndex]?.title ?? "";
+				if (
+					url !== currentUrl ||
+					(title ?? "") !== currentTitle ||
+					faviconUrlRef.current !== undefined
+				) {
+					store.updateBrowserUrl(
+						paneId,
+						url,
+						title ?? "",
+						faviconUrlRef.current,
+					);
 				}
 			} catch {
 				// webview may not be ready
@@ -498,14 +506,10 @@ export function usePersistentWebview({
 			const store = useTabsStore.getState();
 			store.updateBrowserLoading(paneId, false);
 
-			if (isHistoryNavigation.current) {
-				isHistoryNavigation.current = false;
-				return;
-			}
-
 			try {
 				const url = wv.getURL();
 				const title = wv.getTitle();
+				lastSyncedUrlRef.current = url ?? null;
 				store.updateBrowserUrl(
 					paneId,
 					url ?? "",
@@ -526,10 +530,7 @@ export function usePersistentWebview({
 		};
 
 		const handleDidNavigate = (e: Electron.DidNavigateEvent) => {
-			if (isHistoryNavigation.current) {
-				isHistoryNavigation.current = false;
-				return;
-			}
+			lastSyncedUrlRef.current = e.url ?? null;
 			const store = useTabsStore.getState();
 			store.updateBrowserUrl(
 				paneId,
@@ -541,10 +542,7 @@ export function usePersistentWebview({
 		};
 
 		const handleDidNavigateInPage = (e: Electron.DidNavigateInPageEvent) => {
-			if (isHistoryNavigation.current) {
-				isHistoryNavigation.current = false;
-				return;
-			}
+			lastSyncedUrlRef.current = e.url ?? null;
 			const store = useTabsStore.getState();
 			store.updateBrowserUrl(
 				paneId,
@@ -555,8 +553,15 @@ export function usePersistentWebview({
 		};
 
 		const handlePageTitleUpdated = (e: Electron.PageTitleUpdatedEvent) => {
+			let currentUrl = "";
+			try {
+				currentUrl = wv.getURL() ?? "";
+				lastSyncedUrlRef.current = currentUrl || lastSyncedUrlRef.current;
+			} catch {
+				currentUrl =
+					useTabsStore.getState().panes[paneId]?.browser?.currentUrl ?? "";
+			}
 			const store = useTabsStore.getState();
-			const currentUrl = store.panes[paneId]?.browser?.currentUrl ?? "";
 			store.updateBrowserUrl(
 				paneId,
 				currentUrl,
@@ -569,12 +574,21 @@ export function usePersistentWebview({
 			const favicons = e.favicons;
 			if (favicons && favicons.length > 0) {
 				faviconUrlRef.current = favicons[0];
+				let currentUrl = "";
+				let currentTitle = "";
+				try {
+					currentUrl = wv.getURL() ?? "";
+					currentTitle = wv.getTitle() ?? "";
+					lastSyncedUrlRef.current = currentUrl || lastSyncedUrlRef.current;
+				} catch {
+					const store = useTabsStore.getState();
+					currentUrl = store.panes[paneId]?.browser?.currentUrl ?? "";
+					currentTitle =
+						store.panes[paneId]?.browser?.history[
+							store.panes[paneId]?.browser?.historyIndex ?? 0
+						]?.title ?? "";
+				}
 				const store = useTabsStore.getState();
-				const currentUrl = store.panes[paneId]?.browser?.currentUrl ?? "";
-				const currentTitle =
-					store.panes[paneId]?.browser?.history[
-						store.panes[paneId]?.browser?.historyIndex ?? 0
-					]?.title ?? "";
 				store.updateBrowserUrl(paneId, currentUrl, currentTitle, favicons[0]);
 				if (currentUrl && currentUrl !== "about:blank") {
 					upsertHistoryRef.current({
@@ -658,28 +672,31 @@ export function usePersistentWebview({
 	}, [paneId, syncStoreFromWebview]);
 
 	useEffect(() => {
+		const normalizedInitialUrl = sanitizeUrl(initialUrl);
+		if (
+			lastSyncedUrlRef.current &&
+			sanitizeUrl(lastSyncedUrlRef.current) === normalizedInitialUrl
+		) {
+			return;
+		}
 		navigatePersistentWebview(paneId, initialUrl);
 	}, [initialUrl, paneId]);
 
 	// -- Navigation methods (operate directly on the webview) ---------------
 
 	const goBack = useCallback(() => {
-		const url = navigateBrowserHistory(paneId, "back");
-		if (url) {
-			isHistoryNavigation.current = true;
-			const webview = getPersistentWebview(paneId);
-			if (webview) webview.loadURL(sanitizeUrl(url));
+		const webview = getPersistentWebview(paneId);
+		if (webview?.canGoBack()) {
+			webview.goBack();
 		}
-	}, [paneId, navigateBrowserHistory]);
+	}, [paneId]);
 
 	const goForward = useCallback(() => {
-		const url = navigateBrowserHistory(paneId, "forward");
-		if (url) {
-			isHistoryNavigation.current = true;
-			const webview = getPersistentWebview(paneId);
-			if (webview) webview.loadURL(sanitizeUrl(url));
+		const webview = getPersistentWebview(paneId);
+		if (webview?.canGoForward()) {
+			webview.goForward();
 		}
-	}, [paneId, navigateBrowserHistory]);
+	}, [paneId]);
 
 	const reload = useCallback(() => {
 		const webview = getPersistentWebview(paneId);

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/hooks/usePersistentWebview/usePersistentWebview.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/hooks/usePersistentWebview/usePersistentWebview.ts
@@ -547,12 +547,15 @@ export function usePersistentWebview({
 
 		const handleDidNavigateInPage = (e: Electron.DidNavigateInPageEvent) => {
 			lastSyncedUrlRef.current = e.url ?? null;
+			const direction = pendingNavDirectionRef.current;
+			pendingNavDirectionRef.current = null;
 			const store = useTabsStore.getState();
 			store.updateBrowserUrl(
 				paneId,
 				e.url ?? "",
 				wv.getTitle() ?? "",
 				faviconUrlRef.current,
+				direction ?? undefined,
 			);
 		};
 

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/hooks/usePersistentWebview/usePersistentWebview.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/hooks/usePersistentWebview/usePersistentWebview.ts
@@ -159,6 +159,7 @@ export function usePersistentWebview({
 	const faviconUrlRef = useRef<string | undefined>(undefined);
 	const initialUrlRef = useRef(initialUrl);
 	const lastSyncedUrlRef = useRef<string | null>(null);
+	const pendingNavDirectionRef = useRef<"back" | "forward" | null>(null);
 
 	const browserState = useTabsStore((s) => s.panes[paneId]?.browser);
 	const historyIndex = browserState?.historyIndex ?? 0;
@@ -531,12 +532,15 @@ export function usePersistentWebview({
 
 		const handleDidNavigate = (e: Electron.DidNavigateEvent) => {
 			lastSyncedUrlRef.current = e.url ?? null;
+			const direction = pendingNavDirectionRef.current;
+			pendingNavDirectionRef.current = null;
 			const store = useTabsStore.getState();
 			store.updateBrowserUrl(
 				paneId,
 				e.url ?? "",
 				wv.getTitle() ?? "",
 				faviconUrlRef.current,
+				direction ?? undefined,
 			);
 			store.updateBrowserLoading(paneId, false);
 		};
@@ -687,6 +691,7 @@ export function usePersistentWebview({
 	const goBack = useCallback(() => {
 		const webview = getPersistentWebview(paneId);
 		if (webview?.canGoBack()) {
+			pendingNavDirectionRef.current = "back";
 			webview.goBack();
 		}
 	}, [paneId]);
@@ -694,6 +699,7 @@ export function usePersistentWebview({
 	const goForward = useCallback(() => {
 		const webview = getPersistentWebview(paneId);
 		if (webview?.canGoForward()) {
+			pendingNavDirectionRef.current = "forward";
 			webview.goForward();
 		}
 	}, [paneId]);

--- a/apps/desktop/src/renderer/stores/tabs/store.ts
+++ b/apps/desktop/src/renderer/stores/tabs/store.ts
@@ -2209,6 +2209,70 @@ export const useTabsStore = create<TabsStore>()(
 						return;
 					}
 
+					// Native browser back/forward should move within existing history
+					// instead of creating a brand-new entry for an old URL.
+					const backwardEntry = prevHistory[historyIndex - 1];
+					if (backwardEntry && backwardEntry.url === url) {
+						const history = [...prevHistory];
+						history[historyIndex - 1] = {
+							...backwardEntry,
+							title,
+							...(faviconUrl !== undefined ? { faviconUrl } : {}),
+						};
+						const newPanes = {
+							...state.panes,
+							[paneId]: {
+								...pane,
+								name: title || "Browser",
+								browser: {
+									...pane.browser,
+									currentUrl: url,
+									history,
+									historyIndex: historyIndex - 1,
+								},
+							},
+						};
+						const tabName = deriveTabName(newPanes, pane.tabId);
+						set({
+							panes: newPanes,
+							tabs: state.tabs.map((t) =>
+								t.id === pane.tabId ? { ...t, name: tabName } : t,
+							),
+						});
+						return;
+					}
+
+					const forwardEntry = prevHistory[historyIndex + 1];
+					if (forwardEntry && forwardEntry.url === url) {
+						const history = [...prevHistory];
+						history[historyIndex + 1] = {
+							...forwardEntry,
+							title,
+							...(faviconUrl !== undefined ? { faviconUrl } : {}),
+						};
+						const newPanes = {
+							...state.panes,
+							[paneId]: {
+								...pane,
+								name: title || "Browser",
+								browser: {
+									...pane.browser,
+									currentUrl: url,
+									history,
+									historyIndex: historyIndex + 1,
+								},
+							},
+						};
+						const tabName = deriveTabName(newPanes, pane.tabId);
+						set({
+							panes: newPanes,
+							tabs: state.tabs.map((t) =>
+								t.id === pane.tabId ? { ...t, name: tabName } : t,
+							),
+						});
+						return;
+					}
+
 					// Truncate forward entries when navigating from a non-end position
 					const history = prevHistory.slice(0, historyIndex + 1);
 					history.push({

--- a/apps/desktop/src/renderer/stores/tabs/store.ts
+++ b/apps/desktop/src/renderer/stores/tabs/store.ts
@@ -2215,12 +2215,14 @@ export const useTabsStore = create<TabsStore>()(
 					// URL-bar navigation or loadURL() calls must never match an adjacent
 					// entry — they should always truncate forward history and push a new
 					// entry, even if the URL happens to coincide with a neighbour.
-					if (historyNavDirection === "back") {
-						const backwardEntry = prevHistory[historyIndex - 1];
-						if (backwardEntry && backwardEntry.url === url) {
+					if (historyNavDirection) {
+						const offset = historyNavDirection === "back" ? -1 : 1;
+						const adjacentIndex = historyIndex + offset;
+						const adjacentEntry = prevHistory[adjacentIndex];
+						if (adjacentEntry && adjacentEntry.url === url) {
 							const history = [...prevHistory];
-							history[historyIndex - 1] = {
-								...backwardEntry,
+							history[adjacentIndex] = {
+								...adjacentEntry,
 								title,
 								...(faviconUrl !== undefined ? { faviconUrl } : {}),
 							};
@@ -2233,40 +2235,7 @@ export const useTabsStore = create<TabsStore>()(
 										...pane.browser,
 										currentUrl: url,
 										history,
-										historyIndex: historyIndex - 1,
-									},
-								},
-							};
-							const tabName = deriveTabName(newPanes, pane.tabId);
-							set({
-								panes: newPanes,
-								tabs: state.tabs.map((t) =>
-									t.id === pane.tabId ? { ...t, name: tabName } : t,
-								),
-							});
-							return;
-						}
-					}
-
-					if (historyNavDirection === "forward") {
-						const forwardEntry = prevHistory[historyIndex + 1];
-						if (forwardEntry && forwardEntry.url === url) {
-							const history = [...prevHistory];
-							history[historyIndex + 1] = {
-								...forwardEntry,
-								title,
-								...(faviconUrl !== undefined ? { faviconUrl } : {}),
-							};
-							const newPanes = {
-								...state.panes,
-								[paneId]: {
-									...pane,
-									name: title || "Browser",
-									browser: {
-										...pane.browser,
-										currentUrl: url,
-										history,
-										historyIndex: historyIndex + 1,
+										historyIndex: adjacentIndex,
 									},
 								},
 							};

--- a/apps/desktop/src/renderer/stores/tabs/store.ts
+++ b/apps/desktop/src/renderer/stores/tabs/store.ts
@@ -2170,6 +2170,7 @@ export const useTabsStore = create<TabsStore>()(
 					url: string,
 					title: string,
 					faviconUrl?: string,
+					historyNavDirection?: "back" | "forward",
 				) => {
 					const state = get();
 					const pane = state.panes[paneId];
@@ -2209,68 +2210,75 @@ export const useTabsStore = create<TabsStore>()(
 						return;
 					}
 
-					// Native browser back/forward should move within existing history
-					// instead of creating a brand-new entry for an old URL.
-					const backwardEntry = prevHistory[historyIndex - 1];
-					if (backwardEntry && backwardEntry.url === url) {
-						const history = [...prevHistory];
-						history[historyIndex - 1] = {
-							...backwardEntry,
-							title,
-							...(faviconUrl !== undefined ? { faviconUrl } : {}),
-						};
-						const newPanes = {
-							...state.panes,
-							[paneId]: {
-								...pane,
-								name: title || "Browser",
-								browser: {
-									...pane.browser,
-									currentUrl: url,
-									history,
-									historyIndex: historyIndex - 1,
+					// Only reuse adjacent history entries when the caller explicitly
+					// signals that a native back/forward gesture triggered this update.
+					// URL-bar navigation or loadURL() calls must never match an adjacent
+					// entry — they should always truncate forward history and push a new
+					// entry, even if the URL happens to coincide with a neighbour.
+					if (historyNavDirection === "back") {
+						const backwardEntry = prevHistory[historyIndex - 1];
+						if (backwardEntry && backwardEntry.url === url) {
+							const history = [...prevHistory];
+							history[historyIndex - 1] = {
+								...backwardEntry,
+								title,
+								...(faviconUrl !== undefined ? { faviconUrl } : {}),
+							};
+							const newPanes = {
+								...state.panes,
+								[paneId]: {
+									...pane,
+									name: title || "Browser",
+									browser: {
+										...pane.browser,
+										currentUrl: url,
+										history,
+										historyIndex: historyIndex - 1,
+									},
 								},
-							},
-						};
-						const tabName = deriveTabName(newPanes, pane.tabId);
-						set({
-							panes: newPanes,
-							tabs: state.tabs.map((t) =>
-								t.id === pane.tabId ? { ...t, name: tabName } : t,
-							),
-						});
-						return;
+							};
+							const tabName = deriveTabName(newPanes, pane.tabId);
+							set({
+								panes: newPanes,
+								tabs: state.tabs.map((t) =>
+									t.id === pane.tabId ? { ...t, name: tabName } : t,
+								),
+							});
+							return;
+						}
 					}
 
-					const forwardEntry = prevHistory[historyIndex + 1];
-					if (forwardEntry && forwardEntry.url === url) {
-						const history = [...prevHistory];
-						history[historyIndex + 1] = {
-							...forwardEntry,
-							title,
-							...(faviconUrl !== undefined ? { faviconUrl } : {}),
-						};
-						const newPanes = {
-							...state.panes,
-							[paneId]: {
-								...pane,
-								name: title || "Browser",
-								browser: {
-									...pane.browser,
-									currentUrl: url,
-									history,
-									historyIndex: historyIndex + 1,
+					if (historyNavDirection === "forward") {
+						const forwardEntry = prevHistory[historyIndex + 1];
+						if (forwardEntry && forwardEntry.url === url) {
+							const history = [...prevHistory];
+							history[historyIndex + 1] = {
+								...forwardEntry,
+								title,
+								...(faviconUrl !== undefined ? { faviconUrl } : {}),
+							};
+							const newPanes = {
+								...state.panes,
+								[paneId]: {
+									...pane,
+									name: title || "Browser",
+									browser: {
+										...pane.browser,
+										currentUrl: url,
+										history,
+										historyIndex: historyIndex + 1,
+									},
 								},
-							},
-						};
-						const tabName = deriveTabName(newPanes, pane.tabId);
-						set({
-							panes: newPanes,
-							tabs: state.tabs.map((t) =>
-								t.id === pane.tabId ? { ...t, name: tabName } : t,
-							),
-						});
-						return;
+							};
+							const tabName = deriveTabName(newPanes, pane.tabId);
+							set({
+								panes: newPanes,
+								tabs: state.tabs.map((t) =>
+									t.id === pane.tabId ? { ...t, name: tabName } : t,
+								),
+							});
+							return;
+						}
 					}
 
 					// Truncate forward entries when navigating from a non-end position

--- a/apps/desktop/src/renderer/stores/tabs/types.ts
+++ b/apps/desktop/src/renderer/stores/tabs/types.ts
@@ -253,6 +253,7 @@ export interface TabsStore extends TabsState {
 		url: string,
 		title: string,
 		faviconUrl?: string,
+		historyNavDirection?: "back" | "forward",
 	) => void;
 	navigateBrowserHistory: (
 		paneId: string,


### PR DESCRIPTION
## Summary

Fixes #157 — browser history/state desync in the desktop built-in browser.

- **Use native back/forward**: `goBack`/`goForward` in the classic browser pane now call `webview.goBack()` / `webview.goForward()` instead of reading stored URL history and calling `loadURL()`. This eliminates redirect chain replays.
- **Live webview as source of truth**: `handlePageTitleUpdated` and `handlePageFaviconUpdated` read `wv.getURL()` / `wv.getTitle()` directly instead of pulling stale values from the store. Store values are only used as a fallback when the webview is not reachable.
- **Adjacent history index movement**: `updateBrowserUrl` in `store.ts` now checks `prevHistory[historyIndex - 1]` and `prevHistory[historyIndex + 1]` before appending a new entry — native back/forward moves the existing index rather than creating duplicate history.
- **Consistent persist in v2 browser**: `browserRuntimeRegistry.ts` now calls `firePersist()` in `handleDidNavigate`, `handleDidNavigateInPage`, and `handlePageTitleUpdated`, and immediately syncs state on re-attach via `onPersist` in `attach()`.

## Test plan

- [ ] Navigate to a redirect-heavy page (e.g. OAuth login flow), press Back — redirects should NOT be replayed
- [ ] Back/forward no longer creates loop-like navigation
- [ ] Tab title and favicon match the actual loaded page after SPA transitions and tab switches
- [ ] Switching away and back to a browser pane shows the correct title/favicon without requiring a reload
- [ ] v2 workspace browser tabs display current metadata on re-attach

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改善**
  * ブラウザの戻る・進む操作の同期がより正確になりました（履歴更新が適切に再利用され、不要な履歴重複を削減）。
  * ナビゲーションやページタイトル、ファビコンの変更時に状態保存が確実に発火するようになりました。
  * Webビューの初期読み込みと添付時に現在のURL/タイトル/ファビコンを即座に保存するようになりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->