### PR TITLE
Apply Right sidebar open view width setting to all split-pane open flows

### DIFF
--- a/apps/desktop/src/renderer/components/Chat/ChatInterface/components/MessageList/MessageList.tsx
+++ b/apps/desktop/src/renderer/components/Chat/ChatInterface/components/MessageList/MessageList.tsx
@@ -71,7 +71,11 @@ export function MessageList({
 	const handleImageClick = useCallback(
 		(url: string) => {
 			if (!workspaceId) return;
-			addFileViewerPane(workspaceId, { filePath: url, isPinned: true });
+			addFileViewerPane(workspaceId, {
+				filePath: url,
+				isPinned: true,
+				useRightSidebarOpenViewWidth: true,
+			});
 		},
 		[workspaceId, addFileViewerPane],
 	);
@@ -197,6 +201,7 @@ export function MessageList({
 																addFileViewerPane(workspaceId, {
 																	filePath: normalizedPath,
 																	isPinned: true,
+																	useRightSidebarOpenViewWidth: true,
 																});
 															}}
 														/>

--- a/apps/desktop/src/renderer/components/Chat/ChatInterface/components/MessagePartsRenderer/MessagePartsRenderer.tsx
+++ b/apps/desktop/src/renderer/components/Chat/ChatInterface/components/MessagePartsRenderer/MessagePartsRenderer.tsx
@@ -69,7 +69,10 @@ export function MessagePartsRenderer({
 				workspaceRoot: workspaceCwd,
 			});
 			if (!normalizedPath) return;
-			addFileViewerPane(workspaceId, { filePath: normalizedPath });
+			addFileViewerPane(workspaceId, {
+				filePath: normalizedPath,
+				useRightSidebarOpenViewWidth: true,
+			});
 		},
 		[addFileViewerPane, workspaceCwd, workspaceId],
 	);

--- a/apps/desktop/src/renderer/components/Chat/ChatInterface/components/ToolCallBlock/ToolCallBlock.tsx
+++ b/apps/desktop/src/renderer/components/Chat/ChatInterface/components/ToolCallBlock/ToolCallBlock.tsx
@@ -98,7 +98,10 @@ export function ToolCallBlock({
 			if (!workspaceId) return;
 			const normalizedPath = normalizeFilePath(filePath);
 			if (!normalizedPath) return;
-			addFileViewerPane(workspaceId, { filePath: normalizedPath });
+			addFileViewerPane(workspaceId, {
+				filePath: normalizedPath,
+				useRightSidebarOpenViewWidth: true,
+			});
 			posthog.capture("chat_file_opened_from_tool", {
 				workspace_id: workspaceId,
 				session_id: sessionId ?? null,
@@ -164,6 +167,7 @@ export function ToolCallBlock({
 				commitHash: diffPaneTarget?.commitHash,
 				oldPath: diffPaneTarget?.oldPath,
 				viewMode: "diff",
+				useRightSidebarOpenViewWidth: true,
 			});
 			posthog.capture("chat_file_opened_from_tool", {
 				workspace_id: workspaceId,

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatPane/components/WorkspaceChatInterface/components/ChatMessageList/components/AssistantMessage/AssistantMessage.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatPane/components/WorkspaceChatInterface/components/ChatMessageList/components/AssistantMessage/AssistantMessage.tsx
@@ -138,6 +138,7 @@ export function AssistantMessage({
 			addFileViewerPane(workspaceId, {
 				filePath: url,
 				isPinned: true,
+				useRightSidebarOpenViewWidth: true,
 				...(filename ? { displayName: filename } : {}),
 			});
 		},

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatPane/components/WorkspaceChatInterface/components/ChatMessageList/components/UserMessage/UserMessage.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatPane/components/WorkspaceChatInterface/components/ChatMessageList/components/UserMessage/UserMessage.tsx
@@ -52,6 +52,7 @@ export function UserMessage({
 			addFileViewerPane(workspaceId, {
 				filePath: url,
 				isPinned: true,
+				useRightSidebarOpenViewWidth: true,
 				...(filename ? { displayName: filename } : {}),
 			});
 		},
@@ -59,7 +60,11 @@ export function UserMessage({
 	);
 	const openMentionedFile = useCallback(
 		(filePath: string) => {
-			addFileViewerPane(workspaceId, { filePath, isPinned: true });
+			addFileViewerPane(workspaceId, {
+				filePath,
+				isPinned: true,
+				useRightSidebarOpenViewWidth: true,
+			});
 		},
 		[addFileViewerPane, workspaceId],
 	);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/workspace/$workspaceId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/workspace/$workspaceId/page.tsx
@@ -292,6 +292,7 @@ export function WorkspacePage({
 			column: pendingWorkspaceIntent.column,
 			viewMode: "raw",
 			isPinned: true,
+			useRightSidebarOpenViewWidth: true,
 		});
 
 		markPendingWorkspaceIntentFileHandled(pendingWorkspaceIntent.id);

--- a/apps/desktop/src/renderer/screens/main/components/CommandPalette/useCommandPalette.ts
+++ b/apps/desktop/src/renderer/screens/main/components/CommandPalette/useCommandPalette.ts
@@ -191,7 +191,10 @@ export function useCommandPalette({
 				});
 				return;
 			}
-			useTabsStore.getState().addFileViewerPane(targetWs, { filePath });
+			useTabsStore.getState().addFileViewerPane(targetWs, {
+				filePath,
+				useRightSidebarOpenViewWidth: true,
+			});
 			handleOpenChange(false);
 			if (targetWs !== workspaceId) {
 				navigateToWorkspace(targetWs, navigate);

--- a/apps/desktop/src/renderer/screens/main/components/KeywordSearch/useKeywordSearch.ts
+++ b/apps/desktop/src/renderer/screens/main/components/KeywordSearch/useKeywordSearch.ts
@@ -95,6 +95,7 @@ export function useKeywordSearch({ workspaceId }: UseKeywordSearchParams) {
 				filePath: match.path,
 				line: match.line,
 				column: match.column,
+				useRightSidebarOpenViewWidth: true,
 			});
 			handleOpenChange(false);
 		},

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/EmptyTabView.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/EmptyTabView.tsx
@@ -76,6 +76,7 @@ export function EmptyTabView({
 				filePath: memo.memoFileAbsolutePath,
 				displayName: memo.displayName,
 				isPinned: true,
+				useRightSidebarOpenViewWidth: true,
 			});
 		} catch (error) {
 			const message =

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/GroupStrip/GroupStrip.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/GroupStrip/GroupStrip.tsx
@@ -247,6 +247,7 @@ export function GroupStrip() {
 				filePath: memo.memoFileAbsolutePath,
 				displayName: memo.displayName,
 				isPinned: true,
+				useRightSidebarOpenViewWidth: true,
 			});
 		} catch (error) {
 			const message =

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatPane/ChatPaneInterface/components/ChatMessageList/components/AssistantMessage/AssistantMessage.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatPane/ChatPaneInterface/components/ChatMessageList/components/AssistantMessage/AssistantMessage.tsx
@@ -123,6 +123,7 @@ export function AssistantMessage({
 			addFileViewerPane(workspaceId, {
 				filePath: url,
 				isPinned: true,
+				useRightSidebarOpenViewWidth: true,
 				...(filename ? { displayName: filename } : {}),
 			});
 		},

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatPane/ChatPaneInterface/components/ChatMessageList/components/UserMessage/UserMessage.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatPane/ChatPaneInterface/components/ChatMessageList/components/UserMessage/UserMessage.tsx
@@ -52,6 +52,7 @@ export function UserMessage({
 			addFileViewerPane(workspaceId, {
 				filePath: url,
 				isPinned: true,
+				useRightSidebarOpenViewWidth: true,
 				...(filename ? { displayName: filename } : {}),
 			});
 		},
@@ -59,7 +60,11 @@ export function UserMessage({
 	);
 	const openMentionedFile = useCallback(
 		(filePath: string) => {
-			addFileViewerPane(workspaceId, { filePath, isPinned: true });
+			addFileViewerPane(workspaceId, {
+				filePath,
+				isPinned: true,
+				useRightSidebarOpenViewWidth: true,
+			});
 		},
 		[addFileViewerPane, workspaceId],
 	);

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/components/FileViewerContent/FileViewerContent.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/components/FileViewerContent/FileViewerContent.tsx
@@ -607,6 +607,7 @@ export function FileViewerContent({
 				line: target.line,
 				column: target.column,
 				isPinned: false,
+				useRightSidebarOpenViewWidth: true,
 			});
 		},
 		[

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ReferenceGraphPane/ReferenceGraphPane.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ReferenceGraphPane/ReferenceGraphPane.tsx
@@ -151,6 +151,7 @@ function ReferenceGraphInner({
 				filePath: absolutePath,
 				line,
 				isPinned: false,
+				useRightSidebarOpenViewWidth: true,
 			});
 		},
 		[addFileViewerPane, workspaceId],

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useFileLinkClick.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useFileLinkClick.ts
@@ -54,6 +54,7 @@ export function useFileLinkClick({
 				filePath: resolvedPath,
 				line,
 				column,
+				useRightSidebarOpenViewWidth: true,
 			});
 		},
 		[terminalLinkBehavior, workspaceId, projectId, addFileViewerPane],

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/GitGraphView/CommitDetailsPanel/CommitDetailsPanel.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/GitGraphView/CommitDetailsPanel/CommitDetailsPanel.tsx
@@ -227,6 +227,7 @@ export function CommitDetailsPanel({
 										commitHash: node.hash,
 										oldPath: absoluteOldPath,
 										openInNewTab: false,
+										useRightSidebarOpenViewWidth: true,
 									});
 								}}
 								className="grid w-full grid-cols-[14px_minmax(0,1fr)_auto] items-center gap-2 border-t border-border/50 px-3 py-2 text-left transition-colors hover:bg-muted/50 first:border-t-0"

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/index.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/index.tsx
@@ -582,6 +582,7 @@ export function RightSidebar({ isActive = true }: { isActive?: boolean }) {
 				viewMode: "raw",
 				line,
 				column,
+				useRightSidebarOpenViewWidth: true,
 			});
 		},
 		[workspaceId, worktreePath, addFileViewerPane],

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/hooks/useVscodeDiffSync.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/hooks/useVscodeDiffSync.ts
@@ -25,6 +25,7 @@ export function useVscodeDiffSync() {
 					filePath: data.rightUri,
 					viewMode: "diff",
 					diffCategory: "unstaged",
+					useRightSidebarOpenViewWidth: true,
 					...(isRename ? { oldPath: data.leftUri } : {}),
 				});
 			},

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/hooks/useVscodeOpenFileSync.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/hooks/useVscodeOpenFileSync.ts
@@ -20,6 +20,7 @@ export function useVscodeOpenFileSync() {
 					filePath: data.filePath,
 					line: data.line,
 					viewMode: "raw",
+					useRightSidebarOpenViewWidth: true,
 				});
 			},
 		},


### PR DESCRIPTION
## Summary

The **Right sidebar open view width** setting (Settings → General) controls the initial width of new file/diff views when a file is opened as a split pane. It was only honored in 3 call sites — the Files sidebar double-click and Changes view file / line-jump handlers — so users reported the setting silently not applying most of the time.

Technically, the `splitPercentage` computed from this setting is only applied inside `addFileViewerPane` when the `useRightSidebarOpenViewWidth` option is `true` on the split-pane creation path (`stores/tabs/store.ts`). Every other call site fell back to `DEFAULT_FILE_VIEWER_SPLIT_PERCENTAGE`.

This PR passes `useRightSidebarOpenViewWidth: true` from every remaining `addFileViewerPane` call site that can hit the split-pane path, so the setting now applies uniformly regardless of origin.

## Flows covered

- **Right sidebar**: Search view and Problems view jump-to-line (`RightSidebar/index.tsx` handleOpenFileAtLine)
- **Chat (v1 / WorkspaceView)**: user message attachments, mentioned-file clicks, assistant message attachments
- **Chat (v2-workspace)**: user message attachments, mentioned-file clicks, assistant message attachments
- **Chat (shared components/Chat)**: MessageList image click and mention chip click, MessagePartsRenderer file link, ToolCallBlock open-file and open-diff actions
- **Terminal**: cmd/ctrl-click file links (`useFileLinkClick`)
- **Command Palette** (Quick Open) and **Keyword Search** result selection
- **File viewer internal nav**: go-to-definition from the editor, reference graph node double-click
- **VS Code extension sync**: `openFileInPane` and `openDiffInPane` IPC
- **Git history**: CommitDetailsPanel file click
- **Memo creation**: EmptyTabView and GroupStrip "Create Memo" buttons
- **Workspace initialization**: pending workspace intent auto-open (`?file=...`)

Already-correct call sites (`FilesView`, `RightSidebar handleFileOpenPane`, `RightSidebar handleChangesOpenFileAtLine`) are untouched.

No behavior change for flows that open a file in a **new tab** (`openInNewTab: true`) or reuse an existing preview pane — those paths do not create a new split and ignore this option by design.

## Test plan

- [ ] Set "Right sidebar open view width" to a non-default value (e.g. 40)
- [ ] Open a file via each of the flows above and confirm the new file pane takes the configured percentage
- [ ] Verify behavior is unchanged when "File open mode" is set to `new-tab`
- [ ] `bun run lint` ✅
- [ ] `bun run typecheck` ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * ファイルビューアペインを右サイドバーで開く際の表示幅の処理を改善しました。ファイルクリック、ファイルメンション、検索結果など、複数の操作からファイルを開く場合の動作が一貫性を持つようになります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->