### PR TITLE
[PR2/5] feat(upstream): ホットキー型拡張 + Prev/Next Tab・Workspace の unbound 化 (#3422)

### DIFF
--- a/apps/desktop/src/renderer/hotkeys/hooks/useRecordHotkeys/useRecordHotkeys.ts
+++ b/apps/desktop/src/renderer/hotkeys/hooks/useRecordHotkeys/useRecordHotkeys.ts
@@ -136,7 +136,10 @@ export function useRecordHotkeys(
 			}
 
 			const defaultKey = HOTKEYS[recordingId].key;
-			if (canonicalizeChord(captured) === canonicalizeChord(defaultKey)) {
+			if (
+				defaultKey &&
+				canonicalizeChord(captured) === canonicalizeChord(defaultKey)
+			) {
 				resetOverride(recordingId);
 			} else {
 				setOverride(recordingId, captured);

--- a/apps/desktop/src/renderer/hotkeys/registry.ts
+++ b/apps/desktop/src/renderer/hotkeys/registry.ts
@@ -102,22 +102,16 @@ export const HOTKEYS_REGISTRY = {
 		category: "Workspace",
 	},
 	PREV_WORKSPACE: {
-		key: {
-			mac: "meta+alt+up",
-			windows: "ctrl+shift+alt+up",
-			linux: "ctrl+shift+alt+up",
-		},
+		key: { mac: null, windows: null, linux: null },
 		label: "Previous Workspace",
 		category: "Workspace",
+		description: "Navigate to the previous workspace in the sidebar",
 	},
 	NEXT_WORKSPACE: {
-		key: {
-			mac: "meta+alt+down",
-			windows: "ctrl+shift+alt+down",
-			linux: "ctrl+shift+alt+down",
-		},
+		key: { mac: null, windows: null, linux: null },
 		label: "Next Workspace",
 		category: "Workspace",
+		description: "Navigate to the next workspace in the sidebar",
 	},
 	CLOSE_WORKSPACE: {
 		key: {
@@ -366,6 +360,20 @@ export const HOTKEYS_REGISTRY = {
 		label: "Next Tab (Alt)",
 		category: "Terminal",
 	},
+	PREV_TAB: {
+		key: { mac: null, windows: null, linux: null },
+		label: "Previous Tab",
+		category: "Terminal",
+		description: "Focus the previous tab in the active workspace",
+	},
+	NEXT_TAB: {
+		key: { mac: null, windows: null, linux: null },
+		label: "Next Tab",
+		category: "Terminal",
+		description: "Focus the next tab in the active workspace",
+	},
+	// FORK NOTE: upstream renamed PREV_PANE → FOCUS_PANE_LEFT in #3403 (PR#3).
+	// Keep PREV_PANE until that cherry-pick is applied.
 	PREV_PANE: {
 		key: {
 			mac: "meta+shift+left",

--- a/apps/desktop/src/renderer/hotkeys/registry.ts
+++ b/apps/desktop/src/renderer/hotkeys/registry.ts
@@ -328,24 +328,6 @@ export const HOTKEYS_REGISTRY = {
 		category: "Terminal",
 		description: "Scroll the active terminal to the bottom",
 	},
-	PREV_TAB: {
-		key: {
-			mac: "meta+alt+left",
-			windows: "ctrl+shift+alt+left",
-			linux: "ctrl+shift+alt+left",
-		},
-		label: "Previous Tab",
-		category: "Terminal",
-	},
-	NEXT_TAB: {
-		key: {
-			mac: "meta+alt+right",
-			windows: "ctrl+shift+alt+right",
-			linux: "ctrl+shift+alt+right",
-		},
-		label: "Next Tab",
-		category: "Terminal",
-	},
 	PREV_TAB_ALT: {
 		key: {
 			mac: "ctrl+shift+tab",

--- a/apps/desktop/src/renderer/hotkeys/types.ts
+++ b/apps/desktop/src/renderer/hotkeys/types.ts
@@ -1,6 +1,10 @@
 export type Platform = "mac" | "windows" | "linux";
 
-export type PlatformKey = { mac: string; windows: string; linux: string };
+export type PlatformKey = {
+	mac: string | null;
+	windows: string | null;
+	linux: string | null;
+};
 
 export type HotkeyCategory =
 	| "Navigation"
@@ -19,7 +23,7 @@ export interface HotkeyDisplay {
 }
 
 export interface HotkeyDefinition {
-	key: string;
+	key: string | null;
 	label: string;
 	category: HotkeyCategory;
 	description?: string;

--- a/apps/desktop/src/renderer/hotkeys/utils/resolveHotkeyFromEvent.test.ts
+++ b/apps/desktop/src/renderer/hotkeys/utils/resolveHotkeyFromEvent.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { HOTKEYS } from "../registry";
+import { HOTKEYS, type HotkeyId } from "../registry";
 import { useHotkeyOverridesStore } from "../stores/hotkeyOverridesStore";
+import type { HotkeyDefinition } from "../types";
 import {
 	canonicalizeChord,
 	eventToChord,
@@ -148,10 +149,13 @@ describe("resolveHotkeyFromEvent — live override index", () => {
 	});
 
 	// Resolve once so registry reorders / removals surface as a test failure
-	// here instead of silently skipping the cases below.
-	const sampleEntry = (
-		Object.entries(HOTKEYS) as [keyof typeof HOTKEYS, { key: string }][]
-	).find(([, hotkey]) => !!hotkey.key);
+	// here instead of silently skipping the cases below. The type predicate
+	// narrows to a HotkeyDefinition whose .key is guaranteed non-null after
+	// the filter, so sampleDef.key can be passed to string-only helpers below.
+	const sampleEntry = Object.entries(HOTKEYS).find(
+		(entry): entry is [HotkeyId, HotkeyDefinition & { key: string }] =>
+			entry[1].key !== null,
+	);
 	if (!sampleEntry) throw new Error("HOTKEYS has no bound default");
 	const [sampleId, sampleDef] = sampleEntry;
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarShortcuts/useDashboardSidebarShortcuts.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarShortcuts/useDashboardSidebarShortcuts.ts
@@ -48,7 +48,6 @@ export function useDashboardSidebarShortcuts(
 	useHotkey("JUMP_TO_WORKSPACE_8", () => switchToWorkspace(7));
 	useHotkey("JUMP_TO_WORKSPACE_9", () => switchToWorkspace(8));
 
-	// Prev/next workspace navigation (cycles)
 	const matchRoute = useMatchRoute();
 	const currentWorkspaceMatch = matchRoute({
 		to: "/v2-workspace/$workspaceId",
@@ -62,6 +61,7 @@ export function useDashboardSidebarShortcuts(
 		const index = flattenedWorkspaces.findIndex(
 			(w) => w.id === currentWorkspaceId,
 		);
+		if (index === -1) return;
 		const prevIndex = index <= 0 ? flattenedWorkspaces.length - 1 : index - 1;
 		navigateToV2Workspace(flattenedWorkspaces[prevIndex].id, navigate);
 	});
@@ -71,8 +71,8 @@ export function useDashboardSidebarShortcuts(
 		const index = flattenedWorkspaces.findIndex(
 			(w) => w.id === currentWorkspaceId,
 		);
-		const nextIndex =
-			index >= flattenedWorkspaces.length - 1 || index === -1 ? 0 : index + 1;
+		if (index === -1) return;
+		const nextIndex = index >= flattenedWorkspaces.length - 1 ? 0 : index + 1;
 		navigateToV2Workspace(flattenedWorkspaces[nextIndex].id, navigate);
 	});
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/workspace/$workspaceId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/workspace/$workspaceId/page.tsx
@@ -859,6 +859,29 @@ export function WorkspacePage({
 		{ enabled: isActive },
 	);
 
+	const getPreviousWorkspace =
+		electronTrpc.workspaces.getPreviousWorkspace.useQuery(
+			{ id: workspaceId },
+			{ enabled: !!workspaceId },
+		);
+	useHotkey("PREV_WORKSPACE", () => {
+		const prevWorkspaceId = getPreviousWorkspace.data;
+		if (prevWorkspaceId) {
+			navigateToWorkspace(prevWorkspaceId, navigate);
+		}
+	});
+
+	const getNextWorkspace = electronTrpc.workspaces.getNextWorkspace.useQuery(
+		{ id: workspaceId },
+		{ enabled: !!workspaceId },
+	);
+	useHotkey("NEXT_WORKSPACE", () => {
+		const nextWorkspaceId = getNextWorkspace.data;
+		if (nextWorkspaceId) {
+			navigateToWorkspace(nextWorkspaceId, navigate);
+		}
+	});
+
 	return (
 		<WorkspaceIdProvider value={workspaceId}>
 			<div className="flex-1 h-full flex flex-col overflow-hidden">

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/workspace/$workspaceId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/workspace/$workspaceId/page.tsx
@@ -859,29 +859,6 @@ export function WorkspacePage({
 		{ enabled: isActive },
 	);
 
-	const getPreviousWorkspace =
-		electronTrpc.workspaces.getPreviousWorkspace.useQuery(
-			{ id: workspaceId },
-			{ enabled: !!workspaceId },
-		);
-	useHotkey("PREV_WORKSPACE", () => {
-		const prevWorkspaceId = getPreviousWorkspace.data;
-		if (prevWorkspaceId) {
-			navigateToWorkspace(prevWorkspaceId, navigate);
-		}
-	});
-
-	const getNextWorkspace = electronTrpc.workspaces.getNextWorkspace.useQuery(
-		{ id: workspaceId },
-		{ enabled: !!workspaceId },
-	);
-	useHotkey("NEXT_WORKSPACE", () => {
-		const nextWorkspaceId = getNextWorkspace.data;
-		if (nextWorkspaceId) {
-			navigateToWorkspace(nextWorkspaceId, navigate);
-		}
-	});
-
 	return (
 		<WorkspaceIdProvider value={workspaceId}>
 			<div className="flex-1 h-full flex flex-col overflow-hidden">


### PR DESCRIPTION
## Upstream Merge PR#2 - ホットキー型拡張

upstream #3422 を cherry-pick し、フォーク固有ホットキーと整合させるための手動修正を加えます。

## 改善内容の詳細

### 背景：PR#3403 で何が起きたか（このPRではまだ取り込んでいないが、関連する文脈）

upstream は PR#3403 で「Cmd+Alt+Arrow で v2 ペイン間を空間認識的に移動」する機能を入れるため、以下を削除しました：
- \`PREV_TAB\` / \`NEXT_TAB\` （Cmd+Alt+Left/Right）
- \`PREV_WORKSPACE\` / \`NEXT_WORKSPACE\` （Cmd+Alt+Up/Down）
- \`PREV_PANE\` / \`NEXT_PANE\` （線形循環）

これらのキーを **FOCUS_PANE_LEFT/RIGHT/UP/DOWN** に付け替えるためでした。

### このPRで取り込む #3422 の内容

**問題：** #3403 でタブ切替・ワークスペース切替のホットキーが完全に削除されてしまい、これらの機能に依存していたユーザーが困った。

**解決：** ホットキー ID としては復活させるが、デフォルトキーは \`null\` とし、ユーザーが Settings から自由に rebind できる形にする。

このアプローチのために、ホットキーの型システムを以下のように拡張する必要があります：

### 型定義の拡張（事前修正として手動コミット）

\`\`\`typescript
// Before
export type PlatformKey = { mac: string; windows: string; linux: string };
export interface HotkeyDefinition {
  key: string;
  label: string;
  ...
}

// After
export type PlatformKey = {
  mac: string | null;
  windows: string | null;
  linux: string | null;
};
export interface HotkeyDefinition {
  key: string | null;
  label: string;
  ...
}
\`\`\`

これで \`key: { mac: null, windows: null, linux: null }\` というデフォルト未割当エントリがレジストリに登録できるようになります。

### cherry-pick: c925f4d4a (#3422)

1. **registry.ts**
   - \`PREV_TAB\`, \`NEXT_TAB\` を null-bound エントリとして復活
   - \`PREV_WORKSPACE\`, \`NEXT_WORKSPACE\` を null-bound エントリとして復活
   - 各エントリに \`description\` を追加
   - 旧キーバインド（\`meta+alt+left/right\` 等）は削除

2. **useRecordHotkeys.ts**
   - \`canonicalizeChord(defaultKey)\` を null-guard
   - これで unbound ホットキーに対する新規 chord 記録時に例外が出なくなる

3. **各 handler ファイル**
   - \`useDashboardSidebarShortcuts.ts\`: PREV/NEXT_WORKSPACE ハンドラ復活、\`index === -1\` ガード追加
   - \`v2 useWorkspaceHotkeys.ts\`: PREV/NEXT_TAB ハンドラ復活
   - \`v1 workspace/page.tsx\`: PREV/NEXT_TAB ハンドラ復活

## コンフリクト解決

| ファイル | 解決方針 |
|---|---|
| \`registry.ts\` | フォーク独自の \`BROWSER_RELOAD\` / \`BROWSER_HARD_RELOAD\` / \`SEARCH_IN_FILES\` / \`HotkeyCategory \"Browser\"\` を保持。\`PREV_PANE\` / \`NEXT_PANE\` も PR#3 の取り込み時まで一時的に保持。重複した \`PREV_TAB\`/\`NEXT_TAB\` エントリを削除 |
| \`useDashboardSidebarShortcuts.ts\` | フォークのコメントを除去、upstream の \`index === -1\` ガードを採用 |
| \`workspace/\$workspaceId/page.tsx\` | フォーク独自の deep-link navigation（\`useSearch\` / \`WorkspaceSearchParams\`）を保持。フォーク独自の \`CLOSE_TERMINAL\` / \`CLOSE_TAB\` ハンドラを保持。cherry-pick が挿入した重複 workspace クエリとハンドラを削除 |

## フォーク固有機能の保持

- **ブラウザホットキー**: \`BROWSER_RELOAD\`, \`BROWSER_HARD_RELOAD\`, \`SEARCH_IN_FILES\` すべて維持
- **HotkeyCategory \"Browser\"**: 維持
- **v1 deep-link navigation**: \`useSearch\` 経由のファイル/行/列パラメータ処理を維持
- **v1 tRPC-based PREV/NEXT_WORKSPACE**: 維持（upstream の \`flattenedWorkspaces\` 方式ではなくフォーク独自の tRPC クエリ方式）

## ユーザーへのメリット

1. **既存のカスタムバインディングが保持される**
   - 以前 PREV_TAB/NEXT_TAB に独自のキーを割り当てていたユーザーは、localStorage の override がそのまま有効になり、自動的にバインディングが復活する

2. **設定画面で自由に rebind できる**
   - デフォルトは unbound なので、ユーザーが Settings → Keyboard で好きなキーを設定できる

## テスト計画

- [x] \`bun run typecheck\` パス
- [ ] Settings → Keyboard に PREV_TAB / NEXT_TAB が「unbound」として表示される
- [ ] Settings → Keyboard に PREV_WORKSPACE / NEXT_WORKSPACE が「unbound」として表示される
- [ ] フォーク独自ホットキーが引き続き動作：ブラウザリロード、ハードリロード、ファイル内検索
- [ ] PR#3403 以前の localStorage override を持つユーザーは、PREV_TAB/NEXT_TAB のバインディングが自動復活する