### PR TITLE
fix(desktop): 選択したプリセットをAgentManagerの詳細に表示する

### DIFF
--- a/apps/desktop/src/renderer/features/todo-agent/TodoManager/TodoManager.tsx
+++ b/apps/desktop/src/renderer/features/todo-agent/TodoManager/TodoManager.tsx
@@ -837,6 +837,14 @@ function SessionDetail({ session, onDeleted }: SessionDetailProps) {
 							)}
 						</DetailBlock>
 
+						{session.customSystemPrompt?.trim() && (
+							<DetailBlock label="システムプロンプト（プリセット）">
+								<div className="rounded-md border border-border/40 bg-muted/30 p-2 text-[11px] leading-relaxed whitespace-pre-wrap max-h-40 overflow-y-auto font-mono">
+									{session.customSystemPrompt}
+								</div>
+							</DetailBlock>
+						)}
+
 						<div className="grid grid-cols-2 gap-4">
 							<DetailBlock label="Verify">
 								{session.verifyCommand ? (


### PR DESCRIPTION
## 概要

Issue #187 の対応。TODO 作成時に選んだシステムプロンプトプリセットが、AgentManager の詳細ペインから確認できず 「本当に送られているのか」 が見えない問題。

## 修正

\`SessionDetail\` の左カラムに \`システムプロンプト（プリセット）\` の DetailBlock を追加し、\`session.customSystemPrompt\` が設定されていれば全文をスクロール可能なブロックで表示する。未選択のセッションでは表示しない。

## スコープ外（フォローアップ）

Issue 本文で言及されている以下は、スキーマ変更（\`todoPromptPresets\` への \`folder\` / \`kind\` カラム追加）とマイグレーションが必要なので別 PR に切り分けて対応する予定:
- ワークスペースごとのフォルダ管理
- プリセットを 「ゴール」 / 「やって欲しいこと」 の 2 タイプに分ける

## Test plan
- [ ] プリセット付きで TODO 作成→AgentManager 詳細ペインにプリセット内容が表示される
- [ ] プリセット無しの TODO では当該ブロックが出ない

Refs #187