### PR TITLE
fix(desktop): TODOのStopでclaudeが止まらない問題を修正

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"829fc425-e345-432d-adda-aa50d5c6e7fe","pid":77476,"acquiredAt":1776291557970}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"829fc425-e345-432d-adda-aa50d5c6e7fe","pid":77476,"acquiredAt":1776291557970}

--- a/apps/desktop/src/main/todo-agent/supervisor.ts
+++ b/apps/desktop/src/main/todo-agent/supervisor.ts
@@ -1,4 +1,4 @@
-import { type ChildProcess, spawn } from "node:child_process";
+import { type ChildProcess, spawn, spawnSync } from "node:child_process";
 import { createHash, randomUUID } from "node:crypto";
 import { mkdirSync, writeFileSync } from "node:fs";
 import path from "node:path";
@@ -118,22 +118,21 @@ class TodoSupervisor {
 		}
 		if (this.active?.sessionId === sessionId) {
 			this.active.abortController.abort();
-			// Send SIGINT first (clean shutdown), then SIGKILL as a safety
-			// net via a short timer so we never leak a runaway child.
+			// Kill the whole process group, not just the direct child.
+			// `claude -p` spawns its own children (the Node-side agent
+			// loop, MCP servers, tool helpers). A plain `child.kill()`
+			// on the wrapper only signals the wrapper, leaving the
+			// grandchildren alive and still talking to the Anthropic
+			// API — the exact symptom users hit when Stop doesn't
+			// actually stop. We `spawn` with `detached: true` so the
+			// child becomes a session leader; here we signal the
+			// negative PID to reach every descendant.
 			const child = this.active.currentChild;
-			if (child && !child.killed) {
-				try {
-					child.kill("SIGINT");
-				} catch {
-					// ignore
-				}
+			if (child?.pid && !child.killed) {
+				killProcessTree(child.pid, "SIGINT");
 				setTimeout(() => {
-					if (child && !child.killed) {
-						try {
-							child.kill("SIGKILL");
-						} catch {
-							// ignore
-						}
+					if (child.pid && !child.killed) {
+						killProcessTree(child.pid, "SIGKILL");
 					}
 				}, 1500);
 			}
@@ -504,6 +503,13 @@ class TodoSupervisor {
 				child = spawn("claude", args, {
 					cwd: params.cwd,
 					env: process.env,
+					// Make the child a session / process-group leader so
+					// `abort()` can signal the whole tree via negative PID.
+					// Without this, killing only the direct child leaves
+					// claude's own subprocesses (MCP servers, tool
+					// helpers) alive, which is exactly the "Stop doesn't
+					// stop" bug users hit.
+					detached: process.platform !== "win32",
 				});
 			} catch (error) {
 				resolve({
@@ -531,10 +537,8 @@ class TodoSupervisor {
 			let settled = false;
 
 			const onAbort = () => {
-				try {
-					child.kill("SIGINT");
-				} catch {
-					// ignore
+				if (child.pid) {
+					killProcessTree(child.pid, "SIGINT");
 				}
 			};
 			params.signal.addEventListener("abort", onAbort);
@@ -656,6 +660,40 @@ export function getTodoSupervisor(): TodoSupervisor {
 }
 
 // ---- helpers ----
+
+/**
+ * Kill a process and every descendant it spawned. On POSIX this
+ * uses the negative PID trick to signal the whole process group
+ * (requires the child to have been spawned with `detached: true`
+ * so it is a session leader). On Windows we fall back to
+ * `taskkill /T /F` via the synchronous child_process API.
+ */
+function killProcessTree(
+	pid: number,
+	signal: NodeJS.Signals,
+): void {
+	if (process.platform === "win32") {
+		try {
+			spawnSync("taskkill", ["/pid", String(pid), "/T", "/F"]);
+		} catch {
+			// ignore — best-effort
+		}
+		return;
+	}
+	try {
+		process.kill(-pid, signal);
+	} catch {
+		// Process group might already be gone (e.g. the child exited
+		// on its own between the check and the signal). Try the
+		// direct pid as a fallback so we still kill the wrapper if it
+		// is the only thing still alive.
+		try {
+			process.kill(pid, signal);
+		} catch {
+			// ignore
+		}
+	}
+}
 
 function renderGoalDoc(session: SelectTodoSession): string {
 	const lines: string[] = [

--- a/apps/desktop/src/main/todo-agent/supervisor.ts
+++ b/apps/desktop/src/main/todo-agent/supervisor.ts
@@ -668,10 +668,7 @@ export function getTodoSupervisor(): TodoSupervisor {
  * so it is a session leader). On Windows we fall back to
  * `taskkill /T /F` via the synchronous child_process API.
  */
-function killProcessTree(
-	pid: number,
-	signal: NodeJS.Signals,
-): void {
+function killProcessTree(pid: number, signal: NodeJS.Signals): void {
 	if (process.platform === "win32") {
 		try {
 			spawnSync("taskkill", ["/pid", String(pid), "/T", "/F"]);

--- a/apps/desktop/src/main/todo-agent/supervisor.ts
+++ b/apps/desktop/src/main/todo-agent/supervisor.ts
@@ -1,4 +1,4 @@
-import { type ChildProcess, spawn, spawnSync } from "node:child_process";
+import { type ChildProcess, spawn } from "node:child_process";
 import { createHash, randomUUID } from "node:crypto";
 import { mkdirSync, writeFileSync } from "node:fs";
 import path from "node:path";
@@ -128,13 +128,21 @@ class TodoSupervisor {
 			// child becomes a session leader; here we signal the
 			// negative PID to reach every descendant.
 			const child = this.active.currentChild;
-			if (child?.pid && !child.killed) {
-				killProcessTree(child.pid, "SIGINT");
-				setTimeout(() => {
-					if (child.pid && !child.killed) {
-						killProcessTree(child.pid, "SIGKILL");
+			if (child?.pid) {
+				const pid = child.pid;
+				killProcessTree(pid, "SIGINT");
+				// Use an exit-aware guard instead of `child.killed`.
+				// `killProcessTree` signals via `process.kill(-pid, ...)`
+				// so the node `ChildProcess` never flips its `killed`
+				// flag and `child.killed` alone would make us blindly
+				// SIGKILL 1.5s later even if the process already exited
+				// cleanly — a reused pid could then receive the signal.
+				const kill = setTimeout(() => {
+					if (child.exitCode == null && child.signalCode == null) {
+						killProcessTree(pid, "SIGKILL");
 					}
 				}, 1500);
+				child.once("close", () => clearTimeout(kill));
 			}
 		}
 		const session = store.get(sessionId);
@@ -671,7 +679,17 @@ export function getTodoSupervisor(): TodoSupervisor {
 function killProcessTree(pid: number, signal: NodeJS.Signals): void {
 	if (process.platform === "win32") {
 		try {
-			spawnSync("taskkill", ["/pid", String(pid), "/T", "/F"]);
+			// Async spawn so we never block Electron's main thread on a
+			// slow taskkill (large tool trees can take noticeable time
+			// to unwind). Detach + unref so node does not wait on it.
+			const killer = spawn("taskkill", ["/pid", String(pid), "/T", "/F"], {
+				stdio: "ignore",
+				detached: true,
+			});
+			killer.on("error", () => {
+				/* ignore — best-effort */
+			});
+			killer.unref();
 		} catch {
 			// ignore — best-effort
 		}


### PR DESCRIPTION
## 概要

Issue #191 の対応。AgentManager で Stop を押しても Claude がしばらく動き続けたり、完全に止まらなかったりする症状があった。

## 根本原因

\`supervisor.abort()\` は \`currentChild.kill("SIGINT")\` を呼ぶだけで、\`claude -p\` が spawn した子孫プロセス（Node-side の agent loop、MCP サーバ、tool helpers など）には一切シグナルが届いていなかった。\`claude\` の直接の wrapper が終了しても、実際に Anthropic API と話している孫プロセスが残り続けるので UI 的には止まっていない状態に見える。

## 修正

1. \`spawn\` 時に \`detached: true\` を指定し、子を独立したセッションリーダにする（Windows 以外）。
2. 新ヘルパー \`killProcessTree(pid, signal)\` を追加:
   - POSIX: \`process.kill(-pid, signal)\` で負の PID 指定によりプロセスグループ全体にシグナル送信。失敗時は直接 pid にフォールバック。
   - Windows: \`taskkill /PID <pid> /T /F\`。
3. \`abort()\` と \`onAbort\` ハンドラで \`child.kill\` を \`killProcessTree\` に置換。SIGINT → 1.5 秒後 SIGKILL の二段構えはそのまま。

## Test plan
- [ ] 長時間走るタスクで Stop → claude とその子孫プロセスが全て終了する
- [ ] 即時終了する短いタスクでも従来どおり正常に完了する
- [ ] Stop 後にセッションが aborted 状態で DB に残る

Closes #191