### PR TITLE
[codex] エディタ内 hover と定義ジャンプの表示品質を改善

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/components/CodeMirrorDiffViewer/CodeMirrorDiffViewer.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/components/CodeMirrorDiffViewer/CodeMirrorDiffViewer.tsx
@@ -40,12 +40,12 @@ import {
 	createInlineCompletionPlugin,
 	type InlineCompletionRequest,
 } from "renderer/screens/main/components/WorkspaceView/components/CodeEditor/createInlineCompletionPlugin";
-import {
-	createSymbolInteractions,
-	type SymbolHoverResult,
-	type SymbolPosition,
-} from "renderer/screens/main/components/WorkspaceView/components/CodeEditor/createSymbolInteractions";
+import { createSymbolInteractions } from "renderer/screens/main/components/WorkspaceView/components/CodeEditor/createSymbolInteractions";
 import { loadLanguageSupport } from "renderer/screens/main/components/WorkspaceView/components/CodeEditor/loadLanguageSupport";
+import type {
+	SymbolHoverResult,
+	SymbolPosition,
+} from "renderer/screens/main/components/WorkspaceView/components/CodeEditor/symbolInteractions.types";
 import { getCodeSyntaxHighlighting } from "renderer/screens/main/components/WorkspaceView/utils/code-theme";
 import { useResolvedTheme } from "renderer/stores/theme";
 import type { DiffViewMode } from "shared/changes-types";

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/components/FileViewerContent/FileViewerContent.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/components/FileViewerContent/FileViewerContent.tsx
@@ -23,7 +23,7 @@ import { CodeEditor } from "renderer/screens/main/components/WorkspaceView/compo
 import type {
 	SymbolHoverResult,
 	SymbolPosition,
-} from "renderer/screens/main/components/WorkspaceView/components/CodeEditor/createSymbolInteractions";
+} from "renderer/screens/main/components/WorkspaceView/components/CodeEditor/symbolInteractions.types";
 import { useLanguageServicePreferencesStore } from "renderer/stores/language-service-preferences";
 import { useTabsStore } from "renderer/stores/tabs/store";
 import type { Tab } from "renderer/stores/tabs/types";

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ReferenceGraphPane/lib/highlighter.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ReferenceGraphPane/lib/highlighter.ts
@@ -6,29 +6,36 @@ import {
 
 let highlighterPromise: Promise<Highlighter> | null = null;
 
-const SUPPORTED_LANGUAGES: BundledLanguage[] = [
+const SUPPORTED_LANGUAGES = [
+	"bash",
+	"c",
+	"cpp",
+	"csharp",
+	"css",
+	"dart",
+	"diff",
+	"go",
+	"graphql",
 	"typescript",
 	"javascript",
 	"tsx",
 	"jsx",
-	"python",
-	"go",
-	"rust",
-	"java",
-	"c",
-	"cpp",
-	"csharp",
-	"ruby",
-	"php",
-	"swift",
-	"kotlin",
-	"vue",
 	"html",
-	"css",
+	"java",
 	"json",
+	"kotlin",
 	"yaml",
 	"markdown",
-];
+	"php",
+	"plaintext",
+	"python",
+	"ruby",
+	"rust",
+	"sql",
+	"swift",
+	"toml",
+	"vue",
+] as BundledLanguage[];
 
 async function getHighlighter(): Promise<Highlighter> {
 	if (!highlighterPromise) {
@@ -60,7 +67,7 @@ export async function highlightCode(
 
 	const safeLanguage = SUPPORTED_LANGUAGES.includes(language as BundledLanguage)
 		? (language as BundledLanguage)
-		: "typescript";
+		: "plaintext";
 
 	let themeName = "dark-plus";
 

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/components/CodeEditor/CodeEditor.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/components/CodeEditor/CodeEditor.tsx
@@ -50,13 +50,13 @@ import {
 	createInlineCompletionPlugin,
 	type InlineCompletionRequest,
 } from "./createInlineCompletionPlugin";
-import {
-	createSymbolInteractions,
-	type SymbolHoverResult,
-	type SymbolPosition,
-} from "./createSymbolInteractions";
+import { createSymbolInteractions } from "./createSymbolInteractions";
 import { createTrailingSpacesPlugin } from "./createTrailingSpacesPlugin";
 import { loadLanguageSupport } from "./loadLanguageSupport";
+import type {
+	SymbolHoverResult,
+	SymbolPosition,
+} from "./symbolInteractions.types";
 
 interface CodeEditorProps {
 	value: string;

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/components/CodeEditor/components/CodeEditorSymbolHover/CodeEditorSymbolHover.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/components/CodeEditor/components/CodeEditorSymbolHover/CodeEditorSymbolHover.tsx
@@ -1,0 +1,175 @@
+import { useMemo } from "react";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import { createShikiTheme } from "renderer/screens/main/components/WorkspaceView/utils/code-theme/shiki-theme";
+import { useResolvedTheme } from "renderer/stores/theme";
+import type { SymbolMarkupContent } from "../../symbolInteractions.types";
+import { HoverCodeBlock } from "./components/HoverCodeBlock";
+
+interface CodeEditorSymbolHoverProps {
+	contents: SymbolMarkupContent[];
+	canGoToDefinition: boolean;
+	onGoToDefinition?: (() => void) | undefined;
+}
+
+function extractCodeFenceLanguage(className?: string): string | undefined {
+	if (!className) {
+		return undefined;
+	}
+
+	const match = /language-([\w-]+)/.exec(className);
+	return match?.[1];
+}
+
+export function CodeEditorSymbolHover({
+	contents,
+	canGoToDefinition,
+	onGoToDefinition,
+}: CodeEditorSymbolHoverProps) {
+	const activeTheme = useResolvedTheme();
+	const shikiTheme = useMemo(
+		() => (activeTheme ? createShikiTheme(activeTheme) : undefined),
+		[activeTheme],
+	);
+
+	return (
+		<div className="cm-superset-symbol-hover select-text">
+			<div className="cm-superset-symbol-hover-body">
+				{contents.map((content, index) => {
+					const key = `${content.kind}:${index}:${content.value.slice(0, 24)}`;
+					const sectionClassName =
+						index === 0
+							? "cm-superset-symbol-hover-section"
+							: "cm-superset-symbol-hover-section cm-superset-symbol-hover-section-bordered";
+
+					if (content.kind === "markdown") {
+						return (
+							<div key={key} className={sectionClassName}>
+								<ReactMarkdown
+									remarkPlugins={[remarkGfm]}
+									components={{
+										a: ({ href, children }) => (
+											<a
+												href={href}
+												target="_blank"
+												rel="noreferrer"
+												className="cm-superset-symbol-hover-link"
+											>
+												{children}
+											</a>
+										),
+										code: (props) => {
+											const { className, children } = props;
+											const text = String(children).replace(/\n$/, "");
+											const language = extractCodeFenceLanguage(className);
+											const inline =
+												"inline" in props
+													? Boolean(
+															(
+																props as {
+																	inline?: boolean;
+																}
+															).inline,
+														)
+													: false;
+
+											if (inline) {
+												return (
+													<code className="cm-superset-symbol-hover-inline-code">
+														{text}
+													</code>
+												);
+											}
+
+											return (
+												<HoverCodeBlock
+													code={text}
+													language={language}
+													shikiTheme={shikiTheme}
+												/>
+											);
+										},
+										p: ({ children }) => (
+											<p className="cm-superset-symbol-hover-paragraph">
+												{children}
+											</p>
+										),
+										ul: ({ children }) => (
+											<ul className="cm-superset-symbol-hover-list">
+												{children}
+											</ul>
+										),
+										ol: ({ children }) => (
+											<ol className="cm-superset-symbol-hover-list cm-superset-symbol-hover-list-ordered">
+												{children}
+											</ol>
+										),
+										li: ({ children }) => (
+											<li className="cm-superset-symbol-hover-list-item">
+												{children}
+											</li>
+										),
+										blockquote: ({ children }) => (
+											<blockquote className="cm-superset-symbol-hover-blockquote">
+												{children}
+											</blockquote>
+										),
+										h1: ({ children }) => (
+											<h1 className="cm-superset-symbol-hover-heading">
+												{children}
+											</h1>
+										),
+										h2: ({ children }) => (
+											<h2 className="cm-superset-symbol-hover-heading">
+												{children}
+											</h2>
+										),
+										h3: ({ children }) => (
+											<h3 className="cm-superset-symbol-hover-heading">
+												{children}
+											</h3>
+										),
+										table: ({ children }) => (
+											<div className="cm-superset-symbol-hover-table-wrap">
+												<table className="cm-superset-symbol-hover-table">
+													{children}
+												</table>
+											</div>
+										),
+									}}
+								>
+									{content.value}
+								</ReactMarkdown>
+							</div>
+						);
+					}
+
+					return (
+						<div key={key} className={sectionClassName}>
+							<pre className="cm-superset-symbol-hover-plaintext">
+								{content.value}
+							</pre>
+						</div>
+					);
+				})}
+			</div>
+			{canGoToDefinition ? (
+				<div className="cm-superset-symbol-hover-footer">
+					<button
+						type="button"
+						className="cm-superset-symbol-hover-action"
+						onMouseDown={(event) => {
+							event.preventDefault();
+							onGoToDefinition?.();
+						}}
+					>
+						Go to definition
+					</button>
+					<span className="cm-superset-symbol-hover-shortcut">
+						F12 / Cmd or Ctrl + Click
+					</span>
+				</div>
+			) : null}
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/components/CodeEditor/components/CodeEditorSymbolHover/components/HoverCodeBlock/HoverCodeBlock.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/components/CodeEditor/components/CodeEditorSymbolHover/components/HoverCodeBlock/HoverCodeBlock.tsx
@@ -1,0 +1,137 @@
+import { useEffect, useState } from "react";
+import { highlightCode } from "renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ReferenceGraphPane/lib/highlighter";
+
+const SHIKI_LANGUAGE_ALIASES: Record<string, string> = {
+	cjs: "javascript",
+	cpp: "cpp",
+	cs: "csharp",
+	css: "css",
+	dart: "dart",
+	diff: "diff",
+	go: "go",
+	gql: "graphql",
+	graphql: "graphql",
+	html: "html",
+	java: "java",
+	js: "javascript",
+	json: "json",
+	jsx: "jsx",
+	md: "markdown",
+	mjs: "javascript",
+	py: "python",
+	python: "python",
+	rs: "rust",
+	rust: "rust",
+	scss: "css",
+	sh: "bash",
+	shell: "bash",
+	shellscript: "bash",
+	sql: "sql",
+	text: "plaintext",
+	toml: "toml",
+	ts: "typescript",
+	tsx: "tsx",
+	txt: "plaintext",
+	xml: "html",
+	yaml: "yaml",
+	yml: "yaml",
+};
+
+const SHIKI_SUPPORTED_LANGUAGES = new Set([
+	"bash",
+	"cpp",
+	"csharp",
+	"css",
+	"dart",
+	"diff",
+	"go",
+	"graphql",
+	"html",
+	"java",
+	"javascript",
+	"json",
+	"jsx",
+	"markdown",
+	"plaintext",
+	"python",
+	"rust",
+	"sql",
+	"toml",
+	"tsx",
+	"typescript",
+	"yaml",
+]);
+
+interface HoverCodeBlockProps {
+	code: string;
+	language?: string;
+	shikiTheme?: {
+		name: string;
+		type: string;
+		colors: object;
+		tokenColors: object[];
+	};
+}
+
+function normalizeLanguage(language?: string): string | null {
+	if (!language) {
+		return null;
+	}
+
+	const normalized = language.trim().toLowerCase();
+	if (!normalized) {
+		return null;
+	}
+
+	const resolved = SHIKI_LANGUAGE_ALIASES[normalized] ?? normalized;
+	return SHIKI_SUPPORTED_LANGUAGES.has(resolved) ? resolved : null;
+}
+
+export function HoverCodeBlock({
+	code,
+	language,
+	shikiTheme,
+}: HoverCodeBlockProps) {
+	const [highlightedHtml, setHighlightedHtml] = useState<string | null>(null);
+	const normalizedLanguage = normalizeLanguage(language);
+
+	useEffect(() => {
+		let cancelled = false;
+
+		if (!normalizedLanguage) {
+			setHighlightedHtml(null);
+			return;
+		}
+
+		void highlightCode(code, normalizedLanguage, shikiTheme)
+			.then((html) => {
+				if (!cancelled) {
+					setHighlightedHtml(html);
+				}
+			})
+			.catch(() => {
+				if (!cancelled) {
+					setHighlightedHtml(null);
+				}
+			});
+
+		return () => {
+			cancelled = true;
+		};
+	}, [code, normalizedLanguage, shikiTheme]);
+
+	if (highlightedHtml) {
+		return (
+			<div className="cm-superset-symbol-hover-code-block">
+				{/* biome-ignore lint/security/noDangerouslySetInnerHtml: Shiki generates trusted HTML */}
+				<div dangerouslySetInnerHTML={{ __html: highlightedHtml }} />
+			</div>
+		);
+	}
+
+	return (
+		<pre className="cm-superset-symbol-hover-code-block">
+			<code>{code}</code>
+		</pre>
+	);
+}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/components/CodeEditor/components/CodeEditorSymbolHover/components/HoverCodeBlock/index.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/components/CodeEditor/components/CodeEditorSymbolHover/components/HoverCodeBlock/index.ts
@@ -1,0 +1,1 @@
+export { HoverCodeBlock } from "./HoverCodeBlock";

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/components/CodeEditor/components/CodeEditorSymbolHover/index.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/components/CodeEditor/components/CodeEditorSymbolHover/index.ts
@@ -1,0 +1,1 @@
+export { CodeEditorSymbolHover } from "./CodeEditorSymbolHover";

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/components/CodeEditor/createCodeMirrorTheme.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/components/CodeEditor/createCodeMirrorTheme.ts
@@ -89,6 +89,166 @@ export function createCodeMirrorTheme(
 				color: editorTheme.colors.panelButtonForeground,
 				border: `1px solid ${editorTheme.colors.panelButtonBorder}`,
 			},
+			".cm-tooltip.cm-tooltip-hover": {
+				border: `1px solid ${editorTheme.colors.panelBorder}`,
+				backgroundColor: editorTheme.colors.panel,
+				color: editorTheme.colors.foreground,
+				borderRadius: "10px",
+				boxShadow:
+					"0 16px 40px rgba(0, 0, 0, 0.28), 0 4px 14px rgba(0, 0, 0, 0.16)",
+				overflow: "hidden",
+			},
+			".cm-tooltip.cm-tooltip-hover .cm-tooltip-arrow:before": {
+				borderTopColor: editorTheme.colors.panel,
+				borderBottomColor: editorTheme.colors.panel,
+			},
+			".cm-tooltip.cm-tooltip-hover .cm-tooltip-arrow:after": {
+				borderTopColor: editorTheme.colors.panelBorder,
+				borderBottomColor: editorTheme.colors.panelBorder,
+			},
+			".cm-definition-link": {
+				cursor: "pointer",
+				textDecoration: `underline ${editorTheme.colors.searchActive}`,
+				textUnderlineOffset: "2px",
+				textDecorationThickness: "1px",
+			},
+			"&.cm-definition-link-mode .cm-content": {
+				cursor: "pointer",
+			},
+			".cm-superset-symbol-hover": {
+				width: "min(560px, 70vw)",
+				maxHeight: "min(420px, 60vh)",
+				display: "flex",
+				flexDirection: "column",
+				backgroundColor: editorTheme.colors.panel,
+				color: editorTheme.colors.foreground,
+			},
+			".cm-superset-symbol-hover-body": {
+				overflow: "auto",
+			},
+			".cm-superset-symbol-hover-section": {
+				padding: "10px 12px",
+				fontSize: "12px",
+				lineHeight: "1.6",
+			},
+			".cm-superset-symbol-hover-section-bordered": {
+				borderTop: `1px solid ${editorTheme.colors.border}`,
+			},
+			".cm-superset-symbol-hover-plaintext": {
+				margin: "0",
+				whiteSpace: "pre-wrap",
+				wordBreak: "break-word",
+				fontFamily: fontSettings.fontFamily ?? DEFAULT_CODE_EDITOR_FONT_FAMILY,
+				fontSize: "12px",
+				lineHeight: "1.55",
+			},
+			".cm-superset-symbol-hover-paragraph": {
+				margin: "0 0 8px 0",
+			},
+			".cm-superset-symbol-hover-paragraph:last-child": {
+				marginBottom: "0",
+			},
+			".cm-superset-symbol-hover-inline-code": {
+				padding: "1px 5px",
+				borderRadius: "5px",
+				backgroundColor: editorTheme.colors.activeLine,
+				fontFamily: fontSettings.fontFamily ?? DEFAULT_CODE_EDITOR_FONT_FAMILY,
+				fontSize: "11px",
+			},
+			".cm-superset-symbol-hover-link": {
+				color: editorTheme.colors.searchActive,
+				textDecoration: "underline",
+			},
+			".cm-superset-symbol-hover-list": {
+				margin: "8px 0 0 0",
+				paddingLeft: "18px",
+			},
+			".cm-superset-symbol-hover-list-ordered": {
+				listStyleType: "decimal",
+			},
+			".cm-superset-symbol-hover-list-item": {
+				marginBottom: "4px",
+			},
+			".cm-superset-symbol-hover-blockquote": {
+				margin: "8px 0 0 0",
+				paddingLeft: "10px",
+				borderLeft: `2px solid ${editorTheme.colors.border}`,
+				color: editorTheme.colors.gutterForeground,
+			},
+			".cm-superset-symbol-hover-heading": {
+				margin: "0 0 8px 0",
+				fontSize: "12px",
+				fontWeight: "600",
+			},
+			".cm-superset-symbol-hover-table-wrap": {
+				overflowX: "auto",
+				marginTop: "8px",
+			},
+			".cm-superset-symbol-hover-table": {
+				borderCollapse: "collapse",
+				width: "100%",
+			},
+			".cm-superset-symbol-hover-table th, .cm-superset-symbol-hover-table td":
+				{
+					border: `1px solid ${editorTheme.colors.border}`,
+					padding: "4px 6px",
+					textAlign: "left",
+				},
+			".cm-superset-symbol-hover-code-block": {
+				margin: "8px 0 0 0",
+				borderRadius: "8px",
+				border: `1px solid ${editorTheme.colors.border}`,
+				backgroundColor: editorTheme.colors.background,
+				overflow: "auto",
+			},
+			".cm-superset-symbol-hover-code-block pre": {
+				margin: "0",
+			},
+			".cm-superset-symbol-hover-code-block code": {
+				display: "block",
+				padding: "10px 12px",
+				fontFamily: fontSettings.fontFamily ?? DEFAULT_CODE_EDITOR_FONT_FAMILY,
+				fontSize: "12px",
+				lineHeight: "1.55",
+				whiteSpace: "pre",
+			},
+			".cm-superset-symbol-hover .shiki": {
+				margin: "0",
+				padding: "0",
+				backgroundColor: "transparent !important",
+				fontSize: "12px",
+				lineHeight: "1.55",
+			},
+			".cm-superset-symbol-hover .shiki code": {
+				padding: "10px 0",
+				fontFamily: fontSettings.fontFamily ?? DEFAULT_CODE_EDITOR_FONT_FAMILY,
+			},
+			".cm-superset-symbol-hover .shiki code .line": {
+				display: "block",
+				padding: "0 12px",
+			},
+			".cm-superset-symbol-hover-footer": {
+				display: "flex",
+				alignItems: "center",
+				justifyContent: "space-between",
+				gap: "12px",
+				padding: "8px 12px",
+				borderTop: `1px solid ${editorTheme.colors.border}`,
+				backgroundColor: editorTheme.colors.activeLine,
+			},
+			".cm-superset-symbol-hover-action": {
+				padding: "0",
+				border: "0",
+				background: "transparent",
+				color: editorTheme.colors.searchActive,
+				fontSize: "11px",
+				fontWeight: "600",
+				cursor: "pointer",
+			},
+			".cm-superset-symbol-hover-shortcut": {
+				fontSize: "11px",
+				color: editorTheme.colors.gutterForeground,
+			},
 			// Diff / merge view colors (a = original/left, b = modified/right)
 			"&.cm-merge-a .cm-changedLine": {
 				backgroundColor: `${editorTheme.colors.deletion}14`,

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/components/CodeEditor/createSymbolInteractions.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/components/CodeEditor/createSymbolInteractions.ts
@@ -7,28 +7,13 @@ import {
 	ViewPlugin,
 	type ViewUpdate,
 } from "@codemirror/view";
-
-export interface SymbolPosition {
-	line: number;
-	column: number;
-}
-
-export interface SymbolRange {
-	line: number;
-	column: number;
-	endLine: number;
-	endColumn: number;
-}
-
-export interface SymbolMarkupContent {
-	kind: "plaintext" | "markdown";
-	value: string;
-}
-
-export interface SymbolHoverResult {
-	contents: SymbolMarkupContent[];
-	range: SymbolRange | null;
-}
+import { createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { CodeEditorSymbolHover } from "./components/CodeEditorSymbolHover";
+import type {
+	SymbolHoverResult,
+	SymbolPosition,
+} from "./symbolInteractions.types";
 
 interface CreateSymbolInteractionsOptions {
 	resolveHover?: (
@@ -54,7 +39,7 @@ function positionToDocOffset(doc: Text, position: SymbolPosition): number {
 
 function rangeToOffsets(
 	doc: Text,
-	range: SymbolRange | null,
+	range: SymbolHoverResult["range"],
 	fallbackOffset: number,
 ): { from: number; to: number } {
 	if (!range) {
@@ -79,39 +64,204 @@ function rangeToOffsets(
 	};
 }
 
-function createTooltipDom(contents: SymbolMarkupContent[]): HTMLElement {
+function isDefinitionModifierPressed(event: {
+	metaKey: boolean;
+	ctrlKey: boolean;
+	altKey: boolean;
+	shiftKey: boolean;
+}) {
+	return (event.metaKey || event.ctrlKey) && !event.altKey && !event.shiftKey;
+}
+
+function createTooltip(
+	hover: SymbolHoverResult,
+	doc: Text,
+	pos: number,
+	canGoToDefinition: boolean,
+	onGoToDefinition?: (() => void) | undefined,
+): Tooltip {
 	const dom = document.createElement("div");
-	dom.style.maxWidth = "480px";
-	dom.style.padding = "8px 10px";
-	dom.style.borderRadius = "8px";
-	dom.style.border = "1px solid hsl(var(--border))";
-	dom.style.background = "hsl(var(--popover))";
-	dom.style.color = "hsl(var(--popover-foreground))";
-	dom.style.boxShadow =
-		"0 10px 30px rgba(0, 0, 0, 0.18), 0 2px 8px rgba(0, 0, 0, 0.12)";
-	dom.style.fontSize = "12px";
-	dom.style.lineHeight = "1.5";
-	dom.style.whiteSpace = "pre-wrap";
-	dom.style.wordBreak = "break-word";
+	const root = createRoot(dom);
 
-	contents.forEach((content, index) => {
-		const section = document.createElement("div");
-		if (index > 0) {
-			section.style.marginTop = "8px";
-			section.style.paddingTop = "8px";
-			section.style.borderTop = "1px solid hsl(var(--border))";
-		}
+	root.render(
+		createElement(CodeEditorSymbolHover, {
+			contents: hover.contents,
+			canGoToDefinition,
+			onGoToDefinition,
+		}),
+	);
 
-		if (content.kind === "markdown") {
-			section.style.fontFamily =
-				"ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace";
-		}
+	const { from, to } = rangeToOffsets(doc, hover.range, pos);
+	return {
+		pos: from,
+		end: to,
+		above: true,
+		arrow: true,
+		create() {
+			return {
+				dom,
+				destroy() {
+					root.unmount();
+				},
+			};
+		},
+	};
+}
 
-		section.textContent = content.value;
-		dom.appendChild(section);
-	});
+function createDefinitionLinkPlugin(): Extension {
+	return ViewPlugin.fromClass(
+		class {
+			private modifierPressed = false;
+			private hoveredOffset: number | null = null;
+			private lastPointerCoords: { x: number; y: number } | null = null;
+			private highlightedElement: HTMLElement | null = null;
+			private highlightedElementPreviousStyle: {
+				cursor: string;
+				textDecoration: string;
+				textDecorationColor: string;
+				textDecorationThickness: string;
+				textUnderlineOffset: string;
+			} | null = null;
+			private readonly handleMouseMove = (event: MouseEvent) => {
+				this.onMouseMove(event);
+			};
+			private readonly handleMouseLeave = () => {
+				this.onMouseLeave();
+			};
+			private readonly handleWindowKeyChange = (event: KeyboardEvent) => {
+				this.setModifierPressed(isDefinitionModifierPressed(event));
+			};
+			private readonly handleWindowBlur = () => {
+				this.setModifierPressed(false);
+			};
+			private readonly window: Window | null;
 
-	return dom;
+			constructor(private readonly view: EditorView) {
+				this.window = this.view.dom.ownerDocument.defaultView;
+				this.view.dom.addEventListener("mousemove", this.handleMouseMove);
+				this.view.dom.addEventListener("mouseleave", this.handleMouseLeave);
+				this.window?.addEventListener("keydown", this.handleWindowKeyChange);
+				this.window?.addEventListener("keyup", this.handleWindowKeyChange);
+				this.window?.addEventListener("blur", this.handleWindowBlur);
+			}
+
+			update(update: ViewUpdate) {
+				if (update.docChanged) {
+					this.syncHighlight();
+				}
+			}
+
+			private onMouseMove(event: MouseEvent) {
+				this.lastPointerCoords = {
+					x: event.clientX,
+					y: event.clientY,
+				};
+
+				if (!this.modifierPressed) {
+					this.setHoveredOffset(null);
+					return;
+				}
+
+				this.setHoveredOffset(
+					this.view.posAtCoords({
+						x: event.clientX,
+						y: event.clientY,
+					}),
+				);
+			}
+
+			private onMouseLeave() {
+				this.lastPointerCoords = null;
+				this.setHoveredOffset(null);
+			}
+
+			destroy() {
+				this.view.dom.removeEventListener("mousemove", this.handleMouseMove);
+				this.view.dom.removeEventListener("mouseleave", this.handleMouseLeave);
+				this.window?.removeEventListener("keydown", this.handleWindowKeyChange);
+				this.window?.removeEventListener("keyup", this.handleWindowKeyChange);
+				this.window?.removeEventListener("blur", this.handleWindowBlur);
+				this.clearHighlight();
+			}
+
+			private setModifierPressed(nextValue: boolean) {
+				if (this.modifierPressed === nextValue) {
+					return;
+				}
+
+				this.modifierPressed = nextValue;
+				if (this.modifierPressed && this.lastPointerCoords) {
+					this.setHoveredOffset(this.view.posAtCoords(this.lastPointerCoords));
+					return;
+				}
+
+				this.setHoveredOffset(null);
+			}
+
+			private setHoveredOffset(offset: number | null) {
+				if (this.hoveredOffset === offset) {
+					return;
+				}
+
+				this.hoveredOffset = offset;
+				this.syncHighlight();
+			}
+
+			private clearHighlight() {
+				if (this.highlightedElement && this.highlightedElementPreviousStyle) {
+					this.highlightedElement.style.cursor =
+						this.highlightedElementPreviousStyle.cursor;
+					this.highlightedElement.style.textDecoration =
+						this.highlightedElementPreviousStyle.textDecoration;
+					this.highlightedElement.style.textDecorationColor =
+						this.highlightedElementPreviousStyle.textDecorationColor;
+					this.highlightedElement.style.textDecorationThickness =
+						this.highlightedElementPreviousStyle.textDecorationThickness;
+					this.highlightedElement.style.textUnderlineOffset =
+						this.highlightedElementPreviousStyle.textUnderlineOffset;
+				}
+
+				this.highlightedElement = null;
+				this.highlightedElementPreviousStyle = null;
+				this.view.dom.classList.remove("cm-definition-link-mode");
+			}
+
+			private syncHighlight() {
+				this.clearHighlight();
+				if (!this.modifierPressed || this.hoveredOffset === null) {
+					return;
+				}
+
+				const domAtPos = this.view.domAtPos(this.hoveredOffset);
+				const baseElement =
+					domAtPos.node instanceof HTMLElement
+						? domAtPos.node
+						: domAtPos.node.parentElement;
+				const tokenElement = baseElement?.closest("span");
+				if (
+					!(tokenElement instanceof HTMLElement) ||
+					!this.view.dom.contains(tokenElement)
+				) {
+					return;
+				}
+
+				this.highlightedElementPreviousStyle = {
+					cursor: tokenElement.style.cursor,
+					textDecoration: tokenElement.style.textDecoration,
+					textDecorationColor: tokenElement.style.textDecorationColor,
+					textDecorationThickness: tokenElement.style.textDecorationThickness,
+					textUnderlineOffset: tokenElement.style.textUnderlineOffset,
+				};
+				tokenElement.style.cursor = "pointer";
+				tokenElement.style.textDecoration = "underline";
+				tokenElement.style.textDecorationColor = "currentColor";
+				tokenElement.style.textDecorationThickness = "1px";
+				tokenElement.style.textUnderlineOffset = "2px";
+				this.highlightedElement = tokenElement;
+				this.view.dom.classList.add("cm-definition-link-mode");
+			}
+		},
+	);
 }
 
 export function createSymbolInteractions({
@@ -125,25 +275,23 @@ export function createSymbolInteractions({
 		extensions.push(
 			hoverTooltip(
 				async (view, pos): Promise<Tooltip | null> => {
-					const hover = await resolveHover(
-						docOffsetToPosition(view.state.doc, pos),
-					);
+					const position = docOffsetToPosition(view.state.doc, pos);
+					const hover = await resolveHover(position);
 					if (!hover || hover.contents.length === 0) {
 						return null;
 					}
 
-					const { from, to } = rangeToOffsets(view.state.doc, hover.range, pos);
-					return {
-						pos: from,
-						end: to,
-						above: true,
-						arrow: true,
-						create() {
-							return {
-								dom: createTooltipDom(hover.contents),
-							};
-						},
-					};
+					return createTooltip(
+						hover,
+						view.state.doc,
+						pos,
+						Boolean(onGoToDefinition),
+						onGoToDefinition
+							? () => {
+									void onGoToDefinition(position);
+								}
+							: undefined,
+					);
 				},
 				{ hoverTime: 250 },
 			),
@@ -151,6 +299,7 @@ export function createSymbolInteractions({
 	}
 
 	if (onGoToDefinition) {
+		extensions.push(createDefinitionLinkPlugin());
 		extensions.push(
 			keymap.of([
 				{
@@ -173,9 +322,8 @@ export function createSymbolInteractions({
 				mousedown(event, view) {
 					if (
 						event.button !== 0 ||
-						(!event.metaKey && !event.ctrlKey) ||
-						event.altKey ||
-						event.shiftKey
+						!isDefinitionModifierPressed(event) ||
+						event.defaultPrevented
 					) {
 						return false;
 					}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/components/CodeEditor/symbolInteractions.types.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/components/CodeEditor/symbolInteractions.types.ts
@@ -1,0 +1,21 @@
+export interface SymbolPosition {
+	line: number;
+	column: number;
+}
+
+export interface SymbolRange {
+	line: number;
+	column: number;
+	endLine: number;
+	endColumn: number;
+}
+
+export interface SymbolMarkupContent {
+	kind: "plaintext" | "markdown";
+	value: string;
+}
+
+export interface SymbolHoverResult {
+	contents: SymbolMarkupContent[];
+	range: SymbolRange | null;
+}


### PR DESCRIPTION
## 概要
- ワークスペースエディタの symbol hover を plaintext ベースから Markdown レンダリング対応の UI に刷新しました
- hover 内のコードブロックにシンタックスハイライトを追加し、署名や説明の視認性を改善しました
- `F12` と `Cmd/Ctrl + Click` による定義ジャンプ導線を hover UI とエディタ上の視覚フィードバックの両方で強化しました

## 変更内容
- CodeMirror の symbol interaction 実装を更新し、hover を React ベースの専用コンポーネントで描画するように変更
- Markdown / plaintext の両方の hover payload を扱えるようにし、list・blockquote・table・inline code・link を表示
- hover 内の fenced code block を Shiki ベースのハイライト付きコードブロックとして表示
- `Cmd/Ctrl` 押下時に editor 上の token に下線と pointer を出し、definition navigation の発見性を改善
- raw editor と diff editor の両方で同じ hover / go-to-definition 体験になるように統一
- hover 用に使う symbol type 定義を分離し、関連コードの依存関係を整理

## 背景
- 既存の hover は LSP / tsserver から返ってきた内容をそのまま plaintext で表示しており、VS Code と比べて情報構造が見えづらく、コードブロックもハイライトされていませんでした
- definition jump 自体は存在していましたが、modifier 操作の視覚的なガイドが弱く、発見性が低い状態でした

## ユーザー影響
- hover 時に型情報、説明、コード例を読み取りやすくなります
- definition jump の操作方法が UI 上で明確になり、VS Code に近い感覚で使いやすくなります
- diff editor 上でも raw editor と同様に symbol 情報を参照しやすくなります

## 検証
- `bunx @biomejs/biome check apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/components/CodeMirrorDiffViewer/CodeMirrorDiffViewer.tsx apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/components/FileViewerContent/FileViewerContent.tsx apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ReferenceGraphPane/lib/highlighter.ts apps/desktop/src/renderer/screens/main/components/WorkspaceView/components/CodeEditor/CodeEditor.tsx apps/desktop/src/renderer/screens/main/components/WorkspaceView/components/CodeEditor/createCodeMirrorTheme.ts apps/desktop/src/renderer/screens/main/components/WorkspaceView/components/CodeEditor/createSymbolInteractions.ts apps/desktop/src/renderer/screens/main/components/WorkspaceView/components/CodeEditor/symbolInteractions.types.ts apps/desktop/src/renderer/screens/main/components/WorkspaceView/components/CodeEditor/components/CodeEditorSymbolHover/CodeEditorSymbolHover.tsx apps/desktop/src/renderer/screens/main/components/WorkspaceView/components/CodeEditor/components/CodeEditorSymbolHover/components/HoverCodeBlock/HoverCodeBlock.tsx`
- `bun run typecheck`

## 補足
- 比較用の `mock.html` はローカル検討用として作成していますが、この PR には含めていません