### PR TITLE
feat(desktop): Start前のTODOのdescription/goalを編集可能に

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"829fc425-e345-432d-adda-aa50d5c6e7fe","pid":77476,"acquiredAt":1776291557970}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"829fc425-e345-432d-adda-aa50d5c6e7fe","pid":77476,"acquiredAt":1776291557970}

--- a/apps/desktop/src/main/todo-agent/trpc-router.ts
+++ b/apps/desktop/src/main/todo-agent/trpc-router.ts
@@ -187,6 +187,76 @@ export const createTodoAgentRouter = () => {
 				return { ok: true };
 			}),
 
+		/**
+		 * Edit the user-authored fields (description / goal) of a TODO
+		 * session that has not started yet. Allowed only in pre-start
+		 * states (queued / failed / aborted / escalated) so a running
+		 * worker's prompt can never mutate under its feet. When the
+		 * description / goal changes we rewrite the session's goal.md
+		 * so the next run picks up the edit.
+		 */
+		updateFields: publicProcedure
+			.input(
+				z.object({
+					sessionId: z.string().min(1),
+					description: z.string().trim().min(1).max(10_000).optional(),
+					goal: z
+						.string()
+						.trim()
+						.max(10_000)
+						.optional()
+						.transform((v) => (v && v.length > 0 ? v : undefined)),
+					clearGoal: z.boolean().optional(),
+				}),
+			)
+			.mutation(({ input }) => {
+				const store = getTodoSessionStore();
+				const session = store.get(input.sessionId);
+				if (!session) {
+					throw new TRPCError({
+						code: "NOT_FOUND",
+						message: "セッションが見つかりません",
+					});
+				}
+				if (
+					session.status !== "queued" &&
+					session.status !== "failed" &&
+					session.status !== "aborted" &&
+					session.status !== "escalated"
+				) {
+					throw new TRPCError({
+						code: "PRECONDITION_FAILED",
+						message:
+							"実行中またはキュー済みでないセッションは編集できません。中断してから再度お試しください。",
+					});
+				}
+				const patch: {
+					description?: string;
+					goal?: string | null;
+				} = {};
+				if (input.description !== undefined) {
+					patch.description = input.description;
+				}
+				if (input.clearGoal) {
+					patch.goal = null;
+				} else if (input.goal !== undefined) {
+					patch.goal = input.goal;
+				}
+				const updated = store.update(input.sessionId, patch);
+				// Rewrite goal.md so a subsequent Start reads the edited
+				// content from disk (the iteration prompt tells Claude to
+				// read that file first, so stale on-disk content would
+				// silently shadow the edit).
+				if (updated) {
+					try {
+						getTodoSupervisor().prepareArtifacts(updated);
+					} catch (error) {
+						console.warn("[todo-agent] goal.md rewrite failed", error);
+					}
+				}
+				return { ok: true };
+			}),
+
 		delete: publicProcedure
 			.input(z.object({ sessionId: z.string().min(1) }))
 			.mutation(({ input }) => {

--- a/apps/desktop/src/renderer/features/todo-agent/TodoManager/TodoManager.tsx
+++ b/apps/desktop/src/renderer/features/todo-agent/TodoManager/TodoManager.tsx
@@ -10,6 +10,7 @@ import {
 import { Input } from "@superset/ui/input";
 import { ScrollArea } from "@superset/ui/scroll-area";
 import { toast } from "@superset/ui/sonner";
+import { Textarea } from "@superset/ui/textarea";
 import { cn } from "@superset/ui/utils";
 import type {
 	TodoSessionListEntry,
@@ -554,6 +555,10 @@ function SessionDetail({ session, onDeleted }: SessionDetailProps) {
 	const [starting, setStarting] = useState(false);
 	const [confirmingDelete, setConfirmingDelete] = useState(false);
 	const [streamEvents, setStreamEvents] = useState<TodoStreamEvent[]>([]);
+	const [editingField, setEditingField] = useState<
+		"description" | "goal" | null
+	>(null);
+	const [editDraft, setEditDraft] = useState("");
 
 	const utils = electronTrpc.useUtils();
 	const startMut = electronTrpc.todoAgent.start.useMutation();
@@ -561,6 +566,7 @@ function SessionDetail({ session, onDeleted }: SessionDetailProps) {
 	const sendInputMut = electronTrpc.todoAgent.sendInput.useMutation();
 	const deleteMut = electronTrpc.todoAgent.delete.useMutation();
 	const rerunMut = electronTrpc.todoAgent.rerun.useMutation();
+	const updateFieldsMut = electronTrpc.todoAgent.updateFields.useMutation();
 
 	const isActive =
 		session.status === "queued" ||
@@ -703,6 +709,62 @@ function SessionDetail({ session, onDeleted }: SessionDetailProps) {
 		}
 	}, [invalidate, rerunMut, session.id]);
 
+	const canEditFields = canStart && !isRunning;
+
+	const startEditField = useCallback(
+		(field: "description" | "goal") => {
+			setEditingField(field);
+			setEditDraft(
+				field === "description" ? session.description : (session.goal ?? ""),
+			);
+		},
+		[session.description, session.goal],
+	);
+
+	const cancelEditField = useCallback(() => {
+		setEditingField(null);
+		setEditDraft("");
+	}, []);
+
+	const commitEditField = useCallback(async () => {
+		if (!editingField) return;
+		const trimmed = editDraft.trim();
+		if (editingField === "description") {
+			if (trimmed.length === 0) {
+				toast.error("『やって欲しいこと』は空にできません");
+				return;
+			}
+			try {
+				await updateFieldsMut.mutateAsync({
+					sessionId: session.id,
+					description: trimmed,
+				});
+			} catch (error) {
+				toast.error(
+					error instanceof Error ? error.message : "更新に失敗しました",
+				);
+				return;
+			}
+		} else {
+			try {
+				await updateFieldsMut.mutateAsync({
+					sessionId: session.id,
+					goal: trimmed.length > 0 ? trimmed : undefined,
+					clearGoal: trimmed.length === 0,
+				});
+			} catch (error) {
+				toast.error(
+					error instanceof Error ? error.message : "更新に失敗しました",
+				);
+				return;
+			}
+		}
+		await invalidate();
+		setEditingField(null);
+		setEditDraft("");
+		toast.success("保存しました");
+	}, [editingField, editDraft, updateFieldsMut, session.id, invalidate]);
+
 	return (
 		<div className="flex flex-col h-full min-h-0 overflow-hidden text-sm">
 			{/* Header: title + actions. Fixed, not scrollable. */}
@@ -819,14 +881,103 @@ function SessionDetail({ session, onDeleted }: SessionDetailProps) {
 			<div className="flex flex-1 min-h-0 overflow-hidden">
 				<div className="w-[34%] min-w-[360px] max-w-[520px] border-r min-h-0 overflow-y-auto">
 					<div className="flex flex-col gap-5 p-5">
-						<DetailBlock label="やって欲しいこと">
-							<div className="whitespace-pre-wrap text-xs leading-relaxed">
-								{session.description}
-							</div>
+						<DetailBlock
+							label="やって欲しいこと"
+							action={
+								canEditFields && editingField !== "description" ? (
+									<button
+										type="button"
+										className="text-[10px] text-muted-foreground hover:text-foreground transition"
+										onClick={() => startEditField("description")}
+									>
+										編集
+									</button>
+								) : null
+							}
+						>
+							{editingField === "description" ? (
+								<div className="flex flex-col gap-1.5">
+									<Textarea
+										value={editDraft}
+										onChange={(e) => setEditDraft(e.target.value)}
+										rows={5}
+										className="text-xs"
+										autoFocus
+									/>
+									<div className="flex items-center gap-1.5">
+										<Button
+											type="button"
+											size="sm"
+											className="h-6 px-2 text-[11px]"
+											onClick={commitEditField}
+											disabled={updateFieldsMut.isPending}
+										>
+											保存
+										</Button>
+										<Button
+											type="button"
+											size="sm"
+											variant="ghost"
+											className="h-6 px-2 text-[11px]"
+											onClick={cancelEditField}
+										>
+											キャンセル
+										</Button>
+									</div>
+								</div>
+							) : (
+								<div className="whitespace-pre-wrap text-xs leading-relaxed">
+									{session.description}
+								</div>
+							)}
 						</DetailBlock>
 
-						<DetailBlock label="ゴール">
-							{session.goal?.trim() ? (
+						<DetailBlock
+							label="ゴール"
+							action={
+								canEditFields && editingField !== "goal" ? (
+									<button
+										type="button"
+										className="text-[10px] text-muted-foreground hover:text-foreground transition"
+										onClick={() => startEditField("goal")}
+									>
+										編集
+									</button>
+								) : null
+							}
+						>
+							{editingField === "goal" ? (
+								<div className="flex flex-col gap-1.5">
+									<Textarea
+										value={editDraft}
+										onChange={(e) => setEditDraft(e.target.value)}
+										rows={3}
+										className="text-xs"
+										placeholder="完了条件（空欄可）"
+										autoFocus
+									/>
+									<div className="flex items-center gap-1.5">
+										<Button
+											type="button"
+											size="sm"
+											className="h-6 px-2 text-[11px]"
+											onClick={commitEditField}
+											disabled={updateFieldsMut.isPending}
+										>
+											保存
+										</Button>
+										<Button
+											type="button"
+											size="sm"
+											variant="ghost"
+											className="h-6 px-2 text-[11px]"
+											onClick={cancelEditField}
+										>
+											キャンセル
+										</Button>
+									</div>
+								</div>
+							) : session.goal?.trim() ? (
 								<div className="whitespace-pre-wrap text-xs leading-relaxed">
 									{session.goal}
 								</div>

--- a/apps/desktop/src/renderer/features/todo-agent/TodoManager/TodoManager.tsx
+++ b/apps/desktop/src/renderer/features/todo-agent/TodoManager/TodoManager.tsx
@@ -599,6 +599,13 @@ function SessionDetail({ session, onDeleted }: SessionDetailProps) {
 	// biome-ignore lint/correctness/useExhaustiveDependencies: intentional reset-on-change dep
 	useEffect(() => {
 		setStreamEvents([]);
+		// Also drop any in-progress description/goal edit state from
+		// the previously selected session — SessionDetail is reused
+		// across selections, so leaving stale edit state would let
+		// the user "save" into whichever session happens to be picked
+		// next.
+		setEditingField(null);
+		setEditDraft("");
 	}, [session.id]);
 
 	// Force a re-render once per second while the session is still


### PR DESCRIPTION
## 概要

Issue #186 の対応。AgentManager で作成したばかりの自律 TODO について、Start 前は 「やって欲しいこと」 と 「ゴール」 を編集できるようにしたい、という要望。これまでは一度作ってしまうと作り直すしか手段がなかった。

## 実装

### Backend
- \`todoAgent.updateFields\` mutation を追加
  - input: \`sessionId\` / \`description?\` / \`goal?\` / \`clearGoal?\`
  - 許可状態: \`queued\` / \`failed\` / \`aborted\` / \`escalated\` のみ（実行中セッションは拒否）
  - 更新後に \`supervisor.prepareArtifacts\` を呼び goal.md を再書き出し。iteration プロンプトは goal.md を読ませる仕組みなので、古い内容が残ると編集が無意味になるため。

### Frontend
- \`SessionDetail\` の DetailBlock (\`やって欲しいこと\` / \`ゴール\`) に \`action\` 付きで 「編集」 ボタンを追加
- \`canStart && !isRunning\` のときだけ表示
- 編集モードでは Textarea + 保存 / キャンセル。保存で mutation → invalidate。

## Test plan
- [ ] 新規 TODO 作成直後、Start 前に description/goal を編集できる
- [ ] 保存後の内容で Start すると Claude がそれを読む
- [ ] 実行中セッションでは編集ボタンが出ない
- [ ] failed/aborted のセッションも編集→再 Start できる

Closes #186