### PR TITLE
fix(desktop): preserve imported theme editor colors across app restart

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/ui-state/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/ui-state/index.ts
@@ -259,7 +259,98 @@ const terminalColorsSchema = z.object({
 });
 
 /**
- * Zod schema for Theme
+ * Zod schema for editor chrome colors.
+ * Mirrors EditorColors in shared/themes/types.ts.
+ */
+const editorColorsSchema = z.object({
+	background: z.string(),
+	foreground: z.string(),
+	border: z.string(),
+	cursor: z.string(),
+	gutterBackground: z.string(),
+	gutterForeground: z.string(),
+	activeLine: z.string(),
+	selection: z.string(),
+	search: z.string(),
+	searchActive: z.string(),
+	panel: z.string(),
+	panelBorder: z.string(),
+	panelInputBackground: z.string(),
+	panelInputForeground: z.string(),
+	panelInputBorder: z.string(),
+	panelButtonBackground: z.string(),
+	panelButtonForeground: z.string(),
+	panelButtonBorder: z.string(),
+	diffBuffer: z.string(),
+	diffHover: z.string(),
+	diffSeparator: z.string(),
+	addition: z.string(),
+	deletion: z.string(),
+	modified: z.string(),
+});
+
+/**
+ * Zod schema for editor syntax colors.
+ * Mirrors EditorSyntaxColors in shared/themes/types.ts.
+ */
+const editorSyntaxColorsSchema = z.object({
+	plainText: z.string(),
+	comment: z.string(),
+	docComment: z.string(),
+	keyword: z.string(),
+	controlKeyword: z.string(),
+	storageKeyword: z.string(),
+	string: z.string(),
+	escape: z.string(),
+	number: z.string(),
+	functionCall: z.string(),
+	variableName: z.string(),
+	variableProperty: z.string(),
+	typeName: z.string(),
+	className: z.string(),
+	constant: z.string(),
+	regexp: z.string(),
+	tagName: z.string(),
+	attributeName: z.string(),
+	invalid: z.string(),
+	annotation: z.string(),
+	operator: z.string(),
+	punctuation: z.string(),
+	markdownHeading: z.string(),
+	markdownEmphasis: z.string(),
+	markdownStrong: z.string(),
+	markdownStrikethrough: z.string(),
+	markdownLink: z.string(),
+	markdownUrl: z.string(),
+	markdownCode: z.string(),
+	markdownQuote: z.string(),
+	markdownList: z.string(),
+	markdownSeparator: z.string(),
+	meta: z.string(),
+});
+
+/**
+ * Zod schema for EditorThemeOverrides.
+ * Both `colors` and `syntax` accept partial shapes so imported themes that
+ * only override a subset of tokens still round-trip through persistence.
+ */
+const editorThemeOverridesSchema = z.object({
+	colors: editorColorsSchema.partial().optional(),
+	syntax: editorSyntaxColorsSchema.partial().optional(),
+});
+
+/**
+ * Zod schema for Theme.
+ *
+ * `terminal` and `editor` are optional to match the Theme interface in
+ * shared/themes/types.ts. If they are missing, the app falls back to
+ * defaults derived from the theme type and base UI colors.
+ *
+ * Every field declared on the Theme interface MUST appear here — Zod's
+ * default `z.object()` silently strips unknown keys during
+ * `.input(...)` validation on the `theme.set` tRPC mutation, which
+ * means any missing field would be dropped on every persist cycle and
+ * lost after app restart.
  */
 const themeSchema = z.object({
 	id: z.string(),
@@ -269,7 +360,8 @@ const themeSchema = z.object({
 	description: z.string().optional(),
 	type: z.enum(["dark", "light"]),
 	ui: uiColorsSchema,
-	terminal: terminalColorsSchema,
+	terminal: terminalColorsSchema.optional(),
+	editor: editorThemeOverridesSchema.optional(),
 	isBuiltIn: z.boolean().optional(),
 	isCustom: z.boolean().optional(),
 });
@@ -283,6 +375,11 @@ const themeStateSchema = z.object({
 	systemLightThemeId: z.string().optional(),
 	systemDarkThemeId: z.string().optional(),
 });
+
+export const __testing = {
+	themeSchema,
+	themeStateSchema,
+};
 
 /**
  * UI State router - manages tabs and theme persistence via lowdb

--- a/apps/desktop/src/lib/trpc/routers/ui-state/ui-state-schema.test.ts
+++ b/apps/desktop/src/lib/trpc/routers/ui-state/ui-state-schema.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "bun:test";
+import { darkTheme } from "shared/themes";
+import { __testing } from "./index";
+
+const { themeSchema, themeStateSchema } = __testing;
+
+describe("themeSchema", () => {
+	it("preserves the editor field on a custom theme", () => {
+		const input = {
+			id: "my-custom",
+			name: "My Custom",
+			type: "dark" as const,
+			ui: darkTheme.ui,
+			terminal: darkTheme.terminal,
+			editor: {
+				colors: {
+					background: "#111111",
+					foreground: "#eeeeee",
+				},
+				syntax: {
+					keyword: "#ff6688",
+					string: "#88ff66",
+				},
+			},
+			isCustom: true,
+		};
+
+		const parsed = themeSchema.parse(input);
+
+		expect(parsed.editor).toBeDefined();
+		expect(parsed.editor?.colors?.background).toBe("#111111");
+		expect(parsed.editor?.colors?.foreground).toBe("#eeeeee");
+		expect(parsed.editor?.syntax?.keyword).toBe("#ff6688");
+		expect(parsed.editor?.syntax?.string).toBe("#88ff66");
+	});
+
+	it("accepts a theme without terminal overrides", () => {
+		const input = {
+			id: "no-terminal",
+			name: "No Terminal",
+			type: "light" as const,
+			ui: darkTheme.ui,
+			isCustom: true,
+		};
+
+		expect(() => themeSchema.parse(input)).not.toThrow();
+	});
+
+	it("accepts a theme without editor overrides", () => {
+		const input = {
+			id: "no-editor",
+			name: "No Editor",
+			type: "dark" as const,
+			ui: darkTheme.ui,
+			terminal: darkTheme.terminal,
+			isCustom: true,
+		};
+
+		const parsed = themeSchema.parse(input);
+		expect(parsed.editor).toBeUndefined();
+	});
+
+	it("preserves partial editor.colors overrides", () => {
+		const input = {
+			id: "partial-colors",
+			name: "Partial Colors",
+			type: "dark" as const,
+			ui: darkTheme.ui,
+			editor: {
+				colors: {
+					addition: "#00ff00",
+				},
+			},
+		};
+
+		const parsed = themeSchema.parse(input);
+		expect(parsed.editor?.colors?.addition).toBe("#00ff00");
+	});
+
+	it("preserves partial editor.syntax overrides", () => {
+		const input = {
+			id: "partial-syntax",
+			name: "Partial Syntax",
+			type: "dark" as const,
+			ui: darkTheme.ui,
+			editor: {
+				syntax: {
+					markdownHeading: "#abcdef",
+				},
+			},
+		};
+
+		const parsed = themeSchema.parse(input);
+		expect(parsed.editor?.syntax?.markdownHeading).toBe("#abcdef");
+	});
+
+	it("round-trips a full theme state with editor overrides via themeStateSchema", () => {
+		const customTheme = {
+			id: "round-trip",
+			name: "Round Trip",
+			type: "dark" as const,
+			ui: darkTheme.ui,
+			editor: {
+				colors: { background: "#000000" },
+				syntax: { keyword: "#ffffff" },
+			},
+			isCustom: true,
+		};
+
+		const parsed = themeStateSchema.parse({
+			activeThemeId: "round-trip",
+			customThemes: [customTheme],
+		});
+
+		expect(parsed.customThemes[0]?.editor?.colors?.background).toBe("#000000");
+		expect(parsed.customThemes[0]?.editor?.syntax?.keyword).toBe("#ffffff");
+	});
+});


### PR DESCRIPTION
## Summary

Fixes a silent data-loss bug where imported custom themes revert to default editor/syntax colors after an app restart (reported as: theme colors reset after Superset updates, only re-importing the JSON fixes it temporarily).

The Zod \`themeSchema\` used to validate \`ThemeState\` on the \`theme.set\` tRPC mutation (\`apps/desktop/src/lib/trpc/routers/ui-state/index.ts\`) was missing the \`editor\` field declared on the \`Theme\` interface in \`shared/themes/types.ts\`. Since \`z.object()\` strips unknown keys by default, any editor overrides on a custom/imported theme were silently dropped on every persist cycle and written to disk without them.

### Bug flow

1. User imports a theme JSON with custom \`editor.colors\` / \`editor.syntax\` — display is correct (still in memory).
2. Zustand persist middleware flushes state through \`trpcThemeStorage\` → \`theme.set\` mutation.
3. Zod's \`.input(themeStateSchema)\` strips the unknown \`editor\` field.
4. The stripped state is written to \`app-state.json\`.
5. On next app restart, state rehydrates without \`editor\` — colors fall back to defaults derived from UI + terminal tokens.
6. Switching themes and coming back doesn't help because in-memory state was rehydrated from the already-stripped file.
7. Re-importing the JSON works until the next persist cycle wipes it again.

### Secondary issue

\`terminal\` was declared as **required** in \`themeSchema\` but is **optional** on the \`Theme\` interface, so themes without terminal overrides would fail validation and silently drop the write entirely.

## Changes

- Add \`editorColorsSchema\` and \`editorSyntaxColorsSchema\` mirroring the TypeScript interfaces (\`EditorColors\` and \`EditorSyntaxColors\` in \`shared/themes/types.ts\`).
- Add \`editorThemeOverridesSchema\` using \`.partial()\` on each sub-schema so imported themes that only override a subset of tokens round-trip through persistence.
- Add \`editor\` as optional on \`themeSchema\`.
- Change \`terminal\` to optional on \`themeSchema\` to match the \`Theme\` interface.
- Add an invariant comment on \`themeSchema\` warning future editors that every \`Theme\` field MUST be declared here because Zod strips unknown keys by default.
- Add regression tests covering: editor preservation, partial \`colors\` / \`syntax\` overrides, missing terminal, missing editor, and full round-trip through \`themeStateSchema\`.

## Precedent

There is a prior commit (\`00ec1e703\` — \"fix(desktop): sync Zod persistence schemas with TypeScript types to prevent silent data loss\") that fixed exactly this pattern for tabs/pane/chat-launch schemas. The theme schema was missed at the time; this PR completes that cleanup for the theme branch of the same router.

## Migration note

Users affected by the previous behavior will need to **re-import their theme JSON once** after this fix is released. The previously persisted state already has the \`editor\` data stripped and cannot be recovered — after re-importing once, it will stick across restarts permanently.

## Test plan

- [x] \`bun run lint\`
- [x] \`bun run typecheck\`
- [x] New unit tests (\`ui-state-schema.test.ts\`) — 6 tests pass
- [ ] Manual: import a theme with custom \`editor.colors\`, restart the app, confirm colors persist
- [ ] Manual: import a theme without \`terminal\` overrides, confirm it no longer silently fails to save

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * エディタテーマのカスタマイズ機能を追加しました。エディタの色とシンタックスハイライトを個別に設定できるようになりました。
  * テーマ設定がより柔軟になり、ターミナル設定がオプション化されました。

* **テスト**
  * UIステートのテーマスキーマに関する新しいテストスイートを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->