### PR TITLE
fix(desktop): Webview 内の File System Access API 拒否を回避 (#205)

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Works with any CLI agent. Built for local worktree-based development.
 | **Hover / Go-to-Definition** | エディタで変数・関数にホバーすると Markdown レンダリング対応の型情報・ドキュメントを表示。Shiki ベースのコードブロックハイライト付き。F12 / Cmd+Click / 右クリック「Go to Definition」で定義元にジャンプ。Cmd 押下時にトークンへ下線表示。TypeScript + 外部 LSP 対応 | [#156](https://github.com/MocA-Love/superset/pull/156) [#166](https://github.com/MocA-Love/superset/pull/166) | 2026-04-14 |
 | **タブ分割ボタン** | タブツールバーに縦分割・横分割ボタンを追加。ワンクリックでペインを分割可能 | [#155](https://github.com/MocA-Love/superset/pull/155) | 2026-04-14 |
 | **安定性・パフォーマンス改善** | LSP language services の安定性修正、拡張機能ホストのメモリリーク修正、ターミナル再表示遅延改善、認証切れ時の無限ループ防止、git status タイムアウト追加、ブラウザリダイレクトループ修正、ポップアウトウィンドウの認証修正、エラーの正規化と Sentry フィルタリング | [#88](https://github.com/MocA-Love/superset/pull/88) [#123](https://github.com/MocA-Love/superset/pull/123) [#121](https://github.com/MocA-Love/superset/pull/121) [#67](https://github.com/MocA-Love/superset/pull/67) [#66](https://github.com/MocA-Love/superset/pull/66) [#158](https://github.com/MocA-Love/superset/pull/158) [#146](https://github.com/MocA-Love/superset/pull/146) [#98](https://github.com/MocA-Love/superset/pull/98) | 2026-04-04〜14 |
+| **内部ブラウザの File System Access API 拒否回避** | 内部ブラウザで react-dropzone 系サイトを開くと `FileSystemFileHandle.getFile()` が NotAllowedError で落ちる問題を修正。`persist:superset` セッションに preload を追加し `DataTransferItem.getAsFileSystemHandle()` を null 返却に差し替えて legacy D&D パスへフォールバック | [#207](https://github.com/MocA-Love/superset/pull/207) | 2026-04-16 |
 
 ## Fork のビルド方法 (macOS)
 

--- a/apps/desktop/electron.vite.config.ts
+++ b/apps/desktop/electron.vite.config.ts
@@ -158,6 +158,7 @@ export default defineConfig({
 			rollupOptions: {
 				input: {
 					index: resolve("src/preload/index.ts"),
+					"webview-compat": resolve("src/preload/webview-compat.ts"),
 				},
 			},
 		},

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -31,6 +31,7 @@ import { requestAppleEventsAccess } from "./lib/apple-events-permission";
 import { setupAutoUpdater } from "./lib/auto-updater";
 import { initializeBrowserIdentityManager } from "./lib/browser/browser-identity-manager";
 import { browserSitePermissionManager } from "./lib/browser/browser-site-permission-manager";
+import { initializeBrowserWebviewCompat } from "./lib/browser/browser-webview-compat";
 import { resolveDevWorkspaceName } from "./lib/dev-workspace-name";
 import { setWorkspaceDockIcon } from "./lib/dock-icon";
 import { loadWebviewBrowserExtension } from "./lib/extensions";
@@ -528,6 +529,7 @@ if (!gotTheLock) {
 		registerWithMacOSNotificationCenter();
 		requestAppleEventsAccess();
 		initializeBrowserIdentityManager();
+		initializeBrowserWebviewCompat();
 		browserSitePermissionManager.initialize();
 		// One-shot sweep of 30-day-old pasted attachments so userData
 		// doesn't grow forever from screenshots dropped into TODOs.

--- a/apps/desktop/src/main/lib/browser/browser-webview-compat.ts
+++ b/apps/desktop/src/main/lib/browser/browser-webview-compat.ts
@@ -20,7 +20,6 @@ export function initializeBrowserWebviewCompat(): void {
 	if (initialized) {
 		return;
 	}
-	initialized = true;
 
 	const preloadPath = join(__dirname, "../preload/webview-compat.js");
 	const browserSession = session.fromPartition(APP_BROWSER_PARTITION);
@@ -28,4 +27,5 @@ export function initializeBrowserWebviewCompat(): void {
 	if (!existing.includes(preloadPath)) {
 		browserSession.setPreloads([...existing, preloadPath]);
 	}
+	initialized = true;
 }

--- a/apps/desktop/src/main/lib/browser/browser-webview-compat.ts
+++ b/apps/desktop/src/main/lib/browser/browser-webview-compat.ts
@@ -1,0 +1,31 @@
+import { join } from "node:path";
+import { session } from "electron";
+
+const APP_BROWSER_PARTITION = "persist:superset";
+
+// Register a session-level preload for the embedded browser partition.
+// It neutralizes File System Access API entrypoints that Electron cannot
+// satisfy inside guest web contents: react-dropzone (via file-selector)
+// prefers DataTransferItem.getAsFileSystemHandle() on drop and then calls
+// FileSystemFileHandle.getFile(), which raises
+//   NotAllowedError: Failed to execute 'getFile' on 'FileSystemFileHandle':
+//   The request is not allowed by the user agent or the platform in the
+//   current context.
+// Returning null from getAsFileSystemHandle() makes the library fall back
+// to the legacy DataTransferItem.getAsFile() / webkitGetAsEntry() path.
+
+let initialized = false;
+
+export function initializeBrowserWebviewCompat(): void {
+	if (initialized) {
+		return;
+	}
+	initialized = true;
+
+	const preloadPath = join(__dirname, "../preload/webview-compat.js");
+	const browserSession = session.fromPartition(APP_BROWSER_PARTITION);
+	const existing = browserSession.getPreloads();
+	if (!existing.includes(preloadPath)) {
+		browserSession.setPreloads([...existing, preloadPath]);
+	}
+}

--- a/apps/desktop/src/preload/webview-compat.ts
+++ b/apps/desktop/src/preload/webview-compat.ts
@@ -4,11 +4,18 @@ import { webFrame } from "electron";
 // on drop and then calls FileSystemFileHandle.getFile(), which raises NotAllowedError
 // inside Electron guest web contents. Returning null from getAsFileSystemHandle()
 // triggers the legacy DataTransferItem.getAsFile() / webkitGetAsEntry() fallback.
-webFrame.executeJavaScript(
-	`(() => {
-		const proto = typeof DataTransferItem !== "undefined" ? DataTransferItem.prototype : null;
-		if (proto && typeof proto.getAsFileSystemHandle === "function") {
-			proto.getAsFileSystemHandle = async function() { return null; };
-		}
-	})();`,
-);
+void webFrame
+	.executeJavaScript(
+		`(() => {
+			const proto = typeof DataTransferItem !== "undefined" ? DataTransferItem.prototype : null;
+			if (proto && typeof proto.getAsFileSystemHandle === "function") {
+				proto.getAsFileSystemHandle = async function() { return null; };
+			}
+		})();`,
+	)
+	.catch((error) => {
+		console.warn(
+			"[webview-compat] Failed to install getAsFileSystemHandle shim",
+			error,
+		);
+	});

--- a/apps/desktop/src/preload/webview-compat.ts
+++ b/apps/desktop/src/preload/webview-compat.ts
@@ -1,0 +1,14 @@
+import { webFrame } from "electron";
+
+// react-dropzone (via file-selector) prefers DataTransferItem.getAsFileSystemHandle()
+// on drop and then calls FileSystemFileHandle.getFile(), which raises NotAllowedError
+// inside Electron guest web contents. Returning null from getAsFileSystemHandle()
+// triggers the legacy DataTransferItem.getAsFile() / webkitGetAsEntry() fallback.
+webFrame.executeJavaScript(
+	`(() => {
+		const proto = typeof DataTransferItem !== "undefined" ? DataTransferItem.prototype : null;
+		if (proto && typeof proto.getAsFileSystemHandle === "function") {
+			proto.getAsFileSystemHandle = async function() { return null; };
+		}
+	})();`,
+);


### PR DESCRIPTION
## 概要

内部ブラウザ (BrowserPane / `persist:superset` パーティションの webview) で react-dropzone のように `DataTransferItem.getAsFileSystemHandle()` → `FileSystemFileHandle.getFile()` を使うサイトを開くと、Electron 側で

```
NotAllowedError: Failed to execute 'getFile' on 'FileSystemFileHandle': The request is not allowed by the user agent or the platform in the current context.
```

が発生する問題の修正です。

Closes #205

## 対応内容

- **新規** `apps/desktop/src/preload/webview-compat.ts`
  `webFrame.executeJavaScript` 経由で main world に `DataTransferItem.prototype.getAsFileSystemHandle = async () => null` を注入。
  これにより、react-dropzone (内部で file-selector を利用) は legacy な `DataTransferItem.getAsFile()` / `webkitGetAsEntry()` パスにフォールバックし、`NotAllowedError` を踏まなくなります。
- **新規** `apps/desktop/src/main/lib/browser/browser-webview-compat.ts`
  `persist:superset` セッションに上記プリロードを登録。`getPreloads()` と merge することで既存プリロードを壊さない。
- **編集** `apps/desktop/electron.vite.config.ts`
  プリロードビルドエントリに `webview-compat` を追加。
- **編集** `apps/desktop/src/main/index.ts`
  `initializeBrowserWebviewCompat()` を起動時に呼び出し。

## 既存機能への影響

パッチ対象は `DataTransferItem.getAsFileSystemHandle` のみで、`showOpenFilePicker()` などのファイル選択ダイアログ系 API は触らない。

| 機能 | 実装 | 影響 |
|------|------|------|
| 本体アプリのチャット入力 D&D | `e.dataTransfer.files` (HTML5 標準) | なし |
| Sidebar / NewTab / DropZoneOverlay の D&D | 同上 | なし |
| `window.webUtils.getPathForFile` | 独立 API | なし |
| Webview 内の外部サイトの D&D | 現在 NotAllowedError | 改善 (legacy パスで動作) |

本体アプリは元から `getAsFileSystemHandle` を使っていないため、既存のドラッグ&ドロップ機能に影響なし。

## テスト観点

- [ ] 内部ブラウザで react-dropzone を使っているサイト (例: ChatGPT, Gemini 等) を開き、ファイルをドラッグしても `NotAllowedError` が出ないこと
- [ ] 本体アプリのチャット入力へのファイル D&D が従来通り動作すること
- [ ] Sidebar / NewTab のファイル D&D が従来通り動作すること

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * 内部ブラウザが特定のサイトでクラッシュする問題を修正しました。ファイルハンドリングの互換性を向上させることで、より安定した動作環境を実現します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->