### PR TITLE
fix(desktop): ウィンドウ最小化→復元時にvibrancyが剥がれる問題を修正

### DIFF
--- a/apps/desktop/src/main/lib/window-manager/index.ts
+++ b/apps/desktop/src/main/lib/window-manager/index.ts
@@ -1,6 +1,7 @@
 import { join } from "node:path";
 import { type BrowserWindow, ipcMain, nativeTheme } from "electron";
 import { createWindow } from "lib/electron-app/factories/windows/create";
+import { PLATFORM } from "shared/constants";
 import { appState } from "../app-state";
 import {
 	applyVibrancy,
@@ -157,6 +158,22 @@ export class WindowManager {
 		window.on("closed", () => {
 			this.windows.delete(windowId);
 		});
+
+		// macOS Sequoia+: NSVisualEffectView can detach while the window is
+		// minimized in the Dock — the tearoff needs the same reshow guard as
+		// the main window or it restores opaque.
+		if (PLATFORM.IS_MAC) {
+			const reapplyVibrancyOnReshow = () => {
+				if (window.isDestroyed()) return;
+				applyVibrancy(
+					window,
+					appState.data?.vibrancyState ?? DEFAULT_VIBRANCY_STATE,
+					nativeTheme.shouldUseDarkColors,
+				);
+			};
+			window.on("restore", reapplyVibrancyOnReshow);
+			window.on("show", reapplyVibrancyOnReshow);
+		}
 
 		window.webContents.once("did-finish-load", () => {
 			// Re-apply vibrancy now that the tearoff is on-screen so the

--- a/apps/desktop/src/main/windows/main.ts
+++ b/apps/desktop/src/main/windows/main.ts
@@ -275,15 +275,28 @@ export async function MainWindow() {
 			},
 		);
 
-	// macOS Sequoia+: occluded/minimized windows can lose compositor layers
+	// macOS Sequoia+: occluded/minimized windows can lose compositor layers,
+	// and NSVisualEffectView's vibrancy/native blur can detach while the
+	// window is in the Dock — restoring without re-applying leaves the
+	// window opaque even though the user still has vibrancy enabled.
 	if (PLATFORM.IS_MAC) {
+		const reapplyVibrancyOnReshow = () => {
+			if (window.isDestroyed()) return;
+			applyVibrancy(
+				window,
+				appState.data?.vibrancyState ?? DEFAULT_VIBRANCY_STATE,
+				nativeTheme.shouldUseDarkColors,
+			);
+		};
 		window.on("restore", () => {
 			addWindowLifecycleBreadcrumb("main window restored");
 			window.webContents.invalidate();
+			reapplyVibrancyOnReshow();
 		});
 		window.on("show", () => {
 			addWindowLifecycleBreadcrumb("main window shown");
 			window.webContents.invalidate();
+			reapplyVibrancyOnReshow();
 		});
 	}
 


### PR DESCRIPTION
## 概要

macOS で vibrancy を有効にしたウィンドウを一度最小化して戻すと、透過が効かなくなってしまう問題を修正しました。

## 原因

`apps/desktop/src/main/windows/main.ts` の `restore` / `show` イベントハンドラが `webContents.invalidate()` でChromiumコンポジタ層の再描画だけを行い、NSVisualEffectView に対する `setVibrancy` / `setBackgroundColor`（透過アルファ付き）/ ネイティブ CIGaussianBlur の再適用を行っていませんでした。

macOS Sequoia+ では最小化中にNSVisualEffectViewやCABackdropLayerがデタッチされることがあり、復元時に透過とブラーが剥がれた状態になります。

## 修正内容

`restore` / `show` ハンドラで `applyVibrancy()` を呼び直すようにしました。既存の `did-finish-load` や `nativeTheme.updated` ハンドラと同じパターンです。

- `setVibrancy` で NSVisualEffectView を再アタッチ
- `setBackgroundColor` で透過アルファ付き色を再設定
- `scheduleNativeBlur` のリトライバースト（16/64/180/480/960ms）で CIGaussianBlur を再適用

## テスト方法

- [ ] Settings → Appearance で Vibrancy を ON にする
- [ ] ウィンドウを最小化（Cmd+M）
- [ ] Dockから戻す → 背景が透過されている
- [ ] `window.hide()` 経由の再表示（Cmd+W → 再オープン）でも透過が維持される

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## バグ修正

* **Bug Fixes**
  * macOSで、ウィンドウが隠れた状態や別ウィンドウに覆われた状態から復帰する際に、ウィンドウのビジュアル効果が適切に再度適用されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->