### PR TITLE
fix(desktop): git pull --rebase時のunstagedエラーをフレンドリーダイアログに分類

### DIFF
--- a/apps/desktop/src/renderer/lib/git/classifyGitError.ts
+++ b/apps/desktop/src/renderer/lib/git/classifyGitError.ts
@@ -206,7 +206,13 @@ function classifyPullError(message: string): GitErrorKind | null {
 		) ||
 		lower.includes("would be overwritten by merge") ||
 		lower.includes("would be overwritten by checkout") ||
-		lower.includes("please commit your changes or stash")
+		lower.includes("please commit your changes or stash") ||
+		// `git pull --rebase` variant: "cannot pull with rebase: You have
+		// unstaged changes. Please commit or stash them." — different
+		// wording from the merge path above, so it needs its own match.
+		lower.includes("cannot pull with rebase") ||
+		lower.includes("please commit or stash them") ||
+		lower.includes("you have unstaged changes")
 	) {
 		return "pull-overwrite";
 	}


### PR DESCRIPTION
## 概要

Issue #201 の対応。以下のGitエラー時にフレンドリーなダイアログが出ず、\`Git 操作でエラーが発生しました / 詳細は下の出力を確認してください\` の素通しダイアログになっていた:

\`\`\`
error: cannot pull with rebase: You have unstaged changes.
error: Please commit or stash them.
\`\`\`

## 原因

\`classifyGitError\` の \`pull-overwrite\` パターンは merge系 (\`please commit your changes or stash\`) しか拾っておらず、rebase系の文言にマッチしていなかった。

## 修正

\`classifyGitError\` に rebase系パターンを3つ追加:

- \`cannot pull with rebase\`
- \`please commit or stash them\` (merge系の \`please commit your changes or stash\` との wording 差分)
- \`you have unstaged changes\`

これで \`pull-overwrite\` 扱いになり、 **stash→pull** / **discard→pull** の選択肢付きダイアログが出るようになる。

## Test plan
- [ ] unstaged 変更がある状態で pull → フレンドリーダイアログが出る
- [ ] 「stashして再試行」 / 「破棄して再試行」 のボタンが機能する
- [ ] 従来の merge 経路のエラーも引き続き拾えている

Closes #201