### PR TITLE
[PR3/5] feat(upstream): 空間認識型ペインナビゲーション + v2 Diff ビューア + タブタイトル解決API刷新

### DIFF
--- a/apps/desktop/src/renderer/hotkeys/registry.ts
+++ b/apps/desktop/src/renderer/hotkeys/registry.ts
@@ -354,27 +354,45 @@ export const HOTKEYS_REGISTRY = {
 		category: "Terminal",
 		description: "Focus the next tab in the active workspace",
 	},
-	// FORK NOTE: upstream renamed PREV_PANE → FOCUS_PANE_LEFT in #3403 (PR#3).
-	// Keep PREV_PANE until that cherry-pick is applied.
-	PREV_PANE: {
+	FOCUS_PANE_LEFT: {
 		key: {
-			mac: "meta+shift+left",
+			mac: "meta+alt+left",
 			windows: "ctrl+shift+alt+left",
 			linux: "ctrl+shift+alt+left",
 		},
-		label: "Previous Pane",
+		label: "Focus Pane Left",
 		category: "Terminal",
-		description: "Focus the previous pane in the current tab",
+		description: "Focus the pane to the left of the active pane",
 	},
-	NEXT_PANE: {
+	FOCUS_PANE_RIGHT: {
 		key: {
-			mac: "meta+shift+right",
+			mac: "meta+alt+right",
 			windows: "ctrl+shift+alt+right",
 			linux: "ctrl+shift+alt+right",
 		},
-		label: "Next Pane",
+		label: "Focus Pane Right",
 		category: "Terminal",
-		description: "Focus the next pane in the current tab",
+		description: "Focus the pane to the right of the active pane",
+	},
+	FOCUS_PANE_UP: {
+		key: {
+			mac: "meta+alt+up",
+			windows: "ctrl+shift+alt+up",
+			linux: "ctrl+shift+alt+up",
+		},
+		label: "Focus Pane Up",
+		category: "Terminal",
+		description: "Focus the pane above the active pane",
+	},
+	FOCUS_PANE_DOWN: {
+		key: {
+			mac: "meta+alt+down",
+			windows: "ctrl+shift+alt+down",
+			linux: "ctrl+shift+alt+down",
+		},
+		label: "Focus Pane Down",
+		category: "Terminal",
+		description: "Focus the pane below the active pane",
 	},
 	JUMP_TO_TAB_1: {
 		key: {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pending/$pendingId/buildSetupPaneLayout.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pending/$pendingId/buildSetupPaneLayout.ts
@@ -17,7 +17,6 @@ export function buildSetupPaneLayout(
 		const tabId = `tab-${crypto.randomUUID()}`;
 		return {
 			id: tabId,
-			titleOverride: t.label,
 			createdAt: Date.now(),
 			activePaneId: paneId,
 			layout: { type: "pane" as const, paneId },
@@ -25,6 +24,7 @@ export function buildSetupPaneLayout(
 				[paneId]: {
 					id: paneId,
 					kind: "terminal",
+					titleOverride: t.label,
 					data: { terminalId: t.id } as TerminalPaneData,
 				},
 			},

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useDefaultContextMenuActions/useDefaultContextMenuActions.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useDefaultContextMenuActions/useDefaultContextMenuActions.tsx
@@ -1,4 +1,9 @@
-import type { ContextMenuActionConfig, RendererContext } from "@superset/panes";
+import {
+	type ContextMenuActionConfig,
+	type PaneRegistry,
+	type RendererContext,
+	resolveTabTitle,
+} from "@superset/panes";
 import { useMemo } from "react";
 import {
 	LuColumns2,
@@ -18,7 +23,9 @@ import type {
 	TerminalPaneData,
 } from "../../types";
 
-export function useDefaultContextMenuActions(): ContextMenuActionConfig<PaneViewerData>[] {
+export function useDefaultContextMenuActions(
+	paneRegistry: PaneRegistry<PaneViewerData>,
+): ContextMenuActionConfig<PaneViewerData>[] {
 	const splitDownShortcut = useHotkeyDisplay("SPLIT_DOWN").text;
 	const splitRightShortcut = useHotkeyDisplay("SPLIT_RIGHT").text;
 	const splitWithChatShortcut = useHotkeyDisplay("SPLIT_WITH_CHAT").text;
@@ -115,7 +122,7 @@ export function useDefaultContextMenuActions(): ContextMenuActionConfig<PaneView
 					const items: ContextMenuActionConfig<PaneViewerData>[] =
 						otherTabs.map((tab) => ({
 							key: `move-to-${tab.id}`,
-							label: tab.titleOverride ?? tab.id,
+							label: resolveTabTitle(tab, tabs, paneRegistry),
 							onSelect: () => {
 								ctx.store
 									.getState()
@@ -154,6 +161,7 @@ export function useDefaultContextMenuActions(): ContextMenuActionConfig<PaneView
 			splitWithBrowserShortcut,
 			equalizePaneSplitsShortcut,
 			closePaneShortcut,
+			paneRegistry,
 		],
 	);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/BrowserPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/BrowserPane.tsx
@@ -22,20 +22,6 @@ function getSingleBrowserPane(
 	return { id: pane.id, data: pane.data as BrowserPaneData };
 }
 
-export function getBrowserTabTitle(
-	tab: Tab<PaneViewerData>,
-): string | undefined {
-	const browser = getSingleBrowserPane(tab);
-	if (!browser) return undefined;
-	if (browser.data.pageTitle) return browser.data.pageTitle;
-	if (browser.data.url && browser.data.url !== "about:blank") {
-		try {
-			return new URL(browser.data.url).hostname;
-		} catch {}
-	}
-	return undefined;
-}
-
 export function renderBrowserTabIcon(tab: Tab<PaneViewerData>) {
 	const browser = getSingleBrowserPane(tab);
 	if (!browser?.data.faviconUrl) return null;

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/index.ts
@@ -1,7 +1,6 @@
 export {
 	BrowserPane,
 	BrowserPaneToolbar,
-	getBrowserTabTitle,
 	renderBrowserTabIcon,
 } from "./BrowserPane";
 export { browserRuntimeRegistry } from "./browserRuntimeRegistry";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/usePaneRegistry.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/usePaneRegistry.tsx
@@ -120,7 +120,8 @@ export function usePaneRegistry(
 					const name = getFileName(data.filePath);
 					return <FileIcon fileName={name} className="size-4" />;
 				},
-				getTitle: (ctx: RendererContext<PaneViewerData>) => {
+				getTitle: (pane) => getFileName((pane.data as FilePaneData).filePath),
+				renderTitle: (ctx: RendererContext<PaneViewerData>) => {
 					const data = ctx.pane.data as FilePaneData;
 					const name = data.displayName ?? getFileName(data.filePath);
 					return (
@@ -256,9 +257,15 @@ export function usePaneRegistry(
 			},
 			browser: {
 				getIcon: () => <Globe className="size-4" />,
-				getTitle: (ctx: RendererContext<PaneViewerData>) => {
-					const data = ctx.pane.data as BrowserPaneData;
-					return data.pageTitle || data.url;
+				getTitle: (pane) => {
+					const data = pane.data as BrowserPaneData;
+					if (data.pageTitle) return data.pageTitle;
+					if (data.url && data.url !== "about:blank") {
+						try {
+							return new URL(data.url).host;
+						} catch {}
+					}
+					return "Browser";
 				},
 				renderPane: (ctx: RendererContext<PaneViewerData>) => (
 					<BrowserPane ctx={ctx} />

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/usePaneRegistry.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/usePaneRegistry.tsx
@@ -45,7 +45,7 @@ import { FilePane } from "./components/FilePane";
 import { TerminalPane } from "./components/TerminalPane";
 
 function getFileName(filePath: string): string {
-	return filePath.split("/").pop() ?? filePath;
+	return filePath.split(/[/\\]/).pop() || filePath;
 }
 
 const MOD_KEY = navigator.platform.toLowerCase().includes("mac")

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useV2PresetExecution/useV2PresetExecution.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useV2PresetExecution/useV2PresetExecution.ts
@@ -10,9 +10,13 @@ import { filterMatchingPresetsForProject } from "shared/preset-project-targeting
 import type { StoreApi } from "zustand/vanilla";
 import type { PaneViewerData, TerminalPaneData } from "../../types";
 
-function makeTerminalPane(terminalId: string): CreatePaneInput<PaneViewerData> {
+function makeTerminalPane(
+	terminalId: string,
+	titleOverride?: string,
+): CreatePaneInput<PaneViewerData> {
 	return {
 		kind: "terminal",
+		titleOverride,
 		data: { terminalId } as TerminalPaneData,
 	};
 }
@@ -89,8 +93,7 @@ export function useV2PresetExecution({
 							preset.commands[0] as string,
 						);
 						state.addTab({
-							titleOverride: preset.name || "Terminal",
-							panes: [makeTerminalPane(id)],
+							panes: [makeTerminalPane(id, preset.name || undefined)],
 						});
 						break;
 					}
@@ -99,16 +102,22 @@ export function useV2PresetExecution({
 						const ids = await Promise.all(
 							preset.commands.map((cmd) => createSessionWithCommand(cmd)),
 						);
-						const panes = ids.map((id) => makeTerminalPane(id));
+						const panes = ids.map((id) =>
+							makeTerminalPane(id, preset.name || undefined),
+						);
 						state.addTab({
-							titleOverride: preset.name || "Terminal",
 							panes:
 								panes.length > 0
 									? (panes as [
 											CreatePaneInput<PaneViewerData>,
 											...CreatePaneInput<PaneViewerData>[],
 										])
-									: [makeTerminalPane(crypto.randomUUID())],
+									: [
+											makeTerminalPane(
+												crypto.randomUUID(),
+												preset.name || undefined,
+											),
+										],
 						});
 						break;
 					}
@@ -119,8 +128,9 @@ export function useV2PresetExecution({
 						);
 						for (let i = 0; i < ids.length; i++) {
 							state.addTab({
-								titleOverride: preset.name || "Terminal",
-								panes: [makeTerminalPane(ids[i] as string)],
+								panes: [
+									makeTerminalPane(ids[i] as string, preset.name || undefined),
+								],
 							});
 						}
 						break;
@@ -132,14 +142,13 @@ export function useV2PresetExecution({
 						);
 						if (!activeTabId) {
 							state.addTab({
-								titleOverride: preset.name || "Terminal",
-								panes: [makeTerminalPane(id)],
+								panes: [makeTerminalPane(id, preset.name || undefined)],
 							});
 							break;
 						}
 						state.addPane({
 							tabId: activeTabId,
-							pane: makeTerminalPane(id),
+							pane: makeTerminalPane(id, preset.name || undefined),
 						});
 						break;
 					}
@@ -149,23 +158,29 @@ export function useV2PresetExecution({
 							preset.commands.map((cmd) => createSessionWithCommand(cmd)),
 						);
 						if (!activeTabId) {
-							const panes = ids.map((id) => makeTerminalPane(id));
+							const panes = ids.map((id) =>
+								makeTerminalPane(id, preset.name || undefined),
+							);
 							state.addTab({
-								titleOverride: preset.name || "Terminal",
 								panes:
 									panes.length > 0
 										? (panes as [
 												CreatePaneInput<PaneViewerData>,
 												...CreatePaneInput<PaneViewerData>[],
 											])
-										: [makeTerminalPane(crypto.randomUUID())],
+										: [
+												makeTerminalPane(
+													crypto.randomUUID(),
+													preset.name || undefined,
+												),
+											],
 							});
 							break;
 						}
 						for (const id of ids) {
 							state.addPane({
 								tabId: activeTabId,
-								pane: makeTerminalPane(id),
+								pane: makeTerminalPane(id, preset.name || undefined),
 							});
 						}
 						break;

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useWorkspaceHotkeys/useWorkspaceHotkeys.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useWorkspaceHotkeys/useWorkspaceHotkeys.ts
@@ -84,6 +84,23 @@ export function useWorkspaceHotkeys({
 		}
 	});
 
+	useHotkey("PREV_TAB", () => {
+		const state = store.getState();
+		if (!state.activeTabId || state.tabs.length === 0) return;
+		const index = state.tabs.findIndex((t) => t.id === state.activeTabId);
+		const prevIndex = index <= 0 ? state.tabs.length - 1 : index - 1;
+		state.setActiveTab(state.tabs[prevIndex].id);
+	});
+
+	useHotkey("NEXT_TAB", () => {
+		const state = store.getState();
+		if (!state.activeTabId || state.tabs.length === 0) return;
+		const index = state.tabs.findIndex((t) => t.id === state.activeTabId);
+		const nextIndex =
+			index >= state.tabs.length - 1 || index === -1 ? 0 : index + 1;
+		state.setActiveTab(state.tabs[nextIndex].id);
+	});
+
 	useHotkey("PREV_TAB_ALT", () => {
 		const state = store.getState();
 		if (!state.activeTabId || state.tabs.length === 0) return;

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useWorkspaceHotkeys/useWorkspaceHotkeys.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useWorkspaceHotkeys/useWorkspaceHotkeys.ts
@@ -39,7 +39,6 @@ export function useWorkspaceHotkeys({
 
 	useHotkey("NEW_GROUP", () => {
 		store.getState().addTab({
-			titleOverride: "Terminal",
 			panes: [
 				{
 					kind: "terminal",
@@ -51,14 +50,12 @@ export function useWorkspaceHotkeys({
 
 	useHotkey("NEW_CHAT", () => {
 		store.getState().addTab({
-			titleOverride: "Chat",
 			panes: [{ kind: "chat", data: { sessionId: null } as ChatPaneData }],
 		});
 	});
 
 	useHotkey("NEW_BROWSER", () => {
 		store.getState().addTab({
-			titleOverride: "Browser",
 			panes: [
 				{
 					kind: "browser",

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useWorkspaceHotkeys/useWorkspaceHotkeys.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useWorkspaceHotkeys/useWorkspaceHotkeys.ts
@@ -1,4 +1,8 @@
-import type { WorkspaceStore } from "@superset/panes";
+import {
+	type FocusDirection,
+	getSpatialNeighborPaneId,
+	type WorkspaceStore,
+} from "@superset/panes";
 import { useCallback } from "react";
 import { useHotkey } from "renderer/hotkeys";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
@@ -83,23 +87,6 @@ export function useWorkspaceHotkeys({
 		}
 	});
 
-	useHotkey("PREV_TAB", () => {
-		const state = store.getState();
-		if (!state.activeTabId || state.tabs.length === 0) return;
-		const index = state.tabs.findIndex((t) => t.id === state.activeTabId);
-		const prevIndex = index <= 0 ? state.tabs.length - 1 : index - 1;
-		state.setActiveTab(state.tabs[prevIndex].id);
-	});
-
-	useHotkey("NEXT_TAB", () => {
-		const state = store.getState();
-		if (!state.activeTabId || state.tabs.length === 0) return;
-		const index = state.tabs.findIndex((t) => t.id === state.activeTabId);
-		const nextIndex =
-			index >= state.tabs.length - 1 || index === -1 ? 0 : index + 1;
-		state.setActiveTab(state.tabs[nextIndex].id);
-	});
-
 	useHotkey("PREV_TAB_ALT", () => {
 		const state = store.getState();
 		if (!state.activeTabId || state.tabs.length === 0) return;
@@ -138,25 +125,25 @@ export function useWorkspaceHotkeys({
 
 	// --- Pane management ---
 
-	useHotkey("PREV_PANE", () => {
-		const state = store.getState();
-		const tab = state.getActiveTab();
-		if (!tab || !tab.activePaneId) return;
-		const paneIds = Object.keys(tab.panes);
-		const index = paneIds.indexOf(tab.activePaneId);
-		const prevIndex = index <= 0 ? paneIds.length - 1 : index - 1;
-		state.setActivePane({ tabId: tab.id, paneId: paneIds[prevIndex] });
-	});
+	const moveFocusDirectional = useCallback(
+		(dir: FocusDirection) => {
+			const state = store.getState();
+			const tab = state.getActiveTab();
+			if (!tab || !tab.activePaneId) return;
+			const neighbor = getSpatialNeighborPaneId(
+				tab.layout,
+				tab.activePaneId,
+				dir,
+			);
+			if (neighbor) state.setActivePane({ tabId: tab.id, paneId: neighbor });
+		},
+		[store],
+	);
 
-	useHotkey("NEXT_PANE", () => {
-		const state = store.getState();
-		const tab = state.getActiveTab();
-		if (!tab || !tab.activePaneId) return;
-		const paneIds = Object.keys(tab.panes);
-		const index = paneIds.indexOf(tab.activePaneId);
-		const nextIndex = index >= paneIds.length - 1 ? 0 : index + 1;
-		state.setActivePane({ tabId: tab.id, paneId: paneIds[nextIndex] });
-	});
+	useHotkey("FOCUS_PANE_LEFT", () => moveFocusDirectional("left"));
+	useHotkey("FOCUS_PANE_RIGHT", () => moveFocusDirectional("right"));
+	useHotkey("FOCUS_PANE_UP", () => moveFocusDirectional("up"));
+	useHotkey("FOCUS_PANE_DOWN", () => moveFocusDirectional("down"));
 
 	useHotkey("SPLIT_AUTO", () => {
 		const state = store.getState();

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
@@ -38,10 +38,7 @@ import { WorkspaceNotFoundState } from "./components/WorkspaceNotFoundState";
 import { WorkspaceSidebar } from "./components/WorkspaceSidebar";
 import { useDefaultContextMenuActions } from "./hooks/useDefaultContextMenuActions";
 import { usePaneRegistry } from "./hooks/usePaneRegistry";
-import {
-	getBrowserTabTitle,
-	renderBrowserTabIcon,
-} from "./hooks/usePaneRegistry/components/BrowserPane";
+import { renderBrowserTabIcon } from "./hooks/usePaneRegistry/components/BrowserPane";
 import { useV2PresetExecution } from "./hooks/useV2PresetExecution";
 import { useV2WorkspacePaneLayout } from "./hooks/useV2WorkspacePaneLayout";
 import { useWorkspaceHotkeys } from "./hooks/useWorkspaceHotkeys";
@@ -145,7 +142,7 @@ function WorkspaceContent({
 		projectId,
 	});
 	const paneRegistry = usePaneRegistry(workspaceId);
-	const defaultContextMenuActions = useDefaultContextMenuActions();
+	const defaultContextMenuActions = useDefaultContextMenuActions(paneRegistry);
 	const rightSidebarOpenViewWidth = useRightSidebarOpenViewWidth();
 	const utils = electronTrpc.useUtils();
 	const { data: showPresetsBar } =
@@ -219,7 +216,6 @@ function WorkspaceContent({
 			const state = store.getState();
 			if (openInNewTab) {
 				state.addTab({
-					titleOverride: filePath.split(/[/\\]/).pop() ?? "File",
 					panes: [
 						{
 							kind: "file",
@@ -261,7 +257,6 @@ function WorkspaceContent({
 						hasChanges: false,
 					} as FilePaneData,
 				},
-				tabTitle: "Files",
 			});
 
 			if (!activeTabId || !activePanePath) {
@@ -291,9 +286,8 @@ function WorkspaceContent({
 	const openDiffPane = useCallback(
 		(filePath: string) => {
 			const state = store.getState();
-			const activeTab = state.tabs.find((t) => t.id === state.activeTabId);
-			if (activeTab) {
-				for (const pane of Object.values(activeTab.panes)) {
+			for (const tab of state.tabs) {
+				for (const pane of Object.values(tab.panes)) {
 					if (pane.kind !== "diff") continue;
 					const prev = pane.data as DiffPaneData;
 					state.setPaneData({
@@ -303,19 +297,21 @@ function WorkspaceContent({
 							path: filePath,
 						} as PaneViewerData,
 					});
-					state.setActivePane({ tabId: activeTab.id, paneId: pane.id });
+					state.setActiveTab(tab.id);
+					state.setActivePane({ tabId: tab.id, paneId: pane.id });
 					return;
 				}
 			}
-			state.openPane({
-				pane: {
-					kind: "diff",
-					data: {
-						path: filePath,
-						collapsedFiles: [],
-					} as DiffPaneData,
-				},
-				tabTitle: "Changes",
+			state.addTab({
+				panes: [
+					{
+						kind: "diff",
+						data: {
+							path: filePath,
+							collapsedFiles: [],
+						} as DiffPaneData,
+					},
+				],
 			});
 		},
 		[store],
@@ -323,7 +319,6 @@ function WorkspaceContent({
 
 	const addTerminalTab = useCallback(() => {
 		store.getState().addTab({
-			titleOverride: "Terminal",
 			panes: [
 				{
 					kind: "terminal",
@@ -337,7 +332,6 @@ function WorkspaceContent({
 
 	const addChatTab = useCallback(() => {
 		store.getState().addTab({
-			titleOverride: "Chat",
 			panes: [
 				{
 					kind: "chat",
@@ -349,7 +343,6 @@ function WorkspaceContent({
 
 	const addBrowserTab = useCallback(() => {
 		store.getState().addTab({
-			titleOverride: "Browser",
 			panes: [
 				{
 					kind: "browser",
@@ -469,7 +462,6 @@ function WorkspaceContent({
 							registry={paneRegistry}
 							paneActions={defaultPaneActions}
 							contextMenuActions={defaultContextMenuActions}
-							getTabTitle={getBrowserTabTitle}
 							renderTabIcon={renderBrowserTabIcon}
 							renderBelowTabBar={() => (
 								<V2PresetsBar

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
@@ -205,7 +205,6 @@ function WorkspaceContent({
 						displayName,
 					} as FilePaneData,
 				},
-				tabTitle: "Files",
 			});
 		},
 		[store],

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/workspace/$workspaceId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/workspace/$workspaceId/page.tsx
@@ -20,7 +20,6 @@ import { getWorkspaceDisplayName } from "renderer/lib/getWorkspaceDisplayName";
 import { electronTrpcClient as trpcClient } from "renderer/lib/trpc-client";
 import { usePresets } from "renderer/react-query/presets";
 import type { WorkspaceSearchParams } from "renderer/routes/_authenticated/_dashboard/utils/workspace-navigation";
-import { navigateToWorkspace } from "renderer/routes/_authenticated/_dashboard/utils/workspace-navigation";
 import { usePresetHotkeys } from "renderer/routes/_authenticated/_dashboard/workspace/$workspaceId/hooks/usePresetHotkeys";
 import { useWorkspaceRunCommand } from "renderer/routes/_authenticated/_dashboard/workspace/$workspaceId/hooks/useWorkspaceRunCommand";
 import { NotFound } from "renderer/routes/not-found";
@@ -58,8 +57,6 @@ import {
 	extractPaneIdsFromLayout,
 	findPanePath,
 	getFirstPaneId,
-	getNextPaneId,
-	getPreviousPaneId,
 	resolveActiveTabIdForWorkspace,
 } from "renderer/stores/tabs/utils";
 import {
@@ -514,30 +511,6 @@ export function WorkspacePage({
 	useHotkey("JUMP_TO_TAB_8", () => switchToTab(7), { enabled: isActive });
 	useHotkey("JUMP_TO_TAB_9", () => switchToTab(8), { enabled: isActive });
 
-	useHotkey(
-		"PREV_PANE",
-		() => {
-			if (!activeTabId || !activeTab?.layout || !focusedPaneId) return;
-			const prevPaneId = getPreviousPaneId(activeTab.layout, focusedPaneId);
-			if (prevPaneId) {
-				setFocusedPane(activeTabId, prevPaneId);
-			}
-		},
-		{ enabled: isActive },
-	);
-
-	useHotkey(
-		"NEXT_PANE",
-		() => {
-			if (!activeTabId || !activeTab?.layout || !focusedPaneId) return;
-			const nextPaneId = getNextPaneId(activeTab.layout, focusedPaneId);
-			if (nextPaneId) {
-				setFocusedPane(activeTabId, nextPaneId);
-			}
-		},
-		{ enabled: isActive },
-	);
-
 	// Open in last used app shortcut
 	const projectId = workspace?.projectId;
 	const { data: defaultApp } = electronTrpc.projects.getDefaultApp.useQuery(
@@ -826,7 +799,9 @@ export function WorkspacePage({
 		{ enabled: isActive },
 	);
 
-	// Navigate to previous workspace (⌘↑)
+	// FORK NOTE: v1 workspace uses tRPC-based prev/next workspace navigation.
+	// Upstream removed these handlers in #3403 (they use DashboardSidebar's
+	// flattenedWorkspaces instead). Fork keeps tRPC approach for v1.
 	const getPreviousWorkspace =
 		electronTrpc.workspaces.getPreviousWorkspace.useQuery(
 			{ id: workspaceId },
@@ -843,7 +818,6 @@ export function WorkspacePage({
 		{ enabled: isActive },
 	);
 
-	// Navigate to next workspace (⌘↓)
 	const getNextWorkspace = electronTrpc.workspaces.getNextWorkspace.useQuery(
 		{ id: workspaceId },
 		{ enabled: !!workspaceId },
@@ -858,6 +832,7 @@ export function WorkspacePage({
 		},
 		{ enabled: isActive },
 	);
+
 
 	return (
 		<WorkspaceIdProvider value={workspaceId}>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/workspace/$workspaceId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/workspace/$workspaceId/page.tsx
@@ -20,6 +20,7 @@ import { getWorkspaceDisplayName } from "renderer/lib/getWorkspaceDisplayName";
 import { electronTrpcClient as trpcClient } from "renderer/lib/trpc-client";
 import { usePresets } from "renderer/react-query/presets";
 import type { WorkspaceSearchParams } from "renderer/routes/_authenticated/_dashboard/utils/workspace-navigation";
+import { navigateToWorkspace } from "renderer/routes/_authenticated/_dashboard/utils/workspace-navigation";
 import { usePresetHotkeys } from "renderer/routes/_authenticated/_dashboard/workspace/$workspaceId/hooks/usePresetHotkeys";
 import { useWorkspaceRunCommand } from "renderer/routes/_authenticated/_dashboard/workspace/$workspaceId/hooks/useWorkspaceRunCommand";
 import { NotFound } from "renderer/routes/not-found";
@@ -832,7 +833,6 @@ export function WorkspacePage({
 		},
 		{ enabled: isActive },
 	);
-
 
 	return (
 		<WorkspaceIdProvider value={workspaceId}>

--- a/apps/desktop/src/renderer/stores/tabs/utils.ts
+++ b/apps/desktop/src/renderer/stores/tabs/utils.ts
@@ -628,42 +628,6 @@ export const getFirstPaneId = (layout: MosaicNode<string>): string => {
 };
 
 /**
- * Gets the next pane ID in visual order (left-to-right, top-to-bottom),
- * wrapping around to the first if at the end.
- */
-export const getNextPaneId = (
-	layout: MosaicNode<string>,
-	currentPaneId: string,
-): string | null => {
-	const paneIds = getPaneIdsInVisualOrder(layout);
-	if (paneIds.length <= 1) return null;
-
-	const currentIndex = paneIds.indexOf(currentPaneId);
-	if (currentIndex === -1) return paneIds[0];
-
-	const nextIndex = (currentIndex + 1) % paneIds.length;
-	return paneIds[nextIndex];
-};
-
-/**
- * Gets the previous pane ID in visual order (right-to-left, bottom-to-top),
- * wrapping around to the last if at the beginning.
- */
-export const getPreviousPaneId = (
-	layout: MosaicNode<string>,
-	currentPaneId: string,
-): string | null => {
-	const paneIds = getPaneIdsInVisualOrder(layout);
-	if (paneIds.length <= 1) return null;
-
-	const currentIndex = paneIds.indexOf(currentPaneId);
-	if (currentIndex === -1) return paneIds[paneIds.length - 1];
-
-	const prevIndex = (currentIndex - 1 + paneIds.length) % paneIds.length;
-	return paneIds[prevIndex];
-};
-
-/**
  * Gets the adjacent pane ID for focus fallback when a pane is closed.
  * Prefers the next pane in visual order, falls back to previous if at the end.
  * Returns null only if the pane is the only one in the layout.

--- a/packages/panes/src/core/store/store.test.ts
+++ b/packages/panes/src/core/store/store.test.ts
@@ -433,11 +433,9 @@ describe("openPane", () => {
 
 		store.getState().openPane({
 			pane: tp("p1", "opened"),
-			tabTitle: "My Tab",
 		});
 
 		expect(store.getState().tabs).toHaveLength(1);
-		expect(store.getState().tabs[0]?.titleOverride).toBe("My Tab");
 		expect(store.getState().getActivePane()?.pane.data.label).toBe("opened");
 	});
 

--- a/packages/panes/src/core/store/store.ts
+++ b/packages/panes/src/core/store/store.ts
@@ -121,7 +121,7 @@ export interface WorkspaceStore<TData> extends WorkspaceState<TData> {
 		newPane: CreatePaneInput<TData>;
 	}) => void;
 
-	openPane: (args: { pane: CreatePaneInput<TData>; tabTitle?: string }) => void;
+	openPane: (args: { pane: CreatePaneInput<TData> }) => void;
 
 	splitPane: (args: {
 		tabId: string;
@@ -406,7 +406,6 @@ export function createWorkspaceStore<TData>(
 			// No tab → create one
 			if (!tab || !activeTabId) {
 				get().addTab({
-					titleOverride: args.tabTitle,
 					panes: [args.pane],
 				});
 				return;

--- a/packages/panes/src/core/store/utils/index.ts
+++ b/packages/panes/src/core/store/utils/index.ts
@@ -1,11 +1,14 @@
+export type { FocusDirection } from "./utils";
 export {
 	equalizeAllSplits,
 	findFirstPaneId,
 	findPaneInLayout,
+	findPanePath,
 	findSiblingPaneId,
 	generateId,
 	getNodeAtPath,
 	getOtherBranch,
+	getSpatialNeighborPaneId,
 	positionToDirection,
 	removePaneFromLayout,
 	replacePaneIdInLayout,

--- a/packages/panes/src/core/store/utils/utils.test.ts
+++ b/packages/panes/src/core/store/utils/utils.test.ts
@@ -6,6 +6,7 @@ import {
 	findPaneInLayout,
 	getNodeAtPath,
 	getOtherBranch,
+	getSpatialNeighborPaneId,
 	positionToDirection,
 	removePaneFromLayout,
 	replacePaneIdInLayout,
@@ -318,5 +319,137 @@ describe("positionToDirection", () => {
 	it("maps top/bottom to vertical", () => {
 		expect(positionToDirection("top")).toBe("vertical");
 		expect(positionToDirection("bottom")).toBe("vertical");
+	});
+});
+
+describe("getSpatialNeighborPaneId", () => {
+	//   +---+
+	//   | a |
+	//   +---+
+	it("returns null when there is only one pane", () => {
+		const layout: LayoutNode = { type: "pane", paneId: "a" };
+		expect(getSpatialNeighborPaneId(layout, "a", "left")).toBeNull();
+		expect(getSpatialNeighborPaneId(layout, "a", "right")).toBeNull();
+		expect(getSpatialNeighborPaneId(layout, "a", "up")).toBeNull();
+		expect(getSpatialNeighborPaneId(layout, "a", "down")).toBeNull();
+	});
+
+	//   +---+---+
+	//   | a | b |
+	//   +---+---+
+	it("moves between siblings in a horizontal split", () => {
+		const layout: LayoutNode = {
+			type: "split",
+			direction: "horizontal",
+			first: { type: "pane", paneId: "a" },
+			second: { type: "pane", paneId: "b" },
+		};
+		expect(getSpatialNeighborPaneId(layout, "a", "right")).toBe("b");
+		expect(getSpatialNeighborPaneId(layout, "b", "left")).toBe("a");
+		expect(getSpatialNeighborPaneId(layout, "a", "up")).toBeNull();
+		expect(getSpatialNeighborPaneId(layout, "a", "down")).toBeNull();
+	});
+
+	//   +---+
+	//   | a |
+	//   +---+
+	//   | b |
+	//   +---+
+	it("moves between siblings in a vertical split", () => {
+		const layout: LayoutNode = {
+			type: "split",
+			direction: "vertical",
+			first: { type: "pane", paneId: "a" },
+			second: { type: "pane", paneId: "b" },
+		};
+		expect(getSpatialNeighborPaneId(layout, "a", "down")).toBe("b");
+		expect(getSpatialNeighborPaneId(layout, "b", "up")).toBe("a");
+		expect(getSpatialNeighborPaneId(layout, "a", "right")).toBeNull();
+	});
+
+	//   +---+---+
+	//   | a | b |
+	//   +---+---+
+	it("does not wrap around at the layout edge", () => {
+		const layout: LayoutNode = {
+			type: "split",
+			direction: "horizontal",
+			first: { type: "pane", paneId: "a" },
+			second: { type: "pane", paneId: "b" },
+		};
+		expect(getSpatialNeighborPaneId(layout, "a", "left")).toBeNull();
+		expect(getSpatialNeighborPaneId(layout, "b", "right")).toBeNull();
+	});
+
+	// 2x2 grid built "rows first":
+	//   outer = vertical split { top row / bot row }
+	//     top row = horizontal split { a | b }
+	//     bot row = horizontal split { c | d }
+	//
+	//   +---+---+
+	//   | a | b |
+	//   +---+---+
+	//   | c | d |
+	//   +---+---+
+	it("preserves column alignment in a rows-first 2x2", () => {
+		const layout: LayoutNode = {
+			type: "split",
+			direction: "vertical",
+			first: {
+				type: "split",
+				direction: "horizontal",
+				first: { type: "pane", paneId: "a" },
+				second: { type: "pane", paneId: "b" },
+			},
+			second: {
+				type: "split",
+				direction: "horizontal",
+				first: { type: "pane", paneId: "c" },
+				second: { type: "pane", paneId: "d" },
+			},
+		};
+		expect(getSpatialNeighborPaneId(layout, "b", "down")).toBe("d");
+		expect(getSpatialNeighborPaneId(layout, "d", "up")).toBe("b");
+		expect(getSpatialNeighborPaneId(layout, "c", "up")).toBe("a");
+		expect(getSpatialNeighborPaneId(layout, "a", "down")).toBe("c");
+		expect(getSpatialNeighborPaneId(layout, "a", "right")).toBe("b");
+		expect(getSpatialNeighborPaneId(layout, "d", "left")).toBe("c");
+		expect(getSpatialNeighborPaneId(layout, "a", "left")).toBeNull();
+		expect(getSpatialNeighborPaneId(layout, "b", "up")).toBeNull();
+	});
+
+	// 2x2 grid built "columns first":
+	//   outer = horizontal split { left col / right col }
+	//     left col = vertical split { a / c }
+	//     right col = vertical split { b / d }
+	//
+	//   +---+---+
+	//   | a | b |
+	//   +---+---+
+	//   | c | d |
+	//   +---+---+
+	it("preserves row alignment in a columns-first 2x2", () => {
+		const layout: LayoutNode = {
+			type: "split",
+			direction: "horizontal",
+			first: {
+				type: "split",
+				direction: "vertical",
+				first: { type: "pane", paneId: "a" },
+				second: { type: "pane", paneId: "c" },
+			},
+			second: {
+				type: "split",
+				direction: "vertical",
+				first: { type: "pane", paneId: "b" },
+				second: { type: "pane", paneId: "d" },
+			},
+		};
+		expect(getSpatialNeighborPaneId(layout, "c", "right")).toBe("d");
+		expect(getSpatialNeighborPaneId(layout, "d", "left")).toBe("c");
+		expect(getSpatialNeighborPaneId(layout, "a", "right")).toBe("b");
+		expect(getSpatialNeighborPaneId(layout, "b", "left")).toBe("a");
+		expect(getSpatialNeighborPaneId(layout, "a", "down")).toBe("c");
+		expect(getSpatialNeighborPaneId(layout, "b", "down")).toBe("d");
 	});
 });

--- a/packages/panes/src/core/store/utils/utils.ts
+++ b/packages/panes/src/core/store/utils/utils.ts
@@ -169,3 +169,66 @@ export function positionToDirection(position: SplitPosition): SplitDirection {
 export function generateId(prefix: string): string {
 	return `${prefix}-${crypto.randomUUID()}`;
 }
+
+export type FocusDirection = "left" | "right" | "up" | "down";
+
+export function findPanePath(
+	node: LayoutNode,
+	paneId: string,
+	currentPath: SplitBranch[] = [],
+): SplitPath | null {
+	if (node.type === "pane") {
+		return node.paneId === paneId ? currentPath : null;
+	}
+	const firstPath = findPanePath(node.first, paneId, [...currentPath, "first"]);
+	if (firstPath) return firstPath;
+	return findPanePath(node.second, paneId, [...currentPath, "second"]);
+}
+
+// Descent into a sibling subtree once a pivot split has been chosen.
+// - On splits matching the arrow axis: pick the near edge (first for
+//   right/down, second for left/up), preserving alignmentPath.
+// - On perpendicular splits: consume one entry from alignmentPath to
+//   preserve the source pane's cross-axis position; if exhausted, fall
+//   back to `first`.
+function findEdgePaneId(
+	node: LayoutNode,
+	dir: FocusDirection,
+	alignmentPath: SplitPath = [],
+): string | null {
+	if (node.type === "pane") return node.paneId;
+	const axis: SplitDirection =
+		dir === "left" || dir === "right" ? "horizontal" : "vertical";
+	if (node.direction === axis) {
+		const nearEdge: SplitBranch =
+			dir === "right" || dir === "down" ? "first" : "second";
+		return findEdgePaneId(node[nearEdge], dir, alignmentPath);
+	}
+	const [alignedBranch = "first", ...rest] = alignmentPath;
+	return findEdgePaneId(node[alignedBranch], dir, rest);
+}
+
+export function getSpatialNeighborPaneId(
+	root: LayoutNode,
+	paneId: string,
+	dir: FocusDirection,
+): string | null {
+	const path = findPanePath(root, paneId);
+	if (!path) return null;
+
+	const axis: SplitDirection =
+		dir === "left" || dir === "right" ? "horizontal" : "vertical";
+	const wantSecond = dir === "right" || dir === "down";
+
+	for (let i = path.length - 1; i >= 0; i--) {
+		const ancestor = getNodeAtPath(root, path.slice(0, i));
+		if (!ancestor || ancestor.type !== "split") continue;
+		if (ancestor.direction !== axis) continue;
+		const cameFrom = path[i];
+		if (wantSecond && cameFrom !== "first") continue;
+		if (!wantSecond && cameFrom !== "second") continue;
+		const siblingBranch: SplitBranch = wantSecond ? "second" : "first";
+		return findEdgePaneId(ancestor[siblingBranch], dir, path.slice(i + 1));
+	}
+	return null;
+}

--- a/packages/panes/src/index.ts
+++ b/packages/panes/src/index.ts
@@ -17,7 +17,7 @@ export type {
 	TabContext,
 	WorkspaceProps,
 } from "./react";
-export { Workspace } from "./react";
+export { resolveTabTitle, Workspace } from "./react";
 export type {
 	LayoutNode,
 	Pane,

--- a/packages/panes/src/index.ts
+++ b/packages/panes/src/index.ts
@@ -5,6 +5,8 @@ export type {
 	WorkspaceStore,
 } from "./core/store";
 export { createWorkspaceStore } from "./core/store";
+export type { FocusDirection } from "./core/store/utils";
+export { getSpatialNeighborPaneId } from "./core/store/utils";
 export type {
 	ContextMenuActionConfig,
 	PaneActionConfig,

--- a/packages/panes/src/react/components/Workspace/Workspace.tsx
+++ b/packages/panes/src/react/components/Workspace/Workspace.tsx
@@ -5,6 +5,7 @@ import type { Pane } from "../../../types";
 import type { WorkspaceProps } from "../../types";
 import { Tab } from "./components/Tab";
 import { TabBar } from "./components/TabBar";
+import { resolveTabTitle } from "./utils/resolveTabTitle";
 
 export function Workspace<TData>({
 	store,
@@ -12,7 +13,6 @@ export function Workspace<TData>({
 	className,
 	renderTabAccessory,
 	renderTabIcon,
-	getTabTitle,
 	renderEmptyState,
 	renderAddTabMenu,
 	renderBelowTabBar,
@@ -78,7 +78,7 @@ export function Workspace<TData>({
 				onReorderTab={(tabId, toIndex) =>
 					store.getState().reorderTab({ tabId, toIndex })
 				}
-				getTabTitle={(tab) => tab.titleOverride ?? getTabTitle?.(tab) ?? tab.id}
+				getTabTitle={(tab) => resolveTabTitle(tab, tabs, registry)}
 				renderTabIcon={renderTabIcon}
 				renderAddTabMenu={renderAddTabMenu}
 				renderTabAccessory={renderTabAccessory}

--- a/packages/panes/src/react/components/Workspace/components/Tab/components/Pane/Pane.tsx
+++ b/packages/panes/src/react/components/Workspace/components/Tab/components/Pane/Pane.tsx
@@ -211,7 +211,7 @@ export function Pane<TData>({
 	}
 
 	const title = definition
-		? (pane.titleOverride ?? definition.getTitle?.(context) ?? pane.id)
+		? (pane.titleOverride ?? definition.getTitle?.(pane) ?? pane.id)
 		: `Unknown: ${pane.kind}`;
 	const icon = definition?.getIcon?.(context);
 	const titleContent = definition?.renderTitle?.(context);

--- a/packages/panes/src/react/components/Workspace/index.ts
+++ b/packages/panes/src/react/components/Workspace/index.ts
@@ -1,1 +1,2 @@
+export { resolveTabTitle } from "./utils/resolveTabTitle";
 export { Workspace } from "./Workspace";

--- a/packages/panes/src/react/components/Workspace/utils/resolveTabTitle.ts
+++ b/packages/panes/src/react/components/Workspace/utils/resolveTabTitle.ts
@@ -1,0 +1,18 @@
+import type { Tab } from "../../../../types";
+import type { PaneRegistry } from "../../../types";
+
+export function resolveTabTitle<TData>(
+	tab: Tab<TData>,
+	tabs: Tab<TData>[],
+	registry: PaneRegistry<TData>,
+): string {
+	if (tab.titleOverride) return tab.titleOverride;
+	const panes = Object.values(tab.panes);
+	const onlyPane = panes.length === 1 ? panes[0] : undefined;
+	if (onlyPane) {
+		const fromPane =
+			onlyPane.titleOverride ?? registry[onlyPane.kind]?.getTitle?.(onlyPane);
+		if (fromPane) return fromPane;
+	}
+	return `Tab ${tabs.indexOf(tab) + 1}`;
+}

--- a/packages/panes/src/react/index.ts
+++ b/packages/panes/src/react/index.ts
@@ -1,4 +1,4 @@
-export { Workspace } from "./components/Workspace";
+export { resolveTabTitle, Workspace } from "./components/Workspace";
 export type {
 	ContextMenuActionConfig,
 	PaneActionConfig,

--- a/packages/panes/src/react/types.ts
+++ b/packages/panes/src/react/types.ts
@@ -58,7 +58,7 @@ export interface RendererContext<TData> {
 
 export interface PaneDefinition<TData> {
 	renderPane(context: RendererContext<TData>): ReactNode;
-	getTitle?(context: RendererContext<TData>): ReactNode;
+	getTitle?(pane: Pane<TData>): string | undefined;
 	getIcon?(context: RendererContext<TData>): ReactNode;
 	renderTitle?(context: RendererContext<TData>): ReactNode;
 	renderHeaderExtras?(context: RendererContext<TData>): ReactNode;
@@ -88,7 +88,6 @@ export interface WorkspaceProps<TData> {
 	className?: string;
 	renderTabAccessory?: (tab: Tab<TData>) => ReactNode;
 	renderTabIcon?: (tab: Tab<TData>) => ReactNode;
-	getTabTitle?: (tab: Tab<TData>) => string | undefined;
 	renderEmptyState?: () => ReactNode;
 	renderAddTabMenu?: () => ReactNode;
 	renderBelowTabBar?: () => ReactNode;


### PR DESCRIPTION
## Upstream Merge PR#3 - 空間認識ペインナビ + Diff ビューア

upstream から2つの大きな機能改善コミットを cherry-pick します。フォークにとって初の **大規模 API 変更** を含みます。

## 取り込むコミット

| Commit | Upstream PR | 内容 |
|---|---|---|
| \`039edf21a\` | #3403 | Cmd+Alt+Arrow で v2 ペイン間を空間認識的にフォーカス移動 |
| \`3dd1de2e8\` | #3420 | v2 diff ビューアが独立タブで開く + タブ/ペインタイトル解決の刷新 |

## 改善内容の詳細

### ① 空間認識型ペインナビゲーション (#3403)

#### 何が問題だったか

従来の \`PREV_PANE\` / \`NEXT_PANE\` は **線形循環** でした：
- ペインを登録順に1つずつ次へ/前へ移動
- 2x2 グリッドのような複雑なレイアウトだと、視覚的に隣接していないペインへジャンプしてしまい直感に反する
- Windows/Linux では \`Ctrl+Alt+Arrow\` が Intel HD Graphics ドライバに画面回転ショートカットとして奪われる問題もあった

#### どう直したか

**4方向の空間認識型ナビゲーションに刷新：**

\`\`\`
FOCUS_PANE_LEFT   →  Cmd+Alt+Left   (mac) / Ctrl+Shift+Alt+Left  (win/linux)
FOCUS_PANE_RIGHT  →  Cmd+Alt+Right  (mac) / Ctrl+Shift+Alt+Right (win/linux)
FOCUS_PANE_UP     →  Cmd+Alt+Up     (mac) / Ctrl+Shift+Alt+Up    (win/linux)
FOCUS_PANE_DOWN   →  Cmd+Alt+Down   (mac) / Ctrl+Shift+Alt+Down  (win/linux)
\`\`\`

**新規アルゴリズム \`getSpatialNeighborPaneId()\`：**

1. 現在のペインから LayoutNode ツリーを **逆向きに** 登り、矢印方向に一致する軸（horizontal/vertical）を持つ split を見つける
2. 見つかった split の反対側の subtree を descend し、エッジに最も近い leaf ペインを選ぶ
3. descent 時に **クロス軸の整合性を維持** （2x2 グリッドで「右上から下」を押したときに「右下」に正しく到達するため）

この整合性ロジックはバグ修正が重なってテストが追加されています：
- 単一ペイン
- 単純な horizontal/vertical split
- エッジでの no-wrap（端では移動しない）
- 2x2 グリッド（rows-first と cols-first 両方のレイアウト）

**Windows/Linux での Intel ドライバ回避：**
- \`Ctrl+Alt+Arrow\` ではなく \`Ctrl+Shift+Alt+Arrow\` に割り当て
- これで Intel ドライバの画面回転ショートカットと衝突しない

**新規ファイル：**
- \`packages/panes/src/core/store/utils/utils.ts\` - \`getSpatialNeighborPaneId()\`, \`FocusDirection\` 型
- \`packages/panes/src/core/store/utils/utils.test.ts\` - 上記のユニットテスト

### ② Diff ビューア独立タブ + タブタイトル解決API刷新 (#3420)

#### 何が問題だったか

**Diff ビューアが既存タブに埋め込まれる：**
- Git の変更を見たいとき、現在開いているタブに diff ペインが追加されてしまい、編集中のファイルと混在していた
- 「変更の確認」と「編集」が物理的に分離されず、ワークフローが混乱しがち

**タブタイトルの責任が散らかっていた：**
- \`tab.titleOverride\` がユーザー rename とプリセット名とターミナルラベルを兼ねていた
- タブ分割時に titleOverride が残ってしまい、意味不明なタイトルになることがあった
- 各 pane 定義の \`getTitle()\` が \`ReactNode\` を返せるため、タブバーと context menu で異なる表示になる可能性があった

#### どう直したか

**(a) Diff ビューアが独立タブで開く**
- Git changes から diff を開くと、新規タブを作って開く
- 編集ワークフローを汚染しない

**(b) \`PaneDefinition.getTitle()\` API の刷新**

\`\`\`typescript
// Before
interface PaneDefinition<TData> {
  getTitle?(context: RendererContext<TData>): ReactNode;
}

// After
interface PaneDefinition<TData> {
  getTitle?(pane: Pane<TData>): string | undefined;  // 純粋な文字列のみ
  renderTitle?(context: RendererContext<TData>): ReactNode;  // JSX はこちらへ
}
\`\`\`

これにより：
- タイトル文字列はあらゆる場所（タブバー、\"Move to Tab\" コンテキストメニュー）で一貫
- JSX の rich title は \`renderTitle\` に分離、必要な場所でだけ使う

**(c) \`titleOverride\` をタブ→ペインレベルへ移動**

\`\`\`
Before:
  tab.titleOverride  ← ユーザー rename と preset 名と terminal label が混在

After:
  tab.titleOverride  ← ユーザー rename 専用（タブ分割時にクリア）
  pane.titleOverride ← preset 名 / terminal label （pane 固有のラベル）
\`\`\`

**(d) 新規ヘルパー \`resolveTabTitle()\`**

タブタイトル解決を一元化：

\`\`\`typescript
// packages/panes/src/react/components/Workspace/utils/resolveTabTitle.ts
function resolveTabTitle(tab, tabs, registry) {
  // 1. tab.titleOverride（ユーザー rename）が最優先
  if (tab.titleOverride) return tab.titleOverride;

  // 2. 単一ペインの場合：
  //    - pane.titleOverride
  //    - registry[pane.kind].getTitle(pane)
  const onlyPane = single pane ? ... : undefined;
  if (onlyPane) {
    const fromPane = onlyPane.titleOverride ?? registry[...]?.getTitle?.(onlyPane);
    if (fromPane) return fromPane;
  }

  // 3. 複数ペインの場合: \"Tab N\"
  return \`Tab \${tabs.indexOf(tab) + 1}\`;
}
\`\`\`

**(e) ブラウザタブのタイトルが URL のポート番号を保持**
- \`URL.hostname\` → \`URL.host\` に変更
- \`localhost:3000\` のようにポート付きで表示される

**(f) \`WorkspaceProps.getTabTitle\` を削除、\`openPane({ tabTitle })\` を廃止**
- タブタイトル解決が \`resolveTabTitle()\` に一元化されたため、API を簡素化

## コンフリクト解決

### v1 workspace/\$workspaceId/page.tsx
- ✅ フォーク独自の **deep-link navigation**（\`useSearch\` / \`WorkspaceSearchParams\` / \`useDeepLinkNavigationStore\`）を保持
- ✅ フォーク独自の \`CLOSE_TERMINAL\` / \`CLOSE_TAB\` ハンドラを保持
- ✅ フォーク独自の **tRPC-based PREV/NEXT_WORKSPACE** ハンドラを保持
- ❌ \`PREV_PANE\` / \`NEXT_PANE\` ハンドラは削除（upstreamに合わせる）

### v2 workspace/\$workspaceId/page.tsx
- ✅ フォーク独自の追加 state（\`rightSidebarOpenViewWidth\`, \`showPresetsBar\` 等）を保持
- ✅ upstream の \`useDefaultContextMenuActions(paneRegistry)\` シグネチャ変更を採用
- ❌ \`addTab({ titleOverride })\` を削除（新API に合わせる）

### registry.ts
- 自動マージで \`PREV_PANE\` / \`NEXT_PANE\` 削除 + \`FOCUS_PANE_*\` 追加
- フォーク独自の \`BROWSER_RELOAD\` / \`BROWSER_HARD_RELOAD\` / \`SEARCH_IN_FILES\` は維持

## 追加の型拡張（PR#2 と重複）

cherry-pick 後の typecheck パスのため、以下を追加：
- \`types.ts\` の null-safe 化（PR#2 と同じ）
- \`registry.ts\` に null-bound \`PREV/NEXT_TAB\`, \`PREV/NEXT_WORKSPACE\` を追加（PR#2 と同じ）
- \`useRecordHotkeys.ts\` の null-guard（PR#2 と同じ）
- \`navigateToWorkspace\` import を復活（フォーク固有）
- v2 page.tsx の deprecated \`tabTitle\` 引数を削除

**⚠️ PR#2 との重複について：** \`types.ts\` と \`registry.ts\` の変更は PR#2 と同一内容です。git の3-way merge が identical な変更として自動解決するので、マージ順序は PR#2 → PR#3 のどちらが先でも問題なし。

## フォーク固有機能の保持

- **v1 deep-link navigation**: URL 経由でファイル/行/列を開く機能
- **v1 tRPC-based PREV/NEXT_WORKSPACE**: フォーク独自の workspace 循環実装
- **v2 CLOSE_TERMINAL / CLOSE_TAB**: フォーク独自のペイン・タブクローズホットキー
- **ブラウザホットキー**: \`BROWSER_RELOAD\`, \`BROWSER_HARD_RELOAD\`, \`SEARCH_IN_FILES\`
- **HotkeyCategory \"Browser\"**
- **v2 workspace 独自 state**: \`rightSidebarOpenViewWidth\`, \`showPresetsBar\` 等

## テスト計画

- [x] \`bun run typecheck\` パス
- [x] \`bun run lint\` パス
- [ ] \`Cmd+Alt+Arrow\` で v2 ペイン間を空間認識で移動（水平2ペイン）
- [ ] 2x2 グリッドで \`Cmd+Alt+Arrow\` が正しく動作（クロス軸整合性）
- [ ] エッジで wrap しないことを確認
- [ ] 単一ペインのタブ：ペインの getTitle() がタブタイトル
- [ ] 複数ペインのタブ：\"Tab N\" 表示
- [ ] ユーザーがタブ名を変更した場合：\`tab.titleOverride\` が効く
- [ ] Terminal preset でカスタムラベル：\`pane.titleOverride\` が表示される
- [ ] ブラウザタブのポート番号：\`localhost:3000\` のようにポート付きで表示
- [ ] v1 workspace の既存ホットキーが動作：\`PREV_TAB\`/\`NEXT_TAB\`/\`PREV_WORKSPACE\`/\`NEXT_WORKSPACE\`
- [ ] フォーク独自ホットキーが動作：ブラウザリロード、ハードリロード、ファイル内検索
- [ ] Diff ビューアが新規タブで開く（既存タブに追加されない）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Directional pane focus navigation: Use arrow-based hotkeys (left, right, up, down) to navigate between panes with layout-aware positioning instead of linear cycling.
  * Updated hotkey bindings for improved consistency across platforms.

* **Refactor**
  * Improved tab title resolution to better reflect pane and workspace context.
  * Simplified workspace state management by centralizing title handling.

* **Tests**
  * Added comprehensive test coverage for spatial pane navigation logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->