### PR TITLE
feat(desktop): TODO Agent に cron 風スケジュール実行機能を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Works with any CLI agent. Built for local worktree-based development.
 | **安定性・パフォーマンス改善** | LSP language services の安定性修正、拡張機能ホストのメモリリーク修正、ターミナル再表示遅延改善、認証切れ時の無限ループ防止、git status タイムアウト追加、ブラウザリダイレクトループ修正、ポップアウトウィンドウの認証修正、エラーの正規化と Sentry フィルタリング | [#88](https://github.com/MocA-Love/superset/pull/88) [#123](https://github.com/MocA-Love/superset/pull/123) [#121](https://github.com/MocA-Love/superset/pull/121) [#67](https://github.com/MocA-Love/superset/pull/67) [#66](https://github.com/MocA-Love/superset/pull/66) [#158](https://github.com/MocA-Love/superset/pull/158) [#146](https://github.com/MocA-Love/superset/pull/146) [#98](https://github.com/MocA-Love/superset/pull/98) | 2026-04-04〜14 |
 | **内部ブラウザの File System Access API 拒否回避** | 内部ブラウザで react-dropzone 系サイトを開くと `FileSystemFileHandle.getFile()` が NotAllowedError で落ちる問題を修正。`persist:superset` セッションに preload を追加し `DataTransferItem.getAsFileSystemHandle()` を null 返却に差し替えて legacy D&D パスへフォールバック | [#207](https://github.com/MocA-Love/superset/pull/207) | 2026-04-16 |
 | **PR コメント返信** | Review タブのコメント右上に Reply ボタンを追加。ダイアログから直接返信を投稿できる。レビュースレッドへの返信と通常 PR コメントの両方に対応 | [#206](https://github.com/MocA-Love/superset/pull/206) | 2026-04-16 |
+| **TODO Agent スケジュール実行** | 毎日デプロイ / 毎時 lint のような定型 TODO を UI ビルダー (毎時/毎日/毎週/毎月/cron) で登録可能。アプリ起動中に時刻が来ると TODO セッションが自動作成され発火トーストを表示。前回未完了時は skip / queue 選択可 | [#211](https://github.com/MocA-Love/superset/pull/211) | 2026-04-16 |
 
 ## Fork のビルド方法 (macOS)
 

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -159,6 +159,8 @@
 		"bindings": "^1.5.0",
 		"bufferutil": "^4.1.0",
 		"clsx": "^2.1.1",
+		"cron-parser": "^5.5.0",
+		"cronstrue": "^3.14.0",
 		"culori": "^4.0.2",
 		"date-fns": "^4.1.0",
 		"default-shell": "^2.2.0",

--- a/apps/desktop/plans/20260416-todo-schedule.md
+++ b/apps/desktop/plans/20260416-todo-schedule.md
@@ -1,0 +1,186 @@
+# TODO Agent スケジュール実行 実装計画
+
+既存の TODO 自律エージェントに **cron ライクな定期実行** 機能を追加する。
+ユーザーはスケジュールを登録しておくと、指定時刻にそのプロンプトで TODO セッションが自動作成・キュー投入される。
+
+## 目的
+
+- 「毎日 9:00 にデプロイ」「1時間ごとに lint 走らせる」のような
+  定型的な AI タスクを手動トリガーなしで実行できる。
+- 既存の TODO 作成フロー・実行エンジン (supervisor) をそのまま再利用し、
+  スケジュール層は薄く、単純にトリガー役に徹する。
+- フォーク限定機能。`apps/desktop` 内に閉じる。
+
+## 前提 (ユーザー決定事項)
+
+1. 発火通知は **トースト**
+2. cron 式の直接入力ではなく **UX 重視のビルダー UI** (プリセット + カスタム)
+3. 前回実行中の発火時の挙動 (skip / queue) は **スケジュール毎にユーザーが選択**
+4. UI は TodoManager **内に統合** (独立モーダルにはしない)
+
+## 非目的 (v1)
+
+- missed firing の補完 (閉じてた間の発火を後で実行): 初回は **skip + 通知のみ**
+- タイムゾーン切替: ローカル TZ 固定
+- スケジュール間の依存関係 / 順序制御
+- スケジュール共有 (エクスポート/インポート)
+
+## アーキテクチャ
+
+```
+Renderer                             Main process
+────────                             ────────────
+TodoManager                          TodoScheduler (singleton)
+ └─ SchedulesSection                  ├─ tick (setInterval every 30s)
+     ├─ ScheduleList                  ├─ compute nextRunAt for each schedule
+     └─ ScheduleEditor                │   and compare to now
+        └─ ScheduleFrequencyPicker    ├─ on fire:
+                                      │    ├─ check overlap mode
+                                      │    ├─ call TodoSupervisor.createFromSchedule()
+                                      │    └─ emit `schedule.fired` event
+                                      └─ scheduleStore (SQLite)
+
+trpc todoAgent.schedule.*            ─► scheduleStore CRUD
+trpc todoAgent.schedule.onFire  ─► observable<ScheduleFiredEvent>
+                                      (for toast in renderer)
+```
+
+## DB schema (`packages/local-db/src/schema/todo-schedules.ts`)
+
+```ts
+todo_schedules {
+  id:                text pk
+  workspaceId:       text (FK workspaces, cascade)
+  projectId:         text (FK projects, set null)
+  name:              text not null         -- 表示名
+  enabled:           int bool not null dflt 1
+
+  -- スケジュール定義 (UI ビルダー経由で設定)
+  frequency:         text enum("hourly","daily","weekly","monthly","custom") not null
+  minute:            int         -- 0-59 (hourly+)
+  hour:              int         -- 0-23 (daily+)
+  weekday:           int         -- 0-6, 0=Sun (weekly)
+  monthday:          int         -- 1-31 (monthly)
+  cronExpr:          text        -- frequency=custom のときのみ
+
+  -- 発火時に作成する TODO の雛形
+  title:             text not null
+  description:       text not null
+  goal:              text
+  verifyCommand:     text
+  maxIterations:     int not null dflt 10
+  maxWallClockSec:   int not null dflt 1800
+  customSystemPrompt:text
+
+  overlapMode:       text enum("skip","queue") not null dflt "skip"
+
+  lastRunAt:         int
+  lastRunSessionId:  text
+  nextRunAt:         int         -- 予測値。tick で使う
+  createdAt:         int
+  updatedAt:         int
+}
+
+index (workspaceId), (enabled, nextRunAt)
+```
+
+マイグレーション生成:
+```sh
+cd packages/local-db
+bun run generate --name=add_todo_schedules
+```
+
+## スケジューラ (`apps/desktop/src/main/todo-agent/scheduler.ts`)
+
+- `setInterval(tick, 30_000)` でポーリング
+- tick: 有効なスケジュールを DB から取得、`nextRunAt <= now` なものを発火
+- 発火:
+  1. overlap チェック (skip なら、同 scheduleId の未完了セッションがあればスキップ)
+  2. `TodoSupervisor.createFromSchedule(schedule)` で TODO セッションを作成
+  3. `session-store` に挿入 → 既存のキュー機構に乗る
+  4. `lastRunAt = now`, `lastRunSessionId = ...`, `nextRunAt = computeNext(schedule, now)` を保存
+  5. `schedule.fired` イベントを emit → UI 側のトースト購読に届く
+- `nextRunAt` 計算は frequency enum に応じた専用ヘルパ (custom のみ cron パース)
+- cron パースは `cron-parser` (小さい・7日以上前のリリース確認必須)
+
+## UI (統合: TodoManager 内 Schedules セクション)
+
+配置: TodoManager の左サイドバーにタブ「Tasks / Schedules」を追加。
+
+### ScheduleList
+- 行: enable トグル / 名前 / 次回実行時刻 / 最終実行結果 / ... メニュー (edit / delete)
+- 空状態: "+ New Schedule" ボタン
+
+### ScheduleEditor (ダイアログ)
+
+ビルダー UI:
+1. **名前**: テキスト
+2. **ワークスペース**: select (existing workspaces)
+3. **プロンプト**: 既存の TodoComposer と同じ UI (description / goal / verify / preset / attachments)
+4. **頻度ビルダー**:
+   - Hourly: `毎時 :MM 分`
+   - Daily: `毎日 HH:MM`
+   - Weekly: `毎週[曜日] HH:MM` (曜日チップ複数選択)
+   - Monthly: `毎月 DD 日 HH:MM`
+   - Custom: raw cron 式入力 + `cronstrue` でヒューマン表示
+5. **重複時の挙動**: radio `前回が走っていたらスキップ` / `キューに追加`
+6. **有効/無効**: トグル
+
+次回実行予定をプレビュー表示 (`cronstrue` の locale=ja-JP).
+
+## トースト
+
+`electronTrpc.todoAgent.schedule.onFire.useSubscription` を TodoManager or
+グローバルプロバイダで購読し、以下を表示:
+
+- 成功: `📅 {name} を実行しました` (→ セッション詳細への遷移リンク)
+- skip: `⏭️ {name} の実行をスキップしました (前回が実行中)`
+
+## 実装ファイル一覧 (新規のみ)
+
+### Backend
+- `packages/local-db/src/schema/todo-schedules.ts`
+- `packages/local-db/drizzle/00XX_add_todo_schedules.sql` (自動生成)
+- `packages/local-db/src/schema/index.ts` (追記)
+- `apps/desktop/src/main/todo-agent/scheduler.ts`
+- `apps/desktop/src/main/todo-agent/schedule-store.ts`
+- `apps/desktop/src/main/todo-agent/trpc-router.ts` (nested `schedule` router 追記)
+- `apps/desktop/src/main/todo-agent/supervisor.ts` (`createFromSchedule` 追加)
+
+### Frontend
+- `apps/desktop/src/renderer/features/todo-agent/TodoManager/SchedulesSection/SchedulesSection.tsx`
+- `apps/desktop/src/renderer/features/todo-agent/TodoManager/SchedulesSection/components/ScheduleList/ScheduleList.tsx`
+- `apps/desktop/src/renderer/features/todo-agent/TodoManager/SchedulesSection/components/ScheduleEditor/ScheduleEditor.tsx`
+- `apps/desktop/src/renderer/features/todo-agent/TodoManager/SchedulesSection/components/FrequencyBuilder/FrequencyBuilder.tsx`
+- `apps/desktop/src/renderer/features/todo-agent/TodoManager/SchedulesSection/hooks/useScheduleFireToast/useScheduleFireToast.ts`
+- `apps/desktop/src/renderer/features/todo-agent/TodoManager/TodoManager.tsx` (タブ追加・1箇所変更)
+
+### 依存パッケージ追加
+- `cron-parser` (main side; for custom cron parsing + next-fire computation)
+- `cronstrue` (renderer; human-readable cron)
+両方とも 7日以上前のリリースが存在する安定 lib。
+
+## テスト計画
+
+- `scheduler.test.ts`: frequency → nextRunAt 計算, overlap 判定
+- `schedule-store.test.ts`: CRUD / inserted の shape
+- `FrequencyBuilder` の簡易描画テスト (optional)
+
+## ロールアウト
+
+1. DB schema + migration
+2. scheduler + store + tRPC
+3. TodoManager UI 統合
+4. トースト
+5. 型チェック + lint + 既存 todo セッションテストに干渉しないことを確認
+6. PR → セルフレビュー → マージ
+
+## リスクと対策
+
+| リスク | 対策 |
+|------|------|
+| アプリ閉じてる間の発火が消える | v1 は諦める。UI に「アプリ起動中のみ」明記 |
+| 破壊的コマンドの暴走 | `verifyCommand` は既存通り任意。ユーザー責任。初期はドキュメントで警告 |
+| スケジュールの重複暴発 | overlapMode=skip デフォルト + DB index で pending 検出 |
+| Claude API 料金の想定外消費 | maxIterations / maxWallClockSec は既存制約をそのまま使う |
+| タイムゾーンずれ | ローカル TZ 固定。将来 tz 列追加で拡張可能 |

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -540,6 +540,16 @@ if (!gotTheLock) {
 			console.warn("[main] todo-agent attachment cleanup skipped", error);
 		}
 
+		// Fork-local: start the todo-agent schedule scheduler so cron-like
+		// recurring TODOs fire while the app is running. Scheduler is a
+		// noop until a user creates at least one schedule.
+		try {
+			const { getTodoScheduler } = await import("./todo-agent/scheduler");
+			getTodoScheduler().start();
+		} catch (error) {
+			console.warn("[main] todo-agent scheduler start skipped", error);
+		}
+
 		// Must register on both default session and the app's custom partition
 		const iconProtocolHandler = (request: Request) => {
 			const url = new URL(request.url);

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -548,6 +548,17 @@ if (!gotTheLock) {
 			console.warn("[main] todo-agent attachment cleanup skipped", error);
 		}
 
+		// Fork-local: prune terminal TODO sessions older than the
+		// user-configured retention (0 = off). Runs after the attachment
+		// sweep so deleted sessions' images also drop out of the
+		// attachment reference set on the next run.
+		try {
+			const { cleanupOldSessions } = await import("./todo-agent");
+			cleanupOldSessions();
+		} catch (error) {
+			console.warn("[main] todo-agent session cleanup skipped", error);
+		}
+
 		// Fork-local: start the todo-agent schedule scheduler so cron-like
 		// recurring TODOs fire while the app is running. Scheduler is a
 		// noop until a user creates at least one schedule.
@@ -556,6 +567,30 @@ if (!gotTheLock) {
 			getTodoScheduler().start();
 		} catch (error) {
 			console.warn("[main] todo-agent scheduler start skipped", error);
+			// Surface the failure via the existing schedule-fire event
+			// bus so ScheduleFireToasts shows a one-off toast. Without
+			// this the feature dies silently and the user keeps waiting
+			// for fires that will never come.
+			try {
+				const { getTodoScheduleStore } = await import(
+					"./todo-agent/schedule-store"
+				);
+				getTodoScheduleStore().emitFire({
+					scheduleId: "__scheduler_init__",
+					scheduleName: "スケジューラ",
+					kind: "failed",
+					sessionId: null,
+					message:
+						error instanceof Error
+							? `起動に失敗しました: ${error.message}`
+							: "起動に失敗しました",
+					firedAt: Date.now(),
+				});
+			} catch {
+				// If schedule-store itself failed to load there's
+				// nothing we can surface — console.warn above is our
+				// last resort.
+			}
 		}
 
 		// Must register on both default session and the app's custom partition

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -406,6 +406,14 @@ app.on("before-quit", async (event) => {
 	isQuitting = true;
 	// FORK NOTE: cleanup window resources before exit to prevent port conflicts
 	cleanupMainWindowResources();
+	// Fork-local: stop the todo-agent scheduler before closing local-db so an
+	// in-flight tick can't insert a session into a closed SQLite handle.
+	try {
+		const { getTodoScheduler } = await import("./todo-agent/scheduler");
+		getTodoScheduler().stop();
+	} catch (error) {
+		console.warn("[main] todo-agent scheduler stop skipped", error);
+	}
 	try {
 		const mod = await loadVscodeShim();
 		await mod.shutdownExtensionHost();

--- a/apps/desktop/src/main/todo-agent/index.ts
+++ b/apps/desktop/src/main/todo-agent/index.ts
@@ -1,4 +1,6 @@
 export { cleanupOldAttachments } from "./attachments-cleanup";
+export { getTodoScheduleStore } from "./schedule-store";
+export { getTodoScheduler } from "./scheduler";
 export { getTodoSessionStore } from "./session-store";
 export { getTodoSupervisor } from "./supervisor";
 export type { TodoAgentRouter } from "./trpc-router";

--- a/apps/desktop/src/main/todo-agent/index.ts
+++ b/apps/desktop/src/main/todo-agent/index.ts
@@ -2,6 +2,7 @@ export { cleanupOldAttachments } from "./attachments-cleanup";
 export { getTodoScheduleStore } from "./schedule-store";
 export { getTodoScheduler } from "./scheduler";
 export { getTodoSessionStore } from "./session-store";
+export { cleanupOldSessions } from "./sessions-cleanup";
 export { getTodoSupervisor } from "./supervisor";
 export type { TodoAgentRouter } from "./trpc-router";
 export { createTodoAgentRouter } from "./trpc-router";

--- a/apps/desktop/src/main/todo-agent/schedule-store.ts
+++ b/apps/desktop/src/main/todo-agent/schedule-store.ts
@@ -88,7 +88,8 @@ class TodoScheduleStore {
 		if (rest.overlapMode !== undefined) patch.overlapMode = rest.overlapMode;
 		if (rest.workspaceId !== undefined)
 			patch.workspaceId = rest.workspaceId ?? null;
-		if (rest.projectId !== undefined) patch.projectId = rest.projectId;
+		// projectId is intentionally not patched here — it is immutable
+		// once the schedule is created.
 
 		return localDb
 			.update(todoSchedules)
@@ -152,15 +153,6 @@ class TodoScheduleStore {
 			.where(eq(todoSchedules.id, id))
 			.run();
 		return result.changes > 0;
-	}
-
-	listForWorkspace(workspaceId: string): SelectTodoSchedule[] {
-		return localDb
-			.select()
-			.from(todoSchedules)
-			.where(eq(todoSchedules.workspaceId, workspaceId))
-			.orderBy(desc(todoSchedules.createdAt))
-			.all();
 	}
 
 	listForProject(projectId: string): SelectTodoSchedule[] {

--- a/apps/desktop/src/main/todo-agent/schedule-store.ts
+++ b/apps/desktop/src/main/todo-agent/schedule-store.ts
@@ -1,0 +1,192 @@
+import { EventEmitter } from "node:events";
+import {
+	type InsertTodoSchedule,
+	type SelectTodoSchedule,
+	todoSchedules,
+} from "@superset/local-db";
+import { and, desc, eq } from "drizzle-orm";
+import { localDb } from "main/lib/local-db";
+import type {
+	TodoScheduleCreateInput,
+	TodoScheduleFireEvent,
+	TodoScheduleUpdateInput,
+} from "./types";
+
+/**
+ * Persistence layer for the TODO agent schedules table plus an event bus the
+ * scheduler uses to broadcast fire events into the tRPC subscription.
+ *
+ * Kept deliberately thin: the scheduler is responsible for cadence math,
+ * this module just does CRUD + emit.
+ */
+class TodoScheduleStore {
+	private readonly emitter = new EventEmitter();
+
+	emitFire(event: TodoScheduleFireEvent): void {
+		this.emitter.emit("fire", event);
+	}
+
+	onFire(handler: (event: TodoScheduleFireEvent) => void): () => void {
+		this.emitter.on("fire", handler);
+		return () => {
+			this.emitter.off("fire", handler);
+		};
+	}
+
+	insert(
+		input: TodoScheduleCreateInput & { nextRunAt: number | null },
+	): SelectTodoSchedule {
+		const row: InsertTodoSchedule = {
+			workspaceId: input.workspaceId,
+			projectId: input.projectId ?? null,
+			name: input.name,
+			enabled: input.enabled,
+			frequency: input.frequency,
+			minute: input.minute ?? null,
+			hour: input.hour ?? null,
+			weekday: input.weekday ?? null,
+			monthday: input.monthday ?? null,
+			cronExpr: input.cronExpr ?? null,
+			title: input.title,
+			description: input.description,
+			goal: input.goal ?? null,
+			verifyCommand: input.verifyCommand ?? null,
+			maxIterations: input.maxIterations,
+			maxWallClockSec: input.maxWallClockSec,
+			customSystemPrompt: input.customSystemPrompt ?? null,
+			overlapMode: input.overlapMode,
+			nextRunAt: input.nextRunAt,
+		};
+
+		return localDb.insert(todoSchedules).values(row).returning().get();
+	}
+
+	update(input: TodoScheduleUpdateInput): SelectTodoSchedule | undefined {
+		const { id, ...rest } = input;
+		const patch: Partial<InsertTodoSchedule> & { updatedAt: number } = {
+			updatedAt: Date.now(),
+		};
+		if (rest.name !== undefined) patch.name = rest.name;
+		if (rest.enabled !== undefined) patch.enabled = rest.enabled;
+		if (rest.frequency !== undefined) patch.frequency = rest.frequency;
+		if (rest.minute !== undefined) patch.minute = rest.minute ?? null;
+		if (rest.hour !== undefined) patch.hour = rest.hour ?? null;
+		if (rest.weekday !== undefined) patch.weekday = rest.weekday ?? null;
+		if (rest.monthday !== undefined) patch.monthday = rest.monthday ?? null;
+		if (rest.cronExpr !== undefined) patch.cronExpr = rest.cronExpr ?? null;
+		if (rest.title !== undefined) patch.title = rest.title;
+		if (rest.description !== undefined) patch.description = rest.description;
+		if (rest.goal !== undefined) patch.goal = rest.goal ?? null;
+		if (rest.verifyCommand !== undefined)
+			patch.verifyCommand = rest.verifyCommand ?? null;
+		if (rest.maxIterations !== undefined)
+			patch.maxIterations = rest.maxIterations;
+		if (rest.maxWallClockSec !== undefined)
+			patch.maxWallClockSec = rest.maxWallClockSec;
+		if (rest.customSystemPrompt !== undefined)
+			patch.customSystemPrompt = rest.customSystemPrompt ?? null;
+		if (rest.overlapMode !== undefined) patch.overlapMode = rest.overlapMode;
+		if (rest.workspaceId !== undefined) patch.workspaceId = rest.workspaceId;
+		if (rest.projectId !== undefined) patch.projectId = rest.projectId ?? null;
+
+		return localDb
+			.update(todoSchedules)
+			.set(patch)
+			.where(eq(todoSchedules.id, id))
+			.returning()
+			.get();
+	}
+
+	setNextRunAt(id: string, nextRunAt: number | null): void {
+		localDb
+			.update(todoSchedules)
+			.set({ nextRunAt, updatedAt: Date.now() })
+			.where(eq(todoSchedules.id, id))
+			.run();
+	}
+
+	recordRun({
+		id,
+		sessionId,
+		firedAt,
+		nextRunAt,
+	}: {
+		id: string;
+		sessionId: string | null;
+		firedAt: number;
+		nextRunAt: number | null;
+	}): void {
+		localDb
+			.update(todoSchedules)
+			.set({
+				lastRunAt: firedAt,
+				lastRunSessionId: sessionId,
+				nextRunAt,
+				updatedAt: Date.now(),
+			})
+			.where(eq(todoSchedules.id, id))
+			.run();
+	}
+
+	setEnabled(id: string, enabled: boolean): SelectTodoSchedule | undefined {
+		return localDb
+			.update(todoSchedules)
+			.set({ enabled, updatedAt: Date.now() })
+			.where(eq(todoSchedules.id, id))
+			.returning()
+			.get();
+	}
+
+	get(id: string): SelectTodoSchedule | undefined {
+		return localDb
+			.select()
+			.from(todoSchedules)
+			.where(eq(todoSchedules.id, id))
+			.get();
+	}
+
+	delete(id: string): boolean {
+		const result = localDb
+			.delete(todoSchedules)
+			.where(eq(todoSchedules.id, id))
+			.run();
+		return result.changes > 0;
+	}
+
+	listForWorkspace(workspaceId: string): SelectTodoSchedule[] {
+		return localDb
+			.select()
+			.from(todoSchedules)
+			.where(eq(todoSchedules.workspaceId, workspaceId))
+			.orderBy(desc(todoSchedules.createdAt))
+			.all();
+	}
+
+	listAll(): SelectTodoSchedule[] {
+		return localDb
+			.select()
+			.from(todoSchedules)
+			.orderBy(desc(todoSchedules.createdAt))
+			.all();
+	}
+
+	listDue(now: number): SelectTodoSchedule[] {
+		return localDb
+			.select()
+			.from(todoSchedules)
+			.where(and(eq(todoSchedules.enabled, true)))
+			.all()
+			.filter((row) => row.nextRunAt !== null && (row.nextRunAt ?? 0) <= now);
+	}
+}
+
+let instance: TodoScheduleStore | null = null;
+
+export function getTodoScheduleStore(): TodoScheduleStore {
+	if (!instance) {
+		instance = new TodoScheduleStore();
+	}
+	return instance;
+}
+
+export type { TodoScheduleStore };

--- a/apps/desktop/src/main/todo-agent/schedule-store.ts
+++ b/apps/desktop/src/main/todo-agent/schedule-store.ts
@@ -37,8 +37,8 @@ class TodoScheduleStore {
 		input: TodoScheduleCreateInput & { nextRunAt: number | null },
 	): SelectTodoSchedule {
 		const row: InsertTodoSchedule = {
-			workspaceId: input.workspaceId,
-			projectId: input.projectId ?? null,
+			projectId: input.projectId,
+			workspaceId: input.workspaceId ?? null,
 			name: input.name,
 			enabled: input.enabled,
 			frequency: input.frequency,
@@ -86,8 +86,9 @@ class TodoScheduleStore {
 		if (rest.customSystemPrompt !== undefined)
 			patch.customSystemPrompt = rest.customSystemPrompt ?? null;
 		if (rest.overlapMode !== undefined) patch.overlapMode = rest.overlapMode;
-		if (rest.workspaceId !== undefined) patch.workspaceId = rest.workspaceId;
-		if (rest.projectId !== undefined) patch.projectId = rest.projectId ?? null;
+		if (rest.workspaceId !== undefined)
+			patch.workspaceId = rest.workspaceId ?? null;
+		if (rest.projectId !== undefined) patch.projectId = rest.projectId;
 
 		return localDb
 			.update(todoSchedules)
@@ -158,6 +159,15 @@ class TodoScheduleStore {
 			.select()
 			.from(todoSchedules)
 			.where(eq(todoSchedules.workspaceId, workspaceId))
+			.orderBy(desc(todoSchedules.createdAt))
+			.all();
+	}
+
+	listForProject(projectId: string): SelectTodoSchedule[] {
+		return localDb
+			.select()
+			.from(todoSchedules)
+			.where(eq(todoSchedules.projectId, projectId))
 			.orderBy(desc(todoSchedules.createdAt))
 			.all();
 	}

--- a/apps/desktop/src/main/todo-agent/schedule-store.ts
+++ b/apps/desktop/src/main/todo-agent/schedule-store.ts
@@ -21,13 +21,30 @@ import type {
  */
 class TodoScheduleStore {
 	private readonly emitter = new EventEmitter();
+	/**
+	 * Cached init failure (kind="failed", scheduleId="__scheduler_init__").
+	 * The renderer subscribes after it mounts, which is well after the
+	 * main-process bootstrap emits the failure. Replaying it on first
+	 * subscription ensures the user still sees the toast.
+	 */
+	private pendingInitFailure: TodoScheduleFireEvent | null = null;
 
 	emitFire(event: TodoScheduleFireEvent): void {
+		if (event.kind === "failed" && event.scheduleId === "__scheduler_init__") {
+			this.pendingInitFailure = event;
+		}
 		this.emitter.emit("fire", event);
 	}
 
 	onFire(handler: (event: TodoScheduleFireEvent) => void): () => void {
 		this.emitter.on("fire", handler);
+		if (this.pendingInitFailure) {
+			const replayed = this.pendingInitFailure;
+			this.pendingInitFailure = null;
+			// Replay asynchronously so the subscriber is fully wired up
+			// before its handler runs, matching ordinary emit timing.
+			queueMicrotask(() => handler(replayed));
+		}
 		return () => {
 			this.emitter.off("fire", handler);
 		};
@@ -55,6 +72,7 @@ class TodoScheduleStore {
 			maxWallClockSec: input.maxWallClockSec,
 			customSystemPrompt: input.customSystemPrompt ?? null,
 			overlapMode: input.overlapMode,
+			autoSyncBeforeFire: input.autoSyncBeforeFire,
 			nextRunAt: input.nextRunAt,
 		};
 
@@ -86,6 +104,8 @@ class TodoScheduleStore {
 		if (rest.customSystemPrompt !== undefined)
 			patch.customSystemPrompt = rest.customSystemPrompt ?? null;
 		if (rest.overlapMode !== undefined) patch.overlapMode = rest.overlapMode;
+		if (rest.autoSyncBeforeFire !== undefined)
+			patch.autoSyncBeforeFire = rest.autoSyncBeforeFire;
 		if (rest.workspaceId !== undefined)
 			patch.workspaceId = rest.workspaceId ?? null;
 		// projectId is intentionally not patched here — it is immutable

--- a/apps/desktop/src/main/todo-agent/schedule-store.ts
+++ b/apps/desktop/src/main/todo-agent/schedule-store.ts
@@ -4,7 +4,7 @@ import {
 	type SelectTodoSchedule,
 	todoSchedules,
 } from "@superset/local-db";
-import { and, desc, eq } from "drizzle-orm";
+import { and, desc, eq, isNotNull, lte } from "drizzle-orm";
 import { localDb } from "main/lib/local-db";
 import type {
 	TodoScheduleCreateInput,
@@ -174,9 +174,14 @@ class TodoScheduleStore {
 		return localDb
 			.select()
 			.from(todoSchedules)
-			.where(and(eq(todoSchedules.enabled, true)))
-			.all()
-			.filter((row) => row.nextRunAt !== null && (row.nextRunAt ?? 0) <= now);
+			.where(
+				and(
+					eq(todoSchedules.enabled, true),
+					isNotNull(todoSchedules.nextRunAt),
+					lte(todoSchedules.nextRunAt, now),
+				),
+			)
+			.all();
 	}
 }
 

--- a/apps/desktop/src/main/todo-agent/schedule-sync.ts
+++ b/apps/desktop/src/main/todo-agent/schedule-sync.ts
@@ -1,0 +1,96 @@
+import { execGitWithShellPath } from "lib/trpc/routers/workspaces/utils/git-client";
+
+export type ScheduleSyncResult =
+	| { kind: "ok"; checkedOut: string }
+	| { kind: "dirty"; message: string }
+	| { kind: "error"; message: string };
+
+async function runGit(
+	args: string[],
+	cwd: string,
+	timeout = 60_000,
+): Promise<{ stdout: string; stderr: string }> {
+	const result = await execGitWithShellPath(args, { cwd, timeout });
+	return { stdout: result.stdout, stderr: result.stderr };
+}
+
+async function hasUncommittedChanges(cwd: string): Promise<boolean> {
+	try {
+		const { stdout } = await runGit(["status", "--porcelain"], cwd, 15_000);
+		return stdout.trim().length > 0;
+	} catch {
+		// If status itself fails we can't be sure — treat as dirty to
+		// avoid destructive actions.
+		return true;
+	}
+}
+
+async function resolveDefaultBranch(cwd: string): Promise<string> {
+	try {
+		const { stdout } = await runGit(
+			["symbolic-ref", "refs/remotes/origin/HEAD", "--short"],
+			cwd,
+			10_000,
+		);
+		const ref = stdout.trim();
+		if (ref.startsWith("origin/")) {
+			return ref.slice("origin/".length);
+		}
+	} catch {}
+	// Fallbacks — conservative default.
+	return "main";
+}
+
+/**
+ * Opt-in "freshen the main repo before firing a schedule". Keeps the
+ * scope deliberately narrow:
+ *
+ *   - `git fetch origin`
+ *   - abort if the working tree has uncommitted changes (never stash —
+ *     we refuse to touch the user's work)
+ *   - `git checkout <default>`
+ *   - `git pull --ff-only origin <default>`
+ *
+ * Called only when `todoSchedule.autoSyncBeforeFire` is true and the
+ * schedule is firing on the project main repo (no specific worktree).
+ */
+export async function autoSyncProjectMain(
+	cwd: string,
+): Promise<ScheduleSyncResult> {
+	try {
+		await runGit(["fetch", "origin"], cwd, 120_000);
+	} catch (error) {
+		const message =
+			error instanceof Error ? error.message : "git fetch が失敗しました";
+		return { kind: "error", message };
+	}
+
+	if (await hasUncommittedChanges(cwd)) {
+		return {
+			kind: "dirty",
+			message: "未コミット変更があるため main を更新できませんでした",
+		};
+	}
+
+	const defaultBranch = await resolveDefaultBranch(cwd);
+
+	try {
+		await runGit(["checkout", defaultBranch], cwd, 60_000);
+	} catch (error) {
+		const message =
+			error instanceof Error
+				? error.message
+				: `git checkout ${defaultBranch} が失敗しました`;
+		return { kind: "error", message };
+	}
+
+	try {
+		await runGit(["pull", "--ff-only", "origin", defaultBranch], cwd, 120_000);
+	} catch (error) {
+		const message =
+			error instanceof Error ? error.message : "git pull が失敗しました";
+		return { kind: "error", message };
+	}
+
+	return { kind: "ok", checkedOut: defaultBranch };
+}

--- a/apps/desktop/src/main/todo-agent/scheduler.ts
+++ b/apps/desktop/src/main/todo-agent/scheduler.ts
@@ -1,0 +1,306 @@
+import type { SelectTodoSchedule, SelectTodoSession } from "@superset/local-db";
+import { CronExpressionParser } from "cron-parser";
+import { getTodoScheduleStore } from "./schedule-store";
+import { getTodoSessionStore, resolveWorktreePath } from "./session-store";
+import { getTodoSupervisor } from "./supervisor";
+import type { TodoScheduleFireEvent } from "./types";
+
+const TICK_INTERVAL_MS = 30_000;
+
+/**
+ * Compute the next fire time (epoch ms) for a schedule, starting from
+ * `from`. For `custom` we delegate to cron-parser; for the builder-backed
+ * frequencies we compute it directly to avoid forcing the user through
+ * cron syntax.
+ */
+export function computeNextRunAt(
+	schedule: Pick<
+		SelectTodoSchedule,
+		"frequency" | "minute" | "hour" | "weekday" | "monthday" | "cronExpr"
+	>,
+	from: Date,
+): number | null {
+	if (schedule.frequency === "custom") {
+		if (!schedule.cronExpr) return null;
+		try {
+			const interval = CronExpressionParser.parse(schedule.cronExpr, {
+				currentDate: from,
+			});
+			return interval.next().getTime();
+		} catch {
+			return null;
+		}
+	}
+
+	const minute = schedule.minute ?? 0;
+	const hour = schedule.hour ?? 0;
+	const next = new Date(from);
+	// Snap seconds/ms to zero so fires land exactly on the minute boundary.
+	next.setSeconds(0, 0);
+
+	switch (schedule.frequency) {
+		case "hourly": {
+			next.setMinutes(minute);
+			if (next.getTime() <= from.getTime()) {
+				next.setHours(next.getHours() + 1);
+			}
+			return next.getTime();
+		}
+		case "daily": {
+			next.setHours(hour, minute, 0, 0);
+			if (next.getTime() <= from.getTime()) {
+				next.setDate(next.getDate() + 1);
+			}
+			return next.getTime();
+		}
+		case "weekly": {
+			const targetWeekday = schedule.weekday ?? 0;
+			next.setHours(hour, minute, 0, 0);
+			const currentWeekday = next.getDay();
+			let delta = targetWeekday - currentWeekday;
+			if (delta < 0) delta += 7;
+			if (delta === 0 && next.getTime() <= from.getTime()) {
+				delta = 7;
+			}
+			next.setDate(next.getDate() + delta);
+			return next.getTime();
+		}
+		case "monthly": {
+			const targetMonthday = schedule.monthday ?? 1;
+			next.setDate(targetMonthday);
+			next.setHours(hour, minute, 0, 0);
+			if (next.getTime() <= from.getTime()) {
+				next.setMonth(next.getMonth() + 1);
+				next.setDate(targetMonthday);
+			}
+			return next.getTime();
+		}
+		default:
+			return null;
+	}
+}
+
+function isSessionActive(session: SelectTodoSession | undefined): boolean {
+	if (!session) return false;
+	return (
+		session.status === "queued" ||
+		session.status === "preparing" ||
+		session.status === "running" ||
+		session.status === "verifying" ||
+		session.status === "paused"
+	);
+}
+
+class TodoScheduler {
+	private timer: ReturnType<typeof setInterval> | null = null;
+	private inFlight = false;
+
+	start(): void {
+		if (this.timer) return;
+		// Re-seed nextRunAt for any schedule that lost its value (e.g. migration
+		// from schedules inserted before this field got populated). Safe to
+		// re-run on every boot because `lastRunAt` is respected.
+		this.rebuildNextRunTimes();
+		this.timer = setInterval(() => {
+			void this.tick();
+		}, TICK_INTERVAL_MS);
+		// Run an immediate tick so schedules already past-due when the app
+		// starts up fire on the first 30s window instead of waiting for it.
+		void this.tick();
+	}
+
+	stop(): void {
+		if (this.timer) {
+			clearInterval(this.timer);
+			this.timer = null;
+		}
+	}
+
+	private rebuildNextRunTimes(): void {
+		const store = getTodoScheduleStore();
+		const now = new Date();
+		for (const schedule of store.listAll()) {
+			if (!schedule.enabled) continue;
+			if (schedule.nextRunAt !== null) continue;
+			const next = computeNextRunAt(schedule, now);
+			if (next !== null) {
+				store.setNextRunAt(schedule.id, next);
+			}
+		}
+	}
+
+	/**
+	 * Public hook used by the tRPC layer when a schedule is created or its
+	 * cadence definition changes. Recomputes nextRunAt relative to `now`.
+	 */
+	refreshNextRunAt(scheduleId: string): void {
+		const store = getTodoScheduleStore();
+		const schedule = store.get(scheduleId);
+		if (!schedule) return;
+		if (!schedule.enabled) {
+			store.setNextRunAt(scheduleId, null);
+			return;
+		}
+		const next = computeNextRunAt(schedule, new Date());
+		store.setNextRunAt(scheduleId, next);
+	}
+
+	private async tick(): Promise<void> {
+		if (this.inFlight) return;
+		this.inFlight = true;
+		try {
+			const store = getTodoScheduleStore();
+			const now = Date.now();
+			const due = store.listDue(now);
+			for (const schedule of due) {
+				await this.fire(schedule, now);
+			}
+		} catch (error) {
+			console.warn("[todo-scheduler] tick failed:", error);
+		} finally {
+			this.inFlight = false;
+		}
+	}
+
+	private async fire(
+		schedule: SelectTodoSchedule,
+		firedAt: number,
+	): Promise<void> {
+		const store = getTodoScheduleStore();
+		const sessionStore = getTodoSessionStore();
+		const supervisor = getTodoSupervisor();
+
+		const nextRunAt = computeNextRunAt(schedule, new Date(firedAt));
+
+		// Overlap guard: if a previous session from this schedule is still
+		// active and the user asked us to skip, short-circuit without
+		// creating a new session. Still advance nextRunAt so we don't busy
+		// loop on the same tick.
+		if (schedule.overlapMode === "skip" && schedule.lastRunSessionId) {
+			const prev = sessionStore.get(schedule.lastRunSessionId);
+			if (isSessionActive(prev)) {
+				store.recordRun({
+					id: schedule.id,
+					sessionId: schedule.lastRunSessionId,
+					firedAt,
+					nextRunAt,
+				});
+				this.emit({
+					scheduleId: schedule.id,
+					scheduleName: schedule.name,
+					kind: "skipped",
+					sessionId: null,
+					message: "前回の実行が終わっていないためスキップしました",
+					firedAt,
+				});
+				return;
+			}
+		}
+
+		const worktreePath = resolveWorktreePath(schedule.workspaceId);
+		if (!worktreePath) {
+			store.recordRun({
+				id: schedule.id,
+				sessionId: null,
+				firedAt,
+				nextRunAt,
+			});
+			this.emit({
+				scheduleId: schedule.id,
+				scheduleName: schedule.name,
+				kind: "failed",
+				sessionId: null,
+				message: "ワークスペースのパスが解決できませんでした",
+				firedAt,
+			});
+			return;
+		}
+
+		try {
+			const sessionId = crypto.randomUUID();
+			const artifactPath = supervisor.computeArtifactPath({
+				sessionId,
+				workspaceId: schedule.workspaceId,
+			});
+			const inserted = sessionStore.insert({
+				id: sessionId,
+				projectId: schedule.projectId,
+				workspaceId: schedule.workspaceId,
+				title: schedule.title,
+				description: schedule.description,
+				goal: schedule.goal,
+				verifyCommand: schedule.verifyCommand,
+				maxIterations: schedule.maxIterations,
+				maxWallClockSec: schedule.maxWallClockSec,
+				status: "queued",
+				phase: "queued",
+				iteration: 0,
+				attachedPaneId: null,
+				attachedTabId: null,
+				claudeSessionId: null,
+				finalAssistantText: null,
+				totalCostUsd: null,
+				totalNumTurns: null,
+				pendingIntervention: null,
+				startHeadSha: null,
+				customSystemPrompt: schedule.customSystemPrompt,
+				verdictPassed: null,
+				verdictReason: null,
+				verdictFailingTest: null,
+				artifactPath,
+				startedAt: null,
+				completedAt: null,
+			});
+			supervisor.prepareArtifacts(inserted);
+			void supervisor.start(inserted.id).catch((err) => {
+				console.warn(
+					`[todo-scheduler] supervisor.start failed for ${inserted.id}:`,
+					err,
+				);
+			});
+			store.recordRun({
+				id: schedule.id,
+				sessionId: inserted.id,
+				firedAt,
+				nextRunAt,
+			});
+			this.emit({
+				scheduleId: schedule.id,
+				scheduleName: schedule.name,
+				kind: "triggered",
+				sessionId: inserted.id,
+				message: null,
+				firedAt,
+			});
+		} catch (error) {
+			const message = error instanceof Error ? error.message : "Unknown error";
+			store.recordRun({
+				id: schedule.id,
+				sessionId: null,
+				firedAt,
+				nextRunAt,
+			});
+			this.emit({
+				scheduleId: schedule.id,
+				scheduleName: schedule.name,
+				kind: "failed",
+				sessionId: null,
+				message,
+				firedAt,
+			});
+		}
+	}
+
+	private emit(event: TodoScheduleFireEvent): void {
+		getTodoScheduleStore().emitFire(event);
+	}
+}
+
+let instance: TodoScheduler | null = null;
+
+export function getTodoScheduler(): TodoScheduler {
+	if (!instance) {
+		instance = new TodoScheduler();
+	}
+	return instance;
+}

--- a/apps/desktop/src/main/todo-agent/scheduler.ts
+++ b/apps/desktop/src/main/todo-agent/scheduler.ts
@@ -67,11 +67,25 @@ export function computeNextRunAt(
 		}
 		case "monthly": {
 			const targetMonthday = schedule.monthday ?? 1;
-			next.setDate(targetMonthday);
-			next.setHours(hour, minute, 0, 0);
+			// Snap the target to the last valid day of each month so
+			// e.g. "every 31st" doesn't overflow Feb to Mar 3 — users
+			// who pick 31 expect "last day of every month" on short
+			// months.
+			const placeOnMonth = (base: Date) => {
+				const lastDay = new Date(
+					base.getFullYear(),
+					base.getMonth() + 1,
+					0,
+				).getDate();
+				base.setDate(Math.min(targetMonthday, lastDay));
+				base.setHours(hour, minute, 0, 0);
+			};
+			next.setDate(1);
+			placeOnMonth(next);
 			if (next.getTime() <= from.getTime()) {
+				next.setDate(1);
 				next.setMonth(next.getMonth() + 1);
-				next.setDate(targetMonthday);
+				placeOnMonth(next);
 			}
 			return next.getTime();
 		}
@@ -94,9 +108,11 @@ function isSessionActive(session: SelectTodoSession | undefined): boolean {
 class TodoScheduler {
 	private timer: ReturnType<typeof setInterval> | null = null;
 	private inFlight = false;
+	private isStopped = false;
 
 	start(): void {
 		if (this.timer) return;
+		this.isStopped = false;
 		// Re-seed nextRunAt for any schedule that lost its value (e.g. migration
 		// from schedules inserted before this field got populated). Safe to
 		// re-run on every boot because `lastRunAt` is respected.
@@ -110,6 +126,7 @@ class TodoScheduler {
 	}
 
 	stop(): void {
+		this.isStopped = true;
 		if (this.timer) {
 			clearInterval(this.timer);
 			this.timer = null;
@@ -146,13 +163,17 @@ class TodoScheduler {
 	}
 
 	private async tick(): Promise<void> {
-		if (this.inFlight) return;
+		if (this.inFlight || this.isStopped) return;
 		this.inFlight = true;
 		try {
 			const store = getTodoScheduleStore();
 			const now = Date.now();
 			const due = store.listDue(now);
 			for (const schedule of due) {
+				// Abort mid-iteration if a shutdown came in while we were
+				// awaiting a previous fire. Prevents inserting a session
+				// row after closeLocalDb() has torn down SQLite.
+				if (this.isStopped) break;
 				await this.fire(schedule, now);
 			}
 		} catch (error) {
@@ -176,6 +197,11 @@ class TodoScheduler {
 		// active and the user asked us to skip, short-circuit without
 		// creating a new session. Still advance nextRunAt so we don't busy
 		// loop on the same tick.
+		//
+		// `overlapMode === "queue"` is intentionally handled by the existing
+		// TodoSupervisor queue: we always insert the new session and call
+		// supervisor.start(), which enqueues when another session is already
+		// running instead of spawning in parallel. No extra branch needed here.
 		if (schedule.overlapMode === "skip" && schedule.lastRunSessionId) {
 			const prev = sessionStore.get(schedule.lastRunSessionId);
 			if (isSessionActive(prev)) {
@@ -253,10 +279,23 @@ class TodoScheduler {
 			});
 			supervisor.prepareArtifacts(inserted);
 			void supervisor.start(inserted.id).catch((err) => {
+				const failureMessage =
+					err instanceof Error ? err.message : "Unknown error";
 				console.warn(
 					`[todo-scheduler] supervisor.start failed for ${inserted.id}:`,
 					err,
 				);
+				// The triggered toast has already fired, so publish a
+				// follow-up failed event. Otherwise the UI would claim the
+				// fire succeeded even though the supervisor never ran.
+				this.emit({
+					scheduleId: schedule.id,
+					scheduleName: schedule.name,
+					kind: "failed",
+					sessionId: inserted.id,
+					message: `実行開始に失敗しました: ${failureMessage}`,
+					firedAt,
+				});
 			});
 			store.recordRun({
 				id: schedule.id,

--- a/apps/desktop/src/main/todo-agent/scheduler.ts
+++ b/apps/desktop/src/main/todo-agent/scheduler.ts
@@ -172,14 +172,19 @@ class TodoScheduler {
 		this.inFlight = true;
 		try {
 			const store = getTodoScheduleStore();
-			const now = Date.now();
-			const due = store.listDue(now);
+			// Snapshot "due" using tick start time, but compute each
+			// schedule's firedAt from the actual moment fire() runs.
+			// Otherwise a slow fire leaves the next schedule in the loop
+			// advancing `nextRunAt` from a stale tick-start timestamp —
+			// for minute-level cron that can emit a "next run" already
+			// in the past and trigger duplicate fires on the next tick.
+			const due = store.listDue(Date.now());
 			for (const schedule of due) {
 				// Abort mid-iteration if a shutdown came in while we were
 				// awaiting a previous fire. Prevents inserting a session
 				// row after closeLocalDb() has torn down SQLite.
 				if (this.isStopped) break;
-				await this.fire(schedule, now);
+				await this.fire(schedule, Date.now());
 			}
 		} catch (error) {
 			console.warn("[todo-scheduler] tick failed:", error);

--- a/apps/desktop/src/main/todo-agent/scheduler.ts
+++ b/apps/desktop/src/main/todo-agent/scheduler.ts
@@ -1,6 +1,7 @@
 import type { SelectTodoSchedule, SelectTodoSession } from "@superset/local-db";
 import { CronExpressionParser } from "cron-parser";
 import { getTodoScheduleStore } from "./schedule-store";
+import { autoSyncProjectMain } from "./schedule-sync";
 import {
 	ensureProjectBranchWorkspaceId,
 	getTodoSessionStore,
@@ -271,6 +272,32 @@ class TodoScheduler {
 				firedAt,
 			});
 			return;
+		}
+
+		// Opt-in: freshen the project main repo before firing. Applies
+		// only when the schedule itself has no workspaceId (we refuse to
+		// yank HEAD on a worktree workspace — that would rewrite someone
+		// else's working branch). If the tree is dirty we deliberately
+		// skip the fire rather than stash the user's work.
+		if (schedule.autoSyncBeforeFire && schedule.workspaceId === null) {
+			const syncResult = await autoSyncProjectMain(worktreePath);
+			if (syncResult.kind !== "ok") {
+				store.recordRun({
+					id: schedule.id,
+					sessionId: null,
+					firedAt,
+					nextRunAt,
+				});
+				this.emit({
+					scheduleId: schedule.id,
+					scheduleName: schedule.name,
+					kind: syncResult.kind === "dirty" ? "skipped" : "failed",
+					sessionId: null,
+					message: syncResult.message,
+					firedAt,
+				});
+				return;
+			}
 		}
 
 		try {

--- a/apps/desktop/src/main/todo-agent/scheduler.ts
+++ b/apps/desktop/src/main/todo-agent/scheduler.ts
@@ -248,7 +248,7 @@ class TodoScheduler {
 				sessionId,
 				workspaceId: schedule.workspaceId,
 			});
-			const inserted = sessionStore.insert({
+			const inserted = sessionStore.insertQueuedFromTemplate({
 				id: sessionId,
 				projectId: schedule.projectId,
 				workspaceId: schedule.workspaceId,
@@ -258,24 +258,8 @@ class TodoScheduler {
 				verifyCommand: schedule.verifyCommand,
 				maxIterations: schedule.maxIterations,
 				maxWallClockSec: schedule.maxWallClockSec,
-				status: "queued",
-				phase: "queued",
-				iteration: 0,
-				attachedPaneId: null,
-				attachedTabId: null,
-				claudeSessionId: null,
-				finalAssistantText: null,
-				totalCostUsd: null,
-				totalNumTurns: null,
-				pendingIntervention: null,
-				startHeadSha: null,
 				customSystemPrompt: schedule.customSystemPrompt,
-				verdictPassed: null,
-				verdictReason: null,
-				verdictFailingTest: null,
 				artifactPath,
-				startedAt: null,
-				completedAt: null,
 			});
 			supervisor.prepareArtifacts(inserted);
 			void supervisor.start(inserted.id).catch((err) => {

--- a/apps/desktop/src/main/todo-agent/scheduler.ts
+++ b/apps/desktop/src/main/todo-agent/scheduler.ts
@@ -1,7 +1,11 @@
 import type { SelectTodoSchedule, SelectTodoSession } from "@superset/local-db";
 import { CronExpressionParser } from "cron-parser";
 import { getTodoScheduleStore } from "./schedule-store";
-import { getTodoSessionStore, resolveWorktreePath } from "./session-store";
+import {
+	ensureProjectBranchWorkspaceId,
+	getTodoSessionStore,
+	resolveWorktreePath,
+} from "./session-store";
 import { getTodoSupervisor } from "./supervisor";
 import type { TodoScheduleFireEvent } from "./types";
 
@@ -223,7 +227,34 @@ class TodoScheduler {
 			}
 		}
 
-		const worktreePath = resolveWorktreePath(schedule.workspaceId);
+		// Resolve the workspace to attach the fired session to. If the
+		// schedule was saved project-only (workspaceId = null), fall back
+		// to the project's branch-type workspace, materializing one if the
+		// project doesn't already have it. That keeps `todo_sessions`
+		// workspaceId NOT NULL intact while letting the UI expose the
+		// "run on project main repo" mental model.
+		const fireWorkspaceId =
+			schedule.workspaceId ??
+			ensureProjectBranchWorkspaceId(schedule.projectId);
+		if (!fireWorkspaceId) {
+			store.recordRun({
+				id: schedule.id,
+				sessionId: null,
+				firedAt,
+				nextRunAt,
+			});
+			this.emit({
+				scheduleId: schedule.id,
+				scheduleName: schedule.name,
+				kind: "failed",
+				sessionId: null,
+				message: "プロジェクトのワークスペースを用意できませんでした",
+				firedAt,
+			});
+			return;
+		}
+
+		const worktreePath = resolveWorktreePath(fireWorkspaceId);
 		if (!worktreePath) {
 			store.recordRun({
 				id: schedule.id,
@@ -246,12 +277,12 @@ class TodoScheduler {
 			const sessionId = crypto.randomUUID();
 			const artifactPath = supervisor.computeArtifactPath({
 				sessionId,
-				workspaceId: schedule.workspaceId,
+				workspaceId: fireWorkspaceId,
 			});
 			const inserted = sessionStore.insertQueuedFromTemplate({
 				id: sessionId,
 				projectId: schedule.projectId,
-				workspaceId: schedule.workspaceId,
+				workspaceId: fireWorkspaceId,
 				title: schedule.title,
 				description: schedule.description,
 				goal: schedule.goal,

--- a/apps/desktop/src/main/todo-agent/session-store.ts
+++ b/apps/desktop/src/main/todo-agent/session-store.ts
@@ -9,7 +9,7 @@ import {
 	workspaces,
 	worktrees,
 } from "@superset/local-db";
-import { and, desc, eq, inArray, isNull } from "drizzle-orm";
+import { and, desc, eq, inArray, isNull, not } from "drizzle-orm";
 import { localDb } from "main/lib/local-db";
 import type {
 	TodoSessionListEntry,
@@ -452,7 +452,32 @@ export function ensureProjectBranchWorkspaceId(
 		.returning({ id: workspaces.id })
 		.get();
 
-	if (inserted) return inserted.id;
+	if (inserted) {
+		// Mirror the standard workspace-create flow: bump every other
+		// workspace in the project by +1 so the new branch workspace
+		// lands uniquely at tabOrder 0 instead of colliding with an
+		// existing 0-ordered worktree (which would yield a
+		// non-deterministic sort in the sidebar).
+		const siblings = localDb
+			.select({ id: workspaces.id, tabOrder: workspaces.tabOrder })
+			.from(workspaces)
+			.where(
+				and(
+					eq(workspaces.projectId, projectId),
+					not(eq(workspaces.id, inserted.id)),
+					isNull(workspaces.deletingAt),
+				),
+			)
+			.all();
+		for (const sibling of siblings) {
+			localDb
+				.update(workspaces)
+				.set({ tabOrder: (sibling.tabOrder ?? 0) + 1 })
+				.where(eq(workspaces.id, sibling.id))
+				.run();
+		}
+		return inserted.id;
+	}
 
 	// Race: another path materialized it between our check and insert.
 	const raced = localDb

--- a/apps/desktop/src/main/todo-agent/session-store.ts
+++ b/apps/desktop/src/main/todo-agent/session-store.ts
@@ -233,6 +233,57 @@ class TodoSessionStore {
 		return inserted;
 	}
 
+	/**
+	 * Insert a fresh `queued` session from a user-authored template (TODO
+	 * composer, schedule fire, or anywhere else that starts a new session
+	 * from scratch). Centralizing this here keeps the full TodoSession row
+	 * shape in one place — otherwise any new field on `todo_sessions` has
+	 * to be remembered in every call site.
+	 */
+	insertQueuedFromTemplate(template: {
+		id: string;
+		projectId: string | null | undefined;
+		workspaceId: string;
+		title: string;
+		description: string;
+		goal?: string | null;
+		verifyCommand?: string | null;
+		maxIterations: number;
+		maxWallClockSec: number;
+		customSystemPrompt?: string | null;
+		artifactPath: string;
+	}): SelectTodoSession {
+		return this.insert({
+			id: template.id,
+			projectId: template.projectId ?? null,
+			workspaceId: template.workspaceId,
+			title: template.title,
+			description: template.description,
+			goal: template.goal ?? null,
+			verifyCommand: template.verifyCommand ?? null,
+			maxIterations: template.maxIterations,
+			maxWallClockSec: template.maxWallClockSec,
+			status: "queued",
+			phase: "queued",
+			iteration: 0,
+			attachedPaneId: null,
+			attachedTabId: null,
+			claudeSessionId: null,
+			finalAssistantText: null,
+			totalCostUsd: null,
+			totalNumTurns: null,
+			pendingIntervention: null,
+			startHeadSha: null,
+			customSystemPrompt: template.customSystemPrompt ?? null,
+			verdictPassed: null,
+			verdictReason: null,
+			verdictFailingTest: null,
+			artifactPath: template.artifactPath,
+			startedAt: null,
+			completedAt: null,
+		});
+	}
+
 	get(sessionId: string): SelectTodoSession | undefined {
 		return localDb
 			.select()

--- a/apps/desktop/src/main/todo-agent/session-store.ts
+++ b/apps/desktop/src/main/todo-agent/session-store.ts
@@ -9,7 +9,7 @@ import {
 	workspaces,
 	worktrees,
 } from "@superset/local-db";
-import { desc, eq, inArray, isNull } from "drizzle-orm";
+import { and, desc, eq, inArray, isNull } from "drizzle-orm";
 import { localDb } from "main/lib/local-db";
 import type {
 	TodoSessionListEntry,
@@ -405,4 +405,66 @@ export function resolveWorktreePath(workspaceId: string): string | undefined {
 		.where(eq(workspaces.id, workspaceId))
 		.get();
 	return row?.worktreePath ?? row?.mainRepoPath ?? undefined;
+}
+
+/**
+ * Ensure a project has its `type="branch"` workspace (the row that maps
+ * to `mainRepoPath`). Creates one lazily if missing so schedules with
+ * no explicit workspaceId can attach their sessions to something real.
+ * Returns the workspace id, or undefined if the project itself is gone.
+ */
+export function ensureProjectBranchWorkspaceId(
+	projectId: string,
+): string | undefined {
+	const existing = localDb
+		.select({ id: workspaces.id })
+		.from(workspaces)
+		.where(
+			and(
+				eq(workspaces.projectId, projectId),
+				eq(workspaces.type, "branch"),
+				isNull(workspaces.deletingAt),
+			),
+		)
+		.get();
+	if (existing) return existing.id;
+
+	const project = localDb
+		.select({
+			defaultBranch: projects.defaultBranch,
+		})
+		.from(projects)
+		.where(eq(projects.id, projectId))
+		.get();
+	if (!project) return undefined;
+
+	const branchName = project.defaultBranch ?? "main";
+	const inserted = localDb
+		.insert(workspaces)
+		.values({
+			projectId,
+			type: "branch",
+			branch: branchName,
+			name: branchName,
+			tabOrder: 0,
+		})
+		.onConflictDoNothing()
+		.returning({ id: workspaces.id })
+		.get();
+
+	if (inserted) return inserted.id;
+
+	// Race: another path materialized it between our check and insert.
+	const raced = localDb
+		.select({ id: workspaces.id })
+		.from(workspaces)
+		.where(
+			and(
+				eq(workspaces.projectId, projectId),
+				eq(workspaces.type, "branch"),
+				isNull(workspaces.deletingAt),
+			),
+		)
+		.get();
+	return raced?.id;
 }

--- a/apps/desktop/src/main/todo-agent/sessions-cleanup.ts
+++ b/apps/desktop/src/main/todo-agent/sessions-cleanup.ts
@@ -1,0 +1,78 @@
+import { existsSync, rmSync } from "node:fs";
+import { todoSessions } from "@superset/local-db";
+import { and, inArray, lt } from "drizzle-orm";
+import { localDb } from "main/lib/local-db";
+import { getTodoSettings } from "./settings";
+
+const TERMINAL_STATUSES = ["done", "failed", "aborted", "escalated"] as const;
+
+/**
+ * One-shot sweep of old terminal TODO sessions at app startup.
+ *
+ * Respects `todo-agent-settings.sessionRetentionDays`:
+ *   - 0 (default) → no automatic deletion (legacy behavior)
+ *   - N > 0       → delete sessions whose `completedAt` (or createdAt
+ *                   fallback for rows that finished without a timestamp)
+ *                   is older than N days AND whose status is terminal.
+ *
+ * Running / queued / paused / verifying / preparing sessions are NEVER
+ * touched — they're active user work. The session's artifact directory
+ * (`artifactPath`) is removed alongside the row.
+ */
+export function cleanupOldSessions(): void {
+	try {
+		const { sessionRetentionDays } = getTodoSettings();
+		if (sessionRetentionDays <= 0) return;
+
+		const cutoffMs = Date.now() - sessionRetentionDays * 24 * 60 * 60 * 1000;
+
+		const candidates = localDb
+			.select({
+				id: todoSessions.id,
+				artifactPath: todoSessions.artifactPath,
+			})
+			.from(todoSessions)
+			.where(
+				and(
+					inArray(todoSessions.status, [...TERMINAL_STATUSES]),
+					lt(todoSessions.createdAt, cutoffMs),
+				),
+			)
+			.all();
+
+		if (candidates.length === 0) return;
+
+		// Delete rows in a single DB call so we don't thrash the journal
+		// if the retention window has hundreds of pending deletes.
+		localDb
+			.delete(todoSessions)
+			.where(
+				inArray(
+					todoSessions.id,
+					candidates.map((row) => row.id),
+				),
+			)
+			.run();
+
+		for (const row of candidates) {
+			if (!row.artifactPath) continue;
+			try {
+				if (existsSync(row.artifactPath)) {
+					rmSync(row.artifactPath, { recursive: true, force: true });
+				}
+			} catch (error) {
+				console.warn(
+					"[todo-agent] failed to remove session artifact:",
+					row.artifactPath,
+					error,
+				);
+			}
+		}
+
+		console.log(
+			`[todo-agent] cleaned up ${candidates.length} session(s) older than ${sessionRetentionDays} days`,
+		);
+	} catch (error) {
+		console.warn("[todo-agent] session cleanup failed:", error);
+	}
+}

--- a/apps/desktop/src/main/todo-agent/sessions-cleanup.ts
+++ b/apps/desktop/src/main/todo-agent/sessions-cleanup.ts
@@ -1,6 +1,6 @@
 import { existsSync, rmSync } from "node:fs";
 import { todoSessions } from "@superset/local-db";
-import { and, inArray, lt } from "drizzle-orm";
+import { and, inArray, sql } from "drizzle-orm";
 import { localDb } from "main/lib/local-db";
 import { getTodoSettings } from "./settings";
 
@@ -26,6 +26,11 @@ export function cleanupOldSessions(): void {
 
 		const cutoffMs = Date.now() - sessionRetentionDays * 24 * 60 * 60 * 1000;
 
+		// The retention cutoff must be based on when the session finished,
+		// not when it started. A session created weeks ago but completed
+		// today is still "fresh" from the user's perspective. Fall back
+		// to createdAt only for the rare terminal row with no
+		// completedAt timestamp.
 		const candidates = localDb
 			.select({
 				id: todoSessions.id,
@@ -35,7 +40,7 @@ export function cleanupOldSessions(): void {
 			.where(
 				and(
 					inArray(todoSessions.status, [...TERMINAL_STATUSES]),
-					lt(todoSessions.createdAt, cutoffMs),
+					sql`COALESCE(${todoSessions.completedAt}, ${todoSessions.createdAt}) < ${cutoffMs}`,
 				),
 			)
 			.all();

--- a/apps/desktop/src/main/todo-agent/settings.ts
+++ b/apps/desktop/src/main/todo-agent/settings.ts
@@ -15,6 +15,7 @@ const DEFAULT_SETTINGS: TodoSettings = {
 	defaultMaxIterations: 10,
 	defaultMaxWallClockMin: 30,
 	maxConcurrentTasks: 1,
+	sessionRetentionDays: 0,
 };
 
 let cached: TodoSettings | null = null;

--- a/apps/desktop/src/main/todo-agent/trpc-router.ts
+++ b/apps/desktop/src/main/todo-agent/trpc-router.ts
@@ -16,17 +16,22 @@ import {
 	getSessionGitSnapshot,
 	type SessionDiffScope,
 } from "./git-status";
+import { getTodoScheduleStore } from "./schedule-store";
+import { computeNextRunAt, getTodoScheduler } from "./scheduler";
 import { getTodoSessionStore, resolveWorktreePath } from "./session-store";
 import { getTodoSettings, updateTodoSettings } from "./settings";
 import { getTodoSupervisor } from "./supervisor";
 import {
 	TODO_ARTIFACT_SUBDIR,
+	type TodoScheduleFireEvent,
 	type TodoSessionStateEvent,
 	type TodoStreamUpdate,
 	todoCreateInputSchema,
 	todoEnhanceTextInputSchema,
 	todoPresetCreateInputSchema,
 	todoPresetUpdateInputSchema,
+	todoScheduleCreateInputSchema,
+	todoScheduleUpdateInputSchema,
 	todoSendInputSchema,
 	todoSettingsUpdateSchema,
 } from "./types";
@@ -661,6 +666,109 @@ export const createTodoAgentRouter = () => {
 			update: publicProcedure
 				.input(todoSettingsUpdateSchema)
 				.mutation(({ input }) => updateTodoSettings(input)),
+		}),
+
+		schedule: router({
+			list: publicProcedure
+				.input(z.object({ workspaceId: z.string().min(1) }))
+				.query(({ input }) =>
+					getTodoScheduleStore().listForWorkspace(input.workspaceId),
+				),
+			listAll: publicProcedure.query(() => getTodoScheduleStore().listAll()),
+			create: publicProcedure
+				.input(todoScheduleCreateInputSchema)
+				.mutation(({ input }) => {
+					const nextRunAt = input.enabled
+						? computeNextRunAt(
+								{
+									frequency: input.frequency,
+									minute: input.minute ?? null,
+									hour: input.hour ?? null,
+									weekday: input.weekday ?? null,
+									monthday: input.monthday ?? null,
+									cronExpr: input.cronExpr ?? null,
+								},
+								new Date(),
+							)
+						: null;
+					const row = getTodoScheduleStore().insert({
+						...input,
+						nextRunAt,
+					});
+					return row;
+				}),
+			update: publicProcedure
+				.input(todoScheduleUpdateInputSchema)
+				.mutation(({ input }) => {
+					const row = getTodoScheduleStore().update(input);
+					if (row) {
+						getTodoScheduler().refreshNextRunAt(row.id);
+					}
+					return row ?? null;
+				}),
+			setEnabled: publicProcedure
+				.input(
+					z.object({
+						id: z.string().min(1),
+						enabled: z.boolean(),
+					}),
+				)
+				.mutation(({ input }) => {
+					const row = getTodoScheduleStore().setEnabled(
+						input.id,
+						input.enabled,
+					);
+					if (row) {
+						getTodoScheduler().refreshNextRunAt(row.id);
+					}
+					return row ?? null;
+				}),
+			delete: publicProcedure
+				.input(z.object({ id: z.string().min(1) }))
+				.mutation(({ input }) => {
+					const ok = getTodoScheduleStore().delete(input.id);
+					return { ok };
+				}),
+			previewNextRun: publicProcedure
+				.input(
+					z.object({
+						frequency: z.enum([
+							"hourly",
+							"daily",
+							"weekly",
+							"monthly",
+							"custom",
+						]),
+						minute: z.number().int().min(0).max(59).nullish(),
+						hour: z.number().int().min(0).max(23).nullish(),
+						weekday: z.number().int().min(0).max(6).nullish(),
+						monthday: z.number().int().min(1).max(31).nullish(),
+						cronExpr: z.string().trim().max(200).nullish(),
+					}),
+				)
+				.query(({ input }) =>
+					computeNextRunAt(
+						{
+							frequency: input.frequency,
+							minute: input.minute ?? null,
+							hour: input.hour ?? null,
+							weekday: input.weekday ?? null,
+							monthday: input.monthday ?? null,
+							cronExpr: input.cronExpr ?? null,
+						},
+						new Date(),
+					),
+				),
+			onFire: publicProcedure.subscription(() =>
+				observable<TodoScheduleFireEvent>((emit) => {
+					const off = getTodoScheduleStore().onFire((event) => {
+						emit.next(event);
+					});
+					return () => {
+						off();
+					};
+				}),
+			),
 		}),
 	});
 };

--- a/apps/desktop/src/main/todo-agent/trpc-router.ts
+++ b/apps/desktop/src/main/todo-agent/trpc-router.ts
@@ -654,9 +654,9 @@ export const createTodoAgentRouter = () => {
 
 		schedule: router({
 			list: publicProcedure
-				.input(z.object({ workspaceId: z.string().min(1) }))
+				.input(z.object({ projectId: z.string().min(1) }))
 				.query(({ input }) =>
-					getTodoScheduleStore().listForWorkspace(input.workspaceId),
+					getTodoScheduleStore().listForProject(input.projectId),
 				),
 			listAll: publicProcedure.query(() => getTodoScheduleStore().listAll()),
 			create: publicProcedure

--- a/apps/desktop/src/main/todo-agent/trpc-router.ts
+++ b/apps/desktop/src/main/todo-agent/trpc-router.ts
@@ -103,34 +103,18 @@ export const createTodoAgentRouter = () => {
 					workspaceId: input.workspaceId,
 				});
 
-				const session = store.insert({
+				const session = store.insertQueuedFromTemplate({
 					id: sessionId,
 					projectId: input.projectId ?? null,
 					workspaceId: input.workspaceId,
 					title: input.title,
 					description: input.description,
-					goal: input.goal ?? null,
-					verifyCommand: input.verifyCommand ?? null,
+					goal: input.goal,
+					verifyCommand: input.verifyCommand,
 					maxIterations: input.maxIterations,
 					maxWallClockSec: input.maxWallClockSec,
-					status: "queued",
-					phase: "queued",
-					iteration: 0,
-					attachedPaneId: null,
-					attachedTabId: null,
-					claudeSessionId: null,
-					finalAssistantText: null,
-					totalCostUsd: null,
-					totalNumTurns: null,
-					pendingIntervention: null,
-					startHeadSha: null,
-					customSystemPrompt: input.customSystemPrompt ?? null,
-					verdictPassed: null,
-					verdictReason: null,
-					verdictFailingTest: null,
+					customSystemPrompt: input.customSystemPrompt,
 					artifactPath,
-					startedAt: null,
-					completedAt: null,
 				});
 
 				// Materialize the directory + goal.md. If this throws after

--- a/apps/desktop/src/main/todo-agent/types.ts
+++ b/apps/desktop/src/main/todo-agent/types.ts
@@ -256,7 +256,12 @@ const todoScheduleBaseSchema = z.object({
 	overlapMode: todoScheduleOverlapModeSchema,
 });
 
+// projectId is intentionally omitted from the update surface: a schedule's
+// project is immutable, otherwise `lastRunSessionId` could point at a
+// session from a different project than the schedule currently belongs to.
+// Users who want to move a schedule to another project should recreate it.
 export const todoScheduleUpdateInputSchema = todoScheduleBaseSchema
+	.omit({ projectId: true })
 	.partial()
 	.extend({ id: z.string().min(1) });
 

--- a/apps/desktop/src/main/todo-agent/types.ts
+++ b/apps/desktop/src/main/todo-agent/types.ts
@@ -1,4 +1,9 @@
-import type { SelectTodoSession } from "@superset/local-db";
+import type {
+	SelectTodoSchedule,
+	SelectTodoSession,
+	TodoScheduleFrequency,
+	TodoScheduleOverlapMode,
+} from "@superset/local-db";
 import { z } from "zod";
 
 /**
@@ -170,3 +175,110 @@ export interface TodoStreamUpdate {
 	sessionId: string;
 	events: TodoStreamEvent[];
 }
+
+// ---- Schedules ----
+
+export const todoScheduleFrequencySchema = z.enum([
+	"hourly",
+	"daily",
+	"weekly",
+	"monthly",
+	"custom",
+]);
+
+export const todoScheduleOverlapModeSchema = z.enum(["skip", "queue"]);
+
+export const todoScheduleCreateInputSchema = z
+	.object({
+		workspaceId: z.string().min(1),
+		projectId: z.string().min(1).nullish(),
+		name: z.string().trim().min(1).max(120),
+		enabled: z.boolean().default(true),
+		frequency: todoScheduleFrequencySchema,
+		minute: z.number().int().min(0).max(59).nullish(),
+		hour: z.number().int().min(0).max(23).nullish(),
+		weekday: z.number().int().min(0).max(6).nullish(),
+		monthday: z.number().int().min(1).max(31).nullish(),
+		cronExpr: z.string().trim().min(1).max(200).nullish(),
+		title: z.string().trim().min(1).max(200),
+		description: z.string().trim().min(1).max(10_000),
+		goal: z.string().trim().max(10_000).nullish(),
+		verifyCommand: z.string().trim().max(10_000).nullish(),
+		maxIterations: z.number().int().min(1).max(100).default(10),
+		maxWallClockSec: z
+			.number()
+			.int()
+			.min(60)
+			.max(60 * 60 * 4)
+			.default(1800),
+		customSystemPrompt: z.string().trim().max(20_000).nullish(),
+		overlapMode: todoScheduleOverlapModeSchema.default("skip"),
+	})
+	.refine(
+		(v) =>
+			v.frequency !== "custom" ||
+			(typeof v.cronExpr === "string" && v.cronExpr.length > 0),
+		{
+			message: "cronExpr is required when frequency is 'custom'",
+			path: ["cronExpr"],
+		},
+	);
+
+export type TodoScheduleCreateInput = z.infer<
+	typeof todoScheduleCreateInputSchema
+>;
+
+const todoScheduleBaseSchema = z.object({
+	workspaceId: z.string().min(1),
+	projectId: z.string().min(1).nullish(),
+	name: z.string().trim().min(1).max(120),
+	enabled: z.boolean(),
+	frequency: todoScheduleFrequencySchema,
+	minute: z.number().int().min(0).max(59).nullish(),
+	hour: z.number().int().min(0).max(23).nullish(),
+	weekday: z.number().int().min(0).max(6).nullish(),
+	monthday: z.number().int().min(1).max(31).nullish(),
+	cronExpr: z.string().trim().min(1).max(200).nullish(),
+	title: z.string().trim().min(1).max(200),
+	description: z.string().trim().min(1).max(10_000),
+	goal: z.string().trim().max(10_000).nullish(),
+	verifyCommand: z.string().trim().max(10_000).nullish(),
+	maxIterations: z.number().int().min(1).max(100),
+	maxWallClockSec: z
+		.number()
+		.int()
+		.min(60)
+		.max(60 * 60 * 4),
+	customSystemPrompt: z.string().trim().max(20_000).nullish(),
+	overlapMode: todoScheduleOverlapModeSchema,
+});
+
+export const todoScheduleUpdateInputSchema = todoScheduleBaseSchema
+	.partial()
+	.extend({ id: z.string().min(1) });
+
+export type TodoScheduleUpdateInput = z.infer<
+	typeof todoScheduleUpdateInputSchema
+>;
+
+/**
+ * Event emitted by the scheduler when a schedule fires. The renderer uses
+ * this to show a toast and, when `sessionId` is non-null, deep-link to the
+ * freshly-created session.
+ */
+export type TodoScheduleFireKind = "triggered" | "skipped" | "failed";
+
+export interface TodoScheduleFireEvent {
+	scheduleId: string;
+	scheduleName: string;
+	kind: TodoScheduleFireKind;
+	sessionId: string | null;
+	message: string | null;
+	firedAt: number;
+}
+
+export type {
+	SelectTodoSchedule,
+	TodoScheduleFrequency,
+	TodoScheduleOverlapMode,
+};

--- a/apps/desktop/src/main/todo-agent/types.ts
+++ b/apps/desktop/src/main/todo-agent/types.ts
@@ -90,6 +90,9 @@ export const todoSettingsSchema = z.object({
 	defaultMaxIterations: z.number().int().min(1).max(100).default(10),
 	defaultMaxWallClockMin: z.number().int().min(1).max(240).default(30),
 	maxConcurrentTasks: z.number().int().min(1).max(10).default(1),
+	// 0 = 無制限 (手動削除のみ). 1-365 = その日数より古い終了済み
+	// セッションを起動時に自動削除する (queued / running / paused は対象外)。
+	sessionRetentionDays: z.number().int().min(0).max(365).default(0),
 });
 
 export type TodoSettings = z.infer<typeof todoSettingsSchema>;
@@ -216,6 +219,7 @@ export const todoScheduleCreateInputSchema = z
 			.default(1800),
 		customSystemPrompt: z.string().trim().max(20_000).nullish(),
 		overlapMode: todoScheduleOverlapModeSchema.default("skip"),
+		autoSyncBeforeFire: z.boolean().default(false),
 	})
 	.refine(
 		(v) =>
@@ -254,6 +258,7 @@ const todoScheduleBaseSchema = z.object({
 		.max(60 * 60 * 4),
 	customSystemPrompt: z.string().trim().max(20_000).nullish(),
 	overlapMode: todoScheduleOverlapModeSchema,
+	autoSyncBeforeFire: z.boolean(),
 });
 
 // projectId is intentionally omitted from the update surface: a schedule's

--- a/apps/desktop/src/main/todo-agent/types.ts
+++ b/apps/desktop/src/main/todo-agent/types.ts
@@ -190,8 +190,11 @@ export const todoScheduleOverlapModeSchema = z.enum(["skip", "queue"]);
 
 export const todoScheduleCreateInputSchema = z
 	.object({
-		workspaceId: z.string().min(1),
-		projectId: z.string().min(1).nullish(),
+		projectId: z.string().min(1),
+		// Null/omitted means "run on the project's main repo path" (the
+		// non-worktree source tree). Set to a workspace id to bind the
+		// schedule to a specific worktree instead.
+		workspaceId: z.string().min(1).nullish(),
 		name: z.string().trim().min(1).max(120),
 		enabled: z.boolean().default(true),
 		frequency: todoScheduleFrequencySchema,
@@ -229,8 +232,8 @@ export type TodoScheduleCreateInput = z.infer<
 >;
 
 const todoScheduleBaseSchema = z.object({
-	workspaceId: z.string().min(1),
-	projectId: z.string().min(1).nullish(),
+	projectId: z.string().min(1),
+	workspaceId: z.string().min(1).nullish(),
 	name: z.string().trim().min(1).max(120),
 	enabled: z.boolean(),
 	frequency: todoScheduleFrequencySchema,

--- a/apps/desktop/src/renderer/features/todo-agent/ScheduleFireToasts/ScheduleFireToasts.tsx
+++ b/apps/desktop/src/renderer/features/todo-agent/ScheduleFireToasts/ScheduleFireToasts.tsx
@@ -12,6 +12,9 @@ export function ScheduleFireToasts() {
 	const utils = electronTrpc.useUtils();
 
 	electronTrpc.todoAgent.schedule.onFire.useSubscription(undefined, {
+		onError: (err) => {
+			console.warn("[schedule-toasts] subscription error", err);
+		},
 		onData: (event) => {
 			if (event.kind === "triggered") {
 				toast.success(`📅 ${event.scheduleName} を実行しました`, {

--- a/apps/desktop/src/renderer/features/todo-agent/ScheduleFireToasts/ScheduleFireToasts.tsx
+++ b/apps/desktop/src/renderer/features/todo-agent/ScheduleFireToasts/ScheduleFireToasts.tsx
@@ -1,0 +1,38 @@
+import { toast } from "@superset/ui/sonner";
+import { electronTrpc } from "renderer/lib/electron-trpc";
+
+/**
+ * Subscribes to the scheduler's fire events in the main process and shows
+ * a toast for each one. Mounted once at the layout level so notifications
+ * surface regardless of whether the TodoManager dialog is open.
+ *
+ * Renders nothing.
+ */
+export function ScheduleFireToasts() {
+	const utils = electronTrpc.useUtils();
+
+	electronTrpc.todoAgent.schedule.onFire.useSubscription(undefined, {
+		onData: (event) => {
+			if (event.kind === "triggered") {
+				toast.success(`📅 ${event.scheduleName} を実行しました`, {
+					description: event.sessionId
+						? "TODO Manager のタスクタブから進捗を確認できます"
+						: undefined,
+				});
+			} else if (event.kind === "skipped") {
+				toast.info(`⏭️ ${event.scheduleName} をスキップしました`, {
+					description: event.message ?? undefined,
+				});
+			} else if (event.kind === "failed") {
+				toast.error(`⚠️ ${event.scheduleName} の発火に失敗しました`, {
+					description: event.message ?? undefined,
+				});
+			}
+
+			void utils.todoAgent.schedule.listAll.invalidate();
+			void utils.todoAgent.listAll.invalidate();
+		},
+	});
+
+	return null;
+}

--- a/apps/desktop/src/renderer/features/todo-agent/ScheduleFireToasts/index.ts
+++ b/apps/desktop/src/renderer/features/todo-agent/ScheduleFireToasts/index.ts
@@ -1,0 +1,1 @@
+export { ScheduleFireToasts } from "./ScheduleFireToasts";

--- a/apps/desktop/src/renderer/features/todo-agent/TodoManager/PresetsDialog/PresetsDialog.tsx
+++ b/apps/desktop/src/renderer/features/todo-agent/TodoManager/PresetsDialog/PresetsDialog.tsx
@@ -100,12 +100,14 @@ function SettingsTab() {
 	const [maxIter, setMaxIter] = useState(10);
 	const [maxMin, setMaxMin] = useState(30);
 	const [maxConcurrent, setMaxConcurrent] = useState(1);
+	const [retentionDays, setRetentionDays] = useState(0);
 
 	useEffect(() => {
 		if (settings) {
 			setMaxIter(settings.defaultMaxIterations);
 			setMaxMin(settings.defaultMaxWallClockMin);
 			setMaxConcurrent(settings.maxConcurrentTasks);
+			setRetentionDays(settings.sessionRetentionDays);
 		}
 	}, [settings]);
 
@@ -113,7 +115,8 @@ function SettingsTab() {
 		settings != null &&
 		(maxIter !== settings.defaultMaxIterations ||
 			maxMin !== settings.defaultMaxWallClockMin ||
-			maxConcurrent !== settings.maxConcurrentTasks);
+			maxConcurrent !== settings.maxConcurrentTasks ||
+			retentionDays !== settings.sessionRetentionDays);
 
 	const handleSave = useCallback(async () => {
 		try {
@@ -121,6 +124,7 @@ function SettingsTab() {
 				defaultMaxIterations: maxIter,
 				defaultMaxWallClockMin: maxMin,
 				maxConcurrentTasks: maxConcurrent,
+				sessionRetentionDays: retentionDays,
 			});
 			await utils.todoAgent.settings.get.invalidate();
 			toast.success("設定を保存しました");
@@ -129,7 +133,7 @@ function SettingsTab() {
 				error instanceof Error ? error.message : "保存に失敗しました",
 			);
 		}
-	}, [maxIter, maxMin, maxConcurrent, updateMut, utils]);
+	}, [maxIter, maxMin, maxConcurrent, retentionDays, updateMut, utils]);
 
 	return (
 		<div className="flex-1 p-6 overflow-y-auto">
@@ -177,6 +181,25 @@ function SettingsTab() {
 					/>
 					<p className="text-[10px] text-muted-foreground">
 						同時に実行する TODO セッションの上限。超えた分はキューで待機。
+					</p>
+				</div>
+				<div className="flex flex-col gap-1.5">
+					<Label htmlFor="set-retention-days">セッション自動削除 (日)</Label>
+					<Input
+						id="set-retention-days"
+						type="number"
+						min={0}
+						max={365}
+						value={retentionDays}
+						onChange={(e) =>
+							setRetentionDays(Math.max(0, Number(e.target.value) || 0))
+						}
+						className="w-32"
+					/>
+					<p className="text-[10px] text-muted-foreground">
+						この日数より古い終了済みセッション (done / failed / aborted /
+						escalated) をアプリ起動時に自動削除する。0
+						で無効（手動削除のみ）。実行中・キュー中のセッションは対象外。
 					</p>
 				</div>
 				<div className="pt-2 border-t">

--- a/apps/desktop/src/renderer/features/todo-agent/TodoManager/SchedulesSection/SchedulesSection.tsx
+++ b/apps/desktop/src/renderer/features/todo-agent/TodoManager/SchedulesSection/SchedulesSection.tsx
@@ -23,12 +23,19 @@ export function SchedulesSection() {
 		},
 	);
 	const { data: workspaces } = electronTrpc.workspaces.getAll.useQuery();
+	const { data: projects } = electronTrpc.projects.getRecents.useQuery();
 
 	const workspaceNameById = useMemo(() => {
 		const map = new Map<string, string>();
 		for (const w of workspaces ?? []) map.set(w.id, w.name);
 		return map;
 	}, [workspaces]);
+
+	const projectNameById = useMemo(() => {
+		const map = new Map<string, string>();
+		for (const p of projects ?? []) map.set(p.id, p.name);
+		return map;
+	}, [projects]);
 
 	const openNew = () => {
 		setEditing(null);
@@ -73,8 +80,11 @@ export function SchedulesSection() {
 						<ScheduleListRow
 							key={schedule.id}
 							schedule={schedule}
+							projectName={projectNameById.get(schedule.projectId) ?? null}
 							workspaceName={
-								workspaceNameById.get(schedule.workspaceId) ?? null
+								schedule.workspaceId
+									? (workspaceNameById.get(schedule.workspaceId) ?? null)
+									: null
 							}
 							onEdit={() => openEdit(schedule)}
 						/>

--- a/apps/desktop/src/renderer/features/todo-agent/TodoManager/SchedulesSection/SchedulesSection.tsx
+++ b/apps/desktop/src/renderer/features/todo-agent/TodoManager/SchedulesSection/SchedulesSection.tsx
@@ -1,0 +1,92 @@
+import type { SelectTodoSchedule } from "@superset/local-db";
+import { Button } from "@superset/ui/button";
+import { ScrollArea } from "@superset/ui/scroll-area";
+import { useMemo, useState } from "react";
+import { HiMiniPlus } from "react-icons/hi2";
+import { electronTrpc } from "renderer/lib/electron-trpc";
+import { ScheduleEditorDialog } from "./components/ScheduleEditorDialog";
+import { ScheduleListRow } from "./components/ScheduleListRow";
+
+/**
+ * Tab shown inside TodoManager's left sidebar when the user flips to
+ * "スケジュール". Renders the list of saved schedules plus the editor
+ * dialog for creating / updating one.
+ */
+export function SchedulesSection() {
+	const [editorOpen, setEditorOpen] = useState(false);
+	const [editing, setEditing] = useState<SelectTodoSchedule | null>(null);
+
+	const { data: schedules } = electronTrpc.todoAgent.schedule.listAll.useQuery(
+		undefined,
+		{
+			refetchInterval: 30_000,
+		},
+	);
+	const { data: workspaces } = electronTrpc.workspaces.getAll.useQuery();
+
+	const workspaceNameById = useMemo(() => {
+		const map = new Map<string, string>();
+		for (const w of workspaces ?? []) map.set(w.id, w.name);
+		return map;
+	}, [workspaces]);
+
+	const openNew = () => {
+		setEditing(null);
+		setEditorOpen(true);
+	};
+
+	const openEdit = (schedule: SelectTodoSchedule) => {
+		setEditing(schedule);
+		setEditorOpen(true);
+	};
+
+	return (
+		<div className="flex flex-col h-full min-h-0">
+			<div className="p-2 border-b shrink-0 flex items-center justify-between gap-2">
+				<span className="text-xs text-muted-foreground">
+					{(schedules?.length ?? 0) > 0
+						? `${schedules?.length} 件のスケジュール`
+						: "スケジュールなし"}
+				</span>
+				<Button
+					type="button"
+					size="sm"
+					className="h-7 gap-1 px-2.5 text-xs rounded-md"
+					onClick={openNew}
+				>
+					<HiMiniPlus className="size-4" />
+					新規
+				</Button>
+			</div>
+			<ScrollArea className="flex-1">
+				<div className="flex flex-col gap-1.5 p-2">
+					{(schedules?.length ?? 0) === 0 && (
+						<p className="text-xs text-muted-foreground px-1 py-4">
+							まだスケジュールはありません。「新規」ボタンから作成してください。
+							<br />
+							<span className="text-[10px]">
+								スケジュールはアプリ起動中のみ発火します。
+							</span>
+						</p>
+					)}
+					{(schedules ?? []).map((schedule) => (
+						<ScheduleListRow
+							key={schedule.id}
+							schedule={schedule}
+							workspaceName={
+								workspaceNameById.get(schedule.workspaceId) ?? null
+							}
+							onEdit={() => openEdit(schedule)}
+						/>
+					))}
+				</div>
+			</ScrollArea>
+
+			<ScheduleEditorDialog
+				open={editorOpen}
+				onOpenChange={setEditorOpen}
+				initial={editing}
+			/>
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/features/todo-agent/TodoManager/SchedulesSection/components/FrequencyPicker/FrequencyPicker.tsx
+++ b/apps/desktop/src/renderer/features/todo-agent/TodoManager/SchedulesSection/components/FrequencyPicker/FrequencyPicker.tsx
@@ -1,0 +1,227 @@
+import { Input } from "@superset/ui/input";
+import { Label } from "@superset/ui/label";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@superset/ui/select";
+import { cn } from "@superset/ui/utils";
+
+export type Frequency = "hourly" | "daily" | "weekly" | "monthly" | "custom";
+
+export interface FrequencyValue {
+	frequency: Frequency;
+	minute: number | null;
+	hour: number | null;
+	weekday: number | null;
+	monthday: number | null;
+	cronExpr: string | null;
+}
+
+interface FrequencyPickerProps {
+	value: FrequencyValue;
+	onChange: (next: FrequencyValue) => void;
+	disabled?: boolean;
+}
+
+const WEEKDAYS = [
+	{ value: 0, label: "日" },
+	{ value: 1, label: "月" },
+	{ value: 2, label: "火" },
+	{ value: 3, label: "水" },
+	{ value: 4, label: "木" },
+	{ value: 5, label: "金" },
+	{ value: 6, label: "土" },
+];
+
+function clampInt(raw: string, min: number, max: number): number | null {
+	if (raw === "") return null;
+	const n = Number.parseInt(raw, 10);
+	if (Number.isNaN(n)) return null;
+	return Math.min(max, Math.max(min, n));
+}
+
+export function FrequencyPicker({
+	value,
+	onChange,
+	disabled,
+}: FrequencyPickerProps) {
+	const patch = (partial: Partial<FrequencyValue>) => {
+		onChange({ ...value, ...partial });
+	};
+
+	const setFrequency = (frequency: Frequency) => {
+		// Re-seed sensible defaults whenever the frequency changes so each
+		// field has a visible starting value instead of the previous
+		// frequency's empty slots.
+		const base: FrequencyValue = {
+			frequency,
+			minute: null,
+			hour: null,
+			weekday: null,
+			monthday: null,
+			cronExpr: null,
+		};
+		switch (frequency) {
+			case "hourly":
+				base.minute = value.minute ?? 0;
+				break;
+			case "daily":
+				base.hour = value.hour ?? 9;
+				base.minute = value.minute ?? 0;
+				break;
+			case "weekly":
+				base.weekday = value.weekday ?? 1;
+				base.hour = value.hour ?? 9;
+				base.minute = value.minute ?? 0;
+				break;
+			case "monthly":
+				base.monthday = value.monthday ?? 1;
+				base.hour = value.hour ?? 9;
+				base.minute = value.minute ?? 0;
+				break;
+			case "custom":
+				base.cronExpr = value.cronExpr ?? "0 9 * * *";
+				break;
+		}
+		onChange(base);
+	};
+
+	return (
+		<div className="flex flex-col gap-3">
+			<div className="flex flex-col gap-1.5">
+				<Label className="text-xs">頻度</Label>
+				<Select
+					value={value.frequency}
+					onValueChange={(v) => setFrequency(v as Frequency)}
+					disabled={disabled}
+				>
+					<SelectTrigger className="h-8 text-xs">
+						<SelectValue />
+					</SelectTrigger>
+					<SelectContent>
+						<SelectItem value="hourly">毎時</SelectItem>
+						<SelectItem value="daily">毎日</SelectItem>
+						<SelectItem value="weekly">毎週</SelectItem>
+						<SelectItem value="monthly">毎月</SelectItem>
+						<SelectItem value="custom">カスタム (cron)</SelectItem>
+					</SelectContent>
+				</Select>
+			</div>
+
+			{value.frequency === "hourly" && (
+				<div className="flex items-center gap-2">
+					<Label className="text-xs w-20 shrink-0">毎時 :</Label>
+					<Input
+						type="number"
+						min={0}
+						max={59}
+						value={value.minute ?? 0}
+						onChange={(e) =>
+							patch({ minute: clampInt(e.target.value, 0, 59) ?? 0 })
+						}
+						disabled={disabled}
+						className="h-8 w-20 text-xs"
+					/>
+					<span className="text-xs text-muted-foreground">分</span>
+				</div>
+			)}
+
+			{(value.frequency === "daily" ||
+				value.frequency === "weekly" ||
+				value.frequency === "monthly") && (
+				<div className="flex items-center gap-2">
+					<Label className="text-xs w-20 shrink-0">時刻</Label>
+					<Input
+						type="number"
+						min={0}
+						max={23}
+						value={value.hour ?? 9}
+						onChange={(e) =>
+							patch({ hour: clampInt(e.target.value, 0, 23) ?? 9 })
+						}
+						disabled={disabled}
+						className="h-8 w-20 text-xs"
+					/>
+					<span className="text-xs text-muted-foreground">時</span>
+					<Input
+						type="number"
+						min={0}
+						max={59}
+						value={value.minute ?? 0}
+						onChange={(e) =>
+							patch({ minute: clampInt(e.target.value, 0, 59) ?? 0 })
+						}
+						disabled={disabled}
+						className="h-8 w-20 text-xs"
+					/>
+					<span className="text-xs text-muted-foreground">分</span>
+				</div>
+			)}
+
+			{value.frequency === "weekly" && (
+				<div className="flex flex-col gap-1.5">
+					<Label className="text-xs">曜日</Label>
+					<div className="flex gap-1">
+						{WEEKDAYS.map((w) => {
+							const selected = value.weekday === w.value;
+							return (
+								<button
+									key={w.value}
+									type="button"
+									onClick={() => patch({ weekday: w.value })}
+									disabled={disabled}
+									className={cn(
+										"h-8 w-8 rounded-md text-xs border transition-colors",
+										selected
+											? "bg-primary text-primary-foreground border-primary"
+											: "hover:bg-accent",
+										disabled && "opacity-50 cursor-not-allowed",
+									)}
+								>
+									{w.label}
+								</button>
+							);
+						})}
+					</div>
+				</div>
+			)}
+
+			{value.frequency === "monthly" && (
+				<div className="flex items-center gap-2">
+					<Label className="text-xs w-20 shrink-0">日</Label>
+					<Input
+						type="number"
+						min={1}
+						max={31}
+						value={value.monthday ?? 1}
+						onChange={(e) =>
+							patch({ monthday: clampInt(e.target.value, 1, 31) ?? 1 })
+						}
+						disabled={disabled}
+						className="h-8 w-20 text-xs"
+					/>
+					<span className="text-xs text-muted-foreground">日</span>
+				</div>
+			)}
+
+			{value.frequency === "custom" && (
+				<div className="flex flex-col gap-1.5">
+					<Label className="text-xs">cron 式</Label>
+					<Input
+						value={value.cronExpr ?? ""}
+						onChange={(e) => patch({ cronExpr: e.target.value })}
+						placeholder="0 9 * * * (毎日 9:00)"
+						disabled={disabled}
+						className="h-8 text-xs font-mono"
+					/>
+					<p className="text-[10px] text-muted-foreground">
+						5 フィールド形式 (分 時 日 月 曜)。秒は使えません。
+					</p>
+				</div>
+			)}
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/features/todo-agent/TodoManager/SchedulesSection/components/FrequencyPicker/index.ts
+++ b/apps/desktop/src/renderer/features/todo-agent/TodoManager/SchedulesSection/components/FrequencyPicker/index.ts
@@ -1,0 +1,1 @@
+export { FrequencyPicker, type FrequencyValue } from "./FrequencyPicker";

--- a/apps/desktop/src/renderer/features/todo-agent/TodoManager/SchedulesSection/components/ScheduleEditorDialog/ScheduleEditorDialog.tsx
+++ b/apps/desktop/src/renderer/features/todo-agent/TodoManager/SchedulesSection/components/ScheduleEditorDialog/ScheduleEditorDialog.tsx
@@ -42,6 +42,12 @@ const DEFAULT_FREQUENCY: FrequencyValue = {
 	cronExpr: null,
 };
 
+// Sentinel for the "run on the project's main repo (no specific worktree)"
+// option in the 実行対象 Select. Kept out of the persisted workspaceId
+// space — translated to null when saving, and back to empty string when
+// loading an initial row with workspaceId = null.
+const MAIN_REPO_SENTINEL = "__main__";
+
 export function ScheduleEditorDialog({
 	open,
 	onOpenChange,
@@ -247,15 +253,17 @@ export function ScheduleEditorDialog({
 						<div className="flex flex-col gap-1.5">
 							<Label className="text-xs">実行対象</Label>
 							<Select
-								value={workspaceId || "__main__"}
-								onValueChange={(v) => setWorkspaceId(v === "__main__" ? "" : v)}
+								value={workspaceId || MAIN_REPO_SENTINEL}
+								onValueChange={(v) =>
+									setWorkspaceId(v === MAIN_REPO_SENTINEL ? "" : v)
+								}
 								disabled={submitting || !projectId}
 							>
 								<SelectTrigger className="h-8 text-xs">
 									<SelectValue />
 								</SelectTrigger>
 								<SelectContent>
-									<SelectItem value="__main__">
+									<SelectItem value={MAIN_REPO_SENTINEL}>
 										プロジェクト本体 (main)
 									</SelectItem>
 									{(workspaces ?? [])

--- a/apps/desktop/src/renderer/features/todo-agent/TodoManager/SchedulesSection/components/ScheduleEditorDialog/ScheduleEditorDialog.tsx
+++ b/apps/desktop/src/renderer/features/todo-agent/TodoManager/SchedulesSection/components/ScheduleEditorDialog/ScheduleEditorDialog.tsx
@@ -49,8 +49,13 @@ export function ScheduleEditorDialog({
 	onSaved,
 }: ScheduleEditorDialogProps) {
 	const { data: workspaces } = electronTrpc.workspaces.getAll.useQuery();
+	const { data: projects } = electronTrpc.projects.getRecents.useQuery();
 
 	const [name, setName] = useState("");
+	const [projectId, setProjectId] = useState<string>("");
+	// Empty string = "プロジェクト本体 (main repo)" — resolved to the
+	// project's branch workspace at fire time. Otherwise a specific
+	// worktree workspace id.
 	const [workspaceId, setWorkspaceId] = useState<string>("");
 	const [title, setTitle] = useState("");
 	const [description, setDescription] = useState("");
@@ -68,7 +73,8 @@ export function ScheduleEditorDialog({
 		if (!open) return;
 		if (initial) {
 			setName(initial.name);
-			setWorkspaceId(initial.workspaceId);
+			setProjectId(initial.projectId);
+			setWorkspaceId(initial.workspaceId ?? "");
 			setTitle(initial.title);
 			setDescription(initial.description);
 			setGoal(initial.goal ?? "");
@@ -88,6 +94,7 @@ export function ScheduleEditorDialog({
 			});
 		} else {
 			setName("");
+			setProjectId("");
 			setWorkspaceId("");
 			setTitle("");
 			setDescription("");
@@ -102,12 +109,23 @@ export function ScheduleEditorDialog({
 		}
 	}, [open, initial]);
 
-	// Pre-select first workspace if creating fresh.
+	// Pre-select first project when creating a brand-new schedule.
 	useEffect(() => {
-		if (!open || initial || workspaceId) return;
-		const first = (workspaces ?? [])[0];
-		if (first) setWorkspaceId(first.id);
-	}, [open, initial, workspaceId, workspaces]);
+		if (!open || initial || projectId) return;
+		const first = (projects ?? [])[0];
+		if (first) setProjectId(first.id);
+	}, [open, initial, projectId, projects]);
+
+	// Whenever the chosen project changes, drop a stale workspaceId that
+	// no longer belongs to this project so we don't save a cross-project
+	// mismatch.
+	useEffect(() => {
+		if (!workspaceId) return;
+		const ws = (workspaces ?? []).find((w) => w.id === workspaceId);
+		if (ws && ws.projectId !== projectId) {
+			setWorkspaceId("");
+		}
+	}, [projectId, workspaceId, workspaces]);
 
 	const { data: nextRunPreview } =
 		electronTrpc.todoAgent.schedule.previewNextRun.useQuery({
@@ -126,7 +144,7 @@ export function ScheduleEditorDialog({
 
 	const canSubmit =
 		name.trim().length > 0 &&
-		workspaceId.length > 0 &&
+		projectId.length > 0 &&
 		title.trim().length > 0 &&
 		description.trim().length > 0 &&
 		(freq.frequency !== "custom" ||
@@ -138,7 +156,8 @@ export function ScheduleEditorDialog({
 		setSubmitting(true);
 		try {
 			const payload = {
-				workspaceId,
+				projectId,
+				workspaceId: workspaceId.length > 0 ? workspaceId : null,
 				name: name.trim(),
 				enabled,
 				frequency: freq.frequency,
@@ -206,21 +225,48 @@ export function ScheduleEditorDialog({
 						</div>
 
 						<div className="flex flex-col gap-1.5">
-							<Label className="text-xs">ワークスペース</Label>
+							<Label className="text-xs">プロジェクト</Label>
 							<Select
-								value={workspaceId}
-								onValueChange={setWorkspaceId}
+								value={projectId}
+								onValueChange={setProjectId}
 								disabled={submitting}
 							>
 								<SelectTrigger className="h-8 text-xs">
-									<SelectValue placeholder="ワークスペースを選択" />
+									<SelectValue placeholder="プロジェクトを選択" />
 								</SelectTrigger>
 								<SelectContent>
-									{(workspaces ?? []).map((w) => (
-										<SelectItem key={w.id} value={w.id}>
-											{w.name}
+									{(projects ?? []).map((p) => (
+										<SelectItem key={p.id} value={p.id}>
+											{p.name}
 										</SelectItem>
 									))}
+								</SelectContent>
+							</Select>
+						</div>
+
+						<div className="flex flex-col gap-1.5">
+							<Label className="text-xs">実行対象</Label>
+							<Select
+								value={workspaceId || "__main__"}
+								onValueChange={(v) => setWorkspaceId(v === "__main__" ? "" : v)}
+								disabled={submitting || !projectId}
+							>
+								<SelectTrigger className="h-8 text-xs">
+									<SelectValue />
+								</SelectTrigger>
+								<SelectContent>
+									<SelectItem value="__main__">
+										プロジェクト本体 (main)
+									</SelectItem>
+									{(workspaces ?? [])
+										.filter(
+											(w) => w.projectId === projectId && w.type === "worktree",
+										)
+										.map((w) => (
+											<SelectItem key={w.id} value={w.id}>
+												{w.name}
+											</SelectItem>
+										))}
 								</SelectContent>
 							</Select>
 						</div>

--- a/apps/desktop/src/renderer/features/todo-agent/TodoManager/SchedulesSection/components/ScheduleEditorDialog/ScheduleEditorDialog.tsx
+++ b/apps/desktop/src/renderer/features/todo-agent/TodoManager/SchedulesSection/components/ScheduleEditorDialog/ScheduleEditorDialog.tsx
@@ -191,7 +191,15 @@ export function ScheduleEditorDialog({
 			};
 
 			if (initial) {
-				await updateMut.mutateAsync({ id: initial.id, ...payload });
+				// projectId is immutable server-side and the Select is
+				// disabled while editing; strip it here too so a stale
+				// local state can't ever silently request a project
+				// change that the backend would ignore.
+				const { projectId: _omitProjectId, ...updatePayload } = payload;
+				await updateMut.mutateAsync({
+					id: initial.id,
+					...updatePayload,
+				});
 				toast.success("スケジュールを更新しました");
 			} else {
 				await createMut.mutateAsync(payload);
@@ -239,7 +247,7 @@ export function ScheduleEditorDialog({
 							<Select
 								value={projectId}
 								onValueChange={setProjectId}
-								disabled={submitting}
+								disabled={submitting || initial !== null}
 							>
 								<SelectTrigger className="h-8 text-xs">
 									<SelectValue placeholder="プロジェクトを選択" />
@@ -252,6 +260,11 @@ export function ScheduleEditorDialog({
 									))}
 								</SelectContent>
 							</Select>
+							{initial !== null && (
+								<p className="text-[10px] text-muted-foreground">
+									プロジェクトは編集できません。変更したい場合はスケジュールを作り直してください。
+								</p>
+							)}
 						</div>
 
 						<div className="flex flex-col gap-1.5">

--- a/apps/desktop/src/renderer/features/todo-agent/TodoManager/SchedulesSection/components/ScheduleEditorDialog/ScheduleEditorDialog.tsx
+++ b/apps/desktop/src/renderer/features/todo-agent/TodoManager/SchedulesSection/components/ScheduleEditorDialog/ScheduleEditorDialog.tsx
@@ -71,6 +71,7 @@ export function ScheduleEditorDialog({
 	const [maxIterations, setMaxIterations] = useState(10);
 	const [maxWallClockMin, setMaxWallClockMin] = useState(30);
 	const [overlapMode, setOverlapMode] = useState<"skip" | "queue">("skip");
+	const [autoSyncBeforeFire, setAutoSyncBeforeFire] = useState(false);
 	const [enabled, setEnabled] = useState(true);
 	const [freq, setFreq] = useState<FrequencyValue>(DEFAULT_FREQUENCY);
 	const [submitting, setSubmitting] = useState(false);
@@ -89,6 +90,7 @@ export function ScheduleEditorDialog({
 			setMaxIterations(initial.maxIterations);
 			setMaxWallClockMin(Math.round(initial.maxWallClockSec / 60));
 			setOverlapMode(initial.overlapMode);
+			setAutoSyncBeforeFire(initial.autoSyncBeforeFire);
 			setEnabled(initial.enabled);
 			setFreq({
 				frequency: initial.frequency,
@@ -110,6 +112,7 @@ export function ScheduleEditorDialog({
 			setMaxIterations(10);
 			setMaxWallClockMin(30);
 			setOverlapMode("skip");
+			setAutoSyncBeforeFire(false);
 			setEnabled(true);
 			setFreq(DEFAULT_FREQUENCY);
 		}
@@ -184,6 +187,7 @@ export function ScheduleEditorDialog({
 				maxIterations,
 				maxWallClockSec: maxWallClockMin * 60,
 				overlapMode,
+				autoSyncBeforeFire,
 			};
 
 			if (initial) {
@@ -312,6 +316,29 @@ export function ScheduleEditorDialog({
 								</SelectContent>
 							</Select>
 						</div>
+
+						{!workspaceId && (
+							<div className="flex items-start gap-2 mt-1">
+								<input
+									id="schedule-auto-sync"
+									type="checkbox"
+									checked={autoSyncBeforeFire}
+									onChange={(e) => setAutoSyncBeforeFire(e.target.checked)}
+									disabled={submitting}
+									className="size-4 mt-0.5"
+								/>
+								<Label
+									htmlFor="schedule-auto-sync"
+									className="text-xs cursor-pointer leading-4"
+								>
+									実行前に main ブランチを最新化する
+									<span className="block text-[10px] text-muted-foreground mt-0.5">
+										git fetch / checkout / pull --ff-only を実行。
+										未コミット変更があるときはその回の実行をスキップします。
+									</span>
+								</Label>
+							</div>
+						)}
 
 						<div className="flex items-center gap-2 mt-1">
 							<input

--- a/apps/desktop/src/renderer/features/todo-agent/TodoManager/SchedulesSection/components/ScheduleEditorDialog/ScheduleEditorDialog.tsx
+++ b/apps/desktop/src/renderer/features/todo-agent/TodoManager/SchedulesSection/components/ScheduleEditorDialog/ScheduleEditorDialog.tsx
@@ -1,0 +1,404 @@
+import type { SelectTodoSchedule } from "@superset/local-db";
+import { Button } from "@superset/ui/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "@superset/ui/dialog";
+import { Input } from "@superset/ui/input";
+import { Label } from "@superset/ui/label";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@superset/ui/select";
+import { toast } from "@superset/ui/sonner";
+import { Textarea } from "@superset/ui/textarea";
+import { useEffect, useMemo, useState } from "react";
+import { LuLoaderCircle } from "react-icons/lu";
+import { electronTrpc } from "renderer/lib/electron-trpc";
+import { describeSchedule } from "../../utils/describeSchedule";
+import { formatNextRun } from "../../utils/formatNextRun";
+import { FrequencyPicker, type FrequencyValue } from "../FrequencyPicker";
+
+interface ScheduleEditorDialogProps {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	initial: SelectTodoSchedule | null;
+	onSaved?: () => void;
+}
+
+const DEFAULT_FREQUENCY: FrequencyValue = {
+	frequency: "daily",
+	minute: 0,
+	hour: 9,
+	weekday: null,
+	monthday: null,
+	cronExpr: null,
+};
+
+export function ScheduleEditorDialog({
+	open,
+	onOpenChange,
+	initial,
+	onSaved,
+}: ScheduleEditorDialogProps) {
+	const { data: workspaces } = electronTrpc.workspaces.getAll.useQuery();
+
+	const [name, setName] = useState("");
+	const [workspaceId, setWorkspaceId] = useState<string>("");
+	const [title, setTitle] = useState("");
+	const [description, setDescription] = useState("");
+	const [goal, setGoal] = useState("");
+	const [verifyCommand, setVerifyCommand] = useState("");
+	const [customSystemPrompt, setCustomSystemPrompt] = useState("");
+	const [maxIterations, setMaxIterations] = useState(10);
+	const [maxWallClockMin, setMaxWallClockMin] = useState(30);
+	const [overlapMode, setOverlapMode] = useState<"skip" | "queue">("skip");
+	const [enabled, setEnabled] = useState(true);
+	const [freq, setFreq] = useState<FrequencyValue>(DEFAULT_FREQUENCY);
+	const [submitting, setSubmitting] = useState(false);
+
+	useEffect(() => {
+		if (!open) return;
+		if (initial) {
+			setName(initial.name);
+			setWorkspaceId(initial.workspaceId);
+			setTitle(initial.title);
+			setDescription(initial.description);
+			setGoal(initial.goal ?? "");
+			setVerifyCommand(initial.verifyCommand ?? "");
+			setCustomSystemPrompt(initial.customSystemPrompt ?? "");
+			setMaxIterations(initial.maxIterations);
+			setMaxWallClockMin(Math.round(initial.maxWallClockSec / 60));
+			setOverlapMode(initial.overlapMode);
+			setEnabled(initial.enabled);
+			setFreq({
+				frequency: initial.frequency,
+				minute: initial.minute,
+				hour: initial.hour,
+				weekday: initial.weekday,
+				monthday: initial.monthday,
+				cronExpr: initial.cronExpr,
+			});
+		} else {
+			setName("");
+			setWorkspaceId("");
+			setTitle("");
+			setDescription("");
+			setGoal("");
+			setVerifyCommand("");
+			setCustomSystemPrompt("");
+			setMaxIterations(10);
+			setMaxWallClockMin(30);
+			setOverlapMode("skip");
+			setEnabled(true);
+			setFreq(DEFAULT_FREQUENCY);
+		}
+	}, [open, initial]);
+
+	// Pre-select first workspace if creating fresh.
+	useEffect(() => {
+		if (!open || initial || workspaceId) return;
+		const first = (workspaces ?? [])[0];
+		if (first) setWorkspaceId(first.id);
+	}, [open, initial, workspaceId, workspaces]);
+
+	const { data: nextRunPreview } =
+		electronTrpc.todoAgent.schedule.previewNextRun.useQuery({
+			frequency: freq.frequency,
+			minute: freq.minute,
+			hour: freq.hour,
+			weekday: freq.weekday,
+			monthday: freq.monthday,
+			cronExpr: freq.cronExpr,
+		});
+
+	const createMut = electronTrpc.todoAgent.schedule.create.useMutation();
+	const updateMut = electronTrpc.todoAgent.schedule.update.useMutation();
+
+	const cadenceLabel = useMemo(() => describeSchedule(freq), [freq]);
+
+	const canSubmit =
+		name.trim().length > 0 &&
+		workspaceId.length > 0 &&
+		title.trim().length > 0 &&
+		description.trim().length > 0 &&
+		(freq.frequency !== "custom" ||
+			(freq.cronExpr && freq.cronExpr.trim().length > 0));
+
+	const handleSubmit = async () => {
+		if (!canSubmit || submitting) return;
+
+		setSubmitting(true);
+		try {
+			const payload = {
+				workspaceId,
+				name: name.trim(),
+				enabled,
+				frequency: freq.frequency,
+				minute: freq.minute,
+				hour: freq.hour,
+				weekday: freq.weekday,
+				monthday: freq.monthday,
+				cronExpr: freq.cronExpr,
+				title: title.trim(),
+				description: description.trim(),
+				goal: goal.trim().length > 0 ? goal.trim() : null,
+				verifyCommand:
+					verifyCommand.trim().length > 0 ? verifyCommand.trim() : null,
+				customSystemPrompt:
+					customSystemPrompt.trim().length > 0
+						? customSystemPrompt.trim()
+						: null,
+				maxIterations,
+				maxWallClockSec: maxWallClockMin * 60,
+				overlapMode,
+			};
+
+			if (initial) {
+				await updateMut.mutateAsync({ id: initial.id, ...payload });
+				toast.success("スケジュールを更新しました");
+			} else {
+				await createMut.mutateAsync(payload);
+				toast.success("スケジュールを作成しました");
+			}
+
+			onSaved?.();
+			onOpenChange(false);
+		} catch (error) {
+			const message = error instanceof Error ? error.message : "Unknown error";
+			toast.error(`保存に失敗しました: ${message}`);
+		} finally {
+			setSubmitting(false);
+		}
+	};
+
+	return (
+		<Dialog open={open} onOpenChange={onOpenChange}>
+			<DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
+				<DialogHeader>
+					<DialogTitle>
+						{initial ? "スケジュールを編集" : "新しいスケジュール"}
+					</DialogTitle>
+					<DialogDescription>
+						アプリ起動中に指定時刻が来ると TODO セッションが自動作成されます。
+					</DialogDescription>
+				</DialogHeader>
+
+				<div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+					<div className="flex flex-col gap-3">
+						<div className="flex flex-col gap-1.5">
+							<Label className="text-xs">スケジュール名</Label>
+							<Input
+								value={name}
+								onChange={(e) => setName(e.target.value)}
+								placeholder="例: 毎日デプロイ"
+								className="h-8 text-xs"
+								autoFocus
+								disabled={submitting}
+							/>
+						</div>
+
+						<div className="flex flex-col gap-1.5">
+							<Label className="text-xs">ワークスペース</Label>
+							<Select
+								value={workspaceId}
+								onValueChange={setWorkspaceId}
+								disabled={submitting}
+							>
+								<SelectTrigger className="h-8 text-xs">
+									<SelectValue placeholder="ワークスペースを選択" />
+								</SelectTrigger>
+								<SelectContent>
+									{(workspaces ?? []).map((w) => (
+										<SelectItem key={w.id} value={w.id}>
+											{w.name}
+										</SelectItem>
+									))}
+								</SelectContent>
+							</Select>
+						</div>
+
+						<FrequencyPicker
+							value={freq}
+							onChange={setFreq}
+							disabled={submitting}
+						/>
+
+						<div className="rounded-md border bg-muted/30 p-2 text-xs space-y-1">
+							<div>
+								<span className="text-muted-foreground">発火: </span>
+								<span>{cadenceLabel}</span>
+							</div>
+							<div>
+								<span className="text-muted-foreground">次回: </span>
+								<span>{formatNextRun(nextRunPreview ?? null)}</span>
+							</div>
+						</div>
+
+						<div className="flex flex-col gap-1.5">
+							<Label className="text-xs">前回が実行中の時</Label>
+							<Select
+								value={overlapMode}
+								onValueChange={(v) => setOverlapMode(v as "skip" | "queue")}
+								disabled={submitting}
+							>
+								<SelectTrigger className="h-8 text-xs">
+									<SelectValue />
+								</SelectTrigger>
+								<SelectContent>
+									<SelectItem value="skip">スキップ</SelectItem>
+									<SelectItem value="queue">キューに追加</SelectItem>
+								</SelectContent>
+							</Select>
+						</div>
+
+						<div className="flex items-center gap-2 mt-1">
+							<input
+								id="schedule-enabled"
+								type="checkbox"
+								checked={enabled}
+								onChange={(e) => setEnabled(e.target.checked)}
+								disabled={submitting}
+								className="size-4"
+							/>
+							<Label
+								htmlFor="schedule-enabled"
+								className="text-xs cursor-pointer"
+							>
+								有効
+							</Label>
+						</div>
+					</div>
+
+					<div className="flex flex-col gap-3">
+						<div className="flex flex-col gap-1.5">
+							<Label className="text-xs">TODO タイトル</Label>
+							<Input
+								value={title}
+								onChange={(e) => setTitle(e.target.value)}
+								placeholder="発火時に作られる TODO の見出し"
+								className="h-8 text-xs"
+								disabled={submitting}
+							/>
+						</div>
+
+						<div className="flex flex-col gap-1.5">
+							<Label className="text-xs">やって欲しいこと</Label>
+							<Textarea
+								value={description}
+								onChange={(e) => setDescription(e.target.value)}
+								placeholder="例: 本番 api を最新の main からデプロイしてヘルスチェックが通ったら終了"
+								className="min-h-[96px] text-xs resize-y"
+								disabled={submitting}
+							/>
+						</div>
+
+						<div className="flex flex-col gap-1.5">
+							<Label className="text-xs">
+								ゴール <span className="text-muted-foreground">(任意)</span>
+							</Label>
+							<Textarea
+								value={goal}
+								onChange={(e) => setGoal(e.target.value)}
+								placeholder="完了判定の要件があれば"
+								className="min-h-[60px] text-xs resize-y"
+								disabled={submitting}
+							/>
+						</div>
+
+						<div className="flex flex-col gap-1.5">
+							<Label className="text-xs">
+								verify コマンド{" "}
+								<span className="text-muted-foreground">(任意)</span>
+							</Label>
+							<Input
+								value={verifyCommand}
+								onChange={(e) => setVerifyCommand(e.target.value)}
+								placeholder="例: curl -fsS https://example.com/health"
+								className="h-8 text-xs font-mono"
+								disabled={submitting}
+							/>
+						</div>
+
+						<div className="flex items-center gap-2">
+							<div className="flex flex-col gap-1 flex-1">
+								<Label className="text-xs">最大反復回数</Label>
+								<Input
+									type="number"
+									min={1}
+									max={100}
+									value={maxIterations}
+									onChange={(e) =>
+										setMaxIterations(
+											Math.max(1, Math.min(100, Number(e.target.value) || 1)),
+										)
+									}
+									disabled={submitting}
+									className="h-8 text-xs"
+								/>
+							</div>
+							<div className="flex flex-col gap-1 flex-1">
+								<Label className="text-xs">最大実行時間 (分)</Label>
+								<Input
+									type="number"
+									min={1}
+									max={240}
+									value={maxWallClockMin}
+									onChange={(e) =>
+										setMaxWallClockMin(
+											Math.max(1, Math.min(240, Number(e.target.value) || 1)),
+										)
+									}
+									disabled={submitting}
+									className="h-8 text-xs"
+								/>
+							</div>
+						</div>
+
+						<div className="flex flex-col gap-1.5">
+							<Label className="text-xs">
+								システムプロンプト{" "}
+								<span className="text-muted-foreground">(任意)</span>
+							</Label>
+							<Textarea
+								value={customSystemPrompt}
+								onChange={(e) => setCustomSystemPrompt(e.target.value)}
+								placeholder="Claude に毎回追加で渡すシステムプロンプト"
+								className="min-h-[60px] text-xs resize-y"
+								disabled={submitting}
+							/>
+						</div>
+					</div>
+				</div>
+
+				<DialogFooter>
+					<Button
+						type="button"
+						variant="outline"
+						onClick={() => onOpenChange(false)}
+						disabled={submitting}
+					>
+						キャンセル
+					</Button>
+					<Button
+						type="button"
+						onClick={() => void handleSubmit()}
+						disabled={!canSubmit || submitting}
+					>
+						{submitting ? (
+							<LuLoaderCircle className="mr-1 size-3.5 animate-spin" />
+						) : null}
+						保存
+					</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/apps/desktop/src/renderer/features/todo-agent/TodoManager/SchedulesSection/components/ScheduleEditorDialog/index.ts
+++ b/apps/desktop/src/renderer/features/todo-agent/TodoManager/SchedulesSection/components/ScheduleEditorDialog/index.ts
@@ -1,0 +1,1 @@
+export { ScheduleEditorDialog } from "./ScheduleEditorDialog";

--- a/apps/desktop/src/renderer/features/todo-agent/TodoManager/SchedulesSection/components/ScheduleListRow/ScheduleListRow.tsx
+++ b/apps/desktop/src/renderer/features/todo-agent/TodoManager/SchedulesSection/components/ScheduleListRow/ScheduleListRow.tsx
@@ -20,12 +20,14 @@ import { formatNextRun } from "../../utils/formatNextRun";
 
 interface ScheduleListRowProps {
 	schedule: SelectTodoSchedule;
+	projectName: string | null;
 	workspaceName: string | null;
 	onEdit: () => void;
 }
 
 export function ScheduleListRow({
 	schedule,
+	projectName,
 	workspaceName,
 	onEdit,
 }: ScheduleListRowProps) {
@@ -80,7 +82,10 @@ export function ScheduleListRow({
 				<div className="text-[11px] text-muted-foreground mt-0.5 flex flex-wrap gap-x-2">
 					<span>{describeSchedule(schedule)}</span>
 					<span>→ {formatNextRun(schedule.nextRunAt)}</span>
-					{workspaceName && <span className="truncate">{workspaceName}</span>}
+					<span className="truncate">
+						{projectName ?? "(不明なプロジェクト)"}
+						{workspaceName ? ` / ${workspaceName}` : " / main"}
+					</span>
 				</div>
 				{schedule.lastRunAt && (
 					<div className="text-[10px] text-muted-foreground mt-0.5">

--- a/apps/desktop/src/renderer/features/todo-agent/TodoManager/SchedulesSection/components/ScheduleListRow/ScheduleListRow.tsx
+++ b/apps/desktop/src/renderer/features/todo-agent/TodoManager/SchedulesSection/components/ScheduleListRow/ScheduleListRow.tsx
@@ -1,0 +1,118 @@
+import type { SelectTodoSchedule } from "@superset/local-db";
+import { Button } from "@superset/ui/button";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuTrigger,
+} from "@superset/ui/dropdown-menu";
+import { toast } from "@superset/ui/sonner";
+import { Switch } from "@superset/ui/switch";
+import { cn } from "@superset/ui/utils";
+import {
+	HiMiniEllipsisVertical,
+	HiMiniPencil,
+	HiMiniTrash,
+} from "react-icons/hi2";
+import { electronTrpc } from "renderer/lib/electron-trpc";
+import { describeSchedule } from "../../utils/describeSchedule";
+import { formatNextRun } from "../../utils/formatNextRun";
+
+interface ScheduleListRowProps {
+	schedule: SelectTodoSchedule;
+	workspaceName: string | null;
+	onEdit: () => void;
+}
+
+export function ScheduleListRow({
+	schedule,
+	workspaceName,
+	onEdit,
+}: ScheduleListRowProps) {
+	const utils = electronTrpc.useUtils();
+	const setEnabledMut =
+		electronTrpc.todoAgent.schedule.setEnabled.useMutation();
+	const deleteMut = electronTrpc.todoAgent.schedule.delete.useMutation();
+
+	const handleToggle = async (next: boolean) => {
+		try {
+			await setEnabledMut.mutateAsync({ id: schedule.id, enabled: next });
+			await utils.todoAgent.schedule.listAll.invalidate();
+		} catch (error) {
+			const message = error instanceof Error ? error.message : "Unknown error";
+			toast.error(`更新に失敗しました: ${message}`);
+		}
+	};
+
+	const handleDelete = async () => {
+		if (!window.confirm(`スケジュール「${schedule.name}」を削除しますか？`))
+			return;
+		try {
+			await deleteMut.mutateAsync({ id: schedule.id });
+			await utils.todoAgent.schedule.listAll.invalidate();
+			toast.success("スケジュールを削除しました");
+		} catch (error) {
+			const message = error instanceof Error ? error.message : "Unknown error";
+			toast.error(`削除に失敗しました: ${message}`);
+		}
+	};
+
+	return (
+		<div
+			className={cn(
+				"flex items-start gap-2 p-2 rounded-md border bg-card hover:bg-accent/40 transition-colors",
+				!schedule.enabled && "opacity-60",
+			)}
+		>
+			<Switch
+				checked={schedule.enabled}
+				onCheckedChange={(v) => void handleToggle(v)}
+				className="mt-0.5"
+			/>
+			<button
+				type="button"
+				onClick={onEdit}
+				className="flex-1 min-w-0 text-left"
+			>
+				<div className="flex items-center gap-2">
+					<span className="text-sm font-medium truncate">{schedule.name}</span>
+				</div>
+				<div className="text-[11px] text-muted-foreground mt-0.5 flex flex-wrap gap-x-2">
+					<span>{describeSchedule(schedule)}</span>
+					<span>→ {formatNextRun(schedule.nextRunAt)}</span>
+					{workspaceName && <span className="truncate">{workspaceName}</span>}
+				</div>
+				{schedule.lastRunAt && (
+					<div className="text-[10px] text-muted-foreground mt-0.5">
+						最終: {new Date(schedule.lastRunAt).toLocaleString("ja-JP")}
+					</div>
+				)}
+			</button>
+			<DropdownMenu>
+				<DropdownMenuTrigger asChild>
+					<Button
+						type="button"
+						size="sm"
+						variant="ghost"
+						className="h-7 w-7 p-0 shrink-0"
+					>
+						<HiMiniEllipsisVertical className="size-4" />
+					</Button>
+				</DropdownMenuTrigger>
+				<DropdownMenuContent align="end">
+					<DropdownMenuItem onClick={onEdit}>
+						<HiMiniPencil className="mr-2 size-4" />
+						編集
+					</DropdownMenuItem>
+					<DropdownMenuItem
+						onClick={() => void handleDelete()}
+						className="text-destructive focus:text-destructive"
+					>
+						<HiMiniTrash className="mr-2 size-4" />
+						削除
+					</DropdownMenuItem>
+				</DropdownMenuContent>
+			</DropdownMenu>
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/features/todo-agent/TodoManager/SchedulesSection/components/ScheduleListRow/index.ts
+++ b/apps/desktop/src/renderer/features/todo-agent/TodoManager/SchedulesSection/components/ScheduleListRow/index.ts
@@ -1,0 +1,1 @@
+export { ScheduleListRow } from "./ScheduleListRow";

--- a/apps/desktop/src/renderer/features/todo-agent/TodoManager/SchedulesSection/index.ts
+++ b/apps/desktop/src/renderer/features/todo-agent/TodoManager/SchedulesSection/index.ts
@@ -1,0 +1,1 @@
+export { SchedulesSection } from "./SchedulesSection";

--- a/apps/desktop/src/renderer/features/todo-agent/TodoManager/SchedulesSection/utils/describeSchedule/describeSchedule.ts
+++ b/apps/desktop/src/renderer/features/todo-agent/TodoManager/SchedulesSection/utils/describeSchedule/describeSchedule.ts
@@ -1,0 +1,49 @@
+import cronstrue from "cronstrue/i18n";
+
+const WEEKDAY_LABELS = ["日", "月", "火", "水", "木", "金", "土"];
+
+function padTwo(value: number): string {
+	return value.toString().padStart(2, "0");
+}
+
+interface ScheduleCadenceInput {
+	frequency: "hourly" | "daily" | "weekly" | "monthly" | "custom";
+	minute: number | null | undefined;
+	hour: number | null | undefined;
+	weekday: number | null | undefined;
+	monthday: number | null | undefined;
+	cronExpr: string | null | undefined;
+}
+
+/**
+ * Render a schedule's cadence as a Japanese one-liner users can quickly
+ * skim. For `custom` we delegate to cronstrue so arbitrary cron strings
+ * are readable without the user having to mentally parse them.
+ */
+export function describeSchedule(input: ScheduleCadenceInput): string {
+	const minute = input.minute ?? 0;
+	const hour = input.hour ?? 0;
+
+	switch (input.frequency) {
+		case "hourly":
+			return `毎時 ${padTwo(minute)}分`;
+		case "daily":
+			return `毎日 ${padTwo(hour)}:${padTwo(minute)}`;
+		case "weekly": {
+			const day = WEEKDAY_LABELS[input.weekday ?? 0] ?? "";
+			return `毎週${day}曜 ${padTwo(hour)}:${padTwo(minute)}`;
+		}
+		case "monthly": {
+			const md = input.monthday ?? 1;
+			return `毎月${md}日 ${padTwo(hour)}:${padTwo(minute)}`;
+		}
+		case "custom": {
+			if (!input.cronExpr) return "未設定";
+			try {
+				return cronstrue.toString(input.cronExpr, { locale: "ja" });
+			} catch {
+				return input.cronExpr;
+			}
+		}
+	}
+}

--- a/apps/desktop/src/renderer/features/todo-agent/TodoManager/SchedulesSection/utils/describeSchedule/describeSchedule.ts
+++ b/apps/desktop/src/renderer/features/todo-agent/TodoManager/SchedulesSection/utils/describeSchedule/describeSchedule.ts
@@ -1,4 +1,7 @@
-import cronstrue from "cronstrue/i18n";
+// Load only the ja locale instead of cronstrue/i18n, which pulls every
+// locale (~200KB) into the renderer bundle even though we only render ja.
+import cronstrue from "cronstrue";
+import "cronstrue/locales/ja";
 
 const WEEKDAY_LABELS = ["日", "月", "火", "水", "木", "金", "土"];
 

--- a/apps/desktop/src/renderer/features/todo-agent/TodoManager/SchedulesSection/utils/describeSchedule/index.ts
+++ b/apps/desktop/src/renderer/features/todo-agent/TodoManager/SchedulesSection/utils/describeSchedule/index.ts
@@ -1,0 +1,1 @@
+export { describeSchedule } from "./describeSchedule";

--- a/apps/desktop/src/renderer/features/todo-agent/TodoManager/SchedulesSection/utils/formatNextRun/formatNextRun.ts
+++ b/apps/desktop/src/renderer/features/todo-agent/TodoManager/SchedulesSection/utils/formatNextRun/formatNextRun.ts
@@ -1,0 +1,47 @@
+/**
+ * Format an epoch-ms timestamp as a human-readable "next run" label.
+ * Returns "未設定" for null (e.g. disabled schedules or schedules with
+ * malformed cron expressions).
+ */
+export function formatNextRun(nextRunAt: number | null): string {
+	if (nextRunAt === null) return "未設定";
+
+	const target = new Date(nextRunAt);
+	const now = new Date();
+	const diffMs = target.getTime() - now.getTime();
+
+	const minute = 60_000;
+	const hour = 60 * minute;
+	const day = 24 * hour;
+
+	const isToday =
+		target.getFullYear() === now.getFullYear() &&
+		target.getMonth() === now.getMonth() &&
+		target.getDate() === now.getDate();
+
+	const time = target.toLocaleTimeString("ja-JP", {
+		hour: "2-digit",
+		minute: "2-digit",
+	});
+
+	if (diffMs < 0) {
+		return `${time} (処理待ち)`;
+	}
+
+	if (isToday) {
+		if (diffMs < minute) return "まもなく";
+		if (diffMs < hour) return `${Math.round(diffMs / minute)}分後 (${time})`;
+		return `今日 ${time}`;
+	}
+
+	if (diffMs < 2 * day) {
+		return `明日 ${time}`;
+	}
+
+	return target.toLocaleString("ja-JP", {
+		month: "numeric",
+		day: "numeric",
+		hour: "2-digit",
+		minute: "2-digit",
+	});
+}

--- a/apps/desktop/src/renderer/features/todo-agent/TodoManager/SchedulesSection/utils/formatNextRun/index.ts
+++ b/apps/desktop/src/renderer/features/todo-agent/TodoManager/SchedulesSection/utils/formatNextRun/index.ts
@@ -1,0 +1,1 @@
+export { formatNextRun } from "./formatNextRun";

--- a/apps/desktop/src/renderer/features/todo-agent/TodoManager/TodoManager.tsx
+++ b/apps/desktop/src/renderer/features/todo-agent/TodoManager/TodoManager.tsx
@@ -50,6 +50,7 @@ import { MarkdownRenderer } from "renderer/components/MarkdownRenderer";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { ChangesSidebar } from "./ChangesSidebar";
 import { PresetsDialog } from "./PresetsDialog";
+import { SchedulesSection } from "./SchedulesSection";
 
 async function copyToClipboard(text: string, label = "コピーしました") {
 	try {
@@ -338,6 +339,7 @@ export function TodoManager({
 	const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
 	const [changesSidebarCollapsed, setChangesSidebarCollapsed] = useState(false);
 	const [presetsDialogOpen, setPresetsDialogOpen] = useState(false);
+	const [sidebarTab, setSidebarTab] = useState<"tasks" | "schedules">("tasks");
 	// Inline TODO composer (replaces the old separate modal). Matches
 	// Antigravity IDE's "new conversation inside manager" UX.
 	const [composerOpen, setComposerOpen] = useState(false);
@@ -458,66 +460,98 @@ export function TodoManager({
 							sidebarCollapsed ? "w-0 border-r-0" : "w-[320px]",
 						)}
 					>
-						<div className="p-2 border-b shrink-0">
-							<Input
-								value={filter}
-								onChange={(e) => setFilter(e.target.value)}
-								placeholder="絞り込み（タイトル / ワークスペース）"
-								className="h-8 text-xs rounded-md"
-							/>
+						<div className="p-1.5 border-b shrink-0 flex gap-1">
+							<button
+								type="button"
+								onClick={() => setSidebarTab("tasks")}
+								className={cn(
+									"flex-1 text-xs py-1 rounded-md transition-colors",
+									sidebarTab === "tasks"
+										? "bg-accent text-foreground"
+										: "text-muted-foreground hover:bg-accent/40",
+								)}
+							>
+								タスク
+							</button>
+							<button
+								type="button"
+								onClick={() => setSidebarTab("schedules")}
+								className={cn(
+									"flex-1 text-xs py-1 rounded-md transition-colors",
+									sidebarTab === "schedules"
+										? "bg-accent text-foreground"
+										: "text-muted-foreground hover:bg-accent/40",
+								)}
+							>
+								スケジュール
+							</button>
 						</div>
-						<ScrollArea className="flex-1">
-							{grouped.length === 0 && (
-								<p className="text-xs text-muted-foreground px-3 py-6">
-									{(sessions?.length ?? 0) === 0
-										? "まだ TODO セッションはありません。右上の『新しい TODO』から作成してください。"
-										: "条件に一致するセッションがありません。"}
-								</p>
-							)}
-							{grouped.map((group) => {
-								const collapsed = collapsedGroups.has(group.key);
-								return (
-									<div key={group.key} className="pb-1">
-										<button
-											type="button"
-											onClick={() => toggleGroup(group.key)}
-											className="sticky top-0 z-10 bg-background/95 backdrop-blur w-full flex items-center gap-1 px-2 py-1.5 text-[10px] uppercase tracking-wide text-muted-foreground font-semibold border-b hover:bg-accent/40 transition"
-										>
-											{collapsed ? (
-												<HiMiniChevronRight className="size-3" />
-											) : (
-												<HiMiniChevronDown className="size-3" />
-											)}
-											<span className="flex-1 text-left truncate">
-												{group.label}
-											</span>
-											<span className="text-muted-foreground/60">
-												{group.sessions.length}
-											</span>
-										</button>
-										{!collapsed && (
-											<div className="flex flex-col px-1.5 py-1 gap-0.5">
-												{group.sessions.map((session) => (
-													<SessionRow
-														key={session.id}
-														session={session}
-														isSelected={selected?.id === session.id}
-														onSelect={() => {
-															setSelectedId(session.id);
-															setComposerOpen(false);
-														}}
-														onDeleted={() => {
-															if (selectedId === session.id)
-																setSelectedId(null);
-														}}
-													/>
-												))}
+						{sidebarTab === "schedules" ? (
+							<SchedulesSection />
+						) : (
+							<>
+								<div className="p-2 border-b shrink-0">
+									<Input
+										value={filter}
+										onChange={(e) => setFilter(e.target.value)}
+										placeholder="絞り込み（タイトル / ワークスペース）"
+										className="h-8 text-xs rounded-md"
+									/>
+								</div>
+								<ScrollArea className="flex-1">
+									{grouped.length === 0 && (
+										<p className="text-xs text-muted-foreground px-3 py-6">
+											{(sessions?.length ?? 0) === 0
+												? "まだ TODO セッションはありません。右上の『新しい TODO』から作成してください。"
+												: "条件に一致するセッションがありません。"}
+										</p>
+									)}
+									{grouped.map((group) => {
+										const collapsed = collapsedGroups.has(group.key);
+										return (
+											<div key={group.key} className="pb-1">
+												<button
+													type="button"
+													onClick={() => toggleGroup(group.key)}
+													className="sticky top-0 z-10 bg-background/95 backdrop-blur w-full flex items-center gap-1 px-2 py-1.5 text-[10px] uppercase tracking-wide text-muted-foreground font-semibold border-b hover:bg-accent/40 transition"
+												>
+													{collapsed ? (
+														<HiMiniChevronRight className="size-3" />
+													) : (
+														<HiMiniChevronDown className="size-3" />
+													)}
+													<span className="flex-1 text-left truncate">
+														{group.label}
+													</span>
+													<span className="text-muted-foreground/60">
+														{group.sessions.length}
+													</span>
+												</button>
+												{!collapsed && (
+													<div className="flex flex-col px-1.5 py-1 gap-0.5">
+														{group.sessions.map((session) => (
+															<SessionRow
+																key={session.id}
+																session={session}
+																isSelected={selected?.id === session.id}
+																onSelect={() => {
+																	setSelectedId(session.id);
+																	setComposerOpen(false);
+																}}
+																onDeleted={() => {
+																	if (selectedId === session.id)
+																		setSelectedId(null);
+																}}
+															/>
+														))}
+													</div>
+												)}
 											</div>
-										)}
-									</div>
-								);
-							})}
-						</ScrollArea>
+										);
+									})}
+								</ScrollArea>
+							</>
+						)}
 						<div className="shrink-0 border-t p-1.5">
 							<button
 								type="button"

--- a/apps/desktop/src/renderer/routes/_authenticated/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/layout.tsx
@@ -15,6 +15,7 @@ import { NewWorkspaceModal } from "renderer/components/NewWorkspaceModal";
 import { Paywall } from "renderer/components/Paywall";
 import { useUpdateListener } from "renderer/components/UpdateToast";
 import { env } from "renderer/env.renderer";
+import { ScheduleFireToasts } from "renderer/features/todo-agent/ScheduleFireToasts";
 import { useIsV2CloudEnabled } from "renderer/hooks/useIsV2CloudEnabled";
 import { useOnlineStatus } from "renderer/hooks/useOnlineStatus";
 import { migrateHotkeyOverrides } from "renderer/hotkeys/migrate";
@@ -214,6 +215,7 @@ function AuthenticatedLayout() {
 						highlighterOptions={{ preferredHighlighter: "shiki-wasm" }}
 					>
 						<AgentHooks />
+						<ScheduleFireToasts />
 						<Outlet />
 						<WorkspaceInitEffects />
 						{isV2CloudEnabled ? (

--- a/bun.lock
+++ b/bun.lock
@@ -236,6 +236,8 @@
         "bindings": "^1.5.0",
         "bufferutil": "^4.1.0",
         "clsx": "^2.1.1",
+        "cron-parser": "^5.5.0",
+        "cronstrue": "^3.14.0",
         "culori": "^4.0.2",
         "date-fns": "^4.1.0",
         "default-shell": "^2.2.0",
@@ -3005,9 +3007,9 @@
 
     "@vscode/l10n": ["@vscode/l10n@0.0.18", "", {}, "sha512-KYSIHVmslkaCDyw013pphY+d7x1qV8IZupYfeIfzNA+nsaWHbn5uPuQRvdRFsa9zFzGeudPuoGoZ1Op4jrJXIQ=="],
 
-    "@vue/compiler-core": ["@vue/compiler-core@3.5.31", "", { "dependencies": { "@babel/parser": "^7.29.2", "@vue/shared": "3.5.31", "entities": "^7.0.1", "estree-walker": "^2.0.2", "source-map-js": "^1.2.1" } }, "sha512-k/ueL14aNIEy5Onf0OVzR8kiqF/WThgLdFhxwa4e/KF/0qe38IwIdofoSWBTvvxQOesaz6riAFAUaYjoF9fLLQ=="],
+    "@vue/compiler-core": ["@vue/compiler-core@3.5.32", "", { "dependencies": { "@babel/parser": "^7.29.2", "@vue/shared": "3.5.32", "entities": "^7.0.1", "estree-walker": "^2.0.2", "source-map-js": "^1.2.1" } }, "sha512-4x74Tbtqnda8s/NSD6e1Dr5p1c8HdMU5RWSjMSUzb8RTcUQqevDCxVAitcLBKT+ie3o0Dl9crc/S/opJM7qBGQ=="],
 
-    "@vue/compiler-dom": ["@vue/compiler-dom@3.5.31", "", { "dependencies": { "@vue/compiler-core": "3.5.31", "@vue/shared": "3.5.31" } }, "sha512-BMY/ozS/xxjYqRFL+tKdRpATJYDTTgWSo0+AJvJNg4ig+Hgb0dOsHPXvloHQ5hmlivUqw1Yt2pPIqp4e0v1GUw=="],
+    "@vue/compiler-dom": ["@vue/compiler-dom@3.5.32", "", { "dependencies": { "@vue/compiler-core": "3.5.32", "@vue/shared": "3.5.32" } }, "sha512-ybHAu70NtiEI1fvAUz3oXZqkUYEe5J98GjMDpTGl5iHb0T15wQYLR4wE3h9xfuTNA+Cm2f4czfe8B4s+CCH57Q=="],
 
     "@vue/compiler-sfc": ["@vue/compiler-sfc@3.5.32", "", { "dependencies": { "@babel/parser": "^7.29.2", "@vue/compiler-core": "3.5.32", "@vue/compiler-dom": "3.5.32", "@vue/compiler-ssr": "3.5.32", "@vue/shared": "3.5.32", "estree-walker": "^2.0.2", "magic-string": "^0.30.21", "postcss": "^8.5.8", "source-map-js": "^1.2.1" } }, "sha512-8UYUYo71cP/0YHMO814TRZlPuUUw3oifHuMR7Wp9SNoRSrxRQnhMLNlCeaODNn6kNTJsjFoQ/kqIj4qGvya4Xg=="],
 
@@ -3021,7 +3023,7 @@
 
     "@vue/server-renderer": ["@vue/server-renderer@3.5.32", "", { "dependencies": { "@vue/compiler-ssr": "3.5.32", "@vue/shared": "3.5.32" }, "peerDependencies": { "vue": "3.5.32" } }, "sha512-IOjm2+JQwRFS7W28HNuJeXQle9KdZbODFY7hFGVtnnghF51ta20EWAZJHX+zLGtsHhaU6uC9BGPV52KVpYryMQ=="],
 
-    "@vue/shared": ["@vue/shared@3.5.31", "", {}, "sha512-nBxuiuS9Lj5bPkPbWogPUnjxxWpkRniX7e5UBQDWl6Fsf4roq9wwV+cR7ezQ4zXswNvPIlsdj1slcLB7XCsRAw=="],
+    "@vue/shared": ["@vue/shared@3.5.32", "", {}, "sha512-ksNyrmRQzWJJ8n3cRDuSF7zNNontuJg1YHnmWRJd2AMu8Ij2bqwiiri2lH5rHtYPZjj4STkNcgcmiQqlOjiYGg=="],
 
     "@webassemblyjs/ast": ["@webassemblyjs/ast@1.14.1", "", { "dependencies": { "@webassemblyjs/helper-numbers": "1.13.2", "@webassemblyjs/helper-wasm-bytecode": "1.13.2" } }, "sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ=="],
 
@@ -3500,6 +3502,10 @@
     "crc32-stream": ["crc32-stream@4.0.3", "", { "dependencies": { "crc-32": "^1.2.0", "readable-stream": "^3.4.0" } }, "sha512-NT7w2JVU7DFroFdYkeq8cywxrgjPHWkdX1wjpRQXPX5Asews3tA+Ght6lddQO5Mkumffp3X7GEqku3epj2toIw=="],
 
     "crelt": ["crelt@1.0.6", "", {}, "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g=="],
+
+    "cron-parser": ["cron-parser@5.5.0", "", { "dependencies": { "luxon": "^3.7.1" } }, "sha512-oML4lKUXxizYswqmxuOCpgFS8BNUJpIu6k/2HVHyaL8Ynnf3wdf9tkns0yRdJLSIjkJ+b0DXHMZEHGpMwjnPww=="],
+
+    "cronstrue": ["cronstrue@3.14.0", "", { "bin": { "cronstrue": "bin/cli.js" } }, "sha512-XnW4vuK/jPJjmTyDWiej1Zq36Od7ITwxaV2O1pzHZuyMVvdy7NAvyvIBzybt+idqSpfqYuoDG7uf/ocGtJVWxA=="],
 
     "cross-dirname": ["cross-dirname@0.1.0", "", {}, "sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q=="],
 
@@ -4532,6 +4538,8 @@
     "lucide-react": ["lucide-react@0.563.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-8dXPB2GI4dI8jV4MgUDGBeLdGk8ekfqVZ0BdLcrRzocGgG75ltNEmWS+gE7uokKF/0oSUuczNDT+g9hFJ23FkA=="],
 
     "lucide-react-native": ["lucide-react-native@0.562.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-native": "*", "react-native-svg": "^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0" } }, "sha512-ZF2ok8SzyUaiCIrLGqYh/6SPs+huVzbZOCv0i411L4+oP3tJgQvvKePiVgWCioa7HsT2xaJZSrdd92cuB2/+ew=="],
+
+    "luxon": ["luxon@3.7.2", "", {}, "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew=="],
 
     "maath": ["maath@0.10.8", "", { "peerDependencies": { "@types/three": ">=0.134.0", "three": ">=0.134.0" } }, "sha512-tRvbDF0Pgqz+9XUa4jjfgAQ8/aPKmQdWXilFu2tMy4GWj4NOsx99HlULO4IeREfbO3a0sA145DZYyvXPkybm0g=="],
 
@@ -6043,6 +6051,8 @@
 
     "@babel/polyfill/core-js": ["core-js@2.6.12", "", {}, "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ=="],
 
+    "@code-inspector/core/@vue/compiler-dom": ["@vue/compiler-dom@3.5.31", "", { "dependencies": { "@vue/compiler-core": "3.5.31", "@vue/shared": "3.5.31" } }, "sha512-BMY/ozS/xxjYqRFL+tKdRpATJYDTTgWSo0+AJvJNg4ig+Hgb0dOsHPXvloHQ5hmlivUqw1Yt2pPIqp4e0v1GUw=="],
+
     "@code-inspector/core/chalk": ["chalk@4.1.1", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg=="],
 
     "@code-inspector/core/dotenv": ["dotenv@16.6.1", "", {}, "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow=="],
@@ -6362,24 +6372,6 @@
     "@upstash/qstash/jose": ["jose@5.10.0", "", {}, "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg=="],
 
     "@vue/compiler-core/entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
-
-    "@vue/compiler-sfc/@vue/compiler-core": ["@vue/compiler-core@3.5.32", "", { "dependencies": { "@babel/parser": "^7.29.2", "@vue/shared": "3.5.32", "entities": "^7.0.1", "estree-walker": "^2.0.2", "source-map-js": "^1.2.1" } }, "sha512-4x74Tbtqnda8s/NSD6e1Dr5p1c8HdMU5RWSjMSUzb8RTcUQqevDCxVAitcLBKT+ie3o0Dl9crc/S/opJM7qBGQ=="],
-
-    "@vue/compiler-sfc/@vue/compiler-dom": ["@vue/compiler-dom@3.5.32", "", { "dependencies": { "@vue/compiler-core": "3.5.32", "@vue/shared": "3.5.32" } }, "sha512-ybHAu70NtiEI1fvAUz3oXZqkUYEe5J98GjMDpTGl5iHb0T15wQYLR4wE3h9xfuTNA+Cm2f4czfe8B4s+CCH57Q=="],
-
-    "@vue/compiler-sfc/@vue/shared": ["@vue/shared@3.5.32", "", {}, "sha512-ksNyrmRQzWJJ8n3cRDuSF7zNNontuJg1YHnmWRJd2AMu8Ij2bqwiiri2lH5rHtYPZjj4STkNcgcmiQqlOjiYGg=="],
-
-    "@vue/compiler-ssr/@vue/compiler-dom": ["@vue/compiler-dom@3.5.32", "", { "dependencies": { "@vue/compiler-core": "3.5.32", "@vue/shared": "3.5.32" } }, "sha512-ybHAu70NtiEI1fvAUz3oXZqkUYEe5J98GjMDpTGl5iHb0T15wQYLR4wE3h9xfuTNA+Cm2f4czfe8B4s+CCH57Q=="],
-
-    "@vue/compiler-ssr/@vue/shared": ["@vue/shared@3.5.32", "", {}, "sha512-ksNyrmRQzWJJ8n3cRDuSF7zNNontuJg1YHnmWRJd2AMu8Ij2bqwiiri2lH5rHtYPZjj4STkNcgcmiQqlOjiYGg=="],
-
-    "@vue/reactivity/@vue/shared": ["@vue/shared@3.5.32", "", {}, "sha512-ksNyrmRQzWJJ8n3cRDuSF7zNNontuJg1YHnmWRJd2AMu8Ij2bqwiiri2lH5rHtYPZjj4STkNcgcmiQqlOjiYGg=="],
-
-    "@vue/runtime-core/@vue/shared": ["@vue/shared@3.5.32", "", {}, "sha512-ksNyrmRQzWJJ8n3cRDuSF7zNNontuJg1YHnmWRJd2AMu8Ij2bqwiiri2lH5rHtYPZjj4STkNcgcmiQqlOjiYGg=="],
-
-    "@vue/runtime-dom/@vue/shared": ["@vue/shared@3.5.32", "", {}, "sha512-ksNyrmRQzWJJ8n3cRDuSF7zNNontuJg1YHnmWRJd2AMu8Ij2bqwiiri2lH5rHtYPZjj4STkNcgcmiQqlOjiYGg=="],
-
-    "@vue/server-renderer/@vue/shared": ["@vue/shared@3.5.32", "", {}, "sha512-ksNyrmRQzWJJ8n3cRDuSF7zNNontuJg1YHnmWRJd2AMu8Ij2bqwiiri2lH5rHtYPZjj4STkNcgcmiQqlOjiYGg=="],
 
     "@xterm/addon-ligatures/lru-cache": ["lru-cache@6.0.0", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA=="],
 
@@ -6909,10 +6901,6 @@
 
     "vscode-markdown-languageservice/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 
-    "vue/@vue/compiler-dom": ["@vue/compiler-dom@3.5.32", "", { "dependencies": { "@vue/compiler-core": "3.5.32", "@vue/shared": "3.5.32" } }, "sha512-ybHAu70NtiEI1fvAUz3oXZqkUYEe5J98GjMDpTGl5iHb0T15wQYLR4wE3h9xfuTNA+Cm2f4czfe8B4s+CCH57Q=="],
-
-    "vue/@vue/shared": ["@vue/shared@3.5.32", "", {}, "sha512-ksNyrmRQzWJJ8n3cRDuSF7zNNontuJg1YHnmWRJd2AMu8Ij2bqwiiri2lH5rHtYPZjj4STkNcgcmiQqlOjiYGg=="],
-
     "webpack/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
 
     "wrangler/esbuild": ["esbuild@0.27.3", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.3", "@esbuild/android-arm": "0.27.3", "@esbuild/android-arm64": "0.27.3", "@esbuild/android-x64": "0.27.3", "@esbuild/darwin-arm64": "0.27.3", "@esbuild/darwin-x64": "0.27.3", "@esbuild/freebsd-arm64": "0.27.3", "@esbuild/freebsd-x64": "0.27.3", "@esbuild/linux-arm": "0.27.3", "@esbuild/linux-arm64": "0.27.3", "@esbuild/linux-ia32": "0.27.3", "@esbuild/linux-loong64": "0.27.3", "@esbuild/linux-mips64el": "0.27.3", "@esbuild/linux-ppc64": "0.27.3", "@esbuild/linux-riscv64": "0.27.3", "@esbuild/linux-s390x": "0.27.3", "@esbuild/linux-x64": "0.27.3", "@esbuild/netbsd-arm64": "0.27.3", "@esbuild/netbsd-x64": "0.27.3", "@esbuild/openbsd-arm64": "0.27.3", "@esbuild/openbsd-x64": "0.27.3", "@esbuild/openharmony-arm64": "0.27.3", "@esbuild/sunos-x64": "0.27.3", "@esbuild/win32-arm64": "0.27.3", "@esbuild/win32-ia32": "0.27.3", "@esbuild/win32-x64": "0.27.3" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg=="],
@@ -6978,6 +6966,10 @@
     "@ai-sdk/ui-utils-v5/@ai-sdk/provider-utils/nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
     "@babel/helper-compilation-targets/lru-cache/yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
+
+    "@code-inspector/core/@vue/compiler-dom/@vue/compiler-core": ["@vue/compiler-core@3.5.31", "", { "dependencies": { "@babel/parser": "^7.29.2", "@vue/shared": "3.5.31", "entities": "^7.0.1", "estree-walker": "^2.0.2", "source-map-js": "^1.2.1" } }, "sha512-k/ueL14aNIEy5Onf0OVzR8kiqF/WThgLdFhxwa4e/KF/0qe38IwIdofoSWBTvvxQOesaz6riAFAUaYjoF9fLLQ=="],
+
+    "@code-inspector/core/@vue/compiler-dom/@vue/shared": ["@vue/shared@3.5.31", "", {}, "sha512-nBxuiuS9Lj5bPkPbWogPUnjxxWpkRniX7e5UBQDWl6Fsf4roq9wwV+cR7ezQ4zXswNvPIlsdj1slcLB7XCsRAw=="],
 
     "@develar/schema-utils/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
 
@@ -7294,10 +7286,6 @@
     "@tailwindcss/node/lightningcss/lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.32.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q=="],
 
     "@tanstack/router-plugin/unplugin/webpack-virtual-modules": ["webpack-virtual-modules@0.6.2", "", {}, "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ=="],
-
-    "@vue/compiler-sfc/@vue/compiler-core/entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
-
-    "@vue/compiler-ssr/@vue/compiler-dom/@vue/compiler-core": ["@vue/compiler-core@3.5.32", "", { "dependencies": { "@babel/parser": "^7.29.2", "@vue/shared": "3.5.32", "entities": "^7.0.1", "estree-walker": "^2.0.2", "source-map-js": "^1.2.1" } }, "sha512-4x74Tbtqnda8s/NSD6e1Dr5p1c8HdMU5RWSjMSUzb8RTcUQqevDCxVAitcLBKT+ie3o0Dl9crc/S/opJM7qBGQ=="],
 
     "app-builder-lib/@electron/get/fs-extra": ["fs-extra@8.1.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^4.0.0", "universalify": "^0.1.0" } }, "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g=="],
 
@@ -7715,8 +7703,6 @@
 
     "vscode-languageserver/vscode-languageserver-protocol/vscode-languageserver-types": ["vscode-languageserver-types@3.17.2", "", {}, "sha512-zHhCWatviizPIq9B7Vh9uvrH6x3sK8itC84HkamnBWoDFJtzBf7SWlpLCZUit72b3os45h6RWQNC9xHRDF8dRA=="],
 
-    "vue/@vue/compiler-dom/@vue/compiler-core": ["@vue/compiler-core@3.5.32", "", { "dependencies": { "@babel/parser": "^7.29.2", "@vue/shared": "3.5.32", "entities": "^7.0.1", "estree-walker": "^2.0.2", "source-map-js": "^1.2.1" } }, "sha512-4x74Tbtqnda8s/NSD6e1Dr5p1c8HdMU5RWSjMSUzb8RTcUQqevDCxVAitcLBKT+ie3o0Dl9crc/S/opJM7qBGQ=="],
-
     "webpack/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
 
     "wrangler/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.3", "", { "os": "aix", "cpu": "ppc64" }, "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg=="],
@@ -7793,6 +7779,8 @@
 
     "@a2a-js/sdk/express/type-is/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
 
+    "@code-inspector/core/@vue/compiler-dom/@vue/compiler-core/entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
+
     "@electron/asar/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
     "@electron/rebuild/ora/cli-cursor/restore-cursor": ["restore-cursor@3.1.0", "", { "dependencies": { "onetime": "^5.1.0", "signal-exit": "^3.0.2" } }, "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA=="],
@@ -7866,8 +7854,6 @@
     "@sentry/vite-plugin/@sentry/bundler-plugin-core/glob/minimatch": ["minimatch@9.0.9", "", { "dependencies": { "brace-expansion": "^2.0.2" } }, "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg=="],
 
     "@sentry/vite-plugin/@sentry/bundler-plugin-core/glob/path-scurry": ["path-scurry@1.11.1", "", { "dependencies": { "lru-cache": "^10.2.0", "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0" } }, "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA=="],
-
-    "@vue/compiler-ssr/@vue/compiler-dom/@vue/compiler-core/entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
 
     "app-builder-lib/@electron/get/fs-extra/jsonfile": ["jsonfile@4.0.0", "", { "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg=="],
 
@@ -7964,8 +7950,6 @@
     "vscode-langservers-extracted/vscode-languageserver/vscode-languageserver-protocol/vscode-jsonrpc": ["vscode-jsonrpc@9.0.0-next.11", "", {}, "sha512-u6LElQNbSiE9OugEEmrUKwH6+8BpPz2S5MDHvQUqHL//I4Q8GPikKLOUf856UnbLkZdhxaPrExac1lA3XwpIPA=="],
 
     "vscode-langservers-extracted/vscode-languageserver/vscode-languageserver-protocol/vscode-languageserver-types": ["vscode-languageserver-types@3.17.6-next.6", "", {}, "sha512-aiJY5/yW+xzw7KPNlwi3gQtddq/3EIn5z8X8nCgJfaiAij2R1APKePngv+MUdLdYJBVTLu+Qa0ODsT+pHgYguQ=="],
-
-    "vue/@vue/compiler-dom/@vue/compiler-core/entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
 
     "zip-stream/archiver-utils/glob/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
 

--- a/packages/local-db/drizzle/0056_add_todo_schedules.sql
+++ b/packages/local-db/drizzle/0056_add_todo_schedules.sql
@@ -1,7 +1,7 @@
 CREATE TABLE `todo_schedules` (
 	`id` text PRIMARY KEY NOT NULL,
-	`project_id` text,
-	`workspace_id` text NOT NULL,
+	`project_id` text NOT NULL,
+	`workspace_id` text,
 	`name` text NOT NULL,
 	`enabled` integer DEFAULT true NOT NULL,
 	`frequency` text NOT NULL,
@@ -23,9 +23,10 @@ CREATE TABLE `todo_schedules` (
 	`next_run_at` integer,
 	`created_at` integer NOT NULL,
 	`updated_at` integer NOT NULL,
-	FOREIGN KEY (`project_id`) REFERENCES `projects`(`id`) ON UPDATE no action ON DELETE set null,
-	FOREIGN KEY (`workspace_id`) REFERENCES `workspaces`(`id`) ON UPDATE no action ON DELETE cascade
+	FOREIGN KEY (`project_id`) REFERENCES `projects`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`workspace_id`) REFERENCES `workspaces`(`id`) ON UPDATE no action ON DELETE set null
 );
 --> statement-breakpoint
+CREATE INDEX `todo_schedules_project_idx` ON `todo_schedules` (`project_id`);--> statement-breakpoint
 CREATE INDEX `todo_schedules_workspace_idx` ON `todo_schedules` (`workspace_id`);--> statement-breakpoint
 CREATE INDEX `todo_schedules_enabled_next_run_idx` ON `todo_schedules` (`enabled`,`next_run_at`);

--- a/packages/local-db/drizzle/0056_add_todo_schedules.sql
+++ b/packages/local-db/drizzle/0056_add_todo_schedules.sql
@@ -18,6 +18,7 @@ CREATE TABLE `todo_schedules` (
 	`max_wall_clock_sec` integer DEFAULT 1800 NOT NULL,
 	`custom_system_prompt` text,
 	`overlap_mode` text DEFAULT 'skip' NOT NULL,
+	`auto_sync_before_fire` integer DEFAULT false NOT NULL,
 	`last_run_at` integer,
 	`last_run_session_id` text,
 	`next_run_at` integer,

--- a/packages/local-db/drizzle/0056_add_todo_schedules.sql
+++ b/packages/local-db/drizzle/0056_add_todo_schedules.sql
@@ -1,0 +1,31 @@
+CREATE TABLE `todo_schedules` (
+	`id` text PRIMARY KEY NOT NULL,
+	`project_id` text,
+	`workspace_id` text NOT NULL,
+	`name` text NOT NULL,
+	`enabled` integer DEFAULT true NOT NULL,
+	`frequency` text NOT NULL,
+	`minute` integer,
+	`hour` integer,
+	`weekday` integer,
+	`monthday` integer,
+	`cron_expr` text,
+	`title` text NOT NULL,
+	`description` text NOT NULL,
+	`goal` text,
+	`verify_command` text,
+	`max_iterations` integer DEFAULT 10 NOT NULL,
+	`max_wall_clock_sec` integer DEFAULT 1800 NOT NULL,
+	`custom_system_prompt` text,
+	`overlap_mode` text DEFAULT 'skip' NOT NULL,
+	`last_run_at` integer,
+	`last_run_session_id` text,
+	`next_run_at` integer,
+	`created_at` integer NOT NULL,
+	`updated_at` integer NOT NULL,
+	FOREIGN KEY (`project_id`) REFERENCES `projects`(`id`) ON UPDATE no action ON DELETE set null,
+	FOREIGN KEY (`workspace_id`) REFERENCES `workspaces`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `todo_schedules_workspace_idx` ON `todo_schedules` (`workspace_id`);--> statement-breakpoint
+CREATE INDEX `todo_schedules_enabled_next_run_idx` ON `todo_schedules` (`enabled`,`next_run_at`);

--- a/packages/local-db/drizzle/meta/0056_snapshot.json
+++ b/packages/local-db/drizzle/meta/0056_snapshot.json
@@ -1,7 +1,7 @@
 {
   "version": "6",
   "dialect": "sqlite",
-  "id": "27de5c0a-6155-43a1-a04d-c183d9d6dcb0",
+  "id": "291476c4-5235-4628-b159-d2e09043728d",
   "prevId": "b96cd168-974e-4c4f-9eae-54dc1ffc1cd6",
   "tables": {
     "browser_history": {
@@ -1653,14 +1653,14 @@
           "name": "project_id",
           "type": "text",
           "primaryKey": false,
-          "notNull": false,
+          "notNull": true,
           "autoincrement": false
         },
         "workspace_id": {
           "name": "workspace_id",
           "type": "text",
           "primaryKey": false,
-          "notNull": true,
+          "notNull": false,
           "autoincrement": false
         },
         "name": {
@@ -1816,6 +1816,13 @@
         }
       },
       "indexes": {
+        "todo_schedules_project_idx": {
+          "name": "todo_schedules_project_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
         "todo_schedules_workspace_idx": {
           "name": "todo_schedules_workspace_idx",
           "columns": [
@@ -1843,7 +1850,7 @@
           "columnsTo": [
             "id"
           ],
-          "onDelete": "set null",
+          "onDelete": "cascade",
           "onUpdate": "no action"
         },
         "todo_schedules_workspace_id_workspaces_id_fk": {
@@ -1856,7 +1863,7 @@
           "columnsTo": [
             "id"
           ],
-          "onDelete": "cascade",
+          "onDelete": "set null",
           "onUpdate": "no action"
         }
       },

--- a/packages/local-db/drizzle/meta/0056_snapshot.json
+++ b/packages/local-db/drizzle/meta/0056_snapshot.json
@@ -1,7 +1,7 @@
 {
   "version": "6",
   "dialect": "sqlite",
-  "id": "291476c4-5235-4628-b159-d2e09043728d",
+  "id": "7fb6bb1c-1573-409b-ab09-670bfff160a7",
   "prevId": "b96cd168-974e-4c4f-9eae-54dc1ffc1cd6",
   "tables": {
     "browser_history": {
@@ -1778,6 +1778,14 @@
           "notNull": true,
           "autoincrement": false,
           "default": "'skip'"
+        },
+        "auto_sync_before_fire": {
+          "name": "auto_sync_before_fire",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
         },
         "last_run_at": {
           "name": "last_run_at",

--- a/packages/local-db/drizzle/meta/0056_snapshot.json
+++ b/packages/local-db/drizzle/meta/0056_snapshot.json
@@ -1,0 +1,2144 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "27de5c0a-6155-43a1-a04d-c183d9d6dcb0",
+  "prevId": "b96cd168-974e-4c4f-9eae-54dc1ffc1cd6",
+  "tables": {
+    "browser_history": {
+      "name": "browser_history",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "favicon_url": {
+          "name": "favicon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_visited_at": {
+          "name": "last_visited_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "visit_count": {
+          "name": "visit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "browser_history_url_unique": {
+          "name": "browser_history_url_unique",
+          "columns": [
+            "url"
+          ],
+          "isUnique": true
+        },
+        "browser_history_url_idx": {
+          "name": "browser_history_url_idx",
+          "columns": [
+            "url"
+          ],
+          "isUnique": false
+        },
+        "browser_history_last_visited_at_idx": {
+          "name": "browser_history_last_visited_at_idx",
+          "columns": [
+            "last_visited_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "browser_site_permissions": {
+      "name": "browser_site_permissions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "origin": {
+          "name": "origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'ask'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "browser_site_permissions_origin_idx": {
+          "name": "browser_site_permissions_origin_idx",
+          "columns": [
+            "origin"
+          ],
+          "isUnique": false
+        },
+        "browser_site_permissions_origin_kind_unique": {
+          "name": "browser_site_permissions_origin_kind_unique",
+          "columns": [
+            "origin",
+            "kind"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organization_members": {
+      "name": "organization_members",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organization_members_organization_id_idx": {
+          "name": "organization_members_organization_id_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "organization_members_user_id_idx": {
+          "name": "organization_members_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "organization_members_organization_id_organizations_id_fk": {
+          "name": "organization_members_organization_id_organizations_id_fk",
+          "tableFrom": "organization_members",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_members_user_id_users_id_fk": {
+          "name": "organization_members_user_id_users_id_fk",
+          "tableFrom": "organization_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organizations": {
+      "name": "organizations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "clerk_org_id": {
+          "name": "clerk_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "github_org": {
+          "name": "github_org",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organizations_clerk_org_id_unique": {
+          "name": "organizations_clerk_org_id_unique",
+          "columns": [
+            "clerk_org_id"
+          ],
+          "isUnique": true
+        },
+        "organizations_slug_unique": {
+          "name": "organizations_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        },
+        "organizations_slug_idx": {
+          "name": "organizations_slug_idx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": false
+        },
+        "organizations_clerk_org_id_idx": {
+          "name": "organizations_clerk_org_id_idx",
+          "columns": [
+            "clerk_org_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "main_repo_path": {
+          "name": "main_repo_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tab_order": {
+          "name": "tab_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_opened_at": {
+          "name": "last_opened_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config_toast_dismissed": {
+          "name": "config_toast_dismissed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_branch": {
+          "name": "default_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "workspace_base_branch": {
+          "name": "workspace_base_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "github_owner": {
+          "name": "github_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch_prefix_mode": {
+          "name": "branch_prefix_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch_prefix_custom": {
+          "name": "branch_prefix_custom",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "worktree_base_dir": {
+          "name": "worktree_base_dir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "hide_image": {
+          "name": "hide_image",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "icon_url": {
+          "name": "icon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "neon_project_id": {
+          "name": "neon_project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_app": {
+          "name": "default_app",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "projects_main_repo_path_idx": {
+          "name": "projects_main_repo_path_idx",
+          "columns": [
+            "main_repo_path"
+          ],
+          "isUnique": false
+        },
+        "projects_last_opened_at_idx": {
+          "name": "projects_last_opened_at_idx",
+          "columns": [
+            "last_opened_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "settings": {
+      "name": "settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "last_active_workspace_id": {
+          "name": "last_active_workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "terminal_presets": {
+          "name": "terminal_presets",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "terminal_presets_initialized": {
+          "name": "terminal_presets_initialized",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "agent_preset_overrides": {
+          "name": "agent_preset_overrides",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "agent_custom_definitions": {
+          "name": "agent_custom_definitions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "selected_ringtone_id": {
+          "name": "selected_ringtone_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "confirm_on_quit": {
+          "name": "confirm_on_quit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "terminal_link_behavior": {
+          "name": "terminal_link_behavior",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "persist_terminal": {
+          "name": "persist_terminal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "auto_apply_default_preset": {
+          "name": "auto_apply_default_preset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch_prefix_mode": {
+          "name": "branch_prefix_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch_prefix_custom": {
+          "name": "branch_prefix_custom",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notification_sounds_muted": {
+          "name": "notification_sounds_muted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notification_volume": {
+          "name": "notification_volume",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prevent_agent_sleep": {
+          "name": "prevent_agent_sleep",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "delete_local_branch": {
+          "name": "delete_local_branch",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "file_open_mode": {
+          "name": "file_open_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "right_sidebar_open_view_width": {
+          "name": "right_sidebar_open_view_width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "show_presets_bar": {
+          "name": "show_presets_bar",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "use_compact_terminal_add_button": {
+          "name": "use_compact_terminal_add_button",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "terminal_font_family": {
+          "name": "terminal_font_family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "terminal_font_size": {
+          "name": "terminal_font_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "editor_font_family": {
+          "name": "editor_font_family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "editor_font_size": {
+          "name": "editor_font_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "show_resource_monitor": {
+          "name": "show_resource_monitor",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "worktree_base_dir": {
+          "name": "worktree_base_dir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "open_links_in_app": {
+          "name": "open_links_in_app",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_editor": {
+          "name": "default_editor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "indent_rainbow_enabled": {
+          "name": "indent_rainbow_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "indent_rainbow_colors": {
+          "name": "indent_rainbow_colors",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trailing_spaces_enabled": {
+          "name": "trailing_spaces_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trailing_spaces_color": {
+          "name": "trailing_spaces_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reference_graph_enabled": {
+          "name": "reference_graph_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expose_host_service_via_relay": {
+          "name": "expose_host_service_via_relay",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enable_smart_commit": {
+          "name": "enable_smart_commit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "smart_commit_changes": {
+          "name": "smart_commit_changes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "auto_stash": {
+          "name": "auto_stash",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch_sort_order": {
+          "name": "branch_sort_order",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pin_default_branch": {
+          "name": "pin_default_branch",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "post_commit_command": {
+          "name": "post_commit_command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tasks": {
+      "name": "tasks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status_color": {
+          "name": "status_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status_type": {
+          "name": "status_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status_position": {
+          "name": "status_position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "assignee_id": {
+          "name": "assignee_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "estimate": {
+          "name": "estimate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "labels": {
+          "name": "labels",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pr_url": {
+          "name": "pr_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_provider": {
+          "name": "external_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_key": {
+          "name": "external_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_url": {
+          "name": "external_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sync_error": {
+          "name": "sync_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tasks_slug_unique": {
+          "name": "tasks_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        },
+        "tasks_slug_idx": {
+          "name": "tasks_slug_idx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": false
+        },
+        "tasks_organization_id_idx": {
+          "name": "tasks_organization_id_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "tasks_assignee_id_idx": {
+          "name": "tasks_assignee_id_idx",
+          "columns": [
+            "assignee_id"
+          ],
+          "isUnique": false
+        },
+        "tasks_status_idx": {
+          "name": "tasks_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "tasks_created_at_idx": {
+          "name": "tasks_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "tasks_organization_id_organizations_id_fk": {
+          "name": "tasks_organization_id_organizations_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tasks_assignee_id_users_id_fk": {
+          "name": "tasks_assignee_id_users_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "assignee_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "tasks_creator_id_users_id_fk": {
+          "name": "tasks_creator_id_users_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "clerk_id": {
+          "name": "clerk_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_clerk_id_unique": {
+          "name": "users_clerk_id_unique",
+          "columns": [
+            "clerk_id"
+          ],
+          "isUnique": true
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        },
+        "users_email_idx": {
+          "name": "users_email_idx",
+          "columns": [
+            "email"
+          ],
+          "isUnique": false
+        },
+        "users_clerk_id_idx": {
+          "name": "users_clerk_id_idx",
+          "columns": [
+            "clerk_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "workspace_sections": {
+      "name": "workspace_sections",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tab_order": {
+          "name": "tab_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_collapsed": {
+          "name": "is_collapsed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "workspace_sections_project_id_idx": {
+          "name": "workspace_sections_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "workspace_sections_project_id_projects_id_fk": {
+          "name": "workspace_sections_project_id_projects_id_fk",
+          "tableFrom": "workspace_sections",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "workspaces": {
+      "name": "workspaces",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "worktree_id": {
+          "name": "worktree_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tab_order": {
+          "name": "tab_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_opened_at": {
+          "name": "last_opened_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_unread": {
+          "name": "is_unread",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_unnamed": {
+          "name": "is_unnamed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "deleting_at": {
+          "name": "deleting_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "port_base": {
+          "name": "port_base",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "section_id": {
+          "name": "section_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "workspaces_project_id_idx": {
+          "name": "workspaces_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "workspaces_worktree_id_idx": {
+          "name": "workspaces_worktree_id_idx",
+          "columns": [
+            "worktree_id"
+          ],
+          "isUnique": false
+        },
+        "workspaces_last_opened_at_idx": {
+          "name": "workspaces_last_opened_at_idx",
+          "columns": [
+            "last_opened_at"
+          ],
+          "isUnique": false
+        },
+        "workspaces_section_id_idx": {
+          "name": "workspaces_section_id_idx",
+          "columns": [
+            "section_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "workspaces_project_id_projects_id_fk": {
+          "name": "workspaces_project_id_projects_id_fk",
+          "tableFrom": "workspaces",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workspaces_worktree_id_worktrees_id_fk": {
+          "name": "workspaces_worktree_id_worktrees_id_fk",
+          "tableFrom": "workspaces",
+          "tableTo": "worktrees",
+          "columnsFrom": [
+            "worktree_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workspaces_section_id_workspace_sections_id_fk": {
+          "name": "workspaces_section_id_workspace_sections_id_fk",
+          "tableFrom": "workspaces",
+          "tableTo": "workspace_sections",
+          "columnsFrom": [
+            "section_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "worktrees": {
+      "name": "worktrees",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "base_branch": {
+          "name": "base_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "git_status": {
+          "name": "git_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "github_status": {
+          "name": "github_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_superset": {
+          "name": "created_by_superset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        }
+      },
+      "indexes": {
+        "worktrees_project_id_idx": {
+          "name": "worktrees_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "worktrees_branch_idx": {
+          "name": "worktrees_branch_idx",
+          "columns": [
+            "branch"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "worktrees_project_id_projects_id_fk": {
+          "name": "worktrees_project_id_projects_id_fk",
+          "tableFrom": "worktrees",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "todo_prompt_presets": {
+      "name": "todo_prompt_presets",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'system'"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "todo_prompt_presets_name_idx": {
+          "name": "todo_prompt_presets_name_idx",
+          "columns": [
+            "name"
+          ],
+          "isUnique": false
+        },
+        "todo_prompt_presets_updated_at_idx": {
+          "name": "todo_prompt_presets_updated_at_idx",
+          "columns": [
+            "updated_at"
+          ],
+          "isUnique": false
+        },
+        "todo_prompt_presets_kind_idx": {
+          "name": "todo_prompt_presets_kind_idx",
+          "columns": [
+            "kind"
+          ],
+          "isUnique": false
+        },
+        "todo_prompt_presets_workspace_idx": {
+          "name": "todo_prompt_presets_workspace_idx",
+          "columns": [
+            "workspace_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "todo_schedules": {
+      "name": "todo_schedules",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "frequency": {
+          "name": "frequency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "minute": {
+          "name": "minute",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "hour": {
+          "name": "hour",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "weekday": {
+          "name": "weekday",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "monthday": {
+          "name": "monthday",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cron_expr": {
+          "name": "cron_expr",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "goal": {
+          "name": "goal",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "verify_command": {
+          "name": "verify_command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_iterations": {
+          "name": "max_iterations",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10
+        },
+        "max_wall_clock_sec": {
+          "name": "max_wall_clock_sec",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1800
+        },
+        "custom_system_prompt": {
+          "name": "custom_system_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "overlap_mode": {
+          "name": "overlap_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'skip'"
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_run_session_id": {
+          "name": "last_run_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "todo_schedules_workspace_idx": {
+          "name": "todo_schedules_workspace_idx",
+          "columns": [
+            "workspace_id"
+          ],
+          "isUnique": false
+        },
+        "todo_schedules_enabled_next_run_idx": {
+          "name": "todo_schedules_enabled_next_run_idx",
+          "columns": [
+            "enabled",
+            "next_run_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "todo_schedules_project_id_projects_id_fk": {
+          "name": "todo_schedules_project_id_projects_id_fk",
+          "tableFrom": "todo_schedules",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "todo_schedules_workspace_id_workspaces_id_fk": {
+          "name": "todo_schedules_workspace_id_workspaces_id_fk",
+          "tableFrom": "todo_schedules",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "todo_sessions": {
+      "name": "todo_sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "goal": {
+          "name": "goal",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "verify_command": {
+          "name": "verify_command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_iterations": {
+          "name": "max_iterations",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10
+        },
+        "max_wall_clock_sec": {
+          "name": "max_wall_clock_sec",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1800
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'queued'"
+        },
+        "phase": {
+          "name": "phase",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "iteration": {
+          "name": "iteration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "attached_pane_id": {
+          "name": "attached_pane_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attached_tab_id": {
+          "name": "attached_tab_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "claude_session_id": {
+          "name": "claude_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "final_assistant_text": {
+          "name": "final_assistant_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_cost_usd": {
+          "name": "total_cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_num_turns": {
+          "name": "total_num_turns",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pending_intervention": {
+          "name": "pending_intervention",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start_head_sha": {
+          "name": "start_head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "custom_system_prompt": {
+          "name": "custom_system_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "verdict_passed": {
+          "name": "verdict_passed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "verdict_reason": {
+          "name": "verdict_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "verdict_failing_test": {
+          "name": "verdict_failing_test",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "artifact_path": {
+          "name": "artifact_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "todo_sessions_workspace_idx": {
+          "name": "todo_sessions_workspace_idx",
+          "columns": [
+            "workspace_id"
+          ],
+          "isUnique": false
+        },
+        "todo_sessions_status_idx": {
+          "name": "todo_sessions_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "todo_sessions_created_at_idx": {
+          "name": "todo_sessions_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "todo_sessions_project_id_projects_id_fk": {
+          "name": "todo_sessions_project_id_projects_id_fk",
+          "tableFrom": "todo_sessions",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "todo_sessions_workspace_id_workspaces_id_fk": {
+          "name": "todo_sessions_workspace_id_workspaces_id_fk",
+          "tableFrom": "todo_sessions",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/local-db/drizzle/meta/_journal.json
+++ b/packages/local-db/drizzle/meta/_journal.json
@@ -393,6 +393,13 @@
       "when": 1776307943454,
       "tag": "0055_todo_preset_kind_workspace",
       "breakpoints": true
+    },
+    {
+      "idx": 56,
+      "version": "6",
+      "when": 1776348738578,
+      "tag": "0056_add_todo_schedules",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/local-db/drizzle/meta/_journal.json
+++ b/packages/local-db/drizzle/meta/_journal.json
@@ -397,7 +397,7 @@
     {
       "idx": 56,
       "version": "6",
-      "when": 1776351400803,
+      "when": 1776356076189,
       "tag": "0056_add_todo_schedules",
       "breakpoints": true
     }

--- a/packages/local-db/drizzle/meta/_journal.json
+++ b/packages/local-db/drizzle/meta/_journal.json
@@ -397,7 +397,7 @@
     {
       "idx": 56,
       "version": "6",
-      "when": 1776348738578,
+      "when": 1776351400803,
       "tag": "0056_add_todo_schedules",
       "breakpoints": true
     }

--- a/packages/local-db/src/schema/index.ts
+++ b/packages/local-db/src/schema/index.ts
@@ -1,5 +1,6 @@
 export * from "./relations";
 export * from "./schema";
 export * from "./todo-prompt-presets";
+export * from "./todo-schedules";
 export * from "./todo-sessions";
 export * from "./zod";

--- a/packages/local-db/src/schema/schema.ts
+++ b/packages/local-db/src/schema/schema.ts
@@ -459,4 +459,5 @@ export type SelectBrowserSitePermission =
 // Fork-local: TODO autonomous agent sessions. Re-exported so drizzle-kit
 // (configured with schema="./src/schema/schema.ts") picks up the table.
 export * from "./todo-prompt-presets";
+export * from "./todo-schedules";
 export * from "./todo-sessions";

--- a/packages/local-db/src/schema/todo-schedules.ts
+++ b/packages/local-db/src/schema/todo-schedules.ts
@@ -17,12 +17,18 @@ export const todoSchedules = sqliteTable(
 		id: text("id")
 			.primaryKey()
 			.$defaultFn(() => uuidv4()),
-		projectId: text("project_id").references(() => projects.id, {
+		projectId: text("project_id")
+			.notNull()
+			.references(() => projects.id, {
+				onDelete: "cascade",
+			}),
+		// Optional: when null, the schedule fires against the project's
+		// main repo path (`projects.mainRepoPath`) instead of a specific
+		// worktree. Needed for "run on main every day" use cases where
+		// the user doesn't want to maintain a dedicated workspace row.
+		workspaceId: text("workspace_id").references(() => workspaces.id, {
 			onDelete: "set null",
 		}),
-		workspaceId: text("workspace_id")
-			.notNull()
-			.references(() => workspaces.id, { onDelete: "cascade" }),
 
 		name: text("name").notNull(),
 		enabled: integer("enabled", { mode: "boolean" }).notNull().default(true),
@@ -70,6 +76,7 @@ export const todoSchedules = sqliteTable(
 			.$defaultFn(() => Date.now()),
 	},
 	(table) => [
+		index("todo_schedules_project_idx").on(table.projectId),
 		index("todo_schedules_workspace_idx").on(table.workspaceId),
 		index("todo_schedules_enabled_next_run_idx").on(
 			table.enabled,

--- a/packages/local-db/src/schema/todo-schedules.ts
+++ b/packages/local-db/src/schema/todo-schedules.ts
@@ -1,0 +1,98 @@
+import { index, integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
+import { v4 as uuidv4 } from "uuid";
+
+import { projects, workspaces } from "./schema";
+
+/**
+ * TODO autonomous agent schedules.
+ *
+ * Each row defines a recurring trigger that creates a new todoSessions row
+ * (based on the template fields here) at its configured cadence. The runtime
+ * scheduler lives in the main process; this table is just persistent state.
+ * Fork-local feature; see apps/desktop/plans/20260416-todo-schedule.md.
+ */
+export const todoSchedules = sqliteTable(
+	"todo_schedules",
+	{
+		id: text("id")
+			.primaryKey()
+			.$defaultFn(() => uuidv4()),
+		projectId: text("project_id").references(() => projects.id, {
+			onDelete: "set null",
+		}),
+		workspaceId: text("workspace_id")
+			.notNull()
+			.references(() => workspaces.id, { onDelete: "cascade" }),
+
+		name: text("name").notNull(),
+		enabled: integer("enabled", { mode: "boolean" }).notNull().default(true),
+
+		// Frequency definition. For hourly/daily/weekly/monthly the scheduler
+		// derives the next fire from `minute`/`hour`/`weekday`/`monthday`
+		// without touching a cron parser. `custom` delegates to `cronExpr`.
+		frequency: text("frequency", {
+			enum: ["hourly", "daily", "weekly", "monthly", "custom"],
+		}).notNull(),
+		minute: integer("minute"),
+		hour: integer("hour"),
+		weekday: integer("weekday"),
+		monthday: integer("monthday"),
+		cronExpr: text("cron_expr"),
+
+		// TODO session template. Mirrors the session's own schema so that
+		// creating a session from a schedule is a straight copy.
+		title: text("title").notNull(),
+		description: text("description").notNull(),
+		goal: text("goal"),
+		verifyCommand: text("verify_command"),
+		maxIterations: integer("max_iterations").notNull().default(10),
+		maxWallClockSec: integer("max_wall_clock_sec").notNull().default(1800),
+		customSystemPrompt: text("custom_system_prompt"),
+
+		// How to behave when the previous session from this schedule is
+		// still running at fire time.
+		overlapMode: text("overlap_mode", { enum: ["skip", "queue"] })
+			.notNull()
+			.default("skip"),
+
+		lastRunAt: integer("last_run_at"),
+		lastRunSessionId: text("last_run_session_id"),
+		// Cached next fire time so the scheduler can cheaply scan "due"
+		// schedules in a single query instead of recomputing cadence on
+		// every tick.
+		nextRunAt: integer("next_run_at"),
+
+		createdAt: integer("created_at")
+			.notNull()
+			.$defaultFn(() => Date.now()),
+		updatedAt: integer("updated_at")
+			.notNull()
+			.$defaultFn(() => Date.now()),
+	},
+	(table) => [
+		index("todo_schedules_workspace_idx").on(table.workspaceId),
+		index("todo_schedules_enabled_next_run_idx").on(
+			table.enabled,
+			table.nextRunAt,
+		),
+	],
+);
+
+export type InsertTodoSchedule = typeof todoSchedules.$inferInsert;
+export type SelectTodoSchedule = typeof todoSchedules.$inferSelect;
+
+export const todoScheduleFrequencyValues = [
+	"hourly",
+	"daily",
+	"weekly",
+	"monthly",
+	"custom",
+] as const;
+
+export type TodoScheduleFrequency =
+	(typeof todoScheduleFrequencyValues)[number];
+
+export const todoScheduleOverlapModeValues = ["skip", "queue"] as const;
+
+export type TodoScheduleOverlapMode =
+	(typeof todoScheduleOverlapModeValues)[number];

--- a/packages/local-db/src/schema/todo-schedules.ts
+++ b/packages/local-db/src/schema/todo-schedules.ts
@@ -61,6 +61,16 @@ export const todoSchedules = sqliteTable(
 			.notNull()
 			.default("skip"),
 
+		// Opt-in: before firing on the project's main repo path, do
+		// `git fetch && git checkout <defaultBranch> && git pull
+		// --ff-only`. If the working tree has uncommitted changes the
+		// scheduler skips the fire rather than risk destroying the
+		// user's work. Only applies when workspaceId is null (project
+		// main repo mode); worktree workspaces are unaffected.
+		autoSyncBeforeFire: integer("auto_sync_before_fire", { mode: "boolean" })
+			.notNull()
+			.default(false),
+
 		lastRunAt: integer("last_run_at"),
 		lastRunSessionId: text("last_run_session_id"),
 		// Cached next fire time so the scheduler can cheaply scan "due"


### PR DESCRIPTION
## 概要
既存の TODO Agent にスケジュール機能を追加。毎日デプロイ / 毎時 lint / 毎週レポート生成のような定型タスクを UI ビルダーで登録でき、アプリ起動中に指定時刻が来ると TODO セッションが自動で作られて実行されます。

## 動作イメージ
- TodoManager を開く → 左サイドバーのタブを「スケジュール」に切替
- 「新規」で **プロジェクト** + **実行対象**（プロジェクト本体 (main) or 特定 worktree workspace）+ 頻度 (毎時/毎日/毎週/毎月/cron) + TODO テンプレートを入力
- 発火時はトースト通知 ( 📅 成功 / ⏭️ skip / ⚠️ 失敗 )

## 主要な決定事項 (ユーザー確認済み)
- 頻度は **UX 重視のビルダー**。cron 直書きは custom モードでのみ可、`cronstrue` でヒューマン表示
- **プロジェクト主軸**。ワークスペースは任意選択、省略時はプロジェクトの main repo path (branch workspace を lazy に作成) で実行
- 前回未完了時の挙動は **スケジュールごとに選択** (skip / queue)
- **実行前に main ブランチを最新化する** opt-in (`git fetch → checkout default → pull --ff-only`、未コミット変更時はスキップ)
- **セッション自動削除** (日) 設定を Agent Manager 設定に追加 (0=無効、終了済みセッションのみ対象)
- TodoManager **内に統合** (独立モーダルにしていない)
- スケジューラ起動失敗時はトースト通知（renderer 購読タイミングより先に emit されても replay される）

## アーキテクチャ
- **DB**: `todo_schedules` テーブル新規 (migration `0056_add_todo_schedules.sql`)
  - `projectId` NOT NULL (cascade), `workspaceId` nullable (set null)
  - `autoSyncBeforeFire`, `overlapMode (skip/queue)` 等
- **Main**:
  - `TodoScheduler` (setInterval 30s、before-quit で stop) が DB の `nextRunAt` を監視して発火 → 既存 `TodoSupervisor` に委譲
  - `ensureProjectBranchWorkspaceId` でプロジェクトの branch workspace を lazy 作成
  - `autoSyncProjectMain` で opt-in の git fetch/checkout/pull
  - `cleanupOldSessions` が起動時に `COALESCE(completedAt, createdAt) < cutoff` で終了済みセッション + artifact を掃除
- **Renderer**: `SchedulesSection` (TodoManager 内), `ScheduleFireToasts` (layout に常駐)
- **tRPC**: `todoAgent.schedule.*` (list/listAll/create/update/setEnabled/delete/previewNextRun/onFire)

## 非目的 (v1)
- アプリを閉じている間の発火補完 → UI に「起動中のみ」を明記
- タイムゾーン切替 (ローカル TZ 固定)
- スケジュールのエクスポート/インポート
- スケジュール発火の OS ネイティブ通知 (sonner トーストのみ)

## セルフレビュー + Codex レビュー 対応済み
複数ラウンドで以下を自己 / Codex レビューで検出・対応:

- overlapMode='queue' が既存 supervisor キューに正しく乗る仕様であることをコメントで明記
- `before-quit` で scheduler.stop() + tick 内 isStopped ガードで closeLocalDb 後の race 防止
- `listDue` に `lte(nextRunAt, now)` を入れて composite index を実際に利用
- monthly 31 日指定の Date overflow (Feb 31 → Mar 3) を月末クランプで修正
- supervisor.start 失敗時に `failed` event を再 emit (triggered のまま残る UX 欺瞞を修正)
- `cronstrue/i18n` (~200KB 全ロケール) → `cronstrue` + `ja` ロケール単体に変更
- ScheduleFireToasts の `useSubscription` に onError ハンドラ
- TodoSession 行の構築を `insertQueuedFromTemplate` に集約 (create / fire の重複排除)
- `ensureProjectBranchWorkspaceId` 時に兄弟 workspace の tabOrder を +1 で詰める (既存 workspaces.create 経路と同じ挙動)
- `"__main__"` sentinel を `MAIN_REPO_SENTINEL` 定数化
- `projectId` を schedule update から omit + UI 編集時は Select を disabled (Codex P1)
- scheduler.tick() 内で `Date.now()` を事前計算せず、各 fire 直前に取り直し (Codex P2)
- `cleanupOldSessions` を `COALESCE(completedAt, createdAt)` ベースに修正 (Codex P1)

## 実装ファイル
新規:
- `packages/local-db/src/schema/todo-schedules.ts` + migration
- `apps/desktop/src/main/todo-agent/{schedule-store,scheduler,schedule-sync,sessions-cleanup}.ts`
- `apps/desktop/src/renderer/features/todo-agent/{TodoManager/SchedulesSection,ScheduleFireToasts}/...`
- `apps/desktop/plans/20260416-todo-schedule.md`

既存への小さい追記:
- TodoManager.tsx: サイドバーにタブ追加 (既存タスク一覧はそのまま保持)
- layout.tsx: ScheduleFireToasts を 1 行追加
- main/index.ts: 起動時に scheduler.start() + 失敗時の replay 通知 + cleanupOldSessions() 呼出
- session-store.ts: `insertQueuedFromTemplate` と `ensureProjectBranchWorkspaceId` を追加
- trpc-router.ts: schedule サブルーター
- PresetsDialog.tsx: Settings タブに「セッション自動削除 (日)」入力

新規依存: `cron-parser` (main), `cronstrue` (renderer)

## Test plan
- [x] `bun run typecheck` / `bun run lint` がグリーン
- [ ] 毎時スケジュール作成 → 次回時刻に発火してトースト表示
- [ ] 毎日スケジュール作成 → 指定時刻に TODO が自動生成
- [ ] custom cron (`0 9 * * 1-5`) → cronstrue で「平日の 9:00」と表示
- [ ] monthly=31 → 2月は月末に発火 (オーバーフローしない)
- [ ] overlapMode=skip で前回未完了なら新規セッション作らずにトースト skip
- [ ] overlapMode=queue で前回未完了でも新規セッションが queued 状態で積まれる
- [ ] workspaceId=null で発火 → branch workspace が lazy に作成され、mainRepoPath で実行
- [ ] autoSyncBeforeFire=true で fetch/checkout/pull が走る
- [ ] 未コミット変更がある状態で autoSyncBeforeFire → skip トースト
- [ ] sessionRetentionDays=30 で 31日前の done セッションが起動時に消える
- [ ] sessionRetentionDays=0 で何も消えない
- [ ] 数週間前作成→今日完了のセッションが誤って消えない (completedAt ベース確認)
- [ ] 編集時にプロジェクトを変更できない
- [ ] 有効トグル OFF で nextRunAt がクリアされ発火しない
- [ ] アプリ再起動後もスケジュールが保持され nextRunAt が再計算される
- [ ] scheduler 起動失敗時にトーストが表示される