### PR TITLE
[PR1/5] feat(upstream): 安全パッチ4件取り込み - ターミナルクリップボード/サイドバートグル/CodeMirrorホットキー/エラー選択

### DIFF
--- a/apps/desktop/src/renderer/components/UpdateRequiredPage/UpdateRequiredPage.tsx
+++ b/apps/desktop/src/renderer/components/UpdateRequiredPage/UpdateRequiredPage.tsx
@@ -80,7 +80,7 @@ export function UpdateRequiredPage({
 					</p>
 
 					{isError && (
-						<p className="text-sm text-destructive">
+						<p className="text-sm text-destructive select-text cursor-text break-words">
 							{updateStatus.error || "Update check failed. Please try again."}
 						</p>
 					)}

--- a/apps/desktop/src/renderer/hotkeys/hooks/useHotkey/useHotkey.ts
+++ b/apps/desktop/src/renderer/hotkeys/hooks/useHotkey/useHotkey.ts
@@ -17,7 +17,7 @@ export function useHotkey(
 	useHotkeys(
 		keys ?? "",
 		(e, _h) => callbackRef.current(e),
-		{ enableOnFormTags: true, ...options },
+		{ enableOnFormTags: true, enableOnContentEditable: true, ...options },
 		[keys],
 	);
 	return formatHotkeyDisplay(keys, PLATFORM);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/RightSidebarToggle/RightSidebarToggle.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/RightSidebarToggle/RightSidebarToggle.tsx
@@ -1,4 +1,6 @@
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
+import { eq } from "@tanstack/db";
+import { useLiveQuery } from "@tanstack/react-db";
 import {
 	LuPanelRight,
 	LuPanelRightClose,
@@ -9,8 +11,16 @@ import { useCollections } from "renderer/routes/_authenticated/providers/Collect
 
 export function RightSidebarToggle({ workspaceId }: { workspaceId: string }) {
 	const collections = useCollections();
-	const localState = collections.v2WorkspaceLocalState.get(workspaceId);
-	const isOpen = localState?.rightSidebarOpen ?? false;
+	const { data: localStateRows = [] } = useLiveQuery(
+		(query) =>
+			query
+				.from({ v2WorkspaceLocalState: collections.v2WorkspaceLocalState })
+				.where(({ v2WorkspaceLocalState }) =>
+					eq(v2WorkspaceLocalState.workspaceId, workspaceId),
+				),
+		[collections, workspaceId],
+	);
+	const isOpen = localStateRows[0]?.rightSidebarOpen ?? false;
 
 	const toggle = () => {
 		collections.v2WorkspaceLocalState.update(workspaceId, (draft) => {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pending/$pendingId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pending/$pendingId/page.tsx
@@ -314,7 +314,9 @@ function PendingWorkspacePage() {
 					<div className="space-y-4">
 						<div className="flex items-start gap-2 text-sm text-destructive">
 							<HiExclamationTriangle className="size-4 mt-0.5 shrink-0" />
-							<span>{pending.error ?? "Failed to create workspace"}</span>
+							<span className="select-text cursor-text break-words">
+								{pending.error ?? "Failed to create workspace"}
+							</span>
 						</div>
 						<div className="flex gap-2">
 							<button

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/clipboardShortcuts.test.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/clipboardShortcuts.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from "bun:test";
+import {
+	shouldBubbleClipboardShortcut,
+	shouldSelectAllShortcut,
+} from "./clipboardShortcuts";
+
+function makeEvent(
+	overrides: Partial<{
+		code: string;
+		metaKey: boolean;
+		ctrlKey: boolean;
+		altKey: boolean;
+		shiftKey: boolean;
+	}>,
+) {
+	return {
+		code: "KeyC",
+		metaKey: false,
+		ctrlKey: false,
+		altKey: false,
+		shiftKey: false,
+		...overrides,
+	};
+}
+
+describe("shouldBubbleClipboardShortcut", () => {
+	it("matches the VS Code terminal clipboard bindings", () => {
+		const cases = [
+			{
+				name: "macOS Cmd+V",
+				event: makeEvent({ code: "KeyV", metaKey: true }),
+				options: { isMac: true, isWindows: false, hasSelection: false },
+				expected: true,
+			},
+			{
+				name: "macOS Cmd+C with selection",
+				event: makeEvent({ code: "KeyC", metaKey: true }),
+				options: { isMac: true, isWindows: false, hasSelection: true },
+				expected: true,
+			},
+			{
+				name: "windows Ctrl+V",
+				event: makeEvent({ code: "KeyV", ctrlKey: true }),
+				options: { isMac: false, isWindows: true, hasSelection: false },
+				expected: true,
+			},
+			{
+				name: "windows Ctrl+Shift+V",
+				event: makeEvent({ code: "KeyV", ctrlKey: true, shiftKey: true }),
+				options: { isMac: false, isWindows: true, hasSelection: false },
+				expected: true,
+			},
+			{
+				name: "windows Ctrl+C with selection",
+				event: makeEvent({ code: "KeyC", ctrlKey: true }),
+				options: { isMac: false, isWindows: true, hasSelection: true },
+				expected: true,
+			},
+			{
+				name: "linux Ctrl+Shift+C with selection",
+				event: makeEvent({ code: "KeyC", ctrlKey: true, shiftKey: true }),
+				options: { isMac: false, isWindows: false, hasSelection: true },
+				expected: true,
+			},
+			{
+				name: "linux Ctrl+Shift+V",
+				event: makeEvent({ code: "KeyV", ctrlKey: true, shiftKey: true }),
+				options: { isMac: false, isWindows: false, hasSelection: false },
+				expected: true,
+			},
+			{
+				name: "linux Shift+Insert",
+				event: makeEvent({ code: "Insert", shiftKey: true }),
+				options: { isMac: false, isWindows: false, hasSelection: false },
+				expected: true,
+			},
+			{
+				name: "macOS Cmd+C without selection",
+				event: makeEvent({ code: "KeyC", metaKey: true }),
+				options: { isMac: true, isWindows: false, hasSelection: false },
+				expected: false,
+			},
+			{
+				name: "windows Ctrl+C without selection",
+				event: makeEvent({ code: "KeyC", ctrlKey: true }),
+				options: { isMac: false, isWindows: true, hasSelection: false },
+				expected: false,
+			},
+			{
+				name: "linux Ctrl+Shift+C without selection",
+				event: makeEvent({ code: "KeyC", ctrlKey: true, shiftKey: true }),
+				options: { isMac: false, isWindows: false, hasSelection: false },
+				expected: false,
+			},
+			{
+				name: "linux Ctrl+Insert stays with the PTY",
+				event: makeEvent({ code: "Insert", ctrlKey: true }),
+				options: { isMac: false, isWindows: false, hasSelection: false },
+				expected: false,
+			},
+			{
+				name: "macOS does not inherit linux fallback chords",
+				event: makeEvent({ code: "KeyV", ctrlKey: true, shiftKey: true }),
+				options: { isMac: true, isWindows: false, hasSelection: false },
+				expected: false,
+			},
+			{
+				name: "macOS Shift+Insert stays with the PTY",
+				event: makeEvent({ code: "Insert", shiftKey: true }),
+				options: { isMac: true, isWindows: false, hasSelection: false },
+				expected: false,
+			},
+		];
+
+		for (const { name, event, options, expected } of cases) {
+			expect(shouldBubbleClipboardShortcut(event, options), name).toBe(
+				expected,
+			);
+		}
+	});
+});
+
+describe("shouldSelectAllShortcut", () => {
+	it("matches only the VS Code macOS terminal select-all binding", () => {
+		const cases = [
+			{
+				name: "macOS Cmd+A",
+				event: makeEvent({ code: "KeyA", metaKey: true }),
+				isMac: true,
+				expected: true,
+			},
+			{
+				name: "windows Ctrl+A is not intercepted",
+				event: makeEvent({ code: "KeyA", ctrlKey: true }),
+				isMac: false,
+				expected: false,
+			},
+			{
+				name: "macOS Cmd+Shift+A is not intercepted",
+				event: makeEvent({ code: "KeyA", metaKey: true, shiftKey: true }),
+				isMac: true,
+				expected: false,
+			},
+		];
+
+		for (const { name, event, isMac, expected } of cases) {
+			expect(shouldSelectAllShortcut(event, isMac), name).toBe(expected);
+		}
+	});
+});

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/clipboardShortcuts.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/clipboardShortcuts.ts
@@ -1,0 +1,74 @@
+export interface ClipboardShortcutEvent {
+	code: string;
+	metaKey: boolean;
+	ctrlKey: boolean;
+	altKey: boolean;
+	shiftKey: boolean;
+}
+
+export interface ClipboardShortcutOptions {
+	isMac: boolean;
+	isWindows: boolean;
+	hasSelection: boolean;
+}
+
+/** Match VS Code's macOS terminal `Cmd+A` binding. */
+export function shouldSelectAllShortcut(
+	event: ClipboardShortcutEvent,
+	isMac: boolean,
+): boolean {
+	return (
+		isMac &&
+		event.code === "KeyA" &&
+		event.metaKey &&
+		!event.ctrlKey &&
+		!event.altKey &&
+		!event.shiftKey
+	);
+}
+
+/**
+ * Mirror VS Code terminal clipboard bindings so host copy/paste can run before
+ * xterm's kitty keyboard handler turns the chord into CSI-u input.
+ */
+export function shouldBubbleClipboardShortcut(
+	event: ClipboardShortcutEvent,
+	options: ClipboardShortcutOptions,
+): boolean {
+	const { isMac, isWindows, hasSelection } = options;
+
+	const onlyMeta =
+		event.metaKey && !event.ctrlKey && !event.altKey && !event.shiftKey;
+	const onlyCtrl =
+		event.ctrlKey && !event.metaKey && !event.altKey && !event.shiftKey;
+	const ctrlShiftOnly =
+		event.ctrlKey && event.shiftKey && !event.metaKey && !event.altKey;
+	const onlyShift =
+		event.shiftKey && !event.ctrlKey && !event.metaKey && !event.altKey;
+
+	if (isMac && onlyMeta) {
+		return event.code === "KeyV" || (hasSelection && event.code === "KeyC");
+	}
+
+	if (isWindows) {
+		if (event.code === "KeyV" && (onlyCtrl || ctrlShiftOnly)) {
+			return true;
+		}
+
+		if (hasSelection && event.code === "KeyC" && (onlyCtrl || ctrlShiftOnly)) {
+			return true;
+		}
+
+		return false;
+	}
+
+	if (!isMac) {
+		return (
+			(event.code === "KeyV" && ctrlShiftOnly) ||
+			(event.code === "Insert" && onlyShift) ||
+			(hasSelection && event.code === "KeyC" && ctrlShiftOnly)
+		);
+	}
+
+	return false;
+}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/helpers.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/helpers.ts
@@ -23,6 +23,10 @@ import {
 	DEFAULT_THEME_ID,
 	getTerminalColors,
 } from "shared/themes";
+import {
+	shouldBubbleClipboardShortcut,
+	shouldSelectAllShortcut,
+} from "./clipboardShortcuts";
 import { TERMINAL_OPTIONS } from "./config";
 import { suppressQueryResponses } from "./suppressQueryResponses";
 
@@ -637,6 +641,26 @@ export function setupKeyboardHandler(
 			if (event.type === "keydown" && options.onWrite) {
 				options.onWrite("\x1bf"); // Meta+F - forward word
 			}
+			return false;
+		}
+
+		if (shouldSelectAllShortcut(event, isMac)) {
+			if (event.type === "keydown") {
+				event.preventDefault();
+				xterm.selectAll();
+			}
+			return false;
+		}
+
+		// Mirror VS Code terminal clipboard bindings so host copy/paste happens
+		// before kitty CSI-u handling in xterm consumes the command chord.
+		if (
+			shouldBubbleClipboardShortcut(event, {
+				isMac,
+				isWindows,
+				hasSelection: xterm.hasSelection(),
+			})
+		) {
 			return false;
 		}
 


### PR DESCRIPTION
## Upstream Merge PR#1 - 安全パッチ取り込み

upstream (superset-sh/superset) から安全に取り込める4コミットを cherry-pick します。

## 取り込むコミット

| Commit | Upstream PR | 内容 |
|---|---|---|
| \`d656b7efa\` | #3415 | ターミナルのクリップボード動作を VS Code に合わせる |
| \`b18a00c0b\` | #3421 | v2 workspace の右サイドバートグルを開閉状態に対して reactive に |
| \`b42a1143d\` | #3418 | CodeMirror 内でアプリ側のホットキー（Cmd+W 等）を発火できるように |
| \`47efa7305\` | #3432 | pending workspace / update-required ページのエラーテキストを選択可能に |

## 改善内容の詳細

### 1. ターミナルクリップボード (#3415)

**何が問題だったか：**
- 従来のターミナルでは、コピー/ペーストの挙動が VS Code と異なり、ユーザー体験が不統一だった
- 特に macOS では Cmd+C / Cmd+V のバブリング処理が不完全で、選択範囲がないときにコピーが効かなかったり、全選択が意図せず発動したりした

**どう直したか：**
- 新規ヘルパー \`shouldBubbleClipboardShortcut()\` と \`shouldSelectAllShortcut()\` を追加
- ターミナルのクリップボード処理を VS Code のキーボードショートカット処理と完全に一致させる
- 新規ファイル：
  - \`clipboardShortcuts.ts\`
  - \`clipboardShortcuts.test.ts\`

### 2. v2 右サイドバートグルの reactivity (#3421)

**何が問題だったか：**
- v2 workspace の右サイドバーの開閉トグルボタンが、外部から開閉状態が変わっても再レンダリングされず、UI が追従しない不具合

**どう直したか：**
- collections API の \`useLiveQuery\` を使って React hook 化し、開閉状態変更で自動的に re-render されるように

### 3. CodeMirror 内でのホットキー発火 (#3418)

**何が問題だったか：**
- ファイルエディタ（CodeMirror）にフォーカスがあるとき、\`Cmd+W\` (タブを閉じる) などのアプリ全体のホットキーが発火しなかった
- CodeMirror が contentEditable 要素を使っているため、react-hotkeys-hook のデフォルトでブロックされていた

**どう直したか：**
- \`useHotkey\` フックで \`enableOnContentEditable: true\` をデフォルトに変更
- これで CodeMirror 編集中でもアプリのグローバルホットキーが効くように

### 4. エラーテキストを選択可能に (#3432)

**何が問題だったか：**
- pending workspace の失敗ページや \"update required\" ページで、エラーメッセージのテキストが選択できず、ユーザーがサポートに連絡する際にエラー内容をコピーできなかった

**どう直したか：**
- Tailwind の \`select-text\`, \`cursor-text\`, \`break-words\` クラスを該当箇所に追加
- \`user-select: none\` を上書きしてエラーテキストを選択・コピー可能に

## フォーク影響評価

- フォーク独自の危険領域（auto-updater, quit lifecycle, GitHubSyncService, ホットキーレジストリ, tray メニュー）には**一切触れていません**
- 全 cherry-pick がコンフリクトなしで自動マージ成功

## テスト計画

- [ ] ターミナルクリップボード：エディタとターミナルで Cmd+C/V が正しく動作
- [ ] 右サイドバートグル：開閉状態変更で即座に UI が追従
- [ ] CodeMirror ファイルエディタで Cmd+W がタブを閉じる
- [ ] pending workspace / update-required ページのエラーテキストを選択・コピーできる