### PR TITLE
fix(desktop): TODO新規worktree作成時のgit worktree add競合を解消

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"829fc425-e345-432d-adda-aa50d5c6e7fe","pid":77476,"acquiredAt":1776291557970}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"829fc425-e345-432d-adda-aa50d5c6e7fe","pid":77476,"acquiredAt":1776291557970}

--- a/apps/desktop/src/main/todo-agent/trpc-router.ts
+++ b/apps/desktop/src/main/todo-agent/trpc-router.ts
@@ -7,6 +7,7 @@ import { observable } from "@trpc/server/observable";
 import { desc, eq } from "drizzle-orm";
 import { publicProcedure, router } from "lib/trpc";
 import { localDb } from "main/lib/local-db";
+import { workspaceInitManager } from "main/lib/workspace-init-manager";
 import { z } from "zod";
 import { describeEnhanceFailure, enhanceTodoText } from "./enhance-text";
 import {
@@ -37,6 +38,23 @@ export const createTodoAgentRouter = () => {
 		create: publicProcedure
 			.input(todoCreateInputSchema)
 			.mutation(async ({ input }) => {
+				// When the UI creates a fresh workspace+worktree immediately
+				// before creating the TODO (the "新しい worktree を作成して実行"
+				// checkbox), `workspaces.create` returns while `git worktree
+				// add` is still running in the background. Materializing the
+				// artifact directory now would mkdir inside the future
+				// worktree path, leaving it non-empty and causing the
+				// subsequent `git worktree add` to fail — the symptom users
+				// see as the sidebar error + "ブランチ取得中…" that never
+				// resolves. Block until init is done (or already no-op) so
+				// prepareArtifacts runs against a real worktree.
+				await workspaceInitManager.waitForInit(input.workspaceId);
+				if (workspaceInitManager.hasFailed(input.workspaceId)) {
+					throw new Error(
+						`todo-agent: workspace ${input.workspaceId} の初期化に失敗しました`,
+					);
+				}
+
 				const store = getTodoSessionStore();
 				const worktreePath = resolveWorktreePath(input.workspaceId);
 				if (!worktreePath) {

--- a/apps/desktop/src/main/todo-agent/trpc-router.ts
+++ b/apps/desktop/src/main/todo-agent/trpc-router.ts
@@ -48,11 +48,32 @@ export const createTodoAgentRouter = () => {
 				// see as the sidebar error + "ブランチ取得中…" that never
 				// resolves. Block until init is done (or already no-op) so
 				// prepareArtifacts runs against a real worktree.
-				await workspaceInitManager.waitForInit(input.workspaceId);
-				if (workspaceInitManager.hasFailed(input.workspaceId)) {
-					throw new Error(
-						`todo-agent: workspace ${input.workspaceId} の初期化に失敗しました`,
+				//
+				// `waitForInit` has a 30s internal timeout that resolves
+				// silently even if init is still running, so a slow
+				// fetch/clone path could still slip through. Loop on the
+				// `isInitializing` flag so we really block until the job
+				// reaches a terminal state, up to a generous ceiling.
+				const INIT_WAIT_STEP_MS = 30_000;
+				const INIT_WAIT_CEILING_MS = 10 * 60_000;
+				const waitStartedAt = Date.now();
+				while (workspaceInitManager.isInitializing(input.workspaceId)) {
+					if (Date.now() - waitStartedAt > INIT_WAIT_CEILING_MS) {
+						throw new TRPCError({
+							code: "TIMEOUT",
+							message: `todo-agent: workspace ${input.workspaceId} の初期化が時間内に終わりませんでした`,
+						});
+					}
+					await workspaceInitManager.waitForInit(
+						input.workspaceId,
+						INIT_WAIT_STEP_MS,
 					);
+				}
+				if (workspaceInitManager.hasFailed(input.workspaceId)) {
+					throw new TRPCError({
+						code: "PRECONDITION_FAILED",
+						message: `todo-agent: workspace ${input.workspaceId} の初期化に失敗しました`,
+					});
 				}
 
 				const store = getTodoSessionStore();


### PR DESCRIPTION
## 概要

Issue #188 の対応。TodoModal で「新しい worktree を作成して実行」にチェックを付けて作成すると、

- 左サイドバーからそのワークスペースを選択するとエラー
- AgentManager 右サイドバーの「ブランチ取得中…」が永久に解消されない

という症状が発生していた。

## 根本原因

\`workspaces.create\` mutation は DB 行を挿入したあと \`initializeWorkspaceWorktree\` を **await せず**（fire-and-forget で）返す。
TodoModal は戻り値を受け取ると即座に \`todoAgent.create\` を呼び、\`supervisor.prepareArtifacts\` が \`<worktreePath>/.superset/todo/<id>/goal.md\` を mkdir + 書き込みしていた。

この時点では \`git worktree add\` がまだ走っておらず、ターゲットディレクトリを先に作ってしまうため、その後の \`git worktree add\` が「path is not empty」で失敗。結果として worktree はディスク上に実体を持たないまま DB 行だけが残り、選択時エラー、\`gitSnapshot\` の \`git rev-parse\` も空返答になり「ブランチ取得中…」で止まっていた。

## 修正

\`todoAgent.create\` mutation の先頭で \`workspaceInitManager.waitForInit(workspaceId)\` を await し、初期化完了後に \`prepareArtifacts\` を実行するように変更。初期化が failed だった場合は明示的にエラーを投げる。

\`waitForInit\` は対象 job が登録されていなければ即 resolve するため、既存 worktree を選んだ場合のパスには影響しない。

## Test plan
- [ ] 新規 worktree 付きで TODO 作成 → ディスク上に worktree が正しく作られ、左サイドバー選択もエラーにならない
- [ ] AgentManager 右サイドバーにブランチ名が表示される
- [ ] 既存 worktree 上での TODO 作成が従来どおり即時に成功する

Closes #188

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## バグ修正
* アプリケーション初期化時の信頼性が向上しました
* 初期化失敗時の適切なエラー処理が実装されました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->