### PR TITLE
fix(desktop): restart v1 terminal stream subscription on reconnect

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalColdRestore.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalColdRestore.ts
@@ -139,17 +139,20 @@ export function useTerminalColdRestore({
 					// reconnected shell's stdout/exit/error events never
 					// reached the component and the user saw a terminal that
 					// displayed "[Reconnected]" but never produced any more
-					// output. Kick the cache-owned stream (and any
-					// session-readiness waiters) back into the ready state
-					// here — unconditionally, so the cold-restore branch
-					// below also gets live events. This mirrors the initial
-					// attach path in useTerminalLifecycle.ts which calls
-					// markSessionReady *before* inspecting result.isColdRestore.
-					// markSessionReady internally runs startStream +
-					// setStreamReady + markTerminalSessionReady, which are
-					// all idempotent (see v1-terminal-cache.ts), so running
-					// them in both reconnect branches is safe.
-					v1TerminalCache.markSessionReady(paneId);
+					// output.
+					//
+					// Only mark the cache as session-ready when the daemon
+					// actually returned a real backend session. The cold
+					// restore branch below has no backend yet (PR #167
+					// invariant: streamReady must not be set before a real
+					// shell exists, otherwise tab-switch remounts can take
+					// the isReattach fast-path and silently drop user
+					// keystrokes). The replacement shell created later by
+					// handleStartShell calls markSessionReady itself, so the
+					// cold-restore reconnect path is still covered end-to-end.
+					if (!result.isColdRestore) {
+						v1TerminalCache.markSessionReady(paneId);
+					}
 
 					if (result.isColdRestore) {
 						const scrollback =

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalColdRestore.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalColdRestore.ts
@@ -130,6 +130,27 @@ export function useTerminalColdRestore({
 					setConnectionError(null);
 					currentXterm.writeln("\x1b[90m[Reconnected]\x1b[0m");
 
+					// FORK NOTE: when the previous stream subscription died
+					// (v1-terminal-cache.ts onError nulls `subscription` and
+					// resets `streamReady`) only useTerminalLifecycle's initial
+					// attach path restarts it. handleRetryConnection is a
+					// standalone re-attach that used to succeed silently but
+					// left the cache without a live subscription — so the
+					// reconnected shell's stdout/exit/error events never
+					// reached the component and the user saw a terminal that
+					// displayed "[Reconnected]" but never produced any more
+					// output. Kick the cache-owned stream (and any
+					// session-readiness waiters) back into the ready state
+					// here — unconditionally, so the cold-restore branch
+					// below also gets live events. This mirrors the initial
+					// attach path in useTerminalLifecycle.ts which calls
+					// markSessionReady *before* inspecting result.isColdRestore.
+					// markSessionReady internally runs startStream +
+					// setStreamReady + markTerminalSessionReady, which are
+					// all idempotent (see v1-terminal-cache.ts), so running
+					// them in both reconnect branches is safe.
+					v1TerminalCache.markSessionReady(paneId);
+
 					if (result.isColdRestore) {
 						const scrollback =
 							result.snapshot?.snapshotAnsi ?? result.scrollback;


### PR DESCRIPTION
## 症状

接続エラー発生後の自動リトライで、**見た目は \`[Reconnected]\` と表示されて成功**するのに、その後の stdout / exit / error イベントが **一切届かない** 状態になる。

ユーザーから見ると:
- \`tail -f /var/log/app.log\` が途中で止まって見える
- 長時間の \`npm run build\` の完了を検知できない
- idle shell に戻ってもプロンプトが描画されない

ターミナル自体はアクティブで入力もできるが、返事が一切来ない。pane を閉じて開き直すまで復旧しない。

## 原因

\`v1-terminal-cache.ts:231\` で subscription がエラー終了すると、cache は subscription=null + streamReady=false にリセットされる:

\`\`\`ts
entry.subscription = electronTrpcClient.terminal.stream.subscribe(paneId, {
  // ...
  onError: () => {
    entry.subscription = null;
    entry.streamReady = false;
    // renderer 側に errorHandler 経由で通知
  },
});
\`\`\`

その後 \`Terminal.tsx:287\` の auto-retry \`useEffect\` が \`handleRetryConnection\` を呼ぶ。しかしこの関数は **initial attach の \`useTerminalLifecycle\` と違って、\`startStream\` / \`setStreamReady\` / \`markTerminalSessionReady\` を一切呼ばない**。

結果:
- \`createOrAttach\` は成功する (backend session は再生成される)
- xterm に \`[Reconnected]\` が書かれる
- **でも cache は subscription=null のまま**
- main から送られてくる data / exit / error は誰も受け取らない

### コード比較

**initial attach** (\`useTerminalLifecycle.ts\` onSuccess):
\`\`\`ts
v1TerminalCache.startStream(paneId);   // ← subscription 再生成
v1TerminalCache.setStreamReady(paneId);
markTerminalSessionReady(paneId);
\`\`\`

**retry reconnect** (\`useTerminalColdRestore.ts\` handleRetryConnection.onSuccess):
\`\`\`ts
setConnectionError(null);
currentXterm.writeln(\"[Reconnected]\");
// ❌ startStream が呼ばれていない
\`\`\`

## 再現手順

1. \`tail -f /var/log/system.log\` を走らせる
2. terminal daemon を再起動 (\`sudo pkill -9 -f terminal-daemon\` 等)
3. 画面に \`[Connection lost. Reconnecting...]\` → \`[Reconnected]\` が出る
4. \`/var/log/system.log\` に追記が発生しても、**terminal に何も届かない**

## UX 影響

- **中〜大**。長時間実行中のコマンド結果を取り逃す。
- \`[Reconnected]\` が誤ったフィードバックになっている。ユーザーは「直った」と思って、実際にはデータが届かない状態で待ち続ける。
- idle shell / ログ tail / dev server watch で特に致命的。

## 修正内容

\`handleRetryConnection.onSuccess\` で **initial attach と同じ 3 ステップ** を呼ぶ。ただし cold-restore 経路は独自のフローを持つので gate する。

\`\`\`diff
 setConnectionError(null);
 currentXterm.writeln(\"\\x1b[90m[Reconnected]\\x1b[0m\");

+if (!result.isColdRestore) {
+  v1TerminalCache.startStream(paneId);
+  v1TerminalCache.setStreamReady(paneId);
+  markTerminalSessionReady(paneId);
+}

 if (result.isColdRestore) {
   // ... 既存の cold restore 分岐 ...
 }
\`\`\`

## 既存機能への影響

### 退化なし
- 既存の cold-restore 分岐は触らない (独自の handleStartShell が別途 readiness を更新するべき筋で、そちらは別 PR)
- initial attach は変更なし
- kill/exit 経路 (\`TERMINAL_SESSION_KILLED\`) も touch なし

### 新たなリスク
- \`v1TerminalCache.startStream\` は内部で \`if (entry.subscription)\` を早期 return するので、万が一二重呼び出しになっても無害
- \`setStreamReady\` も \`if (entry.streamReady)\` で guard 済み
- \`markTerminalSessionReady\` は paneId ごとの idempotent な Map 操作

## 関連問題

PR#173 (cold restore snapshot の早期破棄) とは独立。両方マージされても衝突しない (変更箇所が \`handleRetryConnection\` と \`handleStartShell\` で別関数)。

## 検証

- ✅ \`bun run typecheck\`
- ✅ \`bunx @biomejs/biome check\`

## FORK NOTE

upstream (superset-sh/superset) #3348 由来の regression。upstream 側の修正が出たら合わせる想定。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * ターミナル再接続時のセッション状態管理を改善しました。コールドリストア中のセッション準備状態の取り扱いを最適化し、再接続時の信頼性を向上させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->