### PR TITLE
[PR5/5] chore(upstream): デスクトップバージョンを 1.5.3 に更新 (#3419)

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -2,7 +2,7 @@
 	"name": "@superset/desktop",
 	"productName": "Superset",
 	"description": "The last developer tool you'll ever need",
-	"version": "1.5.1",
+	"version": "1.5.3",
 	"main": "./dist/main/index.js",
 	"resources": "src/resources",
 	"repository": {


### PR DESCRIPTION
## Upstream Merge PR#5 - バージョンバンプ

upstream #3419 を cherry-pick し、デスクトップアプリのバージョンを 1.5.1 → 1.5.3 に更新します。

## 取り込むコミット

| Commit | Upstream PR | 内容 |
|---|---|---|
| \`bb12c098f\` | #3419 | chore(desktop): bump version to 1.5.3 |

**変更ファイル:** \`apps/desktop/package.json\` の1行のみ

## バージョン更新の経緯

upstream 1.5.2 → 1.5.3 への変更は、本シリーズで取り込んだ以下の改善を反映したリリースです：

- **PR#1** (MocA-Love/superset#159) 相当：ターミナルクリップボード、サイドバートグル、CodeMirror ホットキー、エラー選択
- **PR#2** (MocA-Love/superset#160) 相当：ホットキー型拡張 + unbound defaults
- **PR#3** (MocA-Love/superset#161) 相当：空間認識ペインナビ + diff ビューア独立タブ
- **PR#4** (MocA-Love/superset#162) 相当：v1 split pane startup sizing 修正

このPRは upstream の 1.5.3 リリースタグを受けて、フォーク側のバージョン表記も同期させるための変更です。

## フォーク固有領域への影響

### auto-updater.ts との互換性

フォーク独自の auto-updater は：

\`\`\`typescript
const IS_FORK = true;

async function checkForkForUpdates(): Promise<void> {
  const latestVersion = await fetchLatestForkRelease();  // GitHub API から取得
  const currentAppVersion = app.getVersion();            // package.json 由来
  if (gt(latestVersion, currentAppVersion)) {
    // update available
  }
}
\`\`\`

**semver の \`gt()\` 比較を使用しているため、バージョン番号の変更は自動更新ロジックに正しく反映されます。** フォーク側で独自 release を作成する際、この 1.5.3 を基準にしてリリース管理できます。

### その他のフォーク固有機能

- \`IS_FORK=true\` フラグ：影響なし
- GitHub Releases API ベースの更新チェック：影響なし
- quit lifecycle（\`QuitMode\`, \`cleanupMainWindowResources\`）：影響なし
- tray メニュー：影響なし

## 推奨マージ順序

このPRは **PR#4（MocA-Love/superset#162）の後** にマージするのが理想的です。これにより、1.5.3 タグが PR#4 のターミナル session readiness 修正を含む状態になります。

フルの upstream 取り込み順序：
1. MocA-Love/superset#159 - 安全パッチ4件
2. MocA-Love/superset#160 - ホットキー型拡張
3. MocA-Love/superset#161 - 空間認識ペインナビ + diff ビューア
4. MocA-Love/superset#162 - ターミナル session readiness
5. **MocA-Love/superset#163（このPR）** - バージョン 1.5.3

## テスト計画

- [x] \`package.json\` のバージョンが \`1.5.3\` になっていることを確認
- [ ] デスクトップアプリの About ダイアログに \`1.5.3\` が表示される
- [ ] auto-updater の GitHub Releases API ベース更新チェックが正常動作