### PR TITLE
fix(desktop): v1 terminal typing dead after tab switch when cold restore cached

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalColdRestore.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalColdRestore.ts
@@ -1,5 +1,9 @@
 import type { Terminal as XTerm } from "@xterm/xterm";
 import { useCallback, useRef, useState } from "react";
+import {
+	markTerminalSessionReady,
+	rejectTerminalSessionReady,
+} from "renderer/lib/terminal/session-readiness";
 import { electronTrpcClient as trpcClient } from "renderer/lib/trpc-client";
 import { isTerminalAttachCanceledMessage } from "../attach-cancel";
 import { coldRestoreState } from "../state";
@@ -9,6 +13,7 @@ import type {
 	TerminalStreamEvent,
 } from "../types";
 import { scrollToBottom } from "../utils";
+import * as v1TerminalCache from "../v1-terminal-cache";
 
 export interface UseTerminalColdRestoreOptions {
 	paneId: string;
@@ -208,6 +213,16 @@ export function useTerminalColdRestore({
 					pendingInitialStateRef.current = result;
 					maybeApplyInitialState();
 
+					// FORK NOTE: now that handleStartShell has a real backend
+					// session, mark the v1 cache + session-readiness waiters as
+					// ready. useTerminalLifecycle.ts intentionally defers this
+					// for the cold-restore path so that a tab-switch remount
+					// does not take the isReattach fast-path before a real
+					// shell exists.
+					v1TerminalCache.startStream(paneId);
+					v1TerminalCache.setStreamReady(paneId);
+					markTerminalSessionReady(paneId);
+
 					setIsRestoredMode(false);
 					coldRestoreState.delete(paneId);
 
@@ -226,6 +241,10 @@ export function useTerminalColdRestore({
 					setConnectionError(error.message || "Failed to start shell");
 					setIsRestoredMode(false);
 					coldRestoreState.delete(paneId);
+					rejectTerminalSessionReady(
+						paneId,
+						new Error(error.message || "Failed to start shell"),
+					);
 					isStreamReadyRef.current = true;
 					flushPendingEvents();
 				},

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalColdRestore.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalColdRestore.ts
@@ -1,9 +1,6 @@
 import type { Terminal as XTerm } from "@xterm/xterm";
 import { useCallback, useRef, useState } from "react";
-import {
-	markTerminalSessionReady,
-	rejectTerminalSessionReady,
-} from "renderer/lib/terminal/session-readiness";
+import { rejectTerminalSessionReady } from "renderer/lib/terminal/session-readiness";
 import { electronTrpcClient as trpcClient } from "renderer/lib/trpc-client";
 import { isTerminalAttachCanceledMessage } from "../attach-cancel";
 import { coldRestoreState } from "../state";
@@ -219,9 +216,7 @@ export function useTerminalColdRestore({
 					// for the cold-restore path so that a tab-switch remount
 					// does not take the isReattach fast-path before a real
 					// shell exists.
-					v1TerminalCache.startStream(paneId);
-					v1TerminalCache.setStreamReady(paneId);
-					markTerminalSessionReady(paneId);
+					v1TerminalCache.markSessionReady(paneId);
 
 					setIsRestoredMode(false);
 					coldRestoreState.delete(paneId);

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalLifecycle.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalLifecycle.ts
@@ -7,7 +7,6 @@ import { writeCommandInPane } from "renderer/lib/terminal/launch-command";
 import type { DetectedLink } from "renderer/lib/terminal/links";
 import {
 	clearTerminalSessionReady,
-	markTerminalSessionReady,
 	rejectTerminalSessionReady,
 } from "renderer/lib/terminal/session-readiness";
 import { electronTrpcClient } from "renderer/lib/trpc-client";
@@ -654,9 +653,7 @@ export function useTerminalLifecycle({
 
 									// Real backend session is live — safe to start the stream
 									// subscription and unblock waiters.
-									v1TerminalCache.startStream(paneId);
-									v1TerminalCache.setStreamReady(paneId);
-									markTerminalSessionReady(paneId);
+									v1TerminalCache.markSessionReady(paneId);
 
 									pendingInitialStateRef.current = result;
 									maybeApplyInitialState();

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalLifecycle.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalLifecycle.ts
@@ -256,9 +256,20 @@ export function useTerminalLifecycle({
 		// Only treat as reattach when the stream is still alive (subscription ≠ null).
 		// If the stream died while the tab was hidden (onError sets subscription=null),
 		// we must go through the full create/attach path to restart it.
+		//
+		// FORK NOTE: Also block the fast-path while the pane is in cold-restore
+		// mode. Cold restore returns `isColdRestore: true` without creating a
+		// backend session, but the onSuccess handler below still marks the
+		// cache as `streamReady=true`. On the next mount (e.g. after a tab
+		// switch unmount) the fast-path would otherwise skip createOrAttach
+		// entirely, leaving a stream with no backend → user typing is silently
+		// dropped by `electronTrpcClient.terminal.write`. Forcing the full
+		// attach path here lets `handleStartShell` run and spawn a real shell.
+		const hasPendingColdRestore = coldRestoreState.has(paneId);
 		const isReattach =
 			cachedBeforeCreate?.streamReady === true &&
-			cachedBeforeCreate.subscription !== null;
+			cachedBeforeCreate.subscription !== null &&
+			!hasPendingColdRestore;
 		if (DEBUG_TERMINAL) {
 			console.log(`[Terminal] isReattach=${isReattach} paneId=${paneId}`);
 		}
@@ -602,13 +613,14 @@ export function useTerminalLifecycle({
 									setConnectionError(null);
 									clearPaneInitialDataRef.current(paneId);
 
-									// Start the cache-owned stream subscription now that the
-									// backend session exists, and mark it ready so events
-									// flow through the component's registered handler.
-									v1TerminalCache.startStream(paneId);
-									v1TerminalCache.setStreamReady(paneId);
-									markTerminalSessionReady(paneId);
-
+									// FORK NOTE: Do NOT mark the cache as streamReady here
+									// yet. Cold-restore responses come back without a real
+									// backend session, so we must defer startStream /
+									// setStreamReady / markTerminalSessionReady until
+									// handleStartShell spawns an actual shell. Marking
+									// readiness up front caused tab-switch remounts to enter
+									// the isReattach fast-path with no backend, silently
+									// dropping every user keystroke.
 									const storedColdRestore = coldRestoreState.get(paneId);
 									if (storedColdRestore?.isRestored) {
 										setIsRestoredMode(true);
@@ -639,6 +651,12 @@ export function useTerminalLifecycle({
 										didFirstRenderRef.current = true;
 										return;
 									}
+
+									// Real backend session is live — safe to start the stream
+									// subscription and unblock waiters.
+									v1TerminalCache.startStream(paneId);
+									v1TerminalCache.setStreamReady(paneId);
+									markTerminalSessionReady(paneId);
 
 									pendingInitialStateRef.current = result;
 									maybeApplyInitialState();

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/v1-terminal-cache.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/v1-terminal-cache.ts
@@ -2,6 +2,7 @@ import type { Unsubscribable } from "@trpc/server/observable";
 import type { FitAddon } from "@xterm/addon-fit";
 import type { SearchAddon } from "@xterm/addon-search";
 import type { Terminal as XTerm } from "@xterm/xterm";
+import { markTerminalSessionReady } from "renderer/lib/terminal/session-readiness";
 import { electronTrpcClient } from "renderer/lib/trpc-client";
 import { DEBUG_TERMINAL } from "./config";
 import { type CreateTerminalOptions, createTerminalInWrapper } from "./helpers";
@@ -264,6 +265,21 @@ export function setStreamReady(paneId: string): void {
 	for (const event of pending) {
 		routeEvent(entry, event);
 	}
+}
+
+/**
+ * Mark a pane as session-ready: start the tRPC stream, flip the cache's
+ * `streamReady` flag, and resolve any {@link waitForTerminalSessionReady}
+ * waiters in one step.
+ *
+ * FORK NOTE: centralizes the three-call sequence so the cold-restore and
+ * normal attach paths can't drift — see useTerminalLifecycle.ts and
+ * useTerminalColdRestore.ts.
+ */
+export function markSessionReady(paneId: string): void {
+	startStream(paneId);
+	setStreamReady(paneId);
+	markTerminalSessionReady(paneId);
 }
 
 /**


### PR DESCRIPTION
## 症状

v1 ターミナルで文字が打てなくなる致命バグ。最新 dmg でテスト中に発覚。

- ターミナル表示はされる（過去の scrollback が見える）
- しかし **入力が一切反映されない**
- タブ切り替えを挟むと高確率で発生

## 根本原因

**Upstream PR superset-sh/superset#3348** (\`feat(desktop): port v2 hide-attach xterm pattern to v1 terminal\`) で導入された、v1 terminal cache と cold restore の状態不整合。

PR #3389 (\`fix(desktop): v1 terminal — emit legacy marker + gate reattach on streamReady\`) で isReattach 判定を \`streamReady\` ベースに厳密化したが、**cold restore 経路が誤って \`streamReady=true\` を立てるので本質的には直っていない**。

### 不整合の流れ

1. ユーザーが v1 ターミナルを開く
2. \`useTerminalLifecycle.ts\` の \`createOrAttach\` onSuccess で**無条件に** \`v1TerminalCache.startStream()\` / \`setStreamReady()\` / \`markTerminalSessionReady()\` が呼ばれる
3. **直後の** \`result.isColdRestore\` チェックで \`setIsRestoredMode(true)\` して return
4. **結果**: backend session は存在しないのに、cache 側だけ \`streamReady=true\` 扱い
5. \`PersistentTabRenderer.tsx\` は terminal pane を persistent views に含めていないので、タブ切替で React が Terminal を unmount する
6. ユーザーが同じターミナルタブに戻る → 再 mount
7. \`isReattach = cachedBeforeCreate?.streamReady === true && cachedBeforeCreate.subscription !== null\` が **true** に
8. \`createOrAttach\` が完全にスキップされる
9. ユーザーが typing → renderer は \`electronTrpcClient.terminal.write.mutate\` を呼ぶ
10. main 側は session 不在で throw
11. \`writeRef\` が callback なしで呼ばれているため、失敗は **握りつぶされる**
12. UI 上は「表示あり、入力反映なし」

### 致命度

- Terminal は PersistentTabRenderer の persistent view 対象外 → **タブ切替のたびに unmount される**
- \`coldRestoreState\` は module-level Map で remount をまたいで残る → cache の誤った ready 状態が固定化
- \`writeRef\` にエラー表面化機構がない → ユーザーには原因不明

## 修正内容

### 1. \`useTerminalLifecycle.ts\` createOrAttach onSuccess

cold restore 判定より **後ろ** に \`startStream\` / \`setStreamReady\` / \`markTerminalSessionReady\` を移動。**実 backend session がある場合のみ** cache を ready にマーク。

\`\`\`diff
 onSuccess: (result) => {
   if (!isAttachActive()) return;
   if (activeAttachRequestId !== requestId) return;
   setConnectionError(null);
   clearPaneInitialDataRef.current(paneId);
-
-  v1TerminalCache.startStream(paneId);
-  v1TerminalCache.setStreamReady(paneId);
-  markTerminalSessionReady(paneId);

   const storedColdRestore = coldRestoreState.get(paneId);
   if (storedColdRestore?.isRestored) { ... return; }

   if (result.isColdRestore) { ... return; }

+  // Real backend session is live — safe to start the stream
+  // subscription and unblock waiters.
+  v1TerminalCache.startStream(paneId);
+  v1TerminalCache.setStreamReady(paneId);
+  markTerminalSessionReady(paneId);

   pendingInitialStateRef.current = result;
\`\`\`

### 2. \`useTerminalLifecycle.ts\` isReattach 判定

\`coldRestoreState.has(paneId)\` の間は isReattach を強制的に false にし、remount 時に必ず full attach 経路を通すようにする belt-and-suspenders。

\`\`\`diff
 const cachedBeforeCreate = v1TerminalCache.get(paneId);
+const hasPendingColdRestore = coldRestoreState.has(paneId);
 const isReattach =
   cachedBeforeCreate?.streamReady === true &&
-  cachedBeforeCreate.subscription !== null;
+  cachedBeforeCreate.subscription !== null &&
+  !hasPendingColdRestore;
\`\`\`

### 3. \`useTerminalColdRestore.ts\` handleStartShell onSuccess

実シェルが spawn されたタイミングで、cache と session-readiness waiters を ready にマークする。失敗時は reject する。

\`\`\`diff
 onSuccess: (result) => {
   pendingInitialStateRef.current = result;
   maybeApplyInitialState();
+
+  // Mark the cache + readiness waiters now that a real shell exists.
+  v1TerminalCache.startStream(paneId);
+  v1TerminalCache.setStreamReady(paneId);
+  markTerminalSessionReady(paneId);

   setIsRestoredMode(false);
   coldRestoreState.delete(paneId);
   ...
 },
 onError: (error) => {
   ...
+  rejectTerminalSessionReady(
+    paneId,
+    new Error(error.message || "Failed to start shell"),
+  );
   isStreamReadyRef.current = true;
\`\`\`

## FORK NOTE

これは upstream 由来のリグレッションなので、通常フォークの方針では修正せず upstream の fix を待つのが原則ですが、terminal が使えないのは致命的なため一時パッチとして適用します。

upstream が自前で fix を出したら、本 PR の修正を revert → upstream の実装に合わせる形で追従する想定。コミットメッセージと各修正箇所の \`FORK NOTE\` コメントに経緯を残してあります。

## 検証

- ✅ \`bun run typecheck\` パス
- ✅ \`bunx biome check\` パス

### 再現手順（修正前）

1. 新規 v1 terminal ペインを作成 → 何か入力 → 動く
2. 別のタブに switch
3. Terminal タブに戻す
4. 入力 → **反映されない** 🔴

### 修正後の期待動作

1〜3 は同じ。4 で入力 → **正常に反映される** ✅

## 影響範囲

- \`apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalLifecycle.ts\`
- \`apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalColdRestore.ts\`

合計 2 ファイル、+45 / -8 行。

## 関連

- upstream superset-sh/superset#3348 (原因)
- upstream superset-sh/superset#3389 (部分的な緩和)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * ターミナルセッションの再開時における初期化の順序を改善し、コールドリストア中のセッション管理を最適化しました
  * セッション再開エラー時のエラーメッセージ処理を強化し、より詳細な情報をユーザーに提供するようにしました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->