### PR TITLE
fix(desktop): TODOのシステムプロンプトテンプレートが効いていない問題を修正

### DIFF
--- a/apps/desktop/src/main/todo-agent/supervisor.ts
+++ b/apps/desktop/src/main/todo-agent/supervisor.ts
@@ -227,6 +227,17 @@ class TodoSupervisor {
 				"予算",
 				`${session0.maxIterations} iter · ${Math.round(session0.maxWallClockSec / 60)} 分`,
 			);
+			if (session0.customSystemPrompt?.trim()) {
+				const preview = session0.customSystemPrompt
+					.trim()
+					.replace(/\s+/g, " ")
+					.slice(0, 200);
+				appendSetupEvent(
+					sessionId,
+					"システムプロンプト",
+					`${preview}${session0.customSystemPrompt.trim().length > 200 ? "…" : ""}`,
+				);
+			}
 			appendSetupEvent(
 				sessionId,
 				"Claude",
@@ -703,6 +714,17 @@ function buildIterationPrompt(params: {
 
 	const sections: string[] = [];
 	if (iteration === 1) {
+		// Mirror the preset / custom system prompt into the first turn's
+		// user message. `--append-system-prompt` alone was not always
+		// visibly honored (users reported "気がする" that Claude never
+		// read the template). Duplicating it as explicit steering at the
+		// top of the prompt guarantees delivery and is cheap — Claude
+		// tolerates the same guidance appearing twice.
+		if (session.customSystemPrompt?.trim()) {
+			sections.push(
+				`ユーザー設定のシステム指示（最優先で遵守）:\n${session.customSystemPrompt.trim()}`,
+			);
+		}
 		sections.push(
 			`${goalPath} を読んで、${goalClause}。作業ディレクトリは worktree のルートです。`,
 		);


### PR DESCRIPTION
## 概要

Issue #190 の対応。「システムプロンプトテンプレートが送られていない気がする / Claude が読めていない気がする」 という報告。

## 根本原因

- \`customSystemPrompt\` は \`claude -p --append-system-prompt <value>\` として子に渡されていたが、ユーザーから見て Claude が本当にそれを読んでいるかどうか確認する手段が UI 上になかった。
- また \`--append-system-prompt\` のみに依存していたため、仮に Claude 側の取り込みが弱い場面があれば完全に無視されてしまう。

## 修正

1. **可視化**: supervisor 起動時、\`customSystemPrompt\` が設定されていれば先頭 200 文字のプレビューを \`システムプロンプト\` ラベル付きの setup イベントとしてストリームに流す。AgentManager 詳細ペインで「このセッションはどんな指示で動いているか」が一目で分かる。
2. **デリバリ保証**: iteration 1 の user プロンプト先頭にも \`ユーザー設定のシステム指示（最優先で遵守）\` として同内容を注入。\`--append-system-prompt\` と重複するが Claude は同じ指示が二重に来ても問題なく扱うため、確実に届けることを優先した。

## Test plan
- [ ] プリセット付きで TODO 作成→開始→AgentManager 詳細ペインの冒頭にシステムプロンプトのプレビューが表示される
- [ ] Claude の 1 ターン目の挙動にプリセット内容が反映されている
- [ ] プリセット無しの TODO では余計な行が出ず従来どおり動く

Closes #190