### PR TITLE
fix(desktop): vibrancy ON時にダイアログ/モーダル背景の透過を修正

### DIFF
--- a/apps/desktop/src/renderer/globals.css
+++ b/apps/desktop/src/renderer/globals.css
@@ -138,6 +138,21 @@
 	);
 }
 
+/*
+ * Overlay components (dialog, sheet, drawer, alert-dialog) use bg-background,
+ * which becomes semi-transparent under vibrancy. Override them to use the
+ * near-opaque --popover value so content remains legible.
+ */
+:root[data-vibrancy="on"]
+	:is(
+		[data-slot="dialog-content"],
+		[data-slot="alert-dialog-content"],
+		[data-slot="sheet-content"],
+		[data-slot="drawer-content"]
+	) {
+	background-color: var(--popover);
+}
+
 :root[data-vibrancy="on"].light {
 	--background: rgb(255 255 255 / var(--vibrancy-alpha));
 	--card: rgb(255 255 255 / min(1, calc(var(--vibrancy-alpha) + 0.1)));


### PR DESCRIPTION
close MocA-Love/superset#185

## 概要

デスクトップアプリでVibrancy(透過)をONにすると、ダイアログ/モーダルの背景まで半透明になり内容が見づらくなる問題を修正。

## 原因

vibrancy ON時に `--background` CSS変数が `rgba(..., 0.6)` に設定される。Dialog/AlertDialog/Sheet/Drawerは `bg-background` を使っているため、そのまま半透明が適用されていた。一方 `--popover`(0.95)は適切な不透明度だが、これらのコンポーネントでは使われていなかった。

## 変更内容

- `apps/desktop/src/renderer/globals.css` のvibrancyセクションに、オーバーレイ系コンポーネント(`data-slot`セレクタ)の背景色を `var(--popover)` でオーバーライドするCSSルールを追加

| 対象コンポーネント | 変更前(alpha) | 変更後(alpha) |
|---|---|---|
| DialogContent | 0.6 | 0.95 |
| AlertDialogContent | 0.6 | 0.95 |
| SheetContent | 0.6 | 0.95 |
| DrawerContent | 0.6 | 0.95 |

## テスト方法

1. Settings > Appearance > Vibrancy をONにする
2. 任意のダイアログ/モーダルを開く（例: Settings自体、ファイル削除確認など）
3. 背景が透けず、コンテンツが読みやすいことを確認
4. Vibrancy OFFの場合に変化がないことを確認