### PR TITLE
[PR4/5] fix(upstream): v1 split pane 起動時のサイジング修正（ターミナル Session Readiness 機構）(#3416)

### DIFF
--- a/apps/desktop/src/renderer/lib/terminal/launch-command.test.ts
+++ b/apps/desktop/src/renderer/lib/terminal/launch-command.test.ts
@@ -5,6 +5,11 @@ import {
 	launchCommandInPane,
 	writeCommandsInPane,
 } from "./launch-command";
+import {
+	clearTerminalSessionReady,
+	markTerminalSessionReady,
+	rejectTerminalSessionReady,
+} from "./session-readiness";
 
 describe("launchCommandInPane", () => {
 	it("creates a terminal session and writes the command with a newline", async () => {
@@ -102,6 +107,57 @@ describe("launchCommandInPane", () => {
 			data: "echo hello\n",
 			throwOnError: true,
 		});
+	});
+
+	it("waits for the mounted session before writing when requested", async () => {
+		const paneId = "pane-mounted-session-ready";
+		const createOrAttach = mock(async () => ({}));
+		const write = mock(async () => ({}));
+
+		const launchPromise = launchCommandInPane({
+			paneId,
+			tabId: "tab-1",
+			workspaceId: "ws-1",
+			command: "echo hello",
+			createOrAttach,
+			write,
+			waitForMountedSession: true,
+		});
+
+		expect(createOrAttach).not.toHaveBeenCalled();
+		expect(write).not.toHaveBeenCalled();
+
+		markTerminalSessionReady(paneId);
+		await launchPromise;
+		clearTerminalSessionReady(paneId);
+
+		expect(write).toHaveBeenCalledWith({
+			paneId,
+			data: "echo hello\n",
+			throwOnError: true,
+		});
+	});
+
+	it("propagates mounted-session readiness failures", async () => {
+		const paneId = "pane-mounted-session-failure";
+		const createOrAttach = mock(async () => ({}));
+		const write = mock(async () => ({}));
+
+		const launchPromise = launchCommandInPane({
+			paneId,
+			tabId: "tab-1",
+			workspaceId: "ws-1",
+			command: "echo hello",
+			createOrAttach,
+			write,
+			waitForMountedSession: true,
+		});
+
+		rejectTerminalSessionReady(paneId, new Error("attach failed"));
+
+		await expect(launchPromise).rejects.toThrow("attach failed");
+		expect(createOrAttach).not.toHaveBeenCalled();
+		expect(write).not.toHaveBeenCalled();
 	});
 });
 

--- a/apps/desktop/src/renderer/lib/terminal/launch-command.ts
+++ b/apps/desktop/src/renderer/lib/terminal/launch-command.ts
@@ -1,4 +1,5 @@
 import { isTerminalAttachCanceledMessage } from "renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/attach-cancel";
+import { waitForTerminalSessionReady } from "./session-readiness";
 
 interface TerminalCreateOrAttachInput {
 	paneId: string;
@@ -23,6 +24,11 @@ interface LaunchCommandInPaneOptions {
 	createOrAttach: (input: TerminalCreateOrAttachInput) => Promise<unknown>;
 	write: (input: TerminalWriteInput) => Promise<unknown>;
 	noExecute?: boolean;
+	/**
+	 * Only use this for panes that will mount immediately in the active tab.
+	 * Background tabs must use the helper-side attach path instead.
+	 */
+	waitForMountedSession?: boolean;
 }
 
 function normalizeTerminalCommand(command: string): string {
@@ -82,7 +88,14 @@ export async function launchCommandInPane({
 	createOrAttach,
 	write,
 	noExecute,
+	waitForMountedSession,
 }: LaunchCommandInPaneOptions): Promise<void> {
+	if (waitForMountedSession) {
+		await waitForTerminalSessionReady(paneId);
+		await writeCommandInPane({ paneId, command, write, noExecute });
+		return;
+	}
+
 	await ensureTerminalAttached({
 		paneId,
 		tabId,

--- a/apps/desktop/src/renderer/lib/terminal/session-readiness.ts
+++ b/apps/desktop/src/renderer/lib/terminal/session-readiness.ts
@@ -1,0 +1,54 @@
+type SessionReadyWaiter = {
+	resolve: () => void;
+	reject: (error: Error) => void;
+};
+
+const readyPaneIds = new Set<string>();
+const waitersByPaneId = new Map<string, Set<SessionReadyWaiter>>();
+
+function resolveWaiters(paneId: string): void {
+	const waiters = waitersByPaneId.get(paneId);
+	if (!waiters) return;
+	waitersByPaneId.delete(paneId);
+	for (const waiter of waiters) {
+		waiter.resolve();
+	}
+}
+
+function rejectWaiters(paneId: string, error: Error): void {
+	const waiters = waitersByPaneId.get(paneId);
+	if (!waiters) return;
+	waitersByPaneId.delete(paneId);
+	for (const waiter of waiters) {
+		waiter.reject(error);
+	}
+}
+
+export function clearTerminalSessionReady(paneId: string): void {
+	readyPaneIds.delete(paneId);
+}
+
+export function markTerminalSessionReady(paneId: string): void {
+	readyPaneIds.add(paneId);
+	resolveWaiters(paneId);
+}
+
+export function rejectTerminalSessionReady(paneId: string, error: Error): void {
+	readyPaneIds.delete(paneId);
+	rejectWaiters(paneId, error);
+}
+
+export function waitForTerminalSessionReady(paneId: string): Promise<void> {
+	if (readyPaneIds.has(paneId)) {
+		return Promise.resolve();
+	}
+
+	return new Promise<void>((resolve, reject) => {
+		let waiters = waitersByPaneId.get(paneId);
+		if (!waiters) {
+			waiters = new Set();
+			waitersByPaneId.set(paneId, waiters);
+		}
+		waiters.add({ resolve, reject });
+	});
+}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalLifecycle.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalLifecycle.ts
@@ -5,6 +5,11 @@ import type { MutableRefObject, RefObject } from "react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { writeCommandInPane } from "renderer/lib/terminal/launch-command";
 import type { DetectedLink } from "renderer/lib/terminal/links";
+import {
+	clearTerminalSessionReady,
+	markTerminalSessionReady,
+	rejectTerminalSessionReady,
+} from "renderer/lib/terminal/session-readiness";
 import { electronTrpcClient } from "renderer/lib/trpc-client";
 import { useTabsStore } from "renderer/stores/tabs/store";
 import { killTerminalForPane } from "renderer/stores/tabs/utils/terminal-cleanup";
@@ -371,6 +376,7 @@ export function useTerminalLifecycle({
 					const requestId = nextAttachRequestId();
 					cancelAttachRequest(activeAttachRequestId);
 					activeAttachRequestId = requestId;
+					clearTerminalSessionReady(paneId);
 					createOrAttachRef.current(
 						{
 							paneId,
@@ -566,6 +572,7 @@ export function useTerminalLifecycle({
 							!isUnmounted && !attachCanceled && attachId === activeAttachId;
 
 						markAttachInFlight(paneId, attachId);
+						clearTerminalSessionReady(paneId);
 
 						const finishAttach = () => {
 							clearAttachInFlight(paneId, attachId);
@@ -600,6 +607,7 @@ export function useTerminalLifecycle({
 									// flow through the component's registered handler.
 									v1TerminalCache.startStream(paneId);
 									v1TerminalCache.setStreamReady(paneId);
+									markTerminalSessionReady(paneId);
 
 									const storedColdRestore = coldRestoreState.get(paneId);
 									if (storedColdRestore?.isRestored) {
@@ -666,6 +674,10 @@ export function useTerminalLifecycle({
 									}
 									const workspaceRun = getPaneWorkspaceRun(paneId);
 									if (error.message?.includes("TERMINAL_SESSION_KILLED")) {
+										rejectTerminalSessionReady(
+											paneId,
+											new Error(error.message || "Terminal session killed"),
+										);
 										if (workspaceRun) {
 											setPaneWorkspaceRunState(paneId, "stopped-by-user");
 										}
@@ -677,6 +689,10 @@ export function useTerminalLifecycle({
 										return;
 									}
 									console.error("[Terminal] Failed to create/attach:", error);
+									rejectTerminalSessionReady(
+										paneId,
+										new Error(error.message || "Failed to connect to terminal"),
+									);
 									if (workspaceRun) {
 										setPaneWorkspaceRunState(paneId, "stopped-by-exit");
 									}

--- a/apps/desktop/src/renderer/stores/tabs/useTabsWithPresets.ts
+++ b/apps/desktop/src/renderer/stores/tabs/useTabsWithPresets.ts
@@ -103,13 +103,17 @@ export function useTabsWithPresets(projectId?: string | null) {
 	}, []);
 
 	const launchPresetCommand = useCallback(
-		({ paneId, tabId, workspaceId, command, cwd }: PresetPaneLaunch) => {
+		(
+			{ paneId, tabId, workspaceId, command, cwd }: PresetPaneLaunch,
+			options?: { waitForMountedSession?: boolean },
+		) => {
 			void launchCommandInPane({
 				paneId,
 				tabId,
 				workspaceId,
 				command,
 				cwd,
+				waitForMountedSession: options?.waitForMountedSession,
 				createOrAttach: (input) => createOrAttach.mutateAsync(input),
 				write: (input) => writeToTerminal.mutateAsync(input),
 			}).catch((error) => {
@@ -125,9 +129,12 @@ export function useTabsWithPresets(projectId?: string | null) {
 	);
 
 	const launchPresetCommands = useCallback(
-		(launches: PresetPaneLaunch[]) => {
+		(
+			launches: PresetPaneLaunch[],
+			options?: { waitForMountedSession?: boolean },
+		) => {
 			for (const launch of launches) {
-				launchPresetCommand(launch);
+				launchPresetCommand(launch, options);
 			}
 		},
 		[launchPresetCommand],
@@ -145,13 +152,16 @@ export function useTabsWithPresets(projectId?: string | null) {
 			if (firstPresetCommand === null) return;
 			const workspaceId = resolveWorkspaceIdForTab(tabId);
 			if (!workspaceId) return;
-			launchPresetCommand({
-				paneId,
-				tabId,
-				workspaceId,
-				command: firstPresetCommand,
-				cwd: firstPreset?.cwd || undefined,
-			});
+			launchPresetCommand(
+				{
+					paneId,
+					tabId,
+					workspaceId,
+					command: firstPresetCommand,
+					cwd: firstPreset?.cwd || undefined,
+				},
+				{ waitForMountedSession: true },
+			);
 		},
 		[
 			firstPreset,
@@ -162,20 +172,27 @@ export function useTabsWithPresets(projectId?: string | null) {
 	);
 
 	const launchFirstPresetInFocusedPane = useCallback(
-		(tabId: string, previousFocusedPaneId: string | undefined) => {
+		(
+			tabId: string,
+			previousFocusedPaneId: string | undefined,
+			options?: { waitForMountedSession?: boolean },
+		) => {
 			if (firstPresetCommand === null) return;
 			const state = useTabsStore.getState();
 			const paneId = state.focusedPaneIds[tabId];
 			if (!paneId || paneId === previousFocusedPaneId) return;
 			const tab = state.tabs.find((tabItem) => tabItem.id === tabId);
 			if (!tab) return;
-			launchPresetCommand({
-				paneId,
-				tabId,
-				workspaceId: tab.workspaceId,
-				command: firstPresetCommand,
-				cwd: firstPreset?.cwd || undefined,
-			});
+			launchPresetCommand(
+				{
+					paneId,
+					tabId,
+					workspaceId: tab.workspaceId,
+					command: firstPresetCommand,
+					cwd: firstPreset?.cwd || undefined,
+				},
+				options,
+			);
 		},
 		[firstPreset, firstPresetCommand, launchPresetCommand],
 	);
@@ -302,7 +319,7 @@ export function useTabsWithPresets(projectId?: string | null) {
 							];
 						},
 					);
-					launchPresetCommands(launches);
+					launchPresetCommands(launches, { waitForMountedSession: true });
 					return { tabId: activeTabId, paneId: paneIds[0] };
 				}
 				return executePresetInNewTab(workspaceId, preset);
@@ -315,13 +332,16 @@ export function useTabsWithPresets(projectId?: string | null) {
 				});
 				if (paneId) {
 					if (command !== null) {
-						launchPresetCommand({
-							paneId,
-							tabId: activeTabId,
-							workspaceId,
-							command,
-							cwd: preset.initialCwd,
-						});
+						launchPresetCommand(
+							{
+								paneId,
+								tabId: activeTabId,
+								workspaceId,
+								command,
+								cwd: preset.initialCwd,
+							},
+							{ waitForMountedSession: true },
+						);
 					}
 					return { tabId: activeTabId, paneId };
 				}
@@ -436,7 +456,9 @@ export function useTabsWithPresets(projectId?: string | null) {
 			const previousFocusedPaneId =
 				useTabsStore.getState().focusedPaneIds[tabId];
 			storeSplitPaneVertical(tabId, sourcePaneId, path, firstPresetOptions);
-			launchFirstPresetInFocusedPane(tabId, previousFocusedPaneId);
+			launchFirstPresetInFocusedPane(tabId, previousFocusedPaneId, {
+				waitForMountedSession: true,
+			});
 		},
 		[
 			storeSplitPaneVertical,
@@ -458,7 +480,9 @@ export function useTabsWithPresets(projectId?: string | null) {
 			const previousFocusedPaneId =
 				useTabsStore.getState().focusedPaneIds[tabId];
 			storeSplitPaneHorizontal(tabId, sourcePaneId, path, firstPresetOptions);
-			launchFirstPresetInFocusedPane(tabId, previousFocusedPaneId);
+			launchFirstPresetInFocusedPane(tabId, previousFocusedPaneId, {
+				waitForMountedSession: true,
+			});
 		},
 		[
 			storeSplitPaneHorizontal,
@@ -493,7 +517,9 @@ export function useTabsWithPresets(projectId?: string | null) {
 				path,
 				firstPresetOptions,
 			);
-			launchFirstPresetInFocusedPane(tabId, previousFocusedPaneId);
+			launchFirstPresetInFocusedPane(tabId, previousFocusedPaneId, {
+				waitForMountedSession: true,
+			});
 		},
 		[storeSplitPaneAuto, firstPresetOptions, launchFirstPresetInFocusedPane],
 	);

--- a/apps/desktop/src/renderer/stores/tabs/utils/terminal-cleanup.ts
+++ b/apps/desktop/src/renderer/stores/tabs/utils/terminal-cleanup.ts
@@ -1,9 +1,14 @@
+import { rejectTerminalSessionReady } from "../../../lib/terminal/session-readiness";
 import { electronTrpcClient } from "../../../lib/trpc-client";
 
 /**
  * Uses standalone tRPC client to avoid React hook dependencies
  */
 export const killTerminalForPane = (paneId: string): void => {
+	rejectTerminalSessionReady(
+		paneId,
+		new Error("Terminal pane was closed before the session became ready"),
+	);
 	electronTrpcClient.terminal.kill.mutate({ paneId }).catch((error) => {
 		console.warn(`Failed to kill terminal for pane ${paneId}:`, error);
 	});


### PR DESCRIPTION
## Upstream Merge PR#4 - Terminal Session Readiness

upstream #3416 を cherry-pick し、v1 split pane での preset コマンド実行バグを修正します。

## 取り込むコミット

| Commit | Upstream PR | 内容 |
|---|---|---|
| \`31fcf191f\` | #3416 | [codex] fix v1 split pane startup sizing |

## 改善内容の詳細

### 何が問題だったか

**v1 split pane でプリセットコマンドが正しく実行されない：**

1. ユーザーが workspace で「水平分割」や「垂直分割」を実行
2. 新しいペインができるが、その pane の DOM マウントとターミナルセッションの attach は非同期
3. ところが、preset コマンドの実行はこれらを待たずに即座に走っていた
4. 結果：
   - ターミナルがまだ正しいサイズになる前に \`echo hello\` が書き込まれ、改行やサイジングが崩れる
   - ひどいケースでは、attach 完了前にコマンドが送られ、完全にスキップされる

背景タブで pane を作る場合は「helper-side attach」経由なので影響なし。**フォアグラウンドの split 操作でのみ** 発生する race condition でした。

### どう直したか

**新しい \"Session Readiness\" 機構を導入：**

#### 新規ファイル \`lib/terminal/session-readiness.ts\`

\`\`\`typescript
// paneId ごとに「準備完了フラグ」と「待機中の Promise」を管理する module-level state

export function waitForTerminalSessionReady(paneId: string): Promise<void>
  // paneId がまだ ready でなければ Promise を返して待つ
  // ready なら即座に resolve

export function markTerminalSessionReady(paneId: string): void
  // paneId を ready 状態に、待機中の Promise を全て resolve

export function rejectTerminalSessionReady(paneId: string, error: Error): void
  // 待機中の Promise を全て reject（attach 失敗時や pane close 時）

export function clearTerminalSessionReady(paneId: string): void
  // ready 状態をクリア（再 attach 時）
\`\`\`

#### \`launch-command.ts\` に \`waitForMountedSession\` オプション追加

\`\`\`typescript
interface LaunchCommandInPaneOptions {
  // ... 既存の項目 ...
  /**
   * アクティブタブに即座にマウントされる pane 用。
   * バックグラウンドタブは helper-side attach 経由にすること。
   */
  waitForMountedSession?: boolean;
}

async function launchCommandInPane(options) {
  if (options.waitForMountedSession) {
    // session が ready になるまで待機
    await waitForTerminalSessionReady(paneId);
    await writeCommandInPane({ paneId, command, write, noExecute });
    return;
  }
  // 従来のパス（helper-side attach）
  // ...
}
\`\`\`

#### \`useTerminalLifecycle.ts\` で readiness シグナルを発火

Terminal の attach ライフサイクルの適切なタイミングでシグナルを送る：

1. **attach 開始時** → \`clearTerminalSessionReady(paneId)\`
2. **attach 成功時**（\`v1TerminalCache.setStreamReady()\` 直後）→ \`markTerminalSessionReady(paneId)\`
3. **attach 失敗時**（\`TERMINAL_SESSION_KILLED\` or その他エラー）→ \`rejectTerminalSessionReady(paneId, error)\`

#### \`useTabsWithPresets.ts\` で split 操作時に \`waitForMountedSession: true\` を渡す

\`\`\`typescript
// split 操作時の preset launch
launchPresetCommands(launches, { waitForMountedSession: true });
\`\`\`

\`launchPresetCommand()\`, \`launchPresetCommands()\`, \`launchFirstPresetInPane()\`, \`launchFirstPresetInFocusedPane()\` に \`options?: { waitForMountedSession?: boolean }\` パラメータを追加。

#### \`terminal-cleanup.ts\` でクリーンアップ

\`\`\`typescript
export const killTerminalForPane = (paneId: string): void => {
  // pane が close されたときに、まだ待機中の Promise を reject
  rejectTerminalSessionReady(
    paneId,
    new Error(\"Terminal pane was closed before the session became ready\"),
  );
  electronTrpcClient.terminal.kill.mutate({ paneId }).catch(...);
};
\`\`\`

これで、ユーザーが session ready 前に pane を close しても、待機中の Promise がリークせず適切に reject されます。

## 変更ファイル

| ファイル | 種別 | 概要 |
|---|---|---|
| \`lib/terminal/session-readiness.ts\` | **新規** | 上記の readiness 機構本体 |
| \`lib/terminal/launch-command.ts\` | 変更 | \`waitForMountedSession\` オプション追加 |
| \`lib/terminal/launch-command.test.ts\` | 変更 | 新規テスト2件追加（mounted-session ready / failure の2パターン） |
| \`Terminal/hooks/useTerminalLifecycle.ts\` | 変更 | 3箇所で readiness シグナル発火 |
| \`stores/tabs/useTabsWithPresets.ts\` | 変更 | split 系メソッドに \`{ waitForMountedSession }\` オプション伝播 |
| \`stores/tabs/utils/terminal-cleanup.ts\` | 変更 | \`killTerminalForPane\` で reject 呼び出し |

## コンフリクト解決

| ファイル | 解決方針 |
|---|---|
| \`launch-command.ts\` | import を両方統合：\`isTerminalAttachCanceledMessage\`（フォーク）+ \`waitForTerminalSessionReady\`（upstream） |
| \`launch-command.test.ts\` | フォーク独自の \"retries once when helper attach is canceled\" テストを保持し、upstream の新規テスト2件をその後に追加 |
| \`useTerminalLifecycle.ts\` | auto-merge で3箇所の readiness シグナルがフォークの attach lifecycle 周りに正しく挿入された |
| \`useTabsWithPresets.ts\` | auto-merge 成功 |
| \`terminal-cleanup.ts\` | auto-merge 成功 |

## フォーク固有機能の保持

- **フォークの \`isTerminalAttachCanceledMessage\` リトライパス**: 引き続き \`launchCommandInPane\` で使用されている
- **\`v1TerminalCache.setStreamReady()\`**: フォーク独自のストリーム状態管理、維持
- **\`TERMINAL_SESSION_KILLED\` エラーハンドリング**: フォーク独自、維持
- **\`markAttachInFlight\` / \`clearAttachInFlight\`**: フォーク独自の attach 状態追跡、維持
- **Quit lifecycle**（\`QuitMode\`, \`cleanupMainWindowResources\`）: 影響なし。session readiness のクリーンアップは quit 処理と直交的

## ユーザーへのメリット

1. **v1 workspace での split 操作が確実に動作**
   - 水平分割・垂直分割で preset コマンドが正しいタイミングで実行される
   - ターミナルサイジングが崩れない

2. **リソースリーク防止**
   - pane を session ready 前に close しても、待機中の Promise が適切に reject され、メモリリークしない

## テスト結果

- ✅ \`bun run typecheck\` パス
- ✅ \`bun run lint\` パス
- ✅ \`bun test launch-command.test.ts\` - 10 pass, 0 fail（upstream 新規テスト2件を含む）

## 手動テスト計画

- [ ] v1 workspace で preset コマンド付き pane を水平分割 → preset コマンドが正常に実行され、サイジング正常
- [ ] v1 workspace で preset コマンド付き pane を垂直分割 → 同上
- [ ] バックグラウンドタブで preset 実行（helper-side attach 経由）は影響なし
- [ ] Session ready 前に pane を close → pending promise が適切に reject される（リークなし）
- [ ] PR#1 で入ったターミナルクリップボード機能は引き続き動作