### PR TITLE
feat(desktop): ステータスインジケータにロゴとツールチップ改善

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/ServiceStatusIndicators/ServiceStatusIndicators.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/ServiceStatusIndicators/ServiceStatusIndicators.tsx
@@ -80,22 +80,26 @@ function ServiceStatusIndicator({
 					/>
 				</button>
 			</TooltipTrigger>
+			{/* Tooltip inherits `text-[var(--background)]` from TooltipContent —
+			 *  keep overrides in the same token space (use opacity, not
+			 *  `text-foreground`) or the text disappears against the
+			 *  inverted background. */}
 			<TooltipContent
 				side="bottom"
 				className="text-sm p-3 max-w-[280px] space-y-1.5"
 			>
-				<div className="flex items-center gap-1.5 font-semibold text-foreground">
+				<div className="flex items-center gap-1.5 font-semibold">
 					<Icon className="size-3.5 shrink-0" />
 					<span>{snapshot.label}</span>
-					<span className="text-muted-foreground">—</span>
+					<span className="opacity-60">—</span>
 					<span>{levelLabel}</span>
 				</div>
-				<div className="text-foreground/90">{snapshot.description}</div>
-				<div className="text-muted-foreground text-xs">
+				<div>{snapshot.description}</div>
+				<div className="text-xs opacity-70">
 					{formatCheckedAt(snapshot.checkedAt)}
 					{snapshot.fetchError ? ` · ${snapshot.fetchError}` : ""}
 				</div>
-				<div className="text-muted-foreground text-xs">
+				<div className="text-xs opacity-60">
 					クリックで {displayHost} を開く
 				</div>
 			</TooltipContent>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/ServiceStatusIndicators/ServiceStatusIndicators.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/ServiceStatusIndicators/ServiceStatusIndicators.tsx
@@ -74,7 +74,7 @@ function ServiceStatusIndicator({
 					aria-label={`${snapshot.label} status: ${levelLabel}`}
 					className="no-drag relative flex items-center justify-center size-7 rounded-md text-foreground/80 hover:text-foreground hover:bg-accent/60 transition-colors"
 				>
-					<Icon className="size-4" />
+					<Icon className="size-[15px]" />
 					<span
 						className={`absolute -bottom-0.5 -right-0.5 size-2 rounded-full ring-2 ring-background ${dotClass}`}
 					/>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/ServiceStatusIndicators/ServiceStatusIndicators.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/ServiceStatusIndicators/ServiceStatusIndicators.tsx
@@ -1,5 +1,7 @@
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { useMemo, useState } from "react";
+import type { IconType } from "react-icons";
+import { SiClaude, SiOpenai } from "react-icons/si";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import {
 	createUnknownSnapshot,
@@ -9,7 +11,7 @@ import {
 	type ServiceStatusSnapshot,
 } from "shared/service-status-types";
 
-const LEVEL_CLASS: Record<ServiceStatusLevel, string> = {
+const LEVEL_DOT_CLASS: Record<ServiceStatusLevel, string> = {
 	operational: "bg-emerald-500",
 	minor: "bg-amber-400",
 	major: "bg-red-500",
@@ -25,6 +27,11 @@ const LEVEL_LABEL: Record<ServiceStatusLevel, string> = {
 	unknown: "ステータス不明",
 };
 
+const SERVICE_ICON: Record<ServiceStatusId, IconType> = {
+	claude: SiClaude,
+	codex: SiOpenai,
+};
+
 function formatCheckedAt(checkedAt: number): string {
 	if (!checkedAt) return "未確認";
 	const diff = Date.now() - checkedAt;
@@ -36,12 +43,6 @@ function formatCheckedAt(checkedAt: number): string {
 	return new Date(checkedAt).toLocaleString();
 }
 
-/**
- * Safely pick a host string for the tooltip footer. `new URL` throws on
- * malformed input — rare for the hardcoded statusUrls, but guarding here
- * keeps a bad upstream value from taking down the whole TopBar via React's
- * render-error boundary.
- */
 function hostOrFallback(statusUrl: string, fallback: string): string {
 	try {
 		return new URL(statusUrl).host;
@@ -50,15 +51,19 @@ function hostOrFallback(statusUrl: string, fallback: string): string {
 	}
 }
 
-interface ServiceStatusDotProps {
+interface ServiceStatusIndicatorProps {
 	snapshot: ServiceStatusSnapshot;
 	onClick: () => void;
 }
 
-function ServiceStatusDot({ snapshot, onClick }: ServiceStatusDotProps) {
-	const colorClass = LEVEL_CLASS[snapshot.level];
+function ServiceStatusIndicator({
+	snapshot,
+	onClick,
+}: ServiceStatusIndicatorProps) {
+	const dotClass = LEVEL_DOT_CLASS[snapshot.level];
 	const levelLabel = LEVEL_LABEL[snapshot.level];
 	const displayHost = hostOrFallback(snapshot.statusUrl, snapshot.label);
+	const Icon = SERVICE_ICON[snapshot.id];
 
 	return (
 		<Tooltip delayDuration={300}>
@@ -67,23 +72,30 @@ function ServiceStatusDot({ snapshot, onClick }: ServiceStatusDotProps) {
 					type="button"
 					onClick={onClick}
 					aria-label={`${snapshot.label} status: ${levelLabel}`}
-					className="no-drag flex items-center justify-center size-6 rounded-md hover:bg-accent/50 transition-colors"
+					className="no-drag relative flex items-center justify-center size-7 rounded-md text-foreground/80 hover:text-foreground hover:bg-accent/60 transition-colors"
 				>
+					<Icon className="size-4" />
 					<span
-						className={`size-2.5 rounded-full ${colorClass} ring-1 ring-black/10 dark:ring-white/10`}
+						className={`absolute -bottom-0.5 -right-0.5 size-2 rounded-full ring-2 ring-background ${dotClass}`}
 					/>
 				</button>
 			</TooltipTrigger>
-			<TooltipContent side="bottom" className="text-xs">
-				<div className="font-medium">
-					{snapshot.label} — {levelLabel}
+			<TooltipContent
+				side="bottom"
+				className="text-sm p-3 max-w-[280px] space-y-1.5"
+			>
+				<div className="flex items-center gap-1.5 font-semibold text-foreground">
+					<Icon className="size-3.5 shrink-0" />
+					<span>{snapshot.label}</span>
+					<span className="text-muted-foreground">—</span>
+					<span>{levelLabel}</span>
 				</div>
-				<div className="text-muted-foreground">{snapshot.description}</div>
-				<div className="text-muted-foreground/80 mt-0.5">
+				<div className="text-foreground/90">{snapshot.description}</div>
+				<div className="text-muted-foreground text-xs">
 					{formatCheckedAt(snapshot.checkedAt)}
 					{snapshot.fetchError ? ` · ${snapshot.fetchError}` : ""}
 				</div>
-				<div className="text-muted-foreground/60 mt-0.5">
+				<div className="text-muted-foreground text-xs">
 					クリックで {displayHost} を開く
 				</div>
 			</TooltipContent>
@@ -123,9 +135,9 @@ export function ServiceStatusIndicators() {
 	);
 
 	return (
-		<div className="no-drag flex items-center gap-0.5">
+		<div className="no-drag flex items-center gap-1">
 			{ordered.map((snapshot) => (
-				<ServiceStatusDot
+				<ServiceStatusIndicator
 					key={snapshot.id}
 					snapshot={snapshot}
 					onClick={() => openUrl.mutate(snapshot.statusUrl)}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/ServiceStatusIndicators/ServiceStatusIndicators.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/ServiceStatusIndicators/ServiceStatusIndicators.tsx
@@ -80,26 +80,29 @@ function ServiceStatusIndicator({
 					/>
 				</button>
 			</TooltipTrigger>
-			{/* Tooltip inherits `text-[var(--background)]` from TooltipContent —
-			 *  keep overrides in the same token space (use opacity, not
-			 *  `text-foreground`) or the text disappears against the
-			 *  inverted background. */}
+			{/* Project's TooltipContent defaults to an inverted color pair
+			 *  (`bg-foreground` + `text-[var(--background)]`). For this
+			 *  multi-line status card we want the regular popover surface
+			 *  instead so description / meta colors (muted-foreground, etc.)
+			 *  work normally. `!` prefix forces the override past the
+			 *  component defaults. */}
 			<TooltipContent
 				side="bottom"
-				className="text-sm p-3 max-w-[280px] space-y-1.5"
+				showArrow={false}
+				className="!bg-popover !text-popover-foreground border shadow-md p-3 max-w-[280px] space-y-1.5 text-sm"
 			>
 				<div className="flex items-center gap-1.5 font-semibold">
 					<Icon className="size-3.5 shrink-0" />
 					<span>{snapshot.label}</span>
-					<span className="opacity-60">—</span>
+					<span className="text-muted-foreground">—</span>
 					<span>{levelLabel}</span>
 				</div>
 				<div>{snapshot.description}</div>
-				<div className="text-xs opacity-70">
+				<div className="text-xs text-muted-foreground">
 					{formatCheckedAt(snapshot.checkedAt)}
 					{snapshot.fetchError ? ` · ${snapshot.fetchError}` : ""}
 				</div>
-				<div className="text-xs opacity-60">
+				<div className="text-xs text-muted-foreground">
 					クリックで {displayHost} を開く
 				</div>
 			</TooltipContent>


### PR DESCRIPTION
## 概要

#210 で追加した Claude / Codex ステータスドットを、ひと目でどのサービスか判別できるよう **ブランドロゴ + 状態ドット** の組み合わせに変更しました。またツールチップがコントラスト不足で読みにくかった問題も修正しています。

## 変更内容

### ブランドロゴ表示
- `react-icons/si` の \`SiClaude\` / \`SiOpenai\` を使用してロゴ表示
- 状態色（緑/黄/赤/紫/グレー）は小さいドットとしてロゴの右下に overlay
- `ring-2 ring-background` でロゴと状態ドットの境界をくっきり

### Tooltip 可読性改善
- \`text-xs\` → \`text-sm\` + \`p-3\` padding で十分な可読性を確保
- ヘッダー行にもロゴアイコンを追加、\`font-semibold\` で強調
- 本文は \`text-muted-foreground\` → \`text-foreground/90\` に変更しコントラスト向上
- 行間を \`space-y-1.5\` で統一

## スクリーンショット（修正前）

以下の問題：
1. 2つのドットが同じ形なのでどちらが Claude でどちらが Codex か判別不能
2. ツールチップの本文が \`text-muted-foreground\` で背景と近く読みにくい

## 修正後の挙動

- ロゴが **Claude** ならバッジ=Claude、**OpenAI (Codex)** ならバッジ=OpenAIロゴ
- ロゴ右下の状態ドットは従来通り緑=正常 / 黄=軽微 / 赤=障害 / 紫=重大 / グレー=不明 or オフライン

## テスト方法

- [ ] 起動直後、TopBar 右上に Claude ロゴ + OpenAI ロゴの2つのバッジが並ぶ
- [ ] それぞれにホバーするとツールチップが Claude / OpenAI のロゴ付きで、本文がくっきり読める
- [ ] クリックで各ステータスページが外部ブラウザで開く
- [ ] 一時的にオフラインにするとロゴの右下がグレードットに、ツールチップ本文が「Offline」