### PR TITLE
upstream merge PR7: IME composition guard for new-workspace Enter handlers

### DIFF
--- a/apps/desktop/src/renderer/components/NewWorkspaceModal/components/PromptGroup/PromptGroup.tsx
+++ b/apps/desktop/src/renderer/components/NewWorkspaceModal/components/PromptGroup/PromptGroup.tsx
@@ -22,6 +22,7 @@ import {
 	CommandSeparator,
 } from "@superset/ui/command";
 import { Input } from "@superset/ui/input";
+import { isEnterSubmit } from "@superset/ui/lib/keyboard";
 import { Popover, PopoverContent, PopoverTrigger } from "@superset/ui/popover";
 import { toast } from "@superset/ui/sonner";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
@@ -1072,10 +1073,9 @@ ${sanitizeText(truncatedBody)}`;
 	useEffect(() => {
 		if (!isNewWorkspaceModalOpen) return;
 		const handler = (e: KeyboardEvent) => {
-			if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
-				e.preventDefault();
-				void handleCreate();
-			}
+			if (!isEnterSubmit(e, { requireMod: true })) return;
+			e.preventDefault();
+			void handleCreate();
 		};
 		window.addEventListener("keydown", handler);
 		return () => window.removeEventListener("keydown", handler);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/$taskId/components/TaskMarkdownRenderer/TaskMarkdownRenderer.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/$taskId/components/TaskMarkdownRenderer/TaskMarkdownRenderer.tsx
@@ -1,6 +1,7 @@
 import "highlight.js/styles/github-dark.css";
 import "./task-markdown.css";
 
+import { isEnterSubmit } from "@superset/ui/lib/keyboard";
 import { cn } from "@superset/ui/utils";
 import { Extension } from "@tiptap/core";
 import { Blockquote } from "@tiptap/extension-blockquote";
@@ -247,11 +248,9 @@ export function TaskMarkdownRenderer({
 				class: cn("focus:outline-none min-h-[100px]", editorClassName),
 			},
 			handleKeyDown: (_, event) => {
-				if ((event.metaKey || event.ctrlKey) && event.key === "Enter") {
-					onModEnter?.();
-					return true;
-				}
-				return false;
+				if (!isEnterSubmit(event, { requireMod: true })) return false;
+				onModEnter?.();
+				return true;
 			},
 		},
 		onUpdate: ({ editor }) => {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/components/TasksTopBar/components/CreateTaskDialog/CreateTaskDialog.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/components/TasksTopBar/components/CreateTaskDialog/CreateTaskDialog.tsx
@@ -11,6 +11,7 @@ import {
 	DialogTitle,
 } from "@superset/ui/dialog";
 import { Kbd, KbdGroup } from "@superset/ui/kbd";
+import { isEnterSubmit } from "@superset/ui/lib/keyboard";
 import { toast } from "@superset/ui/sonner";
 import { useLiveQuery } from "@tanstack/react-db";
 import { useNavigate } from "@tanstack/react-router";
@@ -202,10 +203,9 @@ export function CreateTaskDialog({
 						value={title}
 						onChange={(event) => setTitle(event.target.value)}
 						onKeyDown={(event) => {
-							if (event.key === "Enter" && (event.metaKey || event.ctrlKey)) {
-								event.preventDefault();
-								void handleCreate();
-							}
+							if (!isEnterSubmit(event, { requireMod: true })) return;
+							event.preventDefault();
+							void handleCreate();
 						}}
 						placeholder="Task title"
 						className="w-full bg-transparent text-3xl font-semibold tracking-tight outline-none placeholder:text-muted-foreground/60"

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/PromptGroup.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/PromptGroup.tsx
@@ -9,6 +9,7 @@ import {
 	useProviderAttachments,
 } from "@superset/ui/ai-elements/prompt-input";
 import { Input } from "@superset/ui/input";
+import { isEnterSubmit } from "@superset/ui/lib/keyboard";
 import { cn } from "@superset/ui/utils";
 import { AnimatePresence, motion } from "framer-motion";
 import { ArrowUpIcon } from "lucide-react";
@@ -135,10 +136,9 @@ export function PromptGroup({
 	useEffect(() => {
 		if (!isNewWorkspaceModalOpen) return;
 		const handler = (e: KeyboardEvent) => {
-			if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
-				e.preventDefault();
-				void handleCreate();
-			}
+			if (!isEnterSubmit(e, { requireMod: true })) return;
+			e.preventDefault();
+			void handleCreate();
 		};
 		window.addEventListener("keydown", handler);
 		return () => window.removeEventListener("keydown", handler);

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/CommitInput/CommitInput.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/CommitInput/CommitInput.tsx
@@ -8,6 +8,7 @@ import {
 	DropdownMenuSeparator,
 	DropdownMenuTrigger,
 } from "@superset/ui/dropdown-menu";
+import { isEnterSubmit } from "@superset/ui/lib/keyboard";
 import { toast } from "@superset/ui/sonner";
 import { Textarea } from "@superset/ui/textarea";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
@@ -557,14 +558,10 @@ export function CommitInput({
 						onChange={(e) => setCommitMessage(e.target.value)}
 						className="min-h-[52px] resize-none text-[10px] bg-background pr-7"
 						onKeyDown={(e) => {
-							if (
-								e.key === "Enter" &&
-								(e.metaKey || e.ctrlKey) &&
-								!primary.disabled
-							) {
-								e.preventDefault();
-								primary.handler();
-							}
+							if (!isEnterSubmit(e, { requireMod: true })) return;
+							if (primary.disabled) return;
+							e.preventDefault();
+							primary.handler();
 						}}
 					/>
 				</div>

--- a/packages/ui/src/components/ai-elements/prompt-input.tsx
+++ b/packages/ui/src/components/ai-elements/prompt-input.tsx
@@ -34,6 +34,7 @@ import {
 	useRef,
 	useState,
 } from "react";
+import { isEnterSubmit } from "../../lib/keyboard";
 import { cn } from "../../lib/utils";
 import { Button } from "../ui/button";
 import {
@@ -973,12 +974,8 @@ export const PromptInputTextarea = ({
 		}
 
 		if (e.key === "Enter") {
-			if (isComposing || e.nativeEvent.isComposing) {
-				return;
-			}
-			if (e.shiftKey) {
-				return;
-			}
+			if (isComposing) return;
+			if (!isEnterSubmit(e)) return;
 			e.preventDefault();
 
 			// Check if the submit button is disabled before submitting

--- a/packages/ui/src/lib/keyboard.ts
+++ b/packages/ui/src/lib/keyboard.ts
@@ -1,0 +1,31 @@
+import type { KeyboardEvent as ReactKeyboardEvent } from "react";
+
+type AnyKeyboardEvent = KeyboardEvent | ReactKeyboardEvent;
+
+// True while an IME (Japanese/Chinese/Korean) composition is in progress.
+// `keyCode === 229` is the legacy signal some browsers still emit during
+// composition even when `isComposing` is not set.
+export const isImeComposing = (e: AnyKeyboardEvent): boolean => {
+	const native = "nativeEvent" in e ? e.nativeEvent : e;
+	return native.isComposing || native.keyCode === 229;
+};
+
+export type IsEnterSubmitOptions = {
+	// Require Cmd (mac) / Ctrl (other) to be held. Defaults to false.
+	requireMod?: boolean;
+	// Treat Shift+Enter as submit. Defaults to false (Shift+Enter = newline).
+	allowShift?: boolean;
+};
+
+// Returns true only for an Enter press that should trigger a submit:
+// not during IME composition, and matching the modifier policy.
+export const isEnterSubmit = (
+	e: AnyKeyboardEvent,
+	{ requireMod = false, allowShift = false }: IsEnterSubmitOptions = {},
+): boolean => {
+	if (e.key !== "Enter") return false;
+	if (isImeComposing(e)) return false;
+	if (!allowShift && e.shiftKey) return false;
+	if (requireMod && !(e.metaKey || e.ctrlKey)) return false;
+	return true;
+};


### PR DESCRIPTION
## 概要

upstream の `9fff075f3` (fix(desktop): handle IME composition in new-workspace Enter handlers, #3486) をフォークに取り込みます。behind 1 → 0 化を目的とするシリーズの最後のPRです。

日本語/中国語 IME ユーザーが変換確定の Enter で new-workspace モーダルが誤動作する問題を修正します。

## 取り込み対象 upstream コミット

| commit | タイトル |
|---|---|
| `9fff075f3` | fix(desktop): handle IME composition in new-workspace Enter handlers (#3486) |

変更内容:
1. `packages/ui/src/lib/keyboard.ts` 新設: `isImeComposing()` / `isEnterSubmit()` ヘルパー
2. v1 `NewWorkspaceModal` の `PromptGroup` を `isEnterSubmit(e, { requireMod: true })` に移行
3. v2 `DashboardNewWorkspaceModal` の `PromptGroup` を同上
4. `PromptInputTextarea` を helper 経由に統一（`isComposing` state は据え置き）

チェリーピックはクリーン（コンフリクトなし）。

## フォーク適応修正 (bae99d0dc)

Codex 事前レビューで指摘されたフォーク特有の `Cmd/Ctrl+Enter` ハンドラ 3 箇所を同じ helper に揃えました。従来は IME 変換確定 Enter で誤発火する可能性がありました。

- `CommitInput.tsx` (Changes sidebar のコミットショートカット)
- `CreateTaskDialog.tsx` (タスク作成ダイアログの title input)
- `TaskMarkdownRenderer.tsx` (TipTap `editorProps.handleKeyDown`)

いずれも `isEnterSubmit(e, { requireMod: true })` に移行。副次的な差分として `Cmd/Ctrl+Shift+Enter` での送信は落ちます（upstream の方針と一致）。

## Codex レビュー結果

- **事前**: No 判定。本体差分は安全だが、フォーク固有の 3 箇所が未対応で IME 対応として未完という指摘 → 上記 fork-adaptation commit で修正
- **事後**: **Yes 判定**。ProseMirror 経由の TipTap ケースも `AnyKeyboardEvent` 型で問題なし。唯一の挙動差分（Shift+Mod+Enter 非送信）は upstream の方針と整合

## テストチェックリスト

- [ ] v1 new-workspace モーダル: 日本語 IME で漢字変換 Enter → 送信されない
- [ ] v1 new-workspace モーダル: 通常 `Cmd/Ctrl+Enter` → 送信される
- [ ] v2 dashboard new-workspace モーダル: 同上
- [ ] Changes sidebar commit textarea: 日本語 IME 変換 Enter → commit されない
- [ ] Changes sidebar commit textarea: `Cmd/Ctrl+Enter` → commit される
- [ ] CreateTaskDialog title input: 同上
- [ ] TaskMarkdownRenderer (TipTap): 同上
- [ ] `PromptInputTextarea` (チャット): `Shift+Enter` = 改行、`Enter` = 送信、IME 変換中 Enter = 送信されない

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# リリースノート

* **Refactor**
  * キーボードショートカット処理の統一化により、Enter キーと修飾キー（Cmd/Ctrl）の検出ロジックを複数の入力フィールドで統一。IME 入力対応を改善し、キーボード操作の一貫性と安定性を向上させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->