### PR TITLE
feat(desktop): Claude / Codex サービスステータスをTopBar右上に表示

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/index.ts
@@ -31,6 +31,7 @@ import { createProjectsRouter } from "./projects";
 import { createReferenceGraphRouter } from "./reference-graph";
 import { createResourceMetricsRouter } from "./resource-metrics";
 import { createRingtoneRouter } from "./ringtone";
+import { createServiceStatusRouter } from "./service-status";
 import { createSettingsRouter } from "./settings";
 import { createTabTearoffRouter } from "./tab-tearoff";
 import { createTerminalRouter } from "./terminal";
@@ -76,6 +77,7 @@ export const createAppRouter = (
 		docker: createDockerRouter(),
 		uiState: createUiStateRouter(),
 		ringtone: createRingtoneRouter(getWindow),
+		serviceStatus: createServiceStatusRouter(),
 		hostServiceCoordinator: createHostServiceCoordinatorRouter(),
 		tabTearoff: createTabTearoffRouter(wm),
 		extensions: createExtensionsRouter(getWindow),

--- a/apps/desktop/src/lib/trpc/routers/service-status.ts
+++ b/apps/desktop/src/lib/trpc/routers/service-status.ts
@@ -11,14 +11,16 @@ export const createServiceStatusRouter = () => {
 		// race where the query would later clobber fresh subscription data).
 		onChange: publicProcedure.subscription(() => {
 			return observable<ServiceStatusSnapshot>((emit) => {
-				for (const snapshot of serviceStatusService.getAll()) {
-					emit.next(snapshot);
-				}
-
+				// Register the listener BEFORE emitting the initial snapshots so
+				// that a `change` fired between the two steps (e.g. a polling
+				// cycle completing while we iterate) isn't lost.
 				const onChange = (snapshot: ServiceStatusSnapshot) => {
 					emit.next(snapshot);
 				};
 				serviceStatusService.on("change", onChange);
+				for (const snapshot of serviceStatusService.getAll()) {
+					emit.next(snapshot);
+				}
 				return () => {
 					serviceStatusService.off("change", onChange);
 				};

--- a/apps/desktop/src/lib/trpc/routers/service-status.ts
+++ b/apps/desktop/src/lib/trpc/routers/service-status.ts
@@ -5,12 +5,12 @@ import { publicProcedure, router } from "..";
 
 export const createServiceStatusRouter = () => {
 	return router({
-		getAll: publicProcedure.query(() => serviceStatusService.getAll()),
-
+		// No `getAll` query: the subscription emits the current state for every
+		// snapshot on connect, so the client gets the initial value without a
+		// separate round-trip (and we avoid the staleTime-Infinity / subscription
+		// race where the query would later clobber fresh subscription data).
 		onChange: publicProcedure.subscription(() => {
 			return observable<ServiceStatusSnapshot>((emit) => {
-				// Emit the current state immediately so late subscribers don't
-				// have to wait for the next poll tick.
 				for (const snapshot of serviceStatusService.getAll()) {
 					emit.next(snapshot);
 				}

--- a/apps/desktop/src/lib/trpc/routers/service-status.ts
+++ b/apps/desktop/src/lib/trpc/routers/service-status.ts
@@ -1,0 +1,28 @@
+import { observable } from "@trpc/server/observable";
+import { serviceStatusService } from "main/lib/service-status";
+import type { ServiceStatusSnapshot } from "shared/service-status-types";
+import { publicProcedure, router } from "..";
+
+export const createServiceStatusRouter = () => {
+	return router({
+		getAll: publicProcedure.query(() => serviceStatusService.getAll()),
+
+		onChange: publicProcedure.subscription(() => {
+			return observable<ServiceStatusSnapshot>((emit) => {
+				// Emit the current state immediately so late subscribers don't
+				// have to wait for the next poll tick.
+				for (const snapshot of serviceStatusService.getAll()) {
+					emit.next(snapshot);
+				}
+
+				const onChange = (snapshot: ServiceStatusSnapshot) => {
+					emit.next(snapshot);
+				};
+				serviceStatusService.on("change", onChange);
+				return () => {
+					serviceStatusService.off("change", onChange);
+				};
+			});
+		}),
+	});
+};

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -43,6 +43,7 @@ import { getHostServiceCoordinator as getHostServiceManager } from "./lib/host-s
 import { closeLocalDb, localDb } from "./lib/local-db";
 import { ensureProjectIconsDir, getProjectIconPath } from "./lib/project-icons";
 import { initSentry } from "./lib/sentry";
+import { setupServiceStatusPolling } from "./lib/service-status";
 import {
 	prewarmTerminalRuntime,
 	reconcileDaemonSessions,
@@ -624,6 +625,7 @@ if (!gotTheLock) {
 
 		await makeAppSetup(() => MainWindow());
 		setupAutoUpdater();
+		setupServiceStatusPolling();
 		initTray();
 
 		// Initialize VS Code extension host (registers protocols, starts webview server)

--- a/apps/desktop/src/main/lib/service-status/index.ts
+++ b/apps/desktop/src/main/lib/service-status/index.ts
@@ -1,0 +1,190 @@
+import { EventEmitter } from "node:events";
+import { app, net } from "electron";
+import {
+	indicatorToLevel,
+	SERVICE_STATUS_DEFINITIONS,
+	type ServiceStatusDefinition,
+	type ServiceStatusSnapshot,
+	type StatuspageIndicator,
+} from "shared/service-status-types";
+
+const POLL_INTERVAL_MS = 5 * 60 * 1000;
+const REQUEST_TIMEOUT_MS = 10_000;
+
+type StatuspageResponse = {
+	status?: { indicator?: StatuspageIndicator; description?: string };
+};
+
+class ServiceStatusService extends EventEmitter {
+	private snapshots = new Map<string, ServiceStatusSnapshot>();
+	private pollTimer: ReturnType<typeof setInterval> | null = null;
+	private started = false;
+
+	constructor() {
+		super();
+		for (const def of SERVICE_STATUS_DEFINITIONS) {
+			this.snapshots.set(def.id, {
+				id: def.id,
+				label: def.label,
+				statusUrl: def.statusUrl,
+				level: "unknown",
+				indicator: null,
+				description: "Checking…",
+				checkedAt: 0,
+				fetchError: null,
+			});
+		}
+	}
+
+	start(): void {
+		if (this.started) return;
+		this.started = true;
+		void this.refreshAll();
+		this.pollTimer = setInterval(() => {
+			void this.refreshAll();
+		}, POLL_INTERVAL_MS);
+	}
+
+	stop(): void {
+		if (this.pollTimer) clearInterval(this.pollTimer);
+		this.pollTimer = null;
+		this.started = false;
+	}
+
+	getAll(): ServiceStatusSnapshot[] {
+		return SERVICE_STATUS_DEFINITIONS.map(
+			(def) => this.snapshots.get(def.id) ?? this.unknownFor(def),
+		);
+	}
+
+	refreshAll(): Promise<void> {
+		return Promise.all(
+			SERVICE_STATUS_DEFINITIONS.map((def) => this.refreshOne(def)),
+		).then(() => undefined);
+	}
+
+	private async refreshOne(def: ServiceStatusDefinition): Promise<void> {
+		try {
+			const json = await this.fetchJson(def.apiUrl);
+			const indicator = json.status?.indicator ?? null;
+			const description =
+				json.status?.description ||
+				(indicator === "none"
+					? "All Systems Operational"
+					: "Status unavailable");
+			this.updateSnapshot({
+				id: def.id,
+				label: def.label,
+				statusUrl: def.statusUrl,
+				level: indicatorToLevel(indicator),
+				indicator,
+				description,
+				checkedAt: Date.now(),
+				fetchError: null,
+			});
+		} catch (error) {
+			const message =
+				error instanceof Error ? error.message : String(error ?? "unknown");
+			this.updateSnapshot({
+				id: def.id,
+				label: def.label,
+				statusUrl: def.statusUrl,
+				level: "unknown",
+				indicator: null,
+				description: "ステータスを取得できませんでした",
+				checkedAt: Date.now(),
+				fetchError: message,
+			});
+		}
+	}
+
+	private updateSnapshot(next: ServiceStatusSnapshot): void {
+		const prev = this.snapshots.get(next.id);
+		this.snapshots.set(next.id, next);
+		if (
+			!prev ||
+			prev.level !== next.level ||
+			prev.indicator !== next.indicator ||
+			prev.description !== next.description ||
+			Boolean(prev.fetchError) !== Boolean(next.fetchError)
+		) {
+			this.emit("change", next);
+		}
+	}
+
+	private unknownFor(def: ServiceStatusDefinition): ServiceStatusSnapshot {
+		return {
+			id: def.id,
+			label: def.label,
+			statusUrl: def.statusUrl,
+			level: "unknown",
+			indicator: null,
+			description: "Checking…",
+			checkedAt: 0,
+			fetchError: null,
+		};
+	}
+
+	// Use Electron's net module so fetch uses Chromium's network stack and
+	// bypasses renderer-side CORS / proxy quirks.
+	private fetchJson(url: string): Promise<StatuspageResponse> {
+		return new Promise((resolve, reject) => {
+			const request = net.request({
+				method: "GET",
+				url,
+				redirect: "follow",
+			});
+			let timedOut = false;
+			const timeout = setTimeout(() => {
+				timedOut = true;
+				request.abort();
+				reject(new Error(`Request timed out after ${REQUEST_TIMEOUT_MS}ms`));
+			}, REQUEST_TIMEOUT_MS);
+
+			request.on("response", (response) => {
+				const chunks: Buffer[] = [];
+				response.on("data", (chunk: Buffer) => {
+					chunks.push(chunk);
+				});
+				response.on("end", () => {
+					clearTimeout(timeout);
+					if (timedOut) return;
+					if (response.statusCode < 200 || response.statusCode >= 300) {
+						reject(new Error(`HTTP ${response.statusCode}`));
+						return;
+					}
+					try {
+						const body = Buffer.concat(chunks).toString("utf-8");
+						resolve(JSON.parse(body) as StatuspageResponse);
+					} catch (parseError) {
+						reject(parseError);
+					}
+				});
+				response.on("error", (err: Error) => {
+					clearTimeout(timeout);
+					reject(err);
+				});
+			});
+			request.on("error", (err) => {
+				clearTimeout(timeout);
+				if (timedOut) return;
+				reject(err);
+			});
+			request.end();
+		});
+	}
+}
+
+export const serviceStatusService = new ServiceStatusService();
+
+export function setupServiceStatusPolling(): void {
+	serviceStatusService.start();
+	app.on("browser-window-focus", () => {
+		// Refresh on focus so users returning to the app see fresh state
+		// without waiting for the 5-minute interval.
+		void serviceStatusService.refreshAll();
+	});
+	app.on("before-quit", () => {
+		serviceStatusService.stop();
+	});
+}

--- a/apps/desktop/src/main/lib/service-status/index.ts
+++ b/apps/desktop/src/main/lib/service-status/index.ts
@@ -1,38 +1,40 @@
 import { EventEmitter } from "node:events";
 import { app, net } from "electron";
 import {
+	createUnknownSnapshot,
 	indicatorToLevel,
 	SERVICE_STATUS_DEFINITIONS,
 	type ServiceStatusDefinition,
+	type ServiceStatusId,
 	type ServiceStatusSnapshot,
 	type StatuspageIndicator,
 } from "shared/service-status-types";
 
 const POLL_INTERVAL_MS = 5 * 60 * 1000;
 const REQUEST_TIMEOUT_MS = 10_000;
+// Focus-driven refresh is debounced: if the last successful refresh attempt
+// was within this window we skip rather than hammering the API on every
+// window/tab switch.
+const FOCUS_REFRESH_MIN_INTERVAL_MS = 30_000;
 
 type StatuspageResponse = {
 	status?: { indicator?: StatuspageIndicator; description?: string };
 };
 
 class ServiceStatusService extends EventEmitter {
-	private snapshots = new Map<string, ServiceStatusSnapshot>();
+	private snapshots = new Map<ServiceStatusId, ServiceStatusSnapshot>();
 	private pollTimer: ReturnType<typeof setInterval> | null = null;
 	private started = false;
+	private lastRefreshAt = 0;
 
 	constructor() {
 		super();
+		// Multiple renderers (main window + any tearoff) can each subscribe to
+		// the emitter via tRPC; bump the default cap so dev HMR and StrictMode
+		// remounts don't trip the listener-warning heuristic.
+		this.setMaxListeners(20);
 		for (const def of SERVICE_STATUS_DEFINITIONS) {
-			this.snapshots.set(def.id, {
-				id: def.id,
-				label: def.label,
-				statusUrl: def.statusUrl,
-				level: "unknown",
-				indicator: null,
-				description: "Checking…",
-				checkedAt: 0,
-				fetchError: null,
-			});
+			this.snapshots.set(def.id, createUnknownSnapshot(def));
 		}
 	}
 
@@ -43,6 +45,8 @@ class ServiceStatusService extends EventEmitter {
 		this.pollTimer = setInterval(() => {
 			void this.refreshAll();
 		}, POLL_INTERVAL_MS);
+		// Don't keep the event loop alive just for status polling.
+		this.pollTimer.unref();
 	}
 
 	stop(): void {
@@ -53,14 +57,30 @@ class ServiceStatusService extends EventEmitter {
 
 	getAll(): ServiceStatusSnapshot[] {
 		return SERVICE_STATUS_DEFINITIONS.map(
-			(def) => this.snapshots.get(def.id) ?? this.unknownFor(def),
+			(def) => this.snapshots.get(def.id) ?? createUnknownSnapshot(def),
 		);
 	}
 
-	refreshAll(): Promise<void> {
-		return Promise.all(
+	/**
+	 * Refresh only when the last refresh is older than the given threshold.
+	 * Used for focus-driven refreshes so rapid window switches don't produce
+	 * a fetch storm.
+	 */
+	refreshIfStale(thresholdMs = FOCUS_REFRESH_MIN_INTERVAL_MS): void {
+		if (Date.now() - this.lastRefreshAt < thresholdMs) return;
+		void this.refreshAll();
+	}
+
+	async refreshAll(): Promise<void> {
+		// Skip when offline. net.isOnline() reflects Chromium's connectivity
+		// state which is accurate enough to avoid guaranteed-failure polls on
+		// planes / disconnected laptops while still running when the OS is
+		// merely on a captive-portal / proxy.
+		if (!net.isOnline()) return;
+		this.lastRefreshAt = Date.now();
+		await Promise.allSettled(
 			SERVICE_STATUS_DEFINITIONS.map((def) => this.refreshOne(def)),
-		).then(() => undefined);
+		);
 	}
 
 	private async refreshOne(def: ServiceStatusDefinition): Promise<void> {
@@ -69,9 +89,7 @@ class ServiceStatusService extends EventEmitter {
 			const indicator = json.status?.indicator ?? null;
 			const description =
 				json.status?.description ||
-				(indicator === "none"
-					? "All Systems Operational"
-					: "Status unavailable");
+				(indicator === "none" ? "全システム正常" : "ステータス不明");
 			this.updateSnapshot({
 				id: def.id,
 				label: def.label,
@@ -99,24 +117,20 @@ class ServiceStatusService extends EventEmitter {
 	}
 
 	private updateSnapshot(next: ServiceStatusSnapshot): void {
+		const prev = this.snapshots.get(next.id);
 		this.snapshots.set(next.id, next);
-		// Emit on every poll so the renderer's "last checked" timestamp stays
-		// fresh — the initial getAll query is cached with staleTime: Infinity,
-		// so without an emit here the tooltip would freeze on the first value.
-		this.emit("change", next);
-	}
-
-	private unknownFor(def: ServiceStatusDefinition): ServiceStatusSnapshot {
-		return {
-			id: def.id,
-			label: def.label,
-			statusUrl: def.statusUrl,
-			level: "unknown",
-			indicator: null,
-			description: "Checking…",
-			checkedAt: 0,
-			fetchError: null,
-		};
+		// Only emit when user-visible state actually changes. checkedAt isn't
+		// directly rendered — the tooltip uses a relative formatter on
+		// Date.now() so it auto-refreshes whenever the Tooltip remounts.
+		if (
+			!prev ||
+			prev.level !== next.level ||
+			prev.indicator !== next.indicator ||
+			prev.description !== next.description ||
+			Boolean(prev.fetchError) !== Boolean(next.fetchError)
+		) {
+			this.emit("change", next);
+		}
 	}
 
 	// Use Electron's net module so fetch uses Chromium's network stack and
@@ -156,6 +170,7 @@ class ServiceStatusService extends EventEmitter {
 				});
 				response.on("error", (err: Error) => {
 					clearTimeout(timeout);
+					if (timedOut) return;
 					reject(err);
 				});
 			});
@@ -173,12 +188,13 @@ export const serviceStatusService = new ServiceStatusService();
 
 export function setupServiceStatusPolling(): void {
 	serviceStatusService.start();
-	app.on("browser-window-focus", () => {
-		// Refresh on focus so users returning to the app see fresh state
-		// without waiting for the 5-minute interval.
-		void serviceStatusService.refreshAll();
-	});
+	const onFocus = () => {
+		// Debounced refresh — protects the poller from rapid window switches.
+		serviceStatusService.refreshIfStale();
+	};
+	app.on("browser-window-focus", onFocus);
 	app.on("before-quit", () => {
+		app.off("browser-window-focus", onFocus);
 		serviceStatusService.stop();
 	});
 }

--- a/apps/desktop/src/main/lib/service-status/index.ts
+++ b/apps/desktop/src/main/lib/service-status/index.ts
@@ -99,17 +99,11 @@ class ServiceStatusService extends EventEmitter {
 	}
 
 	private updateSnapshot(next: ServiceStatusSnapshot): void {
-		const prev = this.snapshots.get(next.id);
 		this.snapshots.set(next.id, next);
-		if (
-			!prev ||
-			prev.level !== next.level ||
-			prev.indicator !== next.indicator ||
-			prev.description !== next.description ||
-			Boolean(prev.fetchError) !== Boolean(next.fetchError)
-		) {
-			this.emit("change", next);
-		}
+		// Emit on every poll so the renderer's "last checked" timestamp stays
+		// fresh — the initial getAll query is cached with staleTime: Infinity,
+		// so without an emit here the tooltip would freeze on the first value.
+		this.emit("change", next);
 	}
 
 	private unknownFor(def: ServiceStatusDefinition): ServiceStatusSnapshot {

--- a/apps/desktop/src/main/lib/service-status/index.ts
+++ b/apps/desktop/src/main/lib/service-status/index.ts
@@ -72,18 +72,28 @@ class ServiceStatusService extends EventEmitter {
 	}
 
 	async refreshAll(): Promise<void> {
-		// Skip when offline. net.isOnline() reflects Chromium's connectivity
-		// state which is accurate enough to avoid guaranteed-failure polls on
+		// Skip fetching when offline, but still push an "offline" snapshot so
+		// the UI doesn't keep rendering a stale green dot from the last
+		// successful poll. net.isOnline() reflects Chromium's connectivity
+		// state — accurate enough to avoid guaranteed-failure polls on
 		// planes / disconnected laptops while still running when the OS is
-		// merely on a captive-portal / proxy.
-		if (!net.isOnline()) return;
-		this.lastRefreshAt = Date.now();
-		await Promise.allSettled(
+		// on a captive-portal / proxy.
+		if (!net.isOnline()) {
+			this.markAllOffline();
+			return;
+		}
+		const results = await Promise.all(
 			SERVICE_STATUS_DEFINITIONS.map((def) => this.refreshOne(def)),
 		);
+		// Only record a "successful refresh" when at least one fetch actually
+		// worked, so a transient failure doesn't lock the 30-second debounce
+		// window in refreshIfStale() and prevent a quick recovery.
+		if (results.some(Boolean)) {
+			this.lastRefreshAt = Date.now();
+		}
 	}
 
-	private async refreshOne(def: ServiceStatusDefinition): Promise<void> {
+	private async refreshOne(def: ServiceStatusDefinition): Promise<boolean> {
 		try {
 			const json = await this.fetchJson(def.apiUrl);
 			const indicator = json.status?.indicator ?? null;
@@ -100,6 +110,7 @@ class ServiceStatusService extends EventEmitter {
 				checkedAt: Date.now(),
 				fetchError: null,
 			});
+			return true;
 		} catch (error) {
 			const message =
 				error instanceof Error ? error.message : String(error ?? "unknown");
@@ -112,6 +123,22 @@ class ServiceStatusService extends EventEmitter {
 				description: "ステータスを取得できませんでした",
 				checkedAt: Date.now(),
 				fetchError: message,
+			});
+			return false;
+		}
+	}
+
+	private markAllOffline(): void {
+		for (const def of SERVICE_STATUS_DEFINITIONS) {
+			this.updateSnapshot({
+				id: def.id,
+				label: def.label,
+				statusUrl: def.statusUrl,
+				level: "unknown",
+				indicator: null,
+				description: "オフラインのため取得できません",
+				checkedAt: Date.now(),
+				fetchError: "offline",
 			});
 		}
 	}
@@ -186,7 +213,14 @@ class ServiceStatusService extends EventEmitter {
 
 export const serviceStatusService = new ServiceStatusService();
 
+let pollingWired = false;
+
 export function setupServiceStatusPolling(): void {
+	// Guard against duplicate wiring on HMR / re-init — the inner `start()`
+	// is already idempotent via its `started` flag, but `app.on(...)` would
+	// otherwise accumulate focus listeners across reloads.
+	if (pollingWired) return;
+	pollingWired = true;
 	serviceStatusService.start();
 	const onFocus = () => {
 		// Debounced refresh — protects the poller from rapid window switches.

--- a/apps/desktop/src/main/lib/service-status/index.ts
+++ b/apps/desktop/src/main/lib/service-status/index.ts
@@ -26,6 +26,9 @@ class ServiceStatusService extends EventEmitter {
 	private pollTimer: ReturnType<typeof setInterval> | null = null;
 	private started = false;
 	private lastRefreshAt = 0;
+	// Re-entry guard: ensures start()'s initial refresh and a concurrent
+	// focus-driven refresh share a single fetch round instead of racing.
+	private inflightRefresh: Promise<void> | null = null;
 
 	constructor() {
 		super();
@@ -71,7 +74,20 @@ class ServiceStatusService extends EventEmitter {
 		void this.refreshAll();
 	}
 
-	async refreshAll(): Promise<void> {
+	refreshAll(): Promise<void> {
+		// Collapse concurrent callers onto the same fetch round. The initial
+		// start() refresh is async and can overlap with a focus-driven
+		// refreshIfStale() that passes the 30-second check because
+		// lastRefreshAt is still 0 — without this guard we'd fire the full
+		// fetch twice on every cold start.
+		if (this.inflightRefresh) return this.inflightRefresh;
+		this.inflightRefresh = this.doRefreshAll().finally(() => {
+			this.inflightRefresh = null;
+		});
+		return this.inflightRefresh;
+	}
+
+	private async doRefreshAll(): Promise<void> {
 		// Skip fetching when offline, but still push an "offline" snapshot so
 		// the UI doesn't keep rendering a stale green dot from the last
 		// successful poll. net.isOnline() reflects Chromium's connectivity
@@ -136,9 +152,11 @@ class ServiceStatusService extends EventEmitter {
 				statusUrl: def.statusUrl,
 				level: "unknown",
 				indicator: null,
-				description: "オフラインのため取得できません",
+				description: "Offline",
+				// Leave fetchError null so the tooltip just shows "Offline"
+				// instead of the redundant "… · offline" suffix.
 				checkedAt: Date.now(),
-				fetchError: "offline",
+				fetchError: null,
 			});
 		}
 	}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/TopBar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/TopBar.tsx
@@ -10,6 +10,7 @@ import { OrganizationDropdown } from "./components/OrganizationDropdown";
 import { ResourceConsumption } from "./components/ResourceConsumption";
 import { RightSidebarToggle } from "./components/RightSidebarToggle";
 import { SearchBarTrigger } from "./components/SearchBarTrigger";
+import { ServiceStatusIndicators } from "./components/ServiceStatusIndicators";
 import { SidebarToggle } from "./components/SidebarToggle";
 import { V2WorkspaceOpenInButton } from "./components/V2WorkspaceOpenInButton";
 import { V2WorkspaceSearchBarTrigger } from "./components/V2WorkspaceSearchBarTrigger";
@@ -72,6 +73,7 @@ export function TopBar() {
 			)}
 
 			<div className="flex items-center gap-3 h-full pr-4 shrink-0">
+				<ServiceStatusIndicators />
 				{!isOnline && (
 					<div className="no-drag flex items-center gap-1.5 text-xs text-muted-foreground bg-muted px-2 py-1 rounded">
 						<HiOutlineWifi className="size-3.5" />

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/ServiceStatusIndicators/ServiceStatusIndicators.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/ServiceStatusIndicators/ServiceStatusIndicators.tsx
@@ -1,8 +1,10 @@
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import {
+	createUnknownSnapshot,
 	SERVICE_STATUS_DEFINITIONS,
+	type ServiceStatusId,
 	type ServiceStatusLevel,
 	type ServiceStatusSnapshot,
 } from "shared/service-status-types";
@@ -34,19 +36,18 @@ function formatCheckedAt(checkedAt: number): string {
 	return new Date(checkedAt).toLocaleString();
 }
 
-function placeholderFor(
-	def: (typeof SERVICE_STATUS_DEFINITIONS)[number],
-): ServiceStatusSnapshot {
-	return {
-		id: def.id,
-		label: def.label,
-		statusUrl: def.statusUrl,
-		level: "unknown",
-		indicator: null,
-		description: "Checking…",
-		checkedAt: 0,
-		fetchError: null,
-	};
+/**
+ * Safely pick a host string for the tooltip footer. `new URL` throws on
+ * malformed input — rare for the hardcoded statusUrls, but guarding here
+ * keeps a bad upstream value from taking down the whole TopBar via React's
+ * render-error boundary.
+ */
+function hostOrFallback(statusUrl: string, fallback: string): string {
+	try {
+		return new URL(statusUrl).host;
+	} catch {
+		return fallback;
+	}
 }
 
 interface ServiceStatusDotProps {
@@ -57,6 +58,7 @@ interface ServiceStatusDotProps {
 function ServiceStatusDot({ snapshot, onClick }: ServiceStatusDotProps) {
 	const colorClass = LEVEL_CLASS[snapshot.level];
 	const levelLabel = LEVEL_LABEL[snapshot.level];
+	const displayHost = hostOrFallback(snapshot.statusUrl, snapshot.label);
 
 	return (
 		<Tooltip delayDuration={300}>
@@ -82,30 +84,23 @@ function ServiceStatusDot({ snapshot, onClick }: ServiceStatusDotProps) {
 					{snapshot.fetchError ? ` · ${snapshot.fetchError}` : ""}
 				</div>
 				<div className="text-muted-foreground/60 mt-0.5">
-					クリックで {new URL(snapshot.statusUrl).host} を開く
+					クリックで {displayHost} を開く
 				</div>
 			</TooltipContent>
 		</Tooltip>
 	);
 }
 
-export function ServiceStatusIndicators() {
-	const { data: initialAll } = electronTrpc.serviceStatus.getAll.useQuery(
-		undefined,
-		{ staleTime: Number.POSITIVE_INFINITY },
-	);
-	const [snapshots, setSnapshots] = useState<
-		Map<string, ServiceStatusSnapshot>
-	>(() => new Map());
+function initialSnapshots(): Map<ServiceStatusId, ServiceStatusSnapshot> {
+	const map = new Map<ServiceStatusId, ServiceStatusSnapshot>();
+	for (const def of SERVICE_STATUS_DEFINITIONS) {
+		map.set(def.id, createUnknownSnapshot(def));
+	}
+	return map;
+}
 
-	useEffect(() => {
-		if (!initialAll) return;
-		setSnapshots((prev) => {
-			const next = new Map(prev);
-			for (const snapshot of initialAll) next.set(snapshot.id, snapshot);
-			return next;
-		});
-	}, [initialAll]);
+export function ServiceStatusIndicators() {
+	const [snapshots, setSnapshots] = useState(initialSnapshots);
 
 	electronTrpc.serviceStatus.onChange.useSubscription(undefined, {
 		onData: (snapshot: ServiceStatusSnapshot) => {
@@ -122,7 +117,7 @@ export function ServiceStatusIndicators() {
 	const ordered = useMemo(
 		() =>
 			SERVICE_STATUS_DEFINITIONS.map(
-				(def) => snapshots.get(def.id) ?? placeholderFor(def),
+				(def) => snapshots.get(def.id) ?? createUnknownSnapshot(def),
 			),
 		[snapshots],
 	);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/ServiceStatusIndicators/ServiceStatusIndicators.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/ServiceStatusIndicators/ServiceStatusIndicators.tsx
@@ -1,0 +1,141 @@
+import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
+import { useEffect, useMemo, useState } from "react";
+import { electronTrpc } from "renderer/lib/electron-trpc";
+import {
+	SERVICE_STATUS_DEFINITIONS,
+	type ServiceStatusLevel,
+	type ServiceStatusSnapshot,
+} from "shared/service-status-types";
+
+const LEVEL_CLASS: Record<ServiceStatusLevel, string> = {
+	operational: "bg-emerald-500",
+	minor: "bg-amber-400",
+	major: "bg-red-500",
+	critical: "bg-purple-500",
+	unknown: "bg-zinc-400 dark:bg-zinc-500",
+};
+
+const LEVEL_LABEL: Record<ServiceStatusLevel, string> = {
+	operational: "正常",
+	minor: "軽微な障害",
+	major: "障害発生中",
+	critical: "重大な障害",
+	unknown: "ステータス不明",
+};
+
+function formatCheckedAt(checkedAt: number): string {
+	if (!checkedAt) return "未確認";
+	const diff = Date.now() - checkedAt;
+	if (diff < 60_000) return "たった今確認";
+	const minutes = Math.floor(diff / 60_000);
+	if (minutes < 60) return `${minutes}分前に確認`;
+	const hours = Math.floor(minutes / 60);
+	if (hours < 24) return `${hours}時間前に確認`;
+	return new Date(checkedAt).toLocaleString();
+}
+
+function placeholderFor(
+	def: (typeof SERVICE_STATUS_DEFINITIONS)[number],
+): ServiceStatusSnapshot {
+	return {
+		id: def.id,
+		label: def.label,
+		statusUrl: def.statusUrl,
+		level: "unknown",
+		indicator: null,
+		description: "Checking…",
+		checkedAt: 0,
+		fetchError: null,
+	};
+}
+
+interface ServiceStatusDotProps {
+	snapshot: ServiceStatusSnapshot;
+	onClick: () => void;
+}
+
+function ServiceStatusDot({ snapshot, onClick }: ServiceStatusDotProps) {
+	const colorClass = LEVEL_CLASS[snapshot.level];
+	const levelLabel = LEVEL_LABEL[snapshot.level];
+
+	return (
+		<Tooltip delayDuration={300}>
+			<TooltipTrigger asChild>
+				<button
+					type="button"
+					onClick={onClick}
+					aria-label={`${snapshot.label} status: ${levelLabel}`}
+					className="no-drag flex items-center justify-center size-6 rounded-md hover:bg-accent/50 transition-colors"
+				>
+					<span
+						className={`size-2.5 rounded-full ${colorClass} ring-1 ring-black/10 dark:ring-white/10`}
+					/>
+				</button>
+			</TooltipTrigger>
+			<TooltipContent side="bottom" className="text-xs">
+				<div className="font-medium">
+					{snapshot.label} — {levelLabel}
+				</div>
+				<div className="text-muted-foreground">{snapshot.description}</div>
+				<div className="text-muted-foreground/80 mt-0.5">
+					{formatCheckedAt(snapshot.checkedAt)}
+					{snapshot.fetchError ? ` · ${snapshot.fetchError}` : ""}
+				</div>
+				<div className="text-muted-foreground/60 mt-0.5">
+					クリックで {new URL(snapshot.statusUrl).host} を開く
+				</div>
+			</TooltipContent>
+		</Tooltip>
+	);
+}
+
+export function ServiceStatusIndicators() {
+	const { data: initialAll } = electronTrpc.serviceStatus.getAll.useQuery(
+		undefined,
+		{ staleTime: Number.POSITIVE_INFINITY },
+	);
+	const [snapshots, setSnapshots] = useState<
+		Map<string, ServiceStatusSnapshot>
+	>(() => new Map());
+
+	useEffect(() => {
+		if (!initialAll) return;
+		setSnapshots((prev) => {
+			const next = new Map(prev);
+			for (const snapshot of initialAll) next.set(snapshot.id, snapshot);
+			return next;
+		});
+	}, [initialAll]);
+
+	electronTrpc.serviceStatus.onChange.useSubscription(undefined, {
+		onData: (snapshot: ServiceStatusSnapshot) => {
+			setSnapshots((prev) => {
+				const next = new Map(prev);
+				next.set(snapshot.id, snapshot);
+				return next;
+			});
+		},
+	});
+
+	const openUrl = electronTrpc.external.openUrl.useMutation();
+
+	const ordered = useMemo(
+		() =>
+			SERVICE_STATUS_DEFINITIONS.map(
+				(def) => snapshots.get(def.id) ?? placeholderFor(def),
+			),
+		[snapshots],
+	);
+
+	return (
+		<div className="no-drag flex items-center gap-0.5">
+			{ordered.map((snapshot) => (
+				<ServiceStatusDot
+					key={snapshot.id}
+					snapshot={snapshot}
+					onClick={() => openUrl.mutate(snapshot.statusUrl)}
+				/>
+			))}
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/ServiceStatusIndicators/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/ServiceStatusIndicators/index.ts
@@ -1,0 +1,1 @@
+export { ServiceStatusIndicators } from "./ServiceStatusIndicators";

--- a/apps/desktop/src/shared/service-status-types.ts
+++ b/apps/desktop/src/shared/service-status-types.ts
@@ -1,0 +1,66 @@
+// Statuspage.io `/api/v2/status.json` indicator values.
+// See https://doers.statuspage.io/api/v2/pages/#status
+export type StatuspageIndicator =
+	| "none"
+	| "minor"
+	| "major"
+	| "critical"
+	| "maintenance";
+
+export type ServiceStatusLevel =
+	| "operational"
+	| "minor"
+	| "major"
+	| "critical"
+	| "unknown";
+
+export interface ServiceStatusDefinition {
+	id: "claude" | "codex";
+	label: string;
+	statusUrl: string;
+	apiUrl: string;
+}
+
+export interface ServiceStatusSnapshot {
+	id: ServiceStatusDefinition["id"];
+	label: string;
+	statusUrl: string;
+	level: ServiceStatusLevel;
+	indicator: StatuspageIndicator | null;
+	description: string;
+	checkedAt: number;
+	fetchError: string | null;
+}
+
+export const SERVICE_STATUS_DEFINITIONS: ServiceStatusDefinition[] = [
+	{
+		id: "claude",
+		label: "Claude",
+		statusUrl: "https://status.claude.com/",
+		apiUrl: "https://status.claude.com/api/v2/status.json",
+	},
+	{
+		id: "codex",
+		label: "Codex",
+		statusUrl: "https://status.openai.com/",
+		apiUrl: "https://status.openai.com/api/v2/status.json",
+	},
+];
+
+export function indicatorToLevel(
+	indicator: StatuspageIndicator | null | undefined,
+): ServiceStatusLevel {
+	switch (indicator) {
+		case "none":
+			return "operational";
+		case "minor":
+		case "maintenance":
+			return "minor";
+		case "major":
+			return "major";
+		case "critical":
+			return "critical";
+		default:
+			return "unknown";
+	}
+}

--- a/apps/desktop/src/shared/service-status-types.ts
+++ b/apps/desktop/src/shared/service-status-types.ts
@@ -14,25 +14,16 @@ export type ServiceStatusLevel =
 	| "critical"
 	| "unknown";
 
+export type ServiceStatusId = "claude" | "codex";
+
 export interface ServiceStatusDefinition {
-	id: "claude" | "codex";
+	id: ServiceStatusId;
 	label: string;
 	statusUrl: string;
 	apiUrl: string;
 }
 
-export interface ServiceStatusSnapshot {
-	id: ServiceStatusDefinition["id"];
-	label: string;
-	statusUrl: string;
-	level: ServiceStatusLevel;
-	indicator: StatuspageIndicator | null;
-	description: string;
-	checkedAt: number;
-	fetchError: string | null;
-}
-
-export const SERVICE_STATUS_DEFINITIONS: ServiceStatusDefinition[] = [
+export const SERVICE_STATUS_DEFINITIONS = [
 	{
 		id: "claude",
 		label: "Claude",
@@ -45,7 +36,18 @@ export const SERVICE_STATUS_DEFINITIONS: ServiceStatusDefinition[] = [
 		statusUrl: "https://status.openai.com/",
 		apiUrl: "https://status.openai.com/api/v2/status.json",
 	},
-];
+] as const satisfies readonly ServiceStatusDefinition[];
+
+export interface ServiceStatusSnapshot {
+	id: ServiceStatusId;
+	label: string;
+	statusUrl: string;
+	level: ServiceStatusLevel;
+	indicator: StatuspageIndicator | null;
+	description: string;
+	checkedAt: number;
+	fetchError: string | null;
+}
 
 export function indicatorToLevel(
 	indicator: StatuspageIndicator | null | undefined,
@@ -63,4 +65,19 @@ export function indicatorToLevel(
 		default:
 			return "unknown";
 	}
+}
+
+export function createUnknownSnapshot(
+	def: ServiceStatusDefinition,
+): ServiceStatusSnapshot {
+	return {
+		id: def.id,
+		label: def.label,
+		statusUrl: def.statusUrl,
+		level: "unknown",
+		indicator: null,
+		description: "確認中…",
+		checkedAt: 0,
+		fetchError: null,
+	};
 }


### PR DESCRIPTION
## 概要

TopBar の右上ボタン群（Open in / Organization Dropdown / RightSidebarToggle 等）の**左側**に、Claude と Codex のサービス稼働状況を示す小さなドットインジケータを追加しました。ドットをクリックするとそれぞれのステータスページを外部ブラウザで開きます。

## データソース

両サイトとも Statuspage.io でホストされており、公開JSON APIを利用します（認証不要、レートリミット緩め）。

- https://status.claude.com/api/v2/status.json
- https://status.openai.com/api/v2/status.json

レスポンスの \`status.indicator\` を使ってサービスレベルを判定します。

## 実装

### main プロセス
- \`apps/desktop/src/main/lib/service-status/index.ts\`
  - Electron の \`net\` モジュールで fetch（CORS回避 + Chromiumネットワークスタック利用）
  - 5分ポーリング + \`browser-window-focus\` イベントで即時更新
  - \`EventEmitter\` で状態変化を通知
  - 差分比較で不要なemitを抑制

### tRPC
- \`apps/desktop/src/lib/trpc/routers/service-status.ts\`
  - \`getAll\`: 現在状態を取得するquery
  - \`onChange\`: observableパターンのsubscription（初回emit時に現在のすべての状態を流す）

### UI
- \`apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/ServiceStatusIndicators/\`
  - 8pxの色付きドット×2個を右上に配置
  - Tooltip でサービス名・ステータス説明・最終確認時刻を表示
  - クリックで \`electronTrpc.external.openUrl.mutate()\` 経由で \`shell.openExternal\`

### 色マッピング

| indicator | 意味 | 色 |
|:----------|:-----|:---|
| \`none\` | All systems operational | 緑 (emerald-500) |
| \`minor\` / \`maintenance\` | Minor issue / Maintenance | 黄 (amber-400) |
| \`major\` | Major outage | 赤 (red-500) |
| \`critical\` | Critical outage | **紫 (purple-500)** |
| fetch失敗 | Network/unknown | グレー (zinc-400) |

## テスト方法

- [ ] アプリ起動後、TopBar 右上のボタン群の左に緑ドットが2つ表示されることを確認
- [ ] ドットにホバーするとTooltipで「Claude — 正常 / All Systems Operational / たった今確認」のような表示
- [ ] Claude ドットをクリック → 外部ブラウザで status.claude.com が開く
- [ ] Codex ドットをクリック → 外部ブラウザで status.openai.com が開く
- [ ] オフラインにするとTooltipに「ステータスを取得できませんでした」エラーメッセージが出てドットがグレーになる
- [ ] ウィンドウを別アプリから戻す（focus）と即時再取得される