### PR TITLE
chore(upstream): PR1 低リスク修正5件バンドル (#3457 #3464 #3462 #3466 #3461)

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -14,10 +14,12 @@ import {
 import { makeAppSetup } from "lib/electron-app/factories/app/setup";
 import {
 	handleAuthCallback,
+	loadToken,
 	parseAuthDeepLink,
 } from "lib/trpc/routers/auth/utils/auth-functions";
 import { fetchGitHubOwner } from "lib/trpc/routers/projects/utils/github";
 import { applyShellEnvToProcess } from "lib/trpc/routers/workspaces/utils/shell-env";
+import { env as mainEnv } from "main/env.main";
 import {
 	DEFAULT_CONFIRM_ON_QUIT,
 	PLATFORM,
@@ -601,6 +603,14 @@ if (!gotTheLock) {
 		// Discover and adopt host-services that survived a previous quit
 		// before the tray initializes, so it shows accurate status immediately.
 		await getHostServiceManager().discoverAll();
+
+		if (IS_DEV) {
+			getHostServiceCoordinator().enableDevReload(async () => {
+				const { token } = await loadToken();
+				if (!token) return null;
+				return { authToken: token, cloudApiUrl: mainEnv.NEXT_PUBLIC_API_URL };
+			});
+		}
 
 		await makeAppSetup(() => MainWindow());
 		setupAutoUpdater();

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -605,7 +605,7 @@ if (!gotTheLock) {
 		await getHostServiceManager().discoverAll();
 
 		if (IS_DEV) {
-			getHostServiceCoordinator().enableDevReload(async () => {
+			getHostServiceManager().enableDevReload(async () => {
 				const { token } = await loadToken();
 				if (!token) return null;
 				return { authToken: token, cloudApiUrl: mainEnv.NEXT_PUBLIC_API_URL };

--- a/apps/desktop/src/main/lib/host-service-coordinator.ts
+++ b/apps/desktop/src/main/lib/host-service-coordinator.ts
@@ -1,6 +1,7 @@
 import * as childProcess from "node:child_process";
 import { randomBytes } from "node:crypto";
 import { EventEmitter } from "node:events";
+import * as fs from "node:fs";
 import { createServer } from "node:net";
 import path from "node:path";
 import { settings } from "@superset/local-db";
@@ -103,6 +104,7 @@ export class HostServiceCoordinator extends EventEmitter {
 	>();
 	private scriptPath = path.join(__dirname, "host-service.js");
 	private machineId = getHashedDeviceId();
+	private devReloadWatcher: fs.FSWatcher | null = null;
 
 	async start(
 		organizationId: string,
@@ -220,6 +222,92 @@ export class HostServiceCoordinator extends EventEmitter {
 				this.restart(orgId, config),
 			),
 		);
+	}
+
+	/**
+	 * Dev-only: watch the built host-service bundle and restart running
+	 * instances when it changes. Gives a fast edit→reload loop for code
+	 * under packages/host-service and src/main/host-service without
+	 * restarting Electron. In-memory host-service state (PTYs, watchers,
+	 * chat streams) is torn down on each reload — this is not true HMR.
+	 */
+	enableDevReload(
+		configProvider: () => Promise<SpawnConfig | null>,
+	): () => void {
+		if (this.devReloadWatcher) return () => {};
+
+		const scriptDir = path.dirname(this.scriptPath);
+		const scriptFile = path.basename(this.scriptPath);
+		let debounce: ReturnType<typeof setTimeout> | null = null;
+		let reloading = false;
+
+		const waitForStableBundle = async (): Promise<boolean> => {
+			const deadline = Date.now() + 5_000;
+			let lastSize = -1;
+			let stableSince = 0;
+			while (Date.now() < deadline) {
+				try {
+					const stat = fs.statSync(this.scriptPath);
+					if (stat.size > 0 && stat.size === lastSize) {
+						if (Date.now() - stableSince >= 150) return true;
+					} else {
+						lastSize = stat.size;
+						stableSince = Date.now();
+					}
+				} catch {
+					lastSize = -1;
+					stableSince = 0;
+				}
+				await new Promise((r) => setTimeout(r, 50));
+			}
+			return false;
+		};
+
+		const trigger = () => {
+			if (debounce) clearTimeout(debounce);
+			debounce = setTimeout(() => {
+				void (async () => {
+					if (reloading) return;
+					if (this.getActiveOrganizationIds().length === 0) return;
+					reloading = true;
+					try {
+						const ready = await waitForStableBundle();
+						if (!ready) {
+							console.warn(
+								"[host-service] bundle did not stabilize, skipping reload",
+							);
+							return;
+						}
+						const config = await configProvider();
+						if (!config) return;
+						console.log(
+							"[host-service] bundle changed, restarting running instances",
+						);
+						await this.restartAll(config);
+					} catch (error) {
+						console.error("[host-service] dev reload failed:", error);
+					} finally {
+						reloading = false;
+					}
+				})();
+			}, 250);
+		};
+
+		try {
+			this.devReloadWatcher = fs.watch(scriptDir, (_event, filename) => {
+				if (filename && filename !== scriptFile) return;
+				trigger();
+			});
+		} catch (error) {
+			console.error("[host-service] failed to enable dev reload:", error);
+			return () => {};
+		}
+
+		return () => {
+			if (debounce) clearTimeout(debounce);
+			this.devReloadWatcher?.close();
+			this.devReloadWatcher = null;
+		};
 	}
 
 	// ── Adoption ──────────────────────────────────────────────────────

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/DashboardSidebarWorkspaceItem.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/DashboardSidebarWorkspaceItem.tsx
@@ -107,6 +107,7 @@ export function DashboardSidebarWorkspaceItem({
 								diffStats={diffStats}
 							/>
 						}
+						isLocalWorkspace={hostType === "local-device"}
 						onCreateSection={handleCreateSection}
 						onMoveToSection={(targetSectionId) =>
 							moveWorkspaceToSection(id, projectId, targetSectionId)
@@ -172,6 +173,7 @@ export function DashboardSidebarWorkspaceItem({
 					onMoveToSection={(targetSectionId) =>
 						moveWorkspaceToSection(id, projectId, targetSectionId)
 					}
+					isLocalWorkspace={hostType === "local-device"}
 					onOpenInFinder={handleOpenInFinder}
 					onCopyPath={handleCopyPath}
 					onRemoveFromSidebar={() => removeWorkspaceFromSidebar(id)}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceContextMenu/DashboardSidebarWorkspaceContextMenu.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceContextMenu/DashboardSidebarWorkspaceContextMenu.tsx
@@ -32,6 +32,7 @@ interface DashboardSidebarWorkspaceContextMenuProps {
 	hoverCardContent?: React.ReactNode;
 	projectId: string;
 	isInSection?: boolean;
+	isLocalWorkspace: boolean;
 	onHoverCardOpen?: () => void;
 	onCreateSection: () => void;
 	onMoveToSection: (sectionId: string | null) => void;
@@ -46,6 +47,7 @@ interface DashboardSidebarWorkspaceContextMenuProps {
 export function DashboardSidebarWorkspaceContextMenu({
 	projectId,
 	isInSection,
+	isLocalWorkspace,
 	onHoverCardOpen,
 	hoverCardContent,
 	onCreateSection,
@@ -81,15 +83,19 @@ export function DashboardSidebarWorkspaceContextMenu({
 				<LuPencil className="size-4 mr-2" />
 				Rename
 			</ContextMenuItem>
-			<ContextMenuSeparator />
-			<ContextMenuItem onSelect={onOpenInFinder}>
-				<LuFolderOpen className="size-4 mr-2" />
-				Open in Finder
-			</ContextMenuItem>
-			<ContextMenuItem onSelect={onCopyPath}>
-				<LuCopy className="size-4 mr-2" />
-				Copy Path
-			</ContextMenuItem>
+			{isLocalWorkspace && (
+				<>
+					<ContextMenuSeparator />
+					<ContextMenuItem onSelect={onOpenInFinder}>
+						<LuFolderOpen className="size-4 mr-2" />
+						Open in Finder
+					</ContextMenuItem>
+					<ContextMenuItem onSelect={onCopyPath}>
+						<LuCopy className="size-4 mr-2" />
+						Copy Path
+					</ContextMenuItem>
+				</>
+			)}
 			<ContextMenuSeparator />
 			<ContextMenuSub>
 				<ContextMenuSubTrigger>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/hooks/useDashboardSidebarWorkspaceItemActions/useDashboardSidebarWorkspaceItemActions.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/hooks/useDashboardSidebarWorkspaceItemActions/useDashboardSidebarWorkspaceItemActions.ts
@@ -1,12 +1,16 @@
 import { toast } from "@superset/ui/sonner";
 import { useMatchRoute, useNavigate } from "@tanstack/react-router";
 import { useState } from "react";
+import { useCopyToClipboard } from "renderer/hooks/useCopyToClipboard";
 import { apiTrpcClient } from "renderer/lib/api-trpc-client";
+import { getHostServiceClientByUrl } from "renderer/lib/host-service-client";
+import { electronTrpcClient } from "renderer/lib/trpc-client";
 import { getDeleteFocusTargetWorkspaceId } from "renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/utils/getDeleteFocusTargetWorkspaceId";
 import { getFlattenedV2WorkspaceIds } from "renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/utils/getFlattenedV2WorkspaceIds";
 import { navigateToV2Workspace } from "renderer/routes/_authenticated/_dashboard/utils/workspace-navigation";
 import { useDashboardSidebarState } from "renderer/routes/_authenticated/hooks/useDashboardSidebarState";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
+import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
 
 interface UseDashboardSidebarWorkspaceItemActionsOptions {
 	workspaceId: string;
@@ -22,6 +26,8 @@ export function useDashboardSidebarWorkspaceItemActions({
 	const navigate = useNavigate();
 	const matchRoute = useMatchRoute();
 	const collections = useCollections();
+	const { activeHostUrl } = useLocalHostService();
+	const { copyToClipboard } = useCopyToClipboard();
 	const { createSection, moveWorkspaceToSection, removeWorkspaceFromSidebar } =
 		useDashboardSidebarState();
 
@@ -106,12 +112,44 @@ export function useDashboardSidebarWorkspaceItemActions({
 		moveWorkspaceToSection(workspaceId, projectId, newSectionId);
 	};
 
-	const handleOpenInFinder = () => {
-		toast.info("Open in Finder is coming soon");
+	const resolveWorktreePath = async (): Promise<string | null> => {
+		if (!activeHostUrl) {
+			toast.error("Host service is not available");
+			return null;
+		}
+		const workspace = await getHostServiceClientByUrl(
+			activeHostUrl,
+		).workspace.get.query({ id: workspaceId });
+		if (!workspace?.worktreePath) {
+			toast.error("Workspace path is not available");
+			return null;
+		}
+		return workspace.worktreePath;
 	};
 
-	const handleCopyPath = () => {
-		toast.info("Copy Path is coming soon");
+	const handleOpenInFinder = async () => {
+		try {
+			const path = await resolveWorktreePath();
+			if (!path) return;
+			await electronTrpcClient.external.openInFinder.mutate(path);
+		} catch (error) {
+			toast.error(
+				`Failed to open in Finder: ${error instanceof Error ? error.message : "Unknown error"}`,
+			);
+		}
+	};
+
+	const handleCopyPath = async () => {
+		try {
+			const path = await resolveWorktreePath();
+			if (!path) return;
+			await copyToClipboard(path);
+			toast.success("Path copied");
+		} catch (error) {
+			toast.error(
+				`Failed to copy path: ${error instanceof Error ? error.message : "Unknown error"}`,
+			);
+		}
 	};
 
 	return {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/components/WorkspaceFilesTreeItem/components/FileContextMenu/FileContextMenu.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/components/WorkspaceFilesTreeItem/components/FileContextMenu/FileContextMenu.tsx
@@ -3,8 +3,7 @@ import {
 	ContextMenuItem,
 	ContextMenuSeparator,
 } from "@superset/ui/context-menu";
-import { toast } from "@superset/ui/sonner";
-import { electronTrpcClient } from "renderer/lib/trpc-client";
+import { PathActionsMenuItems } from "../PathActionsMenuItems";
 
 interface FileContextMenuProps {
 	absolutePath: string;
@@ -23,32 +22,10 @@ export function FileContextMenu({
 		<ContextMenuContent className="w-56">
 			<ContextMenuItem>Open to the Side</ContextMenuItem>
 			<ContextMenuSeparator />
-			<ContextMenuItem
-				onSelect={() =>
-					electronTrpcClient.external.openInFinder.mutate(absolutePath)
-				}
-			>
-				Reveal in Finder
-			</ContextMenuItem>
-			<ContextMenuSeparator />
-			<ContextMenuItem
-				onSelect={() => {
-					navigator.clipboard.writeText(absolutePath);
-					toast.success("Path copied");
-				}}
-			>
-				Copy Path
-			</ContextMenuItem>
-			{relativePath && (
-				<ContextMenuItem
-					onSelect={() => {
-						navigator.clipboard.writeText(relativePath);
-						toast.success("Relative path copied");
-					}}
-				>
-					Copy Relative Path
-				</ContextMenuItem>
-			)}
+			<PathActionsMenuItems
+				absolutePath={absolutePath}
+				relativePath={relativePath}
+			/>
 			<ContextMenuSeparator />
 			<ContextMenuItem onSelect={() => setTimeout(onRename, 0)}>
 				Rename...

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/components/WorkspaceFilesTreeItem/components/FolderContextMenu/FolderContextMenu.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/components/WorkspaceFilesTreeItem/components/FolderContextMenu/FolderContextMenu.tsx
@@ -3,8 +3,7 @@ import {
 	ContextMenuItem,
 	ContextMenuSeparator,
 } from "@superset/ui/context-menu";
-import { toast } from "@superset/ui/sonner";
-import { electronTrpcClient } from "renderer/lib/trpc-client";
+import { PathActionsMenuItems } from "../PathActionsMenuItems";
 
 interface FolderContextMenuProps {
 	absolutePath: string;
@@ -32,32 +31,10 @@ export function FolderContextMenu({
 				New Folder...
 			</ContextMenuItem>
 			<ContextMenuSeparator />
-			<ContextMenuItem
-				onSelect={() =>
-					electronTrpcClient.external.openInFinder.mutate(absolutePath)
-				}
-			>
-				Reveal in Finder
-			</ContextMenuItem>
-			<ContextMenuSeparator />
-			<ContextMenuItem
-				onSelect={() => {
-					navigator.clipboard.writeText(absolutePath);
-					toast.success("Path copied");
-				}}
-			>
-				Copy Path
-			</ContextMenuItem>
-			{relativePath && (
-				<ContextMenuItem
-					onSelect={() => {
-						navigator.clipboard.writeText(relativePath);
-						toast.success("Relative path copied");
-					}}
-				>
-					Copy Relative Path
-				</ContextMenuItem>
-			)}
+			<PathActionsMenuItems
+				absolutePath={absolutePath}
+				relativePath={relativePath}
+			/>
 			<ContextMenuSeparator />
 			<ContextMenuItem onSelect={() => setTimeout(onRename, 0)}>
 				Rename...

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/components/WorkspaceFilesTreeItem/components/PathActionsMenuItems/PathActionsMenuItems.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/components/WorkspaceFilesTreeItem/components/PathActionsMenuItems/PathActionsMenuItems.tsx
@@ -1,0 +1,59 @@
+import {
+	ContextMenuItem,
+	ContextMenuSeparator,
+} from "@superset/ui/context-menu";
+import { toast } from "@superset/ui/sonner";
+import { useCopyToClipboard } from "renderer/hooks/useCopyToClipboard";
+import { electronTrpcClient } from "renderer/lib/trpc-client";
+
+interface PathActionsMenuItemsProps {
+	absolutePath: string;
+	relativePath?: string;
+}
+
+export function PathActionsMenuItems({
+	absolutePath,
+	relativePath,
+}: PathActionsMenuItemsProps) {
+	const { copyToClipboard } = useCopyToClipboard();
+
+	const handleCopy = async (path: string, successMessage: string) => {
+		try {
+			await copyToClipboard(path);
+			toast.success(successMessage);
+		} catch (error) {
+			toast.error(
+				`Failed to copy path: ${error instanceof Error ? error.message : "Unknown error"}`,
+			);
+		}
+	};
+
+	const handleRevealInFinder = async () => {
+		try {
+			await electronTrpcClient.external.openInFinder.mutate(absolutePath);
+		} catch (error) {
+			toast.error(
+				`Failed to reveal in Finder: ${error instanceof Error ? error.message : "Unknown error"}`,
+			);
+		}
+	};
+
+	return (
+		<>
+			<ContextMenuItem onSelect={handleRevealInFinder}>
+				Reveal in Finder
+			</ContextMenuItem>
+			<ContextMenuSeparator />
+			<ContextMenuItem onSelect={() => handleCopy(absolutePath, "Path copied")}>
+				Copy Path
+			</ContextMenuItem>
+			{relativePath && (
+				<ContextMenuItem
+					onSelect={() => handleCopy(relativePath, "Relative path copied")}
+				>
+					Copy Relative Path
+				</ContextMenuItem>
+			)}
+		</>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/components/WorkspaceFilesTreeItem/components/PathActionsMenuItems/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/components/WorkspaceFilesTreeItem/components/PathActionsMenuItems/index.ts
@@ -1,0 +1,1 @@
+export { PathActionsMenuItems } from "./PathActionsMenuItems";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/layout.tsx
@@ -29,7 +29,7 @@ function V2WorkspaceLayout() {
 	const { machineId, activeHostUrl } = useLocalHostService();
 	const { ensureWorkspaceInSidebar } = useDashboardSidebarState();
 
-	const { data: workspacesWithHost = [] } = useLiveQuery(
+	const { data: workspacesWithHost = [], isReady } = useLiveQuery(
 		(q) =>
 			q
 				.from({ v2Workspaces: collections.v2Workspaces })
@@ -64,22 +64,14 @@ function V2WorkspaceLayout() {
 		ensureWorkspaceInSidebar(workspace.id, workspace.projectId);
 	}, [ensureWorkspaceInSidebar, workspace]);
 
-	// TODO: This renders child routes without WorkspaceTrpcProvider when
-	// the workspace hasn't loaded from collections yet, or during route
-	// transitions (e.g. navigating away from a workspace). If the outgoing
-	// workspace page hasn't fully unmounted, its components (TerminalPane,
-	// etc.) will crash with "useWorkspaceClient must be used within
-	// WorkspaceClientProvider". Either the layout should never render
-	// children without the provider, or the provider should move to the
-	// page level so each page owns its own context.
-	if (!workspaceId || !workspace) {
-		return <Outlet />;
+	if (!workspaceId || !isReady) {
+		return null;
 	}
 
-	if (!hostUrl) {
+	if (!workspace || !hostUrl) {
 		return (
 			<div className="flex h-full w-full items-center justify-center text-muted-foreground">
-				Workspace host service not available
+				Workspace not found
 			</div>
 		);
 	}

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/layout.tsx
@@ -140,7 +140,16 @@ function SettingsLayout() {
 	useHotkeys(
 		"escape",
 		(event) => {
-			if (document.querySelector('[data-state="open"]')) return;
+			// FORK NOTE: upstream #3466 used `[data-state="open"]` which also
+			// matches Radix Collapsible (AgentCard etc.), silently disabling
+			// Escape whenever any card was expanded. Narrow to role-based
+			// overlays only so we still defer to open Dialog/Menu/Select.
+			if (
+				document.querySelector(
+					'[role="dialog"][data-state="open"], [role="alertdialog"][data-state="open"], [role="menu"][data-state="open"], [role="listbox"][data-state="open"]',
+				)
+			)
+				return;
 			event.preventDefault();
 			navigate({ to: originRoute });
 		},

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/layout.tsx
@@ -142,11 +142,14 @@ function SettingsLayout() {
 		(event) => {
 			// FORK NOTE: upstream #3466 used `[data-state="open"]` which also
 			// matches Radix Collapsible (AgentCard etc.), silently disabling
-			// Escape whenever any card was expanded. Narrow to role-based
-			// overlays only so we still defer to open Dialog/Menu/Select.
+			// Escape whenever any card was expanded. Narrow to explicit
+			// overlay shapes: role-based (Dialog/AlertDialog/Menu/Select) plus
+			// popper-based content (Popover/HoverCard) which has no semantic
+			// role but is always rendered inside [data-radix-popper-content-wrapper].
+			// Collapsible is inline (not popper), so it stays excluded.
 			if (
 				document.querySelector(
-					'[role="dialog"][data-state="open"], [role="alertdialog"][data-state="open"], [role="menu"][data-state="open"], [role="listbox"][data-state="open"]',
+					'[role="dialog"][data-state="open"], [role="alertdialog"][data-state="open"], [role="menu"][data-state="open"], [role="listbox"][data-state="open"], [data-radix-popper-content-wrapper] [data-state="open"]',
 				)
 			)
 				return;

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/layout.tsx
@@ -154,7 +154,7 @@ function SettingsLayout() {
 			)
 				return;
 			event.preventDefault();
-			navigate({ to: originRoute });
+			navigate({ to: originRoute, replace: true });
 		},
 		{ enableOnFormTags: false, enableOnContentEditable: false },
 		[navigate, originRoute],

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/layout.tsx
@@ -5,10 +5,12 @@ import {
 	useNavigate,
 } from "@tanstack/react-router";
 import { useEffect } from "react";
+import { useHotkeys } from "react-hotkeys-hook";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import {
 	type SettingsSection,
 	useSetSettingsSearchQuery,
+	useSettingsOriginRoute,
 	useSettingsSearchQuery,
 } from "renderer/stores/settings-state";
 import { SearchResultsBanner } from "./components/SearchResultsBanner";
@@ -105,6 +107,7 @@ function SettingsLayout() {
 	const isMac = platform === undefined || platform === "darwin";
 	const searchQuery = useSettingsSearchQuery();
 	const setSearchQuery = useSetSettingsSearchQuery();
+	const originRoute = useSettingsOriginRoute();
 	const location = useLocation();
 	const navigate = useNavigate();
 	const normalizedSearchQuery = searchQuery.trim();
@@ -133,6 +136,17 @@ function SettingsLayout() {
 			}
 		}
 	}, [isSearchActive, location.pathname, navigate, normalizedSearchQuery]);
+
+	useHotkeys(
+		"escape",
+		(event) => {
+			if (document.querySelector('[data-state="open"]')) return;
+			event.preventDefault();
+			navigate({ to: originRoute });
+		},
+		{ enableOnFormTags: false, enableOnContentEditable: false },
+		[navigate, originRoute],
+	);
 
 	return (
 		<div className="flex flex-col h-screen w-screen bg-tertiary">

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/helpers.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/helpers.ts
@@ -169,6 +169,9 @@ export function createTerminalInWrapper(options: CreateTerminalOptions = {}): {
 			}
 		},
 		onFileLinkClick: (event, link) => {
+			if (!event.metaKey && !event.ctrlKey) {
+				return;
+			}
 			if (onFileLinkClick) {
 				onFileLinkClick(event, link);
 				return;


### PR DESCRIPTION
## 概要

upstream superset-sh/superset から、低リスクな小修正5件をまとめて取り込みます。前回マージ (PR #159〜#163) 以降に追加された12コミットのうち、最もリスクの低いものを切り出した最初のPRです。

## 取り込む upstream コミット

| # | Commit | 内容 |
|---|--------|------|
| 1 | [#3457](https://github.com/superset-sh/superset/pull/3457) `a3e34bf0d` | fix(desktop): v1 terminal のファイルリンクに Cmd/Ctrl+クリック要件を復元 (3行追加) |
| 2 | [#3464](https://github.com/superset-sh/superset/pull/3464) `57557f806` | fix(desktop): v2 workspace の子要素を collection readiness でゲート |
| 3 | [#3462](https://github.com/superset-sh/superset/pull/3462) `4ee2e612e` | fix(desktop): v2 sidebar の copy path をネイティブクリップボード経由に |
| 4 | [#3466](https://github.com/superset-sh/superset/pull/3466) `87d6e93d4` | feat(desktop): Settings を Escape キーで閉じる |
| 5 | [#3461](https://github.com/superset-sh/superset/pull/3461) `9c7f5f489` | chore(desktop): 開発モードで bundle 変更時に host-service を自動再起動 |

## フォーク適応修正 (追加1コミット)

Codex の事前レビューで 2 件の問題を検出したため、cherry-pick の上に `fix(fork): adapt upstream PR1 low-risk bundle for fork divergence` を積んでいます。

### 1. `apps/desktop/src/main/index.ts`
upstream #3461 は `getHostServiceCoordinator()` を dev-reload 呼び出し箇所で直接使用しますが、フォークは同じシンボルを quit ライフサイクル互換のため `getHostServiceManager` として alias import しています (`apps/desktop/src/main/index.ts:41`)。そのままではビルドが壊れるため、新規呼び出しも alias 名に書き換えました。

### 2. `apps/desktop/src/renderer/routes/_authenticated/settings/layout.tsx`
upstream #3466 は `[data-state=\"open\"]` で Radix オーバーレイ検出をしていましたが、この selector は Radix **Collapsible** にもマッチします。Settings → Agents の `AgentCard` は Collapsible を使用しているため、カードを展開しただけで Escape による Settings クローズが silent に無効化される回帰がありました。

selector を role ベースに狭めて修正:
- `[role=\"dialog\"][data-state=\"open\"]` (Dialog, Sheet)
- `[role=\"alertdialog\"][data-state=\"open\"]` (AlertDialog)
- `[role=\"menu\"][data-state=\"open\"]` (DropdownMenu, ContextMenu)
- `[role=\"listbox\"][data-state=\"open\"]` (Select, Combobox)

Tooltip は `data-state=\"delayed-open\"` / `\"instant-open\"` を使うので Escape の対象外でも問題ありません。

## 衝突・リグレッション調査結果 (Codex承認)

- **v1 terminal helpers.ts**: 3行追加のみ。フォーク固有の stream / cold-restore 実装 (`v1-terminal-cache.ts`, `useTerminalLifecycle.ts` 等) とは独立。
- **v2 sidebar copy path**: フォーク独自の `isLocalWorkspace={hostType === \"local-device\"}` ゲートはそのまま維持され、relay 導入後の local/remote 区別と整合。
- **host-service dev reload**: 上記 fix(fork) 適用後、フォークの `host-service-coordinator` rename と整合。
- **v2 collection readiness gate**: フォークの `v2Hosts` join 前提と矛盾なし。

## テスト

- [x] `bun install --frozen-lockfile`
- [x] `bun run typecheck`  
- [x] `bun run lint`
- [ ] 実機スモーク: Settings 内で Dialog / Popover / Select を開いた状態の Esc 挙動、ローカル workspace の Context Menu → Open in Finder / Copy Path

## 次のステップ

このPRマージ後、PR2 (MCP OAuth + tray refactor) に進みます。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  - ローカルワークスペースのファイルをFinderで開く、パスをコピー機能を実装
  - ファイル・フォルダーのコンテキストメニューにパス操作を追加
  - 設定画面でEscapeキーで前画面に戻る機能を追加

* **改善**
  - ワークスペース読み込み安定性の向上

<!-- end of auto-generated comment: release notes by coderabbit.ai -->