### PR TITLE
feat(desktop): AgentManagerライブストリームを折りたたみグループ化

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"829fc425-e345-432d-adda-aa50d5c6e7fe","pid":77476,"acquiredAt":1776291557970}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"829fc425-e345-432d-adda-aa50d5c6e7fe","pid":77476,"acquiredAt":1776291557970}

--- a/apps/desktop/src/main/todo-agent/settings.ts
+++ b/apps/desktop/src/main/todo-agent/settings.ts
@@ -1,0 +1,45 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { app } from "electron";
+import { type TodoSettings, todoSettingsSchema } from "./types";
+
+const SETTINGS_FILE = "todo-agent-settings.json";
+
+function getSettingsPath(): string {
+	const dir = path.join(app.getPath("userData"), "todo-agent");
+	mkdirSync(dir, { recursive: true });
+	return path.join(dir, SETTINGS_FILE);
+}
+
+const DEFAULT_SETTINGS: TodoSettings = {
+	defaultMaxIterations: 10,
+	defaultMaxWallClockMin: 30,
+	maxConcurrentTasks: 1,
+};
+
+let cached: TodoSettings | null = null;
+
+export function getTodoSettings(): TodoSettings {
+	if (cached) return cached;
+	const filePath = getSettingsPath();
+	if (!existsSync(filePath)) {
+		cached = { ...DEFAULT_SETTINGS };
+		return cached;
+	}
+	try {
+		const raw = JSON.parse(readFileSync(filePath, "utf8"));
+		cached = todoSettingsSchema.parse(raw);
+		return cached;
+	} catch {
+		cached = { ...DEFAULT_SETTINGS };
+		return cached;
+	}
+}
+
+export function updateTodoSettings(patch: Partial<TodoSettings>): TodoSettings {
+	const current = getTodoSettings();
+	const next = todoSettingsSchema.parse({ ...current, ...patch });
+	cached = next;
+	writeFileSync(getSettingsPath(), JSON.stringify(next, null, 2), "utf8");
+	return next;
+}

--- a/apps/desktop/src/main/todo-agent/trpc-router.ts
+++ b/apps/desktop/src/main/todo-agent/trpc-router.ts
@@ -443,6 +443,8 @@ export const createTodoAgentRouter = () => {
 						.values({
 							name: input.name,
 							content: input.content,
+							kind: input.kind,
+							workspaceId: input.workspaceId ?? null,
 							createdAt: now,
 							updatedAt: now,
 						})
@@ -453,13 +455,23 @@ export const createTodoAgentRouter = () => {
 			update: publicProcedure
 				.input(todoPresetUpdateInputSchema)
 				.mutation(({ input }) => {
+					const patch: {
+						name: string;
+						content: string;
+						updatedAt: number;
+						kind?: "system" | "description" | "goal";
+						workspaceId?: string | null;
+					} = {
+						name: input.name,
+						content: input.content,
+						updatedAt: Date.now(),
+					};
+					if (input.kind !== undefined) patch.kind = input.kind;
+					if (input.workspaceId !== undefined)
+						patch.workspaceId = input.workspaceId;
 					const row = localDb
 						.update(todoPromptPresets)
-						.set({
-							name: input.name,
-							content: input.content,
-							updatedAt: Date.now(),
-						})
+						.set(patch)
 						.where(eq(todoPromptPresets.id, input.id))
 						.returning()
 						.get();

--- a/apps/desktop/src/main/todo-agent/trpc-router.ts
+++ b/apps/desktop/src/main/todo-agent/trpc-router.ts
@@ -15,6 +15,7 @@ import {
 	type SessionDiffScope,
 } from "./git-status";
 import { getTodoSessionStore, resolveWorktreePath } from "./session-store";
+import { getTodoSettings, updateTodoSettings } from "./settings";
 import { getTodoSupervisor } from "./supervisor";
 import {
 	TODO_ARTIFACT_SUBDIR,
@@ -25,6 +26,7 @@ import {
 	todoPresetCreateInputSchema,
 	todoPresetUpdateInputSchema,
 	todoSendInputSchema,
+	todoSettingsUpdateSchema,
 } from "./types";
 
 /**
@@ -478,6 +480,13 @@ export const createTodoAgentRouter = () => {
 						.run();
 					return { ok: result.changes > 0 };
 				}),
+		}),
+
+		settings: router({
+			get: publicProcedure.query(() => getTodoSettings()),
+			update: publicProcedure
+				.input(todoSettingsUpdateSchema)
+				.mutation(({ input }) => updateTodoSettings(input)),
 		}),
 	});
 };

--- a/apps/desktop/src/main/todo-agent/types.ts
+++ b/apps/desktop/src/main/todo-agent/types.ts
@@ -74,6 +74,16 @@ export type TodoEnhanceTextInput = z.infer<typeof todoEnhanceTextInputSchema>;
 
 export type TodoCreateInput = z.infer<typeof todoCreateInputSchema>;
 
+export const todoSettingsSchema = z.object({
+	defaultMaxIterations: z.number().int().min(1).max(100).default(10),
+	defaultMaxWallClockMin: z.number().int().min(1).max(240).default(30),
+	maxConcurrentTasks: z.number().int().min(1).max(10).default(1),
+});
+
+export type TodoSettings = z.infer<typeof todoSettingsSchema>;
+
+export const todoSettingsUpdateSchema = todoSettingsSchema.partial();
+
 export const todoAttachPaneInputSchema = z.object({
 	sessionId: z.string().min(1),
 	tabId: z.string().min(1),

--- a/apps/desktop/src/main/todo-agent/types.ts
+++ b/apps/desktop/src/main/todo-agent/types.ts
@@ -54,15 +54,22 @@ export const todoCreateInputSchema = z.object({
 		.transform((v) => (v && v.length > 0 ? v : undefined)),
 });
 
+export const todoPresetKindSchema = z.enum(["system", "description", "goal"]);
+export type TodoPresetKind = z.infer<typeof todoPresetKindSchema>;
+
 export const todoPresetCreateInputSchema = z.object({
 	name: z.string().trim().min(1).max(120),
 	content: z.string().trim().min(1).max(20_000),
+	kind: todoPresetKindSchema.default("system"),
+	workspaceId: z.string().min(1).optional(),
 });
 
 export const todoPresetUpdateInputSchema = z.object({
 	id: z.string().min(1),
 	name: z.string().trim().min(1).max(120),
 	content: z.string().trim().min(1).max(20_000),
+	kind: todoPresetKindSchema.optional(),
+	workspaceId: z.string().min(1).nullable().optional(),
 });
 
 export const todoEnhanceTextInputSchema = z.object({

--- a/apps/desktop/src/renderer/features/todo-agent/TodoButton/TodoButton.tsx
+++ b/apps/desktop/src/renderer/features/todo-agent/TodoButton/TodoButton.tsx
@@ -27,18 +27,21 @@ export const TodoButton = memo(function TodoButton({
 	const [managerOpen, setManagerOpen] = useState(false);
 	const [modalOpen, setModalOpen] = useState(false);
 
-	const { data: sessions } = electronTrpc.todoAgent.list.useQuery(
-		{ workspaceId },
-		{ enabled: !!workspaceId, refetchInterval: 3000 },
+	const { data: allSessions } = electronTrpc.todoAgent.listAll.useQuery(
+		undefined,
+		{ refetchInterval: 3000 },
 	);
 
-	const activeCount = (sessions ?? []).filter(
-		(session) =>
-			session.status === "queued" ||
-			session.status === "preparing" ||
-			session.status === "running" ||
-			session.status === "verifying",
+	const runningCount = (allSessions ?? []).filter(
+		(s) =>
+			s.status === "preparing" ||
+			s.status === "running" ||
+			s.status === "verifying",
 	).length;
+	const queuedCount = (allSessions ?? []).filter(
+		(s) => s.status === "queued",
+	).length;
+	const activeCount = runningCount + queuedCount;
 
 	const handleRequestNewTodo = useCallback(() => {
 		setModalOpen(true);
@@ -59,9 +62,18 @@ export const TodoButton = memo(function TodoButton({
 			>
 				<HiMiniListBullet className="size-4" />
 				<span className="font-medium">TODO</span>
-				{activeCount > 0 && (
-					<span className="ml-1 rounded-full bg-primary/15 px-1.5 py-px text-[10px] font-semibold tabular-nums">
-						{activeCount}
+				{runningCount > 0 && (
+					<span className="relative ml-1 flex items-center gap-1 rounded-full bg-primary/15 px-1.5 py-px text-[10px] font-semibold tabular-nums">
+						<span className="relative flex size-1.5">
+							<span className="absolute inline-flex size-full animate-ping rounded-full bg-primary/60" />
+							<span className="relative inline-flex size-1.5 rounded-full bg-primary" />
+						</span>
+						{runningCount}
+					</span>
+				)}
+				{queuedCount > 0 && (
+					<span className="rounded-full bg-muted px-1.5 py-px text-[10px] font-semibold tabular-nums text-muted-foreground">
+						+{queuedCount}
 					</span>
 				)}
 			</Button>

--- a/apps/desktop/src/renderer/features/todo-agent/TodoManager/PresetsDialog/PresetsDialog.tsx
+++ b/apps/desktop/src/renderer/features/todo-agent/TodoManager/PresetsDialog/PresetsDialog.tsx
@@ -2,12 +2,18 @@ import type { SelectTodoPromptPreset } from "@superset/local-db";
 import { Button } from "@superset/ui/button";
 import { Dialog, DialogContent, DialogTitle } from "@superset/ui/dialog";
 import { Input } from "@superset/ui/input";
+import { Label } from "@superset/ui/label";
 import { ScrollArea } from "@superset/ui/scroll-area";
 import { toast } from "@superset/ui/sonner";
 import { Textarea } from "@superset/ui/textarea";
 import { cn } from "@superset/ui/utils";
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { HiMiniPlus, HiMiniTrash, HiMiniXMark } from "react-icons/hi2";
+import {
+	HiMiniCog6Tooth,
+	HiMiniPlus,
+	HiMiniTrash,
+	HiMiniXMark,
+} from "react-icons/hi2";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 
 interface PresetsDialogProps {
@@ -20,7 +26,166 @@ interface PresetsDialogProps {
  * "設定" row at the bottom of the Agent Manager's left sidebar.
  * Two-pane layout: list of presets on the left, edit form on the right.
  */
+type Tab = "presets" | "settings";
+
 export function PresetsDialog({ open, onOpenChange }: PresetsDialogProps) {
+	const [tab, setTab] = useState<Tab>("presets");
+
+	return (
+		<Dialog open={open} onOpenChange={onOpenChange}>
+			<DialogContent
+				className="w-[960px] max-w-[calc(100vw-4rem)] sm:max-w-[calc(100vw-4rem)] h-[80vh] max-h-[840px] p-0 gap-0 overflow-hidden flex flex-col rounded-xl"
+				showCloseButton={false}
+			>
+				<DialogTitle className="sr-only">Agent Manager 設定</DialogTitle>
+				<div className="shrink-0 border-b h-12 flex items-center justify-between px-4">
+					<div className="flex items-center gap-1">
+						<button
+							type="button"
+							onClick={() => setTab("presets")}
+							className={cn(
+								"px-3 py-1.5 text-xs font-medium rounded-md transition",
+								tab === "presets"
+									? "bg-accent text-foreground"
+									: "text-muted-foreground hover:text-foreground",
+							)}
+						>
+							プリセット
+						</button>
+						<button
+							type="button"
+							onClick={() => setTab("settings")}
+							className={cn(
+								"px-3 py-1.5 text-xs font-medium rounded-md transition flex items-center gap-1",
+								tab === "settings"
+									? "bg-accent text-foreground"
+									: "text-muted-foreground hover:text-foreground",
+							)}
+						>
+							<HiMiniCog6Tooth className="size-3.5" />
+							設定
+						</button>
+					</div>
+					<Button
+						type="button"
+						size="sm"
+						variant="ghost"
+						className="h-7 w-7 p-0 rounded-md"
+						onClick={() => onOpenChange(false)}
+						title="閉じる"
+					>
+						<HiMiniXMark className="size-4" />
+					</Button>
+				</div>
+				{tab === "presets" ? <PresetsTab open={open} /> : <SettingsTab />}
+			</DialogContent>
+		</Dialog>
+	);
+}
+
+function SettingsTab() {
+	const { data: settings } = electronTrpc.todoAgent.settings.get.useQuery();
+	const updateMut = electronTrpc.todoAgent.settings.update.useMutation();
+	const utils = electronTrpc.useUtils();
+
+	const [maxIter, setMaxIter] = useState(10);
+	const [maxMin, setMaxMin] = useState(30);
+	const [maxConcurrent, setMaxConcurrent] = useState(1);
+
+	useEffect(() => {
+		if (settings) {
+			setMaxIter(settings.defaultMaxIterations);
+			setMaxMin(settings.defaultMaxWallClockMin);
+			setMaxConcurrent(settings.maxConcurrentTasks);
+		}
+	}, [settings]);
+
+	const dirty =
+		settings != null &&
+		(maxIter !== settings.defaultMaxIterations ||
+			maxMin !== settings.defaultMaxWallClockMin ||
+			maxConcurrent !== settings.maxConcurrentTasks);
+
+	const handleSave = useCallback(async () => {
+		try {
+			await updateMut.mutateAsync({
+				defaultMaxIterations: maxIter,
+				defaultMaxWallClockMin: maxMin,
+				maxConcurrentTasks: maxConcurrent,
+			});
+			await utils.todoAgent.settings.get.invalidate();
+			toast.success("設定を保存しました");
+		} catch (error) {
+			toast.error(
+				error instanceof Error ? error.message : "保存に失敗しました",
+			);
+		}
+	}, [maxIter, maxMin, maxConcurrent, updateMut, utils]);
+
+	return (
+		<div className="flex-1 p-6 overflow-y-auto">
+			<div className="max-w-md flex flex-col gap-5">
+				<div className="flex flex-col gap-1.5">
+					<Label htmlFor="set-max-iter">デフォルト最大イテレーション数</Label>
+					<Input
+						id="set-max-iter"
+						type="number"
+						min={1}
+						max={100}
+						value={maxIter}
+						onChange={(e) => setMaxIter(Number(e.target.value) || 1)}
+						className="w-32"
+					/>
+					<p className="text-[10px] text-muted-foreground">
+						新規 TODO 作成時のデフォルト値。各セッションで個別に変更可。
+					</p>
+				</div>
+				<div className="flex flex-col gap-1.5">
+					<Label htmlFor="set-max-min">デフォルトタイムアウト（分）</Label>
+					<Input
+						id="set-max-min"
+						type="number"
+						min={1}
+						max={240}
+						value={maxMin}
+						onChange={(e) => setMaxMin(Number(e.target.value) || 1)}
+						className="w-32"
+					/>
+					<p className="text-[10px] text-muted-foreground">
+						壁時計上限。この時間を超えるとセッションはエスカレートされる。
+					</p>
+				</div>
+				<div className="flex flex-col gap-1.5">
+					<Label htmlFor="set-max-concurrent">最大同時実行数</Label>
+					<Input
+						id="set-max-concurrent"
+						type="number"
+						min={1}
+						max={10}
+						value={maxConcurrent}
+						onChange={(e) => setMaxConcurrent(Number(e.target.value) || 1)}
+						className="w-32"
+					/>
+					<p className="text-[10px] text-muted-foreground">
+						同時に実行する TODO セッションの上限。超えた分はキューで待機。
+					</p>
+				</div>
+				<div className="pt-2 border-t">
+					<Button
+						type="button"
+						size="sm"
+						onClick={handleSave}
+						disabled={!dirty || updateMut.isPending}
+					>
+						保存
+					</Button>
+				</div>
+			</div>
+		</div>
+	);
+}
+
+function PresetsTab({ open }: { open: boolean }) {
 	const utils = electronTrpc.useUtils();
 	const { data: presets } = electronTrpc.todoAgent.presets.list.useQuery(
 		undefined,
@@ -120,163 +285,126 @@ export function PresetsDialog({ open, onOpenChange }: PresetsDialogProps) {
 	}, [deleteMut, draft.id, invalidate]);
 
 	return (
-		<Dialog open={open} onOpenChange={onOpenChange}>
-			<DialogContent
-				className="w-[960px] max-w-[calc(100vw-4rem)] sm:max-w-[calc(100vw-4rem)] h-[80vh] max-h-[840px] p-0 gap-0 overflow-hidden flex flex-col rounded-xl"
-				showCloseButton={false}
-			>
-				<DialogTitle className="sr-only">
-					システムプロンプトテンプレート
-				</DialogTitle>
-				<div className="shrink-0 border-b h-12 flex items-center justify-between px-4">
-					<div className="flex items-center gap-3">
-						<span className="text-sm font-semibold">
-							システムプロンプトテンプレート
-						</span>
-						<span className="text-xs text-muted-foreground">
-							TODO に付けられる再利用プロンプト
-						</span>
+		<div className="flex flex-1 min-h-0">
+			<div className="w-[260px] shrink-0 border-r flex flex-col min-h-0">
+				<div className="p-2 border-b shrink-0">
+					<Button
+						type="button"
+						size="sm"
+						className="w-full h-8 text-xs rounded-md gap-1"
+						onClick={handleNew}
+					>
+						<HiMiniPlus className="size-4" />
+						新規プリセット
+					</Button>
+				</div>
+				<ScrollArea className="flex-1">
+					<div className="flex flex-col p-1.5 gap-0.5">
+						{(presets ?? []).length === 0 && (
+							<p className="text-[11px] text-muted-foreground px-2 py-4">
+								まだプリセットはありません。右上から新規作成してください。
+							</p>
+						)}
+						{(presets ?? []).map((preset: SelectTodoPromptPreset) => (
+							<button
+								key={preset.id}
+								type="button"
+								onClick={() => setSelectedId(preset.id)}
+								className={cn(
+									"text-left rounded-md px-2.5 py-1.5 text-xs transition",
+									selectedId === preset.id ? "bg-accent" : "hover:bg-accent/50",
+								)}
+							>
+								<div className="font-medium line-clamp-1">{preset.name}</div>
+								<div className="text-[10px] text-muted-foreground line-clamp-1 mt-0.5">
+									{preset.content.replace(/\s+/g, " ")}
+								</div>
+							</button>
+						))}
+					</div>
+				</ScrollArea>
+			</div>
+
+			<div className="flex-1 min-w-0 flex flex-col p-5 gap-4 overflow-y-auto">
+				<div className="flex flex-col gap-1.5">
+					<label
+						htmlFor="preset-name"
+						className="text-[10px] uppercase tracking-wide text-muted-foreground font-semibold"
+					>
+						名前
+					</label>
+					<Input
+						id="preset-name"
+						value={draft.name}
+						onChange={(e) => setDraft((d) => ({ ...d, name: e.target.value }))}
+						placeholder="例: 日本語で返答"
+						maxLength={120}
+						className="rounded-md"
+					/>
+				</div>
+				<div className="flex flex-col gap-1.5 flex-1 min-h-0">
+					<label
+						htmlFor="preset-content"
+						className="text-[10px] uppercase tracking-wide text-muted-foreground font-semibold"
+					>
+						システムプロンプト
+					</label>
+					<Textarea
+						id="preset-content"
+						value={draft.content}
+						onChange={(e) =>
+							setDraft((d) => ({ ...d, content: e.target.value }))
+						}
+						placeholder="例: 回答は日本語で。コード内コメントは既存言語に合わせて。"
+						className="flex-1 min-h-[200px] rounded-md font-mono text-xs leading-relaxed"
+					/>
+				</div>
+				<div className="flex items-center justify-between gap-2 pt-2 border-t">
+					<div>
+						{draft.id &&
+							(confirmingDelete ? (
+								<div className="flex items-center gap-2">
+									<Button
+										type="button"
+										size="sm"
+										variant="destructive"
+										onClick={handleDelete}
+										disabled={deleteMut.isPending}
+									>
+										本当に削除
+									</Button>
+									<Button
+										type="button"
+										size="sm"
+										variant="ghost"
+										onClick={() => setConfirmingDelete(false)}
+									>
+										キャンセル
+									</Button>
+								</div>
+							) : (
+								<Button
+									type="button"
+									size="sm"
+									variant="ghost"
+									className="gap-1 text-muted-foreground hover:text-destructive"
+									onClick={() => setConfirmingDelete(true)}
+								>
+									<HiMiniTrash className="size-3.5" />
+									削除
+								</Button>
+							))}
 					</div>
 					<Button
 						type="button"
 						size="sm"
-						variant="ghost"
-						className="h-7 w-7 p-0 rounded-md"
-						onClick={() => onOpenChange(false)}
-						title="閉じる"
+						onClick={handleSave}
+						disabled={!dirty || createMut.isPending || updateMut.isPending}
 					>
-						<HiMiniXMark className="size-4" />
+						{draft.id ? "更新" : "作成"}
 					</Button>
 				</div>
-
-				<div className="flex flex-1 min-h-0">
-					<div className="w-[260px] shrink-0 border-r flex flex-col min-h-0">
-						<div className="p-2 border-b shrink-0">
-							<Button
-								type="button"
-								size="sm"
-								className="w-full h-8 text-xs rounded-md gap-1"
-								onClick={handleNew}
-							>
-								<HiMiniPlus className="size-4" />
-								新規プリセット
-							</Button>
-						</div>
-						<ScrollArea className="flex-1">
-							<div className="flex flex-col p-1.5 gap-0.5">
-								{(presets ?? []).length === 0 && (
-									<p className="text-[11px] text-muted-foreground px-2 py-4">
-										まだプリセットはありません。右上から新規作成してください。
-									</p>
-								)}
-								{(presets ?? []).map((preset: SelectTodoPromptPreset) => (
-									<button
-										key={preset.id}
-										type="button"
-										onClick={() => setSelectedId(preset.id)}
-										className={cn(
-											"text-left rounded-md px-2.5 py-1.5 text-xs transition",
-											selectedId === preset.id
-												? "bg-accent"
-												: "hover:bg-accent/50",
-										)}
-									>
-										<div className="font-medium line-clamp-1">
-											{preset.name}
-										</div>
-										<div className="text-[10px] text-muted-foreground line-clamp-1 mt-0.5">
-											{preset.content.replace(/\s+/g, " ")}
-										</div>
-									</button>
-								))}
-							</div>
-						</ScrollArea>
-					</div>
-
-					<div className="flex-1 min-w-0 flex flex-col p-5 gap-4 overflow-y-auto">
-						<div className="flex flex-col gap-1.5">
-							<label
-								htmlFor="preset-name"
-								className="text-[10px] uppercase tracking-wide text-muted-foreground font-semibold"
-							>
-								名前
-							</label>
-							<Input
-								id="preset-name"
-								value={draft.name}
-								onChange={(e) =>
-									setDraft((d) => ({ ...d, name: e.target.value }))
-								}
-								placeholder="例: 日本語で返答"
-								maxLength={120}
-								className="rounded-md"
-							/>
-						</div>
-						<div className="flex flex-col gap-1.5 flex-1 min-h-0">
-							<label
-								htmlFor="preset-content"
-								className="text-[10px] uppercase tracking-wide text-muted-foreground font-semibold"
-							>
-								システムプロンプト
-							</label>
-							<Textarea
-								id="preset-content"
-								value={draft.content}
-								onChange={(e) =>
-									setDraft((d) => ({ ...d, content: e.target.value }))
-								}
-								placeholder="例: 回答は日本語で。コード内コメントは既存言語に合わせて。"
-								className="flex-1 min-h-[200px] rounded-md font-mono text-xs leading-relaxed"
-							/>
-						</div>
-						<div className="flex items-center justify-between gap-2 pt-2 border-t">
-							<div>
-								{draft.id &&
-									(confirmingDelete ? (
-										<div className="flex items-center gap-2">
-											<Button
-												type="button"
-												size="sm"
-												variant="destructive"
-												onClick={handleDelete}
-												disabled={deleteMut.isPending}
-											>
-												本当に削除
-											</Button>
-											<Button
-												type="button"
-												size="sm"
-												variant="ghost"
-												onClick={() => setConfirmingDelete(false)}
-											>
-												キャンセル
-											</Button>
-										</div>
-									) : (
-										<Button
-											type="button"
-											size="sm"
-											variant="ghost"
-											className="gap-1 text-muted-foreground hover:text-destructive"
-											onClick={() => setConfirmingDelete(true)}
-										>
-											<HiMiniTrash className="size-3.5" />
-											削除
-										</Button>
-									))}
-							</div>
-							<Button
-								type="button"
-								size="sm"
-								onClick={handleSave}
-								disabled={!dirty || createMut.isPending || updateMut.isPending}
-							>
-								{draft.id ? "更新" : "作成"}
-							</Button>
-						</div>
-					</div>
-				</div>
-			</DialogContent>
-		</Dialog>
+			</div>
+		</div>
 	);
 }

--- a/apps/desktop/src/renderer/features/todo-agent/TodoManager/TodoManager.tsx
+++ b/apps/desktop/src/renderer/features/todo-agent/TodoManager/TodoManager.tsx
@@ -916,7 +916,7 @@ function SessionDetail({ session, onDeleted }: SessionDetailProps) {
 							Claude の応答 / ライブストリーム
 						</div>
 					</div>
-					<div className="flex-1 min-h-0 px-5 pb-5 overflow-hidden">
+					<div className="flex-1 min-h-0 px-5 pb-5 relative">
 						<StreamView events={streamEvents} />
 					</div>
 				</div>
@@ -1080,7 +1080,7 @@ function StreamView({ events }: { events: TodoStreamEvent[] }) {
 		<div
 			ref={scrollRef}
 			onScroll={handleScroll}
-			className="h-full overflow-auto bg-muted/30 rounded p-3 flex flex-col gap-1.5"
+			className="absolute inset-0 overflow-y-auto overflow-x-hidden bg-muted/30 rounded px-3 py-2"
 		>
 			{events.length === 0 ? (
 				<div className="text-xs text-muted-foreground p-2">
@@ -1088,21 +1088,26 @@ function StreamView({ events }: { events: TodoStreamEvent[] }) {
 					Claude の応答・ツール使用・verify 結果が流れます。
 				</div>
 			) : (
-				items.map((item) =>
-					item.type === "tool" ? (
-						<ToolCallCard key={item.id} item={item} />
-					) : (
-						<MessageRow key={item.id} event={item.event} />
-					),
-				)
+				<div className="flex flex-col gap-1">
+					{items.map((item) =>
+						item.type === "tool" ? (
+							<ToolCallCard key={item.id} item={item} />
+						) : (
+							<MessageRow key={item.id} event={item.event} />
+						),
+					)}
+				</div>
 			)}
 		</div>
 	);
 }
 
 /**
- * VSCode Claude Code style tool card: compact header with tool name +
- * secondary info, then an IN/OUT grid body. No folding — always visible.
+ * VSCode Claude Code extension faithful reproduction: uses `<details>` so
+ * the tool call folds by default, showing only a 2-line summary (bold tool
+ * name + monospace secondary info). Expanded body shows an IN/OUT grid.
+ * This matches the extension's `.Ze/._e/.or/.D/.rr/.ir/.lo/.tr` CSS
+ * classes we reverse-engineered from webview/index.css.
  */
 function ToolCallCard({
 	item,
@@ -1112,53 +1117,57 @@ function ToolCallCard({
 	const { toolUse, toolResult } = item;
 	const toolName = toolUse.label;
 	const secondary = extractSecondaryInfo(toolName, toolUse.text);
+	const hasResult = toolResult != null;
 
 	return (
-		<div className="border border-border/40 rounded-lg bg-background/50 text-xs overflow-hidden">
-			<div className="flex items-center gap-2 px-3 py-1.5 bg-muted/40 border-b border-border/30">
-				<span className="font-semibold text-amber-600 shrink-0">
-					{toolName}
+		<details className="group text-xs">
+			<summary className="list-none cursor-pointer select-none flex items-baseline gap-1 py-0.5 hover:bg-accent/30 rounded px-1 -mx-1 overflow-hidden">
+				<span className="shrink-0 text-muted-foreground/50 group-open:rotate-90 transition-transform text-[10px]">
+					▶
 				</span>
+				<span className="font-bold shrink-0">{toolName}</span>
 				{secondary && (
-					<span className="text-muted-foreground truncate font-mono text-[11px]">
+					<span className="font-mono text-[0.85em] text-primary/70 break-all line-clamp-2 min-w-0 flex-1">
 						{secondary}
 					</span>
 				)}
-				<span className="ml-auto text-[10px] text-muted-foreground tabular-nums shrink-0">
-					{formatClock(toolUse.ts)}
-				</span>
-			</div>
-			<div className="divide-y divide-border/20">
-				<div className="flex min-h-0">
-					<div className="shrink-0 w-10 flex items-start justify-center py-1.5 text-[10px] font-semibold text-muted-foreground/70">
-						IN
-					</div>
-					<div className="flex-1 py-1.5 pr-3 overflow-hidden">
-						<pre className="whitespace-pre-wrap break-all font-mono text-[11px] leading-relaxed max-h-24 overflow-y-auto text-foreground/80">
-							{toolUse.text.slice(0, 500)}
-							{toolUse.text.length > 500 ? "…" : ""}
-						</pre>
-					</div>
-				</div>
-				<div className="flex min-h-0">
-					<div className="shrink-0 w-10 flex items-start justify-center py-1.5 text-[10px] font-semibold text-emerald-600/70">
-						OUT
-					</div>
-					<div className="flex-1 py-1.5 pr-3 overflow-hidden">
-						{toolResult ? (
-							<pre className="whitespace-pre-wrap break-all font-mono text-[11px] leading-relaxed max-h-24 overflow-y-auto text-foreground/80">
-								{toolResult.text.slice(0, 500)}
-								{toolResult.text.length > 500 ? "…" : ""}
+				{!hasResult && (
+					<span className="shrink-0 text-[10px] text-muted-foreground animate-pulse">
+						…
+					</span>
+				)}
+			</summary>
+			<div className="my-1.5 ml-3 border border-border/40 rounded-md bg-muted/20 overflow-hidden">
+				<div className="grid grid-cols-[max-content_1fr] text-[11px]">
+					<div className="col-span-2 grid grid-cols-subgrid border-b border-border/30">
+						<div className="text-muted-foreground/50 font-mono text-[0.85em] py-1 px-2">
+							IN
+						</div>
+						<div className="py-1 pr-2 overflow-hidden">
+							<pre className="whitespace-pre-wrap break-all font-mono leading-relaxed text-foreground/80 max-h-32 overflow-y-auto">
+								{toolUse.text}
 							</pre>
-						) : (
-							<span className="text-[11px] text-muted-foreground animate-pulse">
-								実行中…
-							</span>
-						)}
+						</div>
+					</div>
+					<div className="col-span-2 grid grid-cols-subgrid">
+						<div className="text-muted-foreground/50 font-mono text-[0.85em] py-1 px-2">
+							OUT
+						</div>
+						<div className="py-1 pr-2 overflow-hidden">
+							{toolResult ? (
+								<pre className="whitespace-pre-wrap break-all font-mono leading-relaxed text-foreground/80 max-h-64 overflow-y-auto">
+									{toolResult.text}
+								</pre>
+							) : (
+								<span className="text-muted-foreground animate-pulse">
+									実行中…
+								</span>
+							)}
+						</div>
 					</div>
 				</div>
 			</div>
-		</div>
+		</details>
 	);
 }
 
@@ -1174,87 +1183,52 @@ function extractSecondaryInfo(_toolName: string, text: string): string | null {
 function MessageRow({ event }: { event: TodoStreamEvent }) {
 	if (event.kind === "assistant_text") {
 		return (
-			<div className="group border border-primary/30 bg-primary/5 rounded-lg px-3 py-2 text-xs">
-				<div className="flex items-center justify-between gap-2 mb-1">
-					<span className="text-[10px] font-semibold text-primary/80">
-						Claude
-					</span>
-					<div className="flex items-center gap-1">
-						<span className="text-[10px] text-muted-foreground tabular-nums">
-							{formatClock(event.ts)}
-						</span>
-						<div className="opacity-0 group-hover:opacity-100 transition">
-							<CopyIconButton value={event.text} title="コピー" />
-						</div>
-					</div>
-				</div>
+			<div className="group text-xs py-1">
 				<MarkdownRenderer content={event.text} scrollable={false} />
 			</div>
 		);
 	}
 	if (event.kind === "result") {
 		return (
-			<div className="group border border-emerald-600/40 bg-emerald-600/10 rounded-lg px-3 py-2 text-xs">
-				<div className="flex items-center justify-between gap-2 mb-1">
-					<span className="text-[10px] font-semibold text-emerald-600">
-						Result
-					</span>
-					<div className="flex items-center gap-1">
-						<span className="text-[10px] text-muted-foreground tabular-nums">
-							{formatClock(event.ts)}
-						</span>
-						<div className="opacity-0 group-hover:opacity-100 transition">
-							<CopyIconButton value={event.text} title="コピー" />
-						</div>
-					</div>
-				</div>
+			<div className="group border-l-2 border-emerald-600/40 bg-emerald-600/5 pl-2 py-1 text-xs my-1">
 				<MarkdownRenderer content={event.text} scrollable={false} />
 			</div>
 		);
 	}
 	if (event.kind === "error") {
 		return (
-			<div className="border border-rose-500/40 bg-rose-500/5 rounded-lg px-3 py-2 text-xs">
-				<div className="flex items-center gap-2 mb-1">
-					<span className="text-[10px] font-semibold text-rose-500">Error</span>
-					<span className="text-[10px] text-muted-foreground tabular-nums">
-						{formatClock(event.ts)}
-					</span>
-				</div>
-				<div className="whitespace-pre-wrap font-mono text-[11px] text-rose-400">
-					{event.text}
-				</div>
+			<div className="border-l-2 border-rose-500/60 bg-rose-500/5 pl-2 py-1 text-xs my-1 whitespace-pre-wrap font-mono text-rose-400">
+				{event.text}
 			</div>
 		);
 	}
 	if (event.kind === "system_init") {
 		return (
-			<div className="flex items-center gap-2 px-2 py-1 text-[10px] text-muted-foreground">
-				<span className="font-semibold uppercase tracking-wide">
-					{event.label}
-				</span>
-				<span className="truncate">{event.text}</span>
+			<div className="flex items-baseline gap-2 text-[10px] text-muted-foreground py-0.5">
+				<span className="font-semibold shrink-0">{event.label}</span>
+				<span className="truncate font-mono opacity-70">{event.text}</span>
 			</div>
 		);
 	}
 	return (
-		<div className="border border-border/40 bg-background rounded-lg px-3 py-2 text-xs">
-			<div className="flex items-center gap-2 mb-1">
-				<span className="text-[10px] font-semibold text-muted-foreground uppercase tracking-wide">
+		<details className="text-xs py-0.5">
+			<summary className="list-none cursor-pointer flex items-baseline gap-1 text-muted-foreground hover:text-foreground">
+				<span className="text-[10px] opacity-50">▶</span>
+				<span className="text-[10px] font-semibold uppercase">
 					{event.label}
 				</span>
-				<span className="text-[10px] text-muted-foreground tabular-nums">
-					{formatClock(event.ts)}
+				<span className="text-[10px] truncate font-mono opacity-70">
+					{event.text.slice(0, 100)}
 				</span>
-			</div>
-			<div className="whitespace-pre-wrap font-mono text-[11px] leading-relaxed">
+			</summary>
+			<pre className="ml-3 mt-1 whitespace-pre-wrap break-all font-mono text-[11px] text-foreground/80 max-h-40 overflow-y-auto">
 				{event.text}
-			</div>
-		</div>
+			</pre>
+		</details>
 	);
 }
 
-function formatClock(ms: number): string {
+function _formatClock(ms: number): string {
 	const d = new Date(ms);
 	const pad = (n: number) => n.toString().padStart(2, "0");
 	return `${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`;

--- a/apps/desktop/src/renderer/features/todo-agent/TodoManager/TodoManager.tsx
+++ b/apps/desktop/src/renderer/features/todo-agent/TodoManager/TodoManager.tsx
@@ -1012,64 +1012,49 @@ function formatDuration(startMs: number | null, endMs: number | null): string {
 	return `${h}時間${m}分`;
 }
 
+/**
+ * Pair consecutive tool_use → tool_result events into a single card
+ * (matching VSCode Claude Code extension's IN / OUT grid layout).
+ * Non-tool events stay as singles. Unpaired tool_use (still streaming)
+ * appears as a card with empty OUT row.
+ */
 type StreamItem =
-	| { type: "single"; id: string; event: TodoStreamEvent }
+	| { type: "message"; id: string; event: TodoStreamEvent }
 	| {
-			type: "tools";
+			type: "tool";
 			id: string;
-			events: TodoStreamEvent[];
-			iteration: number;
+			toolUse: TodoStreamEvent;
+			toolResult: TodoStreamEvent | null;
 	  };
 
-/**
- * Collapse consecutive tool_use / tool_result events into a
- * single grouped item so the live stream reads like VS Code's
- * Claude Code extension — a tall, dense list of N tool calls
- * becomes one compact row you can expand when you actually care.
- * assistant_text / result / error / system_init / raw stay as
- * their own rows because they are the narrative checkpoints
- * users scan for (user prompts are emitted as `raw` via
- * appendUserEvent, so grouping them would hide iteration
- * boundaries inside collapsed tool blocks).
- */
-function groupStreamEvents(events: TodoStreamEvent[]): StreamItem[] {
+function pairStreamEvents(events: TodoStreamEvent[]): StreamItem[] {
 	const items: StreamItem[] = [];
-	let toolBucket: TodoStreamEvent[] = [];
-	const flushBucket = () => {
-		if (toolBucket.length === 0) return;
-		const first = toolBucket[0];
-		// Key on the id of the first event in the bucket and the
-		// iteration, NOT the bucket length. Otherwise every newly
-		// streamed event forces a remount of StreamToolGroup and
-		// its local `open` state resets to collapsed — users who
-		// expanded the group to read live output would see it
-		// close on them on every new chunk.
-		items.push({
-			type: "tools",
-			id: `tools:${first?.id ?? ""}`,
-			events: toolBucket,
-			iteration: first?.iteration ?? 0,
-		});
-		toolBucket = [];
-	};
-	for (const ev of events) {
-		if (ev.kind === "tool_use" || ev.kind === "tool_result") {
-			toolBucket.push(ev);
-			continue;
+	for (let i = 0; i < events.length; i++) {
+		const ev = events[i];
+		if (!ev) continue;
+		if (ev.kind === "tool_use") {
+			const next = events[i + 1];
+			if (next?.kind === "tool_result") {
+				items.push({
+					type: "tool",
+					id: ev.id,
+					toolUse: ev,
+					toolResult: next,
+				});
+				i++;
+			} else {
+				items.push({ type: "tool", id: ev.id, toolUse: ev, toolResult: null });
+			}
+		} else if (ev.kind === "tool_result") {
+			items.push({ type: "message", id: ev.id, event: ev });
+		} else {
+			items.push({ type: "message", id: ev.id, event: ev });
 		}
-		flushBucket();
-		items.push({ type: "single", id: ev.id, event: ev });
 	}
-	flushBucket();
 	return items;
 }
 
 function StreamView({ events }: { events: TodoStreamEvent[] }) {
-	// Auto-scroll to the bottom whenever a new event arrives, but only
-	// if the user hadn't scrolled up to read older output. Tracked via
-	// a `pinnedToBottom` ref that flips to false the moment the user
-	// manually scrolls up, and back to true when they scroll near the
-	// bottom again.
 	const scrollRef = useRef<HTMLDivElement | null>(null);
 	const pinnedToBottomRef = useRef(true);
 
@@ -1081,7 +1066,7 @@ function StreamView({ events }: { events: TodoStreamEvent[] }) {
 		pinnedToBottomRef.current = distanceFromBottom < 40;
 	}, []);
 
-	// biome-ignore lint/correctness/useExhaustiveDependencies: events.length intentional — we want to scroll on new events, not on identity changes
+	// biome-ignore lint/correctness/useExhaustiveDependencies: events.length intentional
 	useEffect(() => {
 		if (!pinnedToBottomRef.current) return;
 		const el = scrollRef.current;
@@ -1089,13 +1074,13 @@ function StreamView({ events }: { events: TodoStreamEvent[] }) {
 		el.scrollTop = el.scrollHeight;
 	}, [events.length]);
 
-	const items = useMemo(() => groupStreamEvents(events), [events]);
+	const items = useMemo(() => pairStreamEvents(events), [events]);
 
 	return (
 		<div
 			ref={scrollRef}
 			onScroll={handleScroll}
-			className="h-full overflow-auto bg-muted/30 rounded p-3 flex flex-col gap-2"
+			className="h-full overflow-auto bg-muted/30 rounded p-3 flex flex-col gap-1.5"
 		>
 			{events.length === 0 ? (
 				<div className="text-xs text-muted-foreground p-2">
@@ -1104,10 +1089,10 @@ function StreamView({ events }: { events: TodoStreamEvent[] }) {
 				</div>
 			) : (
 				items.map((item) =>
-					item.type === "single" ? (
-						<StreamEventRow key={item.id} event={item.event} />
+					item.type === "tool" ? (
+						<ToolCallCard key={item.id} item={item} />
 					) : (
-						<StreamToolGroup key={item.id} item={item} />
+						<MessageRow key={item.id} event={item.event} />
 					),
 				)
 			)}
@@ -1115,101 +1100,156 @@ function StreamView({ events }: { events: TodoStreamEvent[] }) {
 	);
 }
 
-function StreamToolGroup({
+/**
+ * VSCode Claude Code style tool card: compact header with tool name +
+ * secondary info, then an IN/OUT grid body. No folding — always visible.
+ */
+function ToolCallCard({
 	item,
 }: {
-	item: Extract<StreamItem, { type: "tools" }>;
+	item: Extract<StreamItem, { type: "tool" }>;
 }) {
-	const [open, setOpen] = useState(false);
-	const toolUseCount = item.events.filter((e) => e.kind === "tool_use").length;
-	const resultCount = item.events.filter(
-		(e) => e.kind === "tool_result",
-	).length;
-	const lastTool = [...item.events]
-		.reverse()
-		.find((e) => e.kind === "tool_use");
-	const summary = lastTool
-		? `${lastTool.label}: ${lastTool.text.replace(/\s+/g, " ").slice(0, 80)}`
-		: "ツール実行";
+	const { toolUse, toolResult } = item;
+	const toolName = toolUse.label;
+	const secondary = extractSecondaryInfo(toolName, toolUse.text);
+
 	return (
-		<div className="border border-border/40 rounded-lg bg-background/40">
-			<button
-				type="button"
-				onClick={() => setOpen((v) => !v)}
-				className="w-full flex items-center gap-2 px-3 py-1.5 text-left hover:bg-accent/30 transition rounded-lg"
-			>
-				{open ? (
-					<HiMiniChevronDown className="size-3 text-muted-foreground shrink-0" />
-				) : (
-					<HiMiniChevronRight className="size-3 text-muted-foreground shrink-0" />
-				)}
-				<span className="text-[10px] uppercase tracking-wide text-muted-foreground font-semibold shrink-0">
-					[iter {item.iteration}]
+		<div className="border border-border/40 rounded-lg bg-background/50 text-xs overflow-hidden">
+			<div className="flex items-center gap-2 px-3 py-1.5 bg-muted/40 border-b border-border/30">
+				<span className="font-semibold text-amber-600 shrink-0">
+					{toolName}
 				</span>
-				<span className="text-[10px] font-semibold text-amber-600 shrink-0">
-					🔧 {toolUseCount}件
-				</span>
-				{resultCount > 0 && (
-					<span className="text-[10px] text-emerald-600 shrink-0">
-						✓ {resultCount}
+				{secondary && (
+					<span className="text-muted-foreground truncate font-mono text-[11px]">
+						{secondary}
 					</span>
 				)}
-				<span className="text-[11px] text-muted-foreground truncate flex-1 font-mono">
-					{summary}
+				<span className="ml-auto text-[10px] text-muted-foreground tabular-nums shrink-0">
+					{formatClock(toolUse.ts)}
 				</span>
-			</button>
-			{open && (
-				<div className="flex flex-col gap-1.5 px-2 pb-2 pt-1">
-					{item.events.map((ev) => (
-						<StreamEventRow key={ev.id} event={ev} />
-					))}
+			</div>
+			<div className="divide-y divide-border/20">
+				<div className="flex min-h-0">
+					<div className="shrink-0 w-10 flex items-start justify-center py-1.5 text-[10px] font-semibold text-muted-foreground/70">
+						IN
+					</div>
+					<div className="flex-1 py-1.5 pr-3 overflow-hidden">
+						<pre className="whitespace-pre-wrap break-all font-mono text-[11px] leading-relaxed max-h-24 overflow-y-auto text-foreground/80">
+							{toolUse.text.slice(0, 500)}
+							{toolUse.text.length > 500 ? "…" : ""}
+						</pre>
+					</div>
 				</div>
-			)}
+				<div className="flex min-h-0">
+					<div className="shrink-0 w-10 flex items-start justify-center py-1.5 text-[10px] font-semibold text-emerald-600/70">
+						OUT
+					</div>
+					<div className="flex-1 py-1.5 pr-3 overflow-hidden">
+						{toolResult ? (
+							<pre className="whitespace-pre-wrap break-all font-mono text-[11px] leading-relaxed max-h-24 overflow-y-auto text-foreground/80">
+								{toolResult.text.slice(0, 500)}
+								{toolResult.text.length > 500 ? "…" : ""}
+							</pre>
+						) : (
+							<span className="text-[11px] text-muted-foreground animate-pulse">
+								実行中…
+							</span>
+						)}
+					</div>
+				</div>
+			</div>
 		</div>
 	);
 }
 
-function StreamEventRow({ event }: { event: TodoStreamEvent }) {
-	const color =
-		event.kind === "assistant_text"
-			? "border-primary/40 bg-primary/5"
-			: event.kind === "tool_use"
-				? "border-amber-500/40 bg-amber-500/5"
-				: event.kind === "tool_result"
-					? "border-emerald-500/30 bg-emerald-500/5"
-					: event.kind === "result"
-						? "border-emerald-600/50 bg-emerald-600/10"
-						: event.kind === "error"
-							? "border-rose-500/50 bg-rose-500/5"
-							: "border-border/40 bg-background";
-	// Markdown rendering for the two kinds where authoring is natural
-	// (Claude's prose assistant messages + the final `result` text).
-	// Tool calls, tool results, and raw log lines stay plain text so
-	// their monospace / short-label nature is preserved.
-	const useMarkdown =
-		event.kind === "assistant_text" || event.kind === "result";
-	return (
-		<div className={cn("group border rounded-lg px-3 py-2 text-xs", color)}>
-			<div className="flex items-center justify-between gap-2 mb-1">
-				<span className="text-[10px] uppercase tracking-wide text-muted-foreground font-semibold">
-					[iter {event.iteration}] {event.label}
-				</span>
-				<div className="flex items-center gap-1">
+function extractSecondaryInfo(_toolName: string, text: string): string | null {
+	const colonIdx = text.indexOf(": ");
+	if (colonIdx > 0 && colonIdx < 60) {
+		return text.slice(colonIdx + 2, colonIdx + 120).trim();
+	}
+	if (text.length <= 120) return text;
+	return text.slice(0, 80);
+}
+
+function MessageRow({ event }: { event: TodoStreamEvent }) {
+	if (event.kind === "assistant_text") {
+		return (
+			<div className="group border border-primary/30 bg-primary/5 rounded-lg px-3 py-2 text-xs">
+				<div className="flex items-center justify-between gap-2 mb-1">
+					<span className="text-[10px] font-semibold text-primary/80">
+						Claude
+					</span>
+					<div className="flex items-center gap-1">
+						<span className="text-[10px] text-muted-foreground tabular-nums">
+							{formatClock(event.ts)}
+						</span>
+						<div className="opacity-0 group-hover:opacity-100 transition">
+							<CopyIconButton value={event.text} title="コピー" />
+						</div>
+					</div>
+				</div>
+				<MarkdownRenderer content={event.text} scrollable={false} />
+			</div>
+		);
+	}
+	if (event.kind === "result") {
+		return (
+			<div className="group border border-emerald-600/40 bg-emerald-600/10 rounded-lg px-3 py-2 text-xs">
+				<div className="flex items-center justify-between gap-2 mb-1">
+					<span className="text-[10px] font-semibold text-emerald-600">
+						Result
+					</span>
+					<div className="flex items-center gap-1">
+						<span className="text-[10px] text-muted-foreground tabular-nums">
+							{formatClock(event.ts)}
+						</span>
+						<div className="opacity-0 group-hover:opacity-100 transition">
+							<CopyIconButton value={event.text} title="コピー" />
+						</div>
+					</div>
+				</div>
+				<MarkdownRenderer content={event.text} scrollable={false} />
+			</div>
+		);
+	}
+	if (event.kind === "error") {
+		return (
+			<div className="border border-rose-500/40 bg-rose-500/5 rounded-lg px-3 py-2 text-xs">
+				<div className="flex items-center gap-2 mb-1">
+					<span className="text-[10px] font-semibold text-rose-500">Error</span>
 					<span className="text-[10px] text-muted-foreground tabular-nums">
 						{formatClock(event.ts)}
 					</span>
-					<div className="opacity-0 group-hover:opacity-100 transition">
-						<CopyIconButton value={event.text} title="このイベントをコピー" />
-					</div>
 				</div>
-			</div>
-			{useMarkdown ? (
-				<MarkdownRenderer content={event.text} scrollable={false} />
-			) : (
-				<div className="whitespace-pre-wrap leading-relaxed font-mono text-[11px]">
+				<div className="whitespace-pre-wrap font-mono text-[11px] text-rose-400">
 					{event.text}
 				</div>
-			)}
+			</div>
+		);
+	}
+	if (event.kind === "system_init") {
+		return (
+			<div className="flex items-center gap-2 px-2 py-1 text-[10px] text-muted-foreground">
+				<span className="font-semibold uppercase tracking-wide">
+					{event.label}
+				</span>
+				<span className="truncate">{event.text}</span>
+			</div>
+		);
+	}
+	return (
+		<div className="border border-border/40 bg-background rounded-lg px-3 py-2 text-xs">
+			<div className="flex items-center gap-2 mb-1">
+				<span className="text-[10px] font-semibold text-muted-foreground uppercase tracking-wide">
+					{event.label}
+				</span>
+				<span className="text-[10px] text-muted-foreground tabular-nums">
+					{formatClock(event.ts)}
+				</span>
+			</div>
+			<div className="whitespace-pre-wrap font-mono text-[11px] leading-relaxed">
+				{event.text}
+			</div>
 		</div>
 	);
 }

--- a/apps/desktop/src/renderer/features/todo-agent/TodoManager/TodoManager.tsx
+++ b/apps/desktop/src/renderer/features/todo-agent/TodoManager/TodoManager.tsx
@@ -1022,32 +1022,38 @@ type StreamItem =
 	  };
 
 /**
- * Collapse consecutive tool_use / tool_result / raw events into a
+ * Collapse consecutive tool_use / tool_result events into a
  * single grouped item so the live stream reads like VS Code's
  * Claude Code extension — a tall, dense list of N tool calls
  * becomes one compact row you can expand when you actually care.
- * assistant_text / result / error / system_init stay as their own
- * rows because they are the narrative checkpoints users scan for.
+ * assistant_text / result / error / system_init / raw stay as
+ * their own rows because they are the narrative checkpoints
+ * users scan for (user prompts are emitted as `raw` via
+ * appendUserEvent, so grouping them would hide iteration
+ * boundaries inside collapsed tool blocks).
  */
 function groupStreamEvents(events: TodoStreamEvent[]): StreamItem[] {
 	const items: StreamItem[] = [];
 	let toolBucket: TodoStreamEvent[] = [];
 	const flushBucket = () => {
 		if (toolBucket.length === 0) return;
+		const first = toolBucket[0];
+		// Key on the id of the first event in the bucket and the
+		// iteration, NOT the bucket length. Otherwise every newly
+		// streamed event forces a remount of StreamToolGroup and
+		// its local `open` state resets to collapsed — users who
+		// expanded the group to read live output would see it
+		// close on them on every new chunk.
 		items.push({
 			type: "tools",
-			id: `tools:${toolBucket[0]?.id ?? ""}:${toolBucket.length}`,
+			id: `tools:${first?.id ?? ""}`,
 			events: toolBucket,
-			iteration: toolBucket[0]?.iteration ?? 0,
+			iteration: first?.iteration ?? 0,
 		});
 		toolBucket = [];
 	};
 	for (const ev of events) {
-		if (
-			ev.kind === "tool_use" ||
-			ev.kind === "tool_result" ||
-			ev.kind === "raw"
-		) {
+		if (ev.kind === "tool_use" || ev.kind === "tool_result") {
 			toolBucket.push(ev);
 			continue;
 		}

--- a/apps/desktop/src/renderer/features/todo-agent/TodoManager/TodoManager.tsx
+++ b/apps/desktop/src/renderer/features/todo-agent/TodoManager/TodoManager.tsx
@@ -1012,6 +1012,52 @@ function formatDuration(startMs: number | null, endMs: number | null): string {
 	return `${h}時間${m}分`;
 }
 
+type StreamItem =
+	| { type: "single"; id: string; event: TodoStreamEvent }
+	| {
+			type: "tools";
+			id: string;
+			events: TodoStreamEvent[];
+			iteration: number;
+	  };
+
+/**
+ * Collapse consecutive tool_use / tool_result / raw events into a
+ * single grouped item so the live stream reads like VS Code's
+ * Claude Code extension — a tall, dense list of N tool calls
+ * becomes one compact row you can expand when you actually care.
+ * assistant_text / result / error / system_init stay as their own
+ * rows because they are the narrative checkpoints users scan for.
+ */
+function groupStreamEvents(events: TodoStreamEvent[]): StreamItem[] {
+	const items: StreamItem[] = [];
+	let toolBucket: TodoStreamEvent[] = [];
+	const flushBucket = () => {
+		if (toolBucket.length === 0) return;
+		items.push({
+			type: "tools",
+			id: `tools:${toolBucket[0]?.id ?? ""}:${toolBucket.length}`,
+			events: toolBucket,
+			iteration: toolBucket[0]?.iteration ?? 0,
+		});
+		toolBucket = [];
+	};
+	for (const ev of events) {
+		if (
+			ev.kind === "tool_use" ||
+			ev.kind === "tool_result" ||
+			ev.kind === "raw"
+		) {
+			toolBucket.push(ev);
+			continue;
+		}
+		flushBucket();
+		items.push({ type: "single", id: ev.id, event: ev });
+	}
+	flushBucket();
+	return items;
+}
+
 function StreamView({ events }: { events: TodoStreamEvent[] }) {
 	// Auto-scroll to the bottom whenever a new event arrives, but only
 	// if the user hadn't scrolled up to read older output. Tracked via
@@ -1037,6 +1083,8 @@ function StreamView({ events }: { events: TodoStreamEvent[] }) {
 		el.scrollTop = el.scrollHeight;
 	}, [events.length]);
 
+	const items = useMemo(() => groupStreamEvents(events), [events]);
+
 	return (
 		<div
 			ref={scrollRef}
@@ -1049,7 +1097,67 @@ function StreamView({ events }: { events: TodoStreamEvent[] }) {
 					Claude の応答・ツール使用・verify 結果が流れます。
 				</div>
 			) : (
-				events.map((event) => <StreamEventRow key={event.id} event={event} />)
+				items.map((item) =>
+					item.type === "single" ? (
+						<StreamEventRow key={item.id} event={item.event} />
+					) : (
+						<StreamToolGroup key={item.id} item={item} />
+					),
+				)
+			)}
+		</div>
+	);
+}
+
+function StreamToolGroup({
+	item,
+}: {
+	item: Extract<StreamItem, { type: "tools" }>;
+}) {
+	const [open, setOpen] = useState(false);
+	const toolUseCount = item.events.filter((e) => e.kind === "tool_use").length;
+	const resultCount = item.events.filter(
+		(e) => e.kind === "tool_result",
+	).length;
+	const lastTool = [...item.events]
+		.reverse()
+		.find((e) => e.kind === "tool_use");
+	const summary = lastTool
+		? `${lastTool.label}: ${lastTool.text.replace(/\s+/g, " ").slice(0, 80)}`
+		: "ツール実行";
+	return (
+		<div className="border border-border/40 rounded-lg bg-background/40">
+			<button
+				type="button"
+				onClick={() => setOpen((v) => !v)}
+				className="w-full flex items-center gap-2 px-3 py-1.5 text-left hover:bg-accent/30 transition rounded-lg"
+			>
+				{open ? (
+					<HiMiniChevronDown className="size-3 text-muted-foreground shrink-0" />
+				) : (
+					<HiMiniChevronRight className="size-3 text-muted-foreground shrink-0" />
+				)}
+				<span className="text-[10px] uppercase tracking-wide text-muted-foreground font-semibold shrink-0">
+					[iter {item.iteration}]
+				</span>
+				<span className="text-[10px] font-semibold text-amber-600 shrink-0">
+					🔧 {toolUseCount}件
+				</span>
+				{resultCount > 0 && (
+					<span className="text-[10px] text-emerald-600 shrink-0">
+						✓ {resultCount}
+					</span>
+				)}
+				<span className="text-[11px] text-muted-foreground truncate flex-1 font-mono">
+					{summary}
+				</span>
+			</button>
+			{open && (
+				<div className="flex flex-col gap-1.5 px-2 pb-2 pt-1">
+					{item.events.map((ev) => (
+						<StreamEventRow key={ev.id} event={ev} />
+					))}
+				</div>
 			)}
 		</div>
 	);

--- a/apps/desktop/src/renderer/features/todo-agent/TodoModal/TodoModal.tsx
+++ b/apps/desktop/src/renderer/features/todo-agent/TodoModal/TodoModal.tsx
@@ -54,6 +54,10 @@ export function TodoModal({
 	const [description, setDescription] = useState("");
 	const [goal, setGoal] = useState("");
 	const [verifyCommand, setVerifyCommand] = useState(DEFAULT_VERIFY_COMMAND);
+	const { data: todoSettings } = electronTrpc.todoAgent.settings.get.useQuery(
+		undefined,
+		{ enabled: open },
+	);
 	const [maxIterations, setMaxIterations] = useState(DEFAULT_MAX_ITERATIONS);
 	const [maxMinutes, setMaxMinutes] = useState(DEFAULT_MAX_MINUTES);
 	const [submitting, setSubmitting] = useState(false);
@@ -83,12 +87,14 @@ export function TodoModal({
 		setDescription("");
 		setGoal("");
 		setVerifyCommand(DEFAULT_VERIFY_COMMAND);
-		setMaxIterations(DEFAULT_MAX_ITERATIONS);
-		setMaxMinutes(DEFAULT_MAX_MINUTES);
+		setMaxIterations(
+			todoSettings?.defaultMaxIterations ?? DEFAULT_MAX_ITERATIONS,
+		);
+		setMaxMinutes(todoSettings?.defaultMaxWallClockMin ?? DEFAULT_MAX_MINUTES);
 		setCreateWorktree(DEFAULT_CREATE_WORKTREE);
 		setSelectedPresetId(null);
 		setSubmitting(false);
-	}, []);
+	}, [todoSettings]);
 
 	const handleOpenChange = useCallback(
 		(next: boolean) => {

--- a/bun.lock
+++ b/bun.lock
@@ -110,7 +110,7 @@
     },
     "apps/desktop": {
       "name": "@superset/desktop",
-      "version": "1.5.3",
+      "version": "1.5.5",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.43",
         "@ai-sdk/openai": "3.0.36",

--- a/packages/local-db/drizzle/0055_todo_preset_kind_workspace.sql
+++ b/packages/local-db/drizzle/0055_todo_preset_kind_workspace.sql
@@ -1,0 +1,4 @@
+ALTER TABLE `todo_prompt_presets` ADD `kind` text DEFAULT 'system' NOT NULL;--> statement-breakpoint
+ALTER TABLE `todo_prompt_presets` ADD `workspace_id` text;--> statement-breakpoint
+CREATE INDEX `todo_prompt_presets_kind_idx` ON `todo_prompt_presets` (`kind`);--> statement-breakpoint
+CREATE INDEX `todo_prompt_presets_workspace_idx` ON `todo_prompt_presets` (`workspace_id`);

--- a/packages/local-db/drizzle/meta/0055_snapshot.json
+++ b/packages/local-db/drizzle/meta/0055_snapshot.json
@@ -1,0 +1,1919 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "b96cd168-974e-4c4f-9eae-54dc1ffc1cd6",
+  "prevId": "9b71dc98-01d0-42cd-8ee5-91c7c1f36996",
+  "tables": {
+    "browser_history": {
+      "name": "browser_history",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "favicon_url": {
+          "name": "favicon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_visited_at": {
+          "name": "last_visited_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "visit_count": {
+          "name": "visit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "browser_history_url_unique": {
+          "name": "browser_history_url_unique",
+          "columns": [
+            "url"
+          ],
+          "isUnique": true
+        },
+        "browser_history_url_idx": {
+          "name": "browser_history_url_idx",
+          "columns": [
+            "url"
+          ],
+          "isUnique": false
+        },
+        "browser_history_last_visited_at_idx": {
+          "name": "browser_history_last_visited_at_idx",
+          "columns": [
+            "last_visited_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "browser_site_permissions": {
+      "name": "browser_site_permissions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "origin": {
+          "name": "origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'ask'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "browser_site_permissions_origin_idx": {
+          "name": "browser_site_permissions_origin_idx",
+          "columns": [
+            "origin"
+          ],
+          "isUnique": false
+        },
+        "browser_site_permissions_origin_kind_unique": {
+          "name": "browser_site_permissions_origin_kind_unique",
+          "columns": [
+            "origin",
+            "kind"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organization_members": {
+      "name": "organization_members",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organization_members_organization_id_idx": {
+          "name": "organization_members_organization_id_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "organization_members_user_id_idx": {
+          "name": "organization_members_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "organization_members_organization_id_organizations_id_fk": {
+          "name": "organization_members_organization_id_organizations_id_fk",
+          "tableFrom": "organization_members",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_members_user_id_users_id_fk": {
+          "name": "organization_members_user_id_users_id_fk",
+          "tableFrom": "organization_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organizations": {
+      "name": "organizations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "clerk_org_id": {
+          "name": "clerk_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "github_org": {
+          "name": "github_org",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organizations_clerk_org_id_unique": {
+          "name": "organizations_clerk_org_id_unique",
+          "columns": [
+            "clerk_org_id"
+          ],
+          "isUnique": true
+        },
+        "organizations_slug_unique": {
+          "name": "organizations_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        },
+        "organizations_slug_idx": {
+          "name": "organizations_slug_idx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": false
+        },
+        "organizations_clerk_org_id_idx": {
+          "name": "organizations_clerk_org_id_idx",
+          "columns": [
+            "clerk_org_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "main_repo_path": {
+          "name": "main_repo_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tab_order": {
+          "name": "tab_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_opened_at": {
+          "name": "last_opened_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config_toast_dismissed": {
+          "name": "config_toast_dismissed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_branch": {
+          "name": "default_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "workspace_base_branch": {
+          "name": "workspace_base_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "github_owner": {
+          "name": "github_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch_prefix_mode": {
+          "name": "branch_prefix_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch_prefix_custom": {
+          "name": "branch_prefix_custom",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "worktree_base_dir": {
+          "name": "worktree_base_dir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "hide_image": {
+          "name": "hide_image",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "icon_url": {
+          "name": "icon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "neon_project_id": {
+          "name": "neon_project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_app": {
+          "name": "default_app",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "projects_main_repo_path_idx": {
+          "name": "projects_main_repo_path_idx",
+          "columns": [
+            "main_repo_path"
+          ],
+          "isUnique": false
+        },
+        "projects_last_opened_at_idx": {
+          "name": "projects_last_opened_at_idx",
+          "columns": [
+            "last_opened_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "settings": {
+      "name": "settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "last_active_workspace_id": {
+          "name": "last_active_workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "terminal_presets": {
+          "name": "terminal_presets",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "terminal_presets_initialized": {
+          "name": "terminal_presets_initialized",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "agent_preset_overrides": {
+          "name": "agent_preset_overrides",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "agent_custom_definitions": {
+          "name": "agent_custom_definitions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "selected_ringtone_id": {
+          "name": "selected_ringtone_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "confirm_on_quit": {
+          "name": "confirm_on_quit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "terminal_link_behavior": {
+          "name": "terminal_link_behavior",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "persist_terminal": {
+          "name": "persist_terminal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "auto_apply_default_preset": {
+          "name": "auto_apply_default_preset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch_prefix_mode": {
+          "name": "branch_prefix_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch_prefix_custom": {
+          "name": "branch_prefix_custom",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notification_sounds_muted": {
+          "name": "notification_sounds_muted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notification_volume": {
+          "name": "notification_volume",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prevent_agent_sleep": {
+          "name": "prevent_agent_sleep",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "delete_local_branch": {
+          "name": "delete_local_branch",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "file_open_mode": {
+          "name": "file_open_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "right_sidebar_open_view_width": {
+          "name": "right_sidebar_open_view_width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "show_presets_bar": {
+          "name": "show_presets_bar",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "use_compact_terminal_add_button": {
+          "name": "use_compact_terminal_add_button",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "terminal_font_family": {
+          "name": "terminal_font_family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "terminal_font_size": {
+          "name": "terminal_font_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "editor_font_family": {
+          "name": "editor_font_family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "editor_font_size": {
+          "name": "editor_font_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "show_resource_monitor": {
+          "name": "show_resource_monitor",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "worktree_base_dir": {
+          "name": "worktree_base_dir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "open_links_in_app": {
+          "name": "open_links_in_app",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_editor": {
+          "name": "default_editor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "indent_rainbow_enabled": {
+          "name": "indent_rainbow_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "indent_rainbow_colors": {
+          "name": "indent_rainbow_colors",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trailing_spaces_enabled": {
+          "name": "trailing_spaces_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trailing_spaces_color": {
+          "name": "trailing_spaces_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reference_graph_enabled": {
+          "name": "reference_graph_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expose_host_service_via_relay": {
+          "name": "expose_host_service_via_relay",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enable_smart_commit": {
+          "name": "enable_smart_commit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "smart_commit_changes": {
+          "name": "smart_commit_changes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "auto_stash": {
+          "name": "auto_stash",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch_sort_order": {
+          "name": "branch_sort_order",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pin_default_branch": {
+          "name": "pin_default_branch",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "post_commit_command": {
+          "name": "post_commit_command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tasks": {
+      "name": "tasks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status_color": {
+          "name": "status_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status_type": {
+          "name": "status_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status_position": {
+          "name": "status_position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "assignee_id": {
+          "name": "assignee_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "estimate": {
+          "name": "estimate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "labels": {
+          "name": "labels",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pr_url": {
+          "name": "pr_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_provider": {
+          "name": "external_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_key": {
+          "name": "external_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_url": {
+          "name": "external_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sync_error": {
+          "name": "sync_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tasks_slug_unique": {
+          "name": "tasks_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        },
+        "tasks_slug_idx": {
+          "name": "tasks_slug_idx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": false
+        },
+        "tasks_organization_id_idx": {
+          "name": "tasks_organization_id_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "tasks_assignee_id_idx": {
+          "name": "tasks_assignee_id_idx",
+          "columns": [
+            "assignee_id"
+          ],
+          "isUnique": false
+        },
+        "tasks_status_idx": {
+          "name": "tasks_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "tasks_created_at_idx": {
+          "name": "tasks_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "tasks_organization_id_organizations_id_fk": {
+          "name": "tasks_organization_id_organizations_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tasks_assignee_id_users_id_fk": {
+          "name": "tasks_assignee_id_users_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "assignee_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "tasks_creator_id_users_id_fk": {
+          "name": "tasks_creator_id_users_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "clerk_id": {
+          "name": "clerk_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_clerk_id_unique": {
+          "name": "users_clerk_id_unique",
+          "columns": [
+            "clerk_id"
+          ],
+          "isUnique": true
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        },
+        "users_email_idx": {
+          "name": "users_email_idx",
+          "columns": [
+            "email"
+          ],
+          "isUnique": false
+        },
+        "users_clerk_id_idx": {
+          "name": "users_clerk_id_idx",
+          "columns": [
+            "clerk_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "workspace_sections": {
+      "name": "workspace_sections",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tab_order": {
+          "name": "tab_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_collapsed": {
+          "name": "is_collapsed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "workspace_sections_project_id_idx": {
+          "name": "workspace_sections_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "workspace_sections_project_id_projects_id_fk": {
+          "name": "workspace_sections_project_id_projects_id_fk",
+          "tableFrom": "workspace_sections",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "workspaces": {
+      "name": "workspaces",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "worktree_id": {
+          "name": "worktree_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tab_order": {
+          "name": "tab_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_opened_at": {
+          "name": "last_opened_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_unread": {
+          "name": "is_unread",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_unnamed": {
+          "name": "is_unnamed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "deleting_at": {
+          "name": "deleting_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "port_base": {
+          "name": "port_base",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "section_id": {
+          "name": "section_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "workspaces_project_id_idx": {
+          "name": "workspaces_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "workspaces_worktree_id_idx": {
+          "name": "workspaces_worktree_id_idx",
+          "columns": [
+            "worktree_id"
+          ],
+          "isUnique": false
+        },
+        "workspaces_last_opened_at_idx": {
+          "name": "workspaces_last_opened_at_idx",
+          "columns": [
+            "last_opened_at"
+          ],
+          "isUnique": false
+        },
+        "workspaces_section_id_idx": {
+          "name": "workspaces_section_id_idx",
+          "columns": [
+            "section_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "workspaces_project_id_projects_id_fk": {
+          "name": "workspaces_project_id_projects_id_fk",
+          "tableFrom": "workspaces",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workspaces_worktree_id_worktrees_id_fk": {
+          "name": "workspaces_worktree_id_worktrees_id_fk",
+          "tableFrom": "workspaces",
+          "tableTo": "worktrees",
+          "columnsFrom": [
+            "worktree_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workspaces_section_id_workspace_sections_id_fk": {
+          "name": "workspaces_section_id_workspace_sections_id_fk",
+          "tableFrom": "workspaces",
+          "tableTo": "workspace_sections",
+          "columnsFrom": [
+            "section_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "worktrees": {
+      "name": "worktrees",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "base_branch": {
+          "name": "base_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "git_status": {
+          "name": "git_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "github_status": {
+          "name": "github_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_superset": {
+          "name": "created_by_superset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        }
+      },
+      "indexes": {
+        "worktrees_project_id_idx": {
+          "name": "worktrees_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "worktrees_branch_idx": {
+          "name": "worktrees_branch_idx",
+          "columns": [
+            "branch"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "worktrees_project_id_projects_id_fk": {
+          "name": "worktrees_project_id_projects_id_fk",
+          "tableFrom": "worktrees",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "todo_prompt_presets": {
+      "name": "todo_prompt_presets",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'system'"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "todo_prompt_presets_name_idx": {
+          "name": "todo_prompt_presets_name_idx",
+          "columns": [
+            "name"
+          ],
+          "isUnique": false
+        },
+        "todo_prompt_presets_updated_at_idx": {
+          "name": "todo_prompt_presets_updated_at_idx",
+          "columns": [
+            "updated_at"
+          ],
+          "isUnique": false
+        },
+        "todo_prompt_presets_kind_idx": {
+          "name": "todo_prompt_presets_kind_idx",
+          "columns": [
+            "kind"
+          ],
+          "isUnique": false
+        },
+        "todo_prompt_presets_workspace_idx": {
+          "name": "todo_prompt_presets_workspace_idx",
+          "columns": [
+            "workspace_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "todo_sessions": {
+      "name": "todo_sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "goal": {
+          "name": "goal",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "verify_command": {
+          "name": "verify_command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_iterations": {
+          "name": "max_iterations",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10
+        },
+        "max_wall_clock_sec": {
+          "name": "max_wall_clock_sec",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1800
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'queued'"
+        },
+        "phase": {
+          "name": "phase",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "iteration": {
+          "name": "iteration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "attached_pane_id": {
+          "name": "attached_pane_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attached_tab_id": {
+          "name": "attached_tab_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "claude_session_id": {
+          "name": "claude_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "final_assistant_text": {
+          "name": "final_assistant_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_cost_usd": {
+          "name": "total_cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_num_turns": {
+          "name": "total_num_turns",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pending_intervention": {
+          "name": "pending_intervention",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start_head_sha": {
+          "name": "start_head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "custom_system_prompt": {
+          "name": "custom_system_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "verdict_passed": {
+          "name": "verdict_passed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "verdict_reason": {
+          "name": "verdict_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "verdict_failing_test": {
+          "name": "verdict_failing_test",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "artifact_path": {
+          "name": "artifact_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "todo_sessions_workspace_idx": {
+          "name": "todo_sessions_workspace_idx",
+          "columns": [
+            "workspace_id"
+          ],
+          "isUnique": false
+        },
+        "todo_sessions_status_idx": {
+          "name": "todo_sessions_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "todo_sessions_created_at_idx": {
+          "name": "todo_sessions_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "todo_sessions_project_id_projects_id_fk": {
+          "name": "todo_sessions_project_id_projects_id_fk",
+          "tableFrom": "todo_sessions",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "todo_sessions_workspace_id_workspaces_id_fk": {
+          "name": "todo_sessions_workspace_id_workspaces_id_fk",
+          "tableFrom": "todo_sessions",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/local-db/drizzle/meta/_journal.json
+++ b/packages/local-db/drizzle/meta/_journal.json
@@ -386,6 +386,13 @@
       "when": 1776281538363,
       "tag": "0054_todo_prompt_presets",
       "breakpoints": true
+    },
+    {
+      "idx": 55,
+      "version": "6",
+      "when": 1776307943454,
+      "tag": "0055_todo_preset_kind_workspace",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/local-db/src/schema/todo-prompt-presets.ts
+++ b/packages/local-db/src/schema/todo-prompt-presets.ts
@@ -14,6 +14,22 @@ export const todoPromptPresets = sqliteTable(
 			.$defaultFn(() => uuidv4()),
 		name: text("name").notNull(),
 		content: text("content").notNull(),
+		/**
+		 * What the preset is meant to fill in:
+		 * - "system": appended to the Claude system prompt (--append-system-prompt)
+		 * - "description": templates the "やって欲しいこと" field at TODO creation
+		 * - "goal": templates the "ゴール" field at TODO creation
+		 * Defaults to "system" so existing rows keep their previous semantics.
+		 */
+		kind: text("kind", { enum: ["system", "description", "goal"] })
+			.notNull()
+			.default("system"),
+		/**
+		 * Optional scoping to a specific workspace. NULL = global preset
+		 * (available across every workspace). Used by the UI to fold
+		 * presets into per-workspace folders.
+		 */
+		workspaceId: text("workspace_id"),
 		createdAt: integer("created_at")
 			.notNull()
 			.$defaultFn(() => Date.now()),
@@ -24,6 +40,8 @@ export const todoPromptPresets = sqliteTable(
 	(table) => [
 		index("todo_prompt_presets_name_idx").on(table.name),
 		index("todo_prompt_presets_updated_at_idx").on(table.updatedAt),
+		index("todo_prompt_presets_kind_idx").on(table.kind),
+		index("todo_prompt_presets_workspace_idx").on(table.workspaceId),
 	],
 );
 


### PR DESCRIPTION
## 概要

Issue #192 の対応。AgentManager のライブストリーム表示について 「ToolCall が全部展開されて忙しい」 「VSCode の Claude Code 拡張のようにシンプルにしたい」 という要望。

## 修正方針

VSCode 拡張と同じく、ツール実行はデフォルト 1 行に畳み、ユーザが気になるときだけ展開する形にした。

- \`groupStreamEvents\`: 連続する \`tool_use\` / \`tool_result\` / \`raw\` イベントを 1 つのグループにまとめる
- \`assistant_text\` / \`result\` / \`error\` / \`system_init\` はナラティブの区切り点なので個別行のまま残す
- 新コンポーネント \`StreamToolGroup\`:
  - 折りたたみヘッダには \`[iter N]\` / \`🔧N件\` / \`✓N件\` / 最後のツール呼び出しのサマリ（先頭 80 文字） を表示
  - クリックで展開し、中に従来どおりの \`StreamEventRow\` を並べる

## スコープ外

Issue 本文で Agent まとめ / VSCode 拡張の実装丸ごと調査 とも書かれているが、現状のストリームは \`tool_use\` / \`tool_result\` しか持たず、ツール種別ごとの固有 UI（Edit diff / Read 行番号など） は情報を追加で取り込まないと描けない。今回の PR は 「忙しい」 ことへの即効薬に絞り、固有 UI は別タスクで段階的に足す。

## Test plan
- [ ] ツールを多用するタスクを走らせ、ストリームが短く見やすくなっている
- [ ] ツールグループをクリックで展開→従来どおりの詳細が見える
- [ ] assistant_text / result / error は個別行として表示される
- [ ] 自動スクロールの振る舞いが変わっていない

Refs #192

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * Added settings panel for configuring agent parameters (max iterations, execution time, concurrent tasks).
  * Enhanced preset system with categorization and workspace support.
  * Redesigned presets dialog with tabbed interface.

* **Improvements**
  * Refined task status badges with running and queued indicators.
  * Improved stream event visualization with collapsible tool details and better formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->