### PR TITLE
fix(desktop): cancel v1 cold-restore attach on unmount / supersede

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/Terminal.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/Terminal.tsx
@@ -248,6 +248,7 @@ export const Terminal = memo(function Terminal({
 		pendingInitialStateRef,
 		pendingEventsRef,
 		createOrAttachRef,
+		cancelCreateOrAttachRef,
 		setConnectionError,
 		setExitStatus,
 		maybeApplyInitialState,

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalColdRestore.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalColdRestore.ts
@@ -1,5 +1,5 @@
 import type { Terminal as XTerm } from "@xterm/xterm";
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { rejectTerminalSessionReady } from "renderer/lib/terminal/session-readiness";
 import { electronTrpcClient as trpcClient } from "renderer/lib/trpc-client";
 import { isTerminalAttachCanceledMessage } from "../attach-cancel";
@@ -7,10 +7,12 @@ import { coldRestoreState } from "../state";
 import type {
 	CreateOrAttachMutate,
 	CreateOrAttachResult,
+	TerminalCancelCreateOrAttachMutate,
 	TerminalStreamEvent,
 } from "../types";
 import { scrollToBottom } from "../utils";
 import * as v1TerminalCache from "../v1-terminal-cache";
+import { createAttachRequestId } from "./attach-request-id";
 
 export interface UseTerminalColdRestoreOptions {
 	paneId: string;
@@ -25,6 +27,7 @@ export interface UseTerminalColdRestoreOptions {
 	pendingInitialStateRef: React.MutableRefObject<CreateOrAttachResult | null>;
 	pendingEventsRef: React.MutableRefObject<TerminalStreamEvent[]>;
 	createOrAttachRef: React.MutableRefObject<CreateOrAttachMutate>;
+	cancelCreateOrAttachRef: React.MutableRefObject<TerminalCancelCreateOrAttachMutate>;
 	setConnectionError: (error: string | null) => void;
 	setExitStatus: (status: "killed" | "exited" | null) => void;
 	maybeApplyInitialState: () => void;
@@ -62,6 +65,7 @@ export function useTerminalColdRestore({
 	pendingInitialStateRef,
 	pendingEventsRef,
 	createOrAttachRef,
+	cancelCreateOrAttachRef,
 	setConnectionError,
 	setExitStatus,
 	maybeApplyInitialState,
@@ -75,6 +79,25 @@ export function useTerminalColdRestore({
 	const restoredCwdRef = useRef(restoredCwd);
 	restoredCwdRef.current = restoredCwd;
 
+	// FORK NOTE: Track the request id of any in-flight createOrAttach kicked
+	// off from handleRetryConnection / handleStartShell so we can cancel it
+	// when the pane unmounts (or the call is superseded by another retry).
+	// Without this, closing a pane mid-reconnect or mid-cold-restore leaves
+	// a daemon-side attach running to completion — potentially spawning an
+	// orphan shell the user never sees, and leaking PTY + fd + memory.
+	const activeRequestIdRef = useRef<string | null>(null);
+
+	const cancelActiveRequest = useCallback(() => {
+		const current = activeRequestIdRef.current;
+		if (!current) return;
+		activeRequestIdRef.current = null;
+		cancelCreateOrAttachRef.current({ paneId, requestId: current });
+	}, [paneId, cancelCreateOrAttachRef]);
+
+	// Cancel any in-flight cold-restore attach on unmount so a rapid
+	// pane close / component teardown does not leave a dangling attach.
+	useEffect(() => cancelActiveRequest, [cancelActiveRequest]);
+
 	const handleRetryConnection = useCallback(() => {
 		setConnectionError(null);
 		const xterm = xtermRef.current;
@@ -83,9 +106,15 @@ export function useTerminalColdRestore({
 		isStreamReadyRef.current = false;
 		pendingInitialStateRef.current = null;
 
+		// Supersede any previous in-flight cold-restore attach — no-op if none.
+		cancelActiveRequest();
+		const requestId = createAttachRequestId(paneId);
+		activeRequestIdRef.current = requestId;
+
 		createOrAttachRef.current(
 			{
 				paneId,
+				requestId,
 				tabId,
 				workspaceId,
 				cols: xterm.cols,
@@ -93,6 +122,8 @@ export function useTerminalColdRestore({
 			},
 			{
 				onSuccess: (result: CreateOrAttachResult) => {
+					if (activeRequestIdRef.current !== requestId) return;
+					activeRequestIdRef.current = null;
 					const currentXterm = xtermRef.current;
 					if (!currentXterm) return;
 
@@ -132,6 +163,8 @@ export function useTerminalColdRestore({
 					}
 				},
 				onError: (error: { message?: string }) => {
+					if (activeRequestIdRef.current !== requestId) return;
+					activeRequestIdRef.current = null;
 					if (isTerminalAttachCanceledMessage(error.message)) {
 						return;
 					}
@@ -161,6 +194,7 @@ export function useTerminalColdRestore({
 		didFirstRenderRef,
 		pendingInitialStateRef,
 		createOrAttachRef,
+		cancelActiveRequest,
 		setConnectionError,
 		setExitStatus,
 		maybeApplyInitialState,
@@ -193,10 +227,18 @@ export function useTerminalColdRestore({
 		pendingInitialStateRef.current = null;
 		resetModes();
 
+		// Supersede any previous cold-restore attach before spawning the
+		// replacement shell — covers the case where handleStartShell is
+		// re-invoked while an earlier attempt is still in flight.
+		cancelActiveRequest();
+		const requestId = createAttachRequestId(paneId);
+		activeRequestIdRef.current = requestId;
+
 		// Create new session with previous cwd
 		createOrAttachRef.current(
 			{
 				paneId,
+				requestId,
 				tabId,
 				workspaceId,
 				cols: xterm.cols,
@@ -207,6 +249,8 @@ export function useTerminalColdRestore({
 			},
 			{
 				onSuccess: (result: CreateOrAttachResult) => {
+					if (activeRequestIdRef.current !== requestId) return;
+					activeRequestIdRef.current = null;
 					pendingInitialStateRef.current = result;
 					maybeApplyInitialState();
 
@@ -229,6 +273,8 @@ export function useTerminalColdRestore({
 					}, 0);
 				},
 				onError: (error: { message?: string }) => {
+					if (activeRequestIdRef.current !== requestId) return;
+					activeRequestIdRef.current = null;
 					if (isTerminalAttachCanceledMessage(error.message)) {
 						return;
 					}
@@ -256,6 +302,7 @@ export function useTerminalColdRestore({
 		pendingInitialStateRef,
 		pendingEventsRef,
 		createOrAttachRef,
+		cancelActiveRequest,
 		setConnectionError,
 		setExitStatus,
 		maybeApplyInitialState,


### PR DESCRIPTION
## 症状

cold-restore パスの \`handleRetryConnection\` と \`handleStartShell\` は \`createOrAttach\` を直接呼ぶが、**\`requestId\` を渡していないため main-side の \`cancelCreateOrAttach\` が効かない**。

結果:
- ユーザーがリトライボタンを押した直後に pane を close → backend attach は走り続け、**孤児 PTY / fd / memory が残る**
- cold-restore 中に新 shell spawn 中にユーザーが pane を閉じる → 同様に孤児化
- 二重起動の race condition: 古い attach の \`onSuccess\` が遅れて届き、新しい attach の state を上書き

## 原因

main-side の cancel API (\`daemon-manager.ts:377\`) は \`requestId\` 必須:

\`\`\`ts
async cancelCreateOrAttach({ paneId, requestId }): Promise<void>
\`\`\`

一方、\`useTerminalColdRestore.ts\` の 2 箇所は requestId を渡さず、かつ unmount 時の cleanup も無い:

\`\`\`ts
// handleRetryConnection
createOrAttachRef.current(
  { paneId, tabId, workspaceId, cols, rows },  // ← requestId なし
  { onSuccess, onError },
);

// handleStartShell
createOrAttachRef.current(
  { paneId, tabId, workspaceId, cols, rows, cwd, skipColdRestore: true, allowKilled: true },  // ← requestId なし
  { onSuccess, onError },
);
\`\`\`

\`useTerminalLifecycle.ts\` の lifecycle attach は既に requestId を通しているが ([:337](https://github.com/MocA-Love/superset/blob/main/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalLifecycle.ts#L337))、cold-restore 経路は対応していなかった。

## 再現シナリオ

### シナリオ 1: 焦って close
1. 接続エラーで auto-retry 発火
2. 2秒 delay 後に \`handleRetryConnection\` が走り始める
3. ユーザーが「まあいいや」と pane を \`Cmd+W\` で close
4. pane の React tree は unmount されるが backend attach はそのまま実行
5. 成功すると **孤児 shell** が PTY を握ったまま残る

### シナリオ 2: cold-restore 中の close
1. 朝アプリ起動 → cold-restore で scrollback 復元表示
2. \`handleStartShell\` が走って新 shell spawn を試みる
3. spawn に 3 秒かかっている最中にユーザーが別の workspace に移動 → pane unmount
4. 新 shell は起動完了するが、誰も attach していない
5. メモリ / fd / PTY リーク

### シナリオ 3: supersede の race
1. auto-retry が連続 2 回走る
2. 1 回目の \`onSuccess\` が遅延して届く
3. 2 回目の \`handleRetryConnection\` が状態を更新した後に 1 回目の callback が再度上書き
4. \`streamReady\` / \`connectionError\` が不整合状態に

## 修正内容

\`useTerminalColdRestore\` に requestId プラミングを追加:

### 1. Hook options に \`cancelCreateOrAttachRef\` を追加

\`\`\`diff
 export interface UseTerminalColdRestoreOptions {
   // ...
   createOrAttachRef: React.MutableRefObject<CreateOrAttachMutate>;
+  cancelCreateOrAttachRef: React.MutableRefObject<TerminalCancelCreateOrAttachMutate>;
   // ...
 }
\`\`\`

### 2. Active request id を ref で追跡

\`\`\`ts
const activeRequestIdRef = useRef<string | null>(null);

const cancelActiveRequest = useCallback(() => {
  const current = activeRequestIdRef.current;
  if (!current) return;
  activeRequestIdRef.current = null;
  cancelCreateOrAttachRef.current({ paneId, requestId: current });
}, [paneId, cancelCreateOrAttachRef]);

// Cancel on unmount
useEffect(() => cancelActiveRequest, [cancelActiveRequest]);
\`\`\`

### 3. \`handleRetryConnection\` / \`handleStartShell\` で requestId を発行して pass

\`\`\`diff
 // Supersede any previous in-flight attempt
+cancelActiveRequest();
+const requestId = createAttachRequestId(paneId);
+activeRequestIdRef.current = requestId;

 createOrAttachRef.current(
-  { paneId, tabId, workspaceId, cols, rows },
+  { paneId, requestId, tabId, workspaceId, cols, rows },
   {
     onSuccess: (result) => {
+      if (activeRequestIdRef.current !== requestId) return;  // superseded
+      activeRequestIdRef.current = null;
       // ... existing success path
     },
     onError: (error) => {
+      if (activeRequestIdRef.current !== requestId) return;  // superseded
+      activeRequestIdRef.current = null;
       // ... existing error path
     },
   },
 );
\`\`\`

### 4. Terminal.tsx で \`cancelCreateOrAttachRef\` を hook に渡す

\`\`\`diff
 } = useTerminalColdRestore({
   // ...
   createOrAttachRef,
+  cancelCreateOrAttachRef,
   // ...
 });
\`\`\`

## 影響範囲

- **変更ファイル**: 2 ファイル
  - \`useTerminalColdRestore.ts\` (+47 / -1)
  - \`Terminal.tsx\` (+1 line)
- **挙動の退化**: なし。正常系 (pane が生きているまま success/error) では挙動同一。
- **追加される挙動**:
  - unmount 時の cleanup で pending attach を cancel
  - 二重呼び出し時の supersede 保護

## このPR の範囲外 (別 PR 予定)

lifecycle 外の他 3 箇所も同様のリークを持つが、このPR では **cold-restore 経路のみ** に絞って変更量を小さく抑える:

- \`apps/desktop/src/renderer/lib/terminal/launch-command.ts\` (helper attach)
- \`apps/desktop/src/renderer/screens/main/components/WorkspaceInitEffects.tsx\` (workspace setup, 2 箇所)

## 検証

- ✅ \`bun run typecheck\`
- ✅ \`bunx @biomejs/biome check\`

## FORK NOTE

upstream (superset-sh/superset) の \`#3348\` で導入された設計漏れ。cancel API の契約を全 call site に徹底する責任は upstream 側にあるので、upstream が統一対応を入れたらこのパッチは revert / 追従する想定。