### PR TITLE
fix(desktop): vibrancy ON時のSettingsプレビューとダイアログ透過の不整合を解消

### DIFF
--- a/apps/desktop/src/renderer/globals.css
+++ b/apps/desktop/src/renderer/globals.css
@@ -141,8 +141,9 @@
 
 /*
  * Overlay components (dialog, sheet, drawer, alert-dialog) use bg-background,
- * which becomes semi-transparent under vibrancy. Override them to use the
- * near-opaque --popover value so content remains legible.
+ * which becomes transparent under vibrancy. Force them to the opaque
+ * --background-solid so dialogs stay fully readable regardless of the
+ * window transparency setting — matches how they look with vibrancy OFF.
  */
 :root[data-vibrancy="on"]
 	:is(
@@ -151,7 +152,7 @@
 		[data-slot="sheet-content"],
 		[data-slot="drawer-content"]
 	) {
-	background-color: var(--popover);
+	background-color: var(--background-solid);
 }
 
 :root[data-vibrancy="on"].light {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/layout.tsx
@@ -105,7 +105,7 @@ function DashboardLayout() {
 	);
 
 	return (
-		<div className="flex flex-col h-full w-full">
+		<div className="flex flex-col h-full w-full bg-tertiary">
 			{!isTearoff && <TopBar />}
 			<div className="flex flex-1 min-h-0 min-w-0 overflow-hidden">
 				{!isTearoff && isWorkspaceSidebarOpen && (


### PR DESCRIPTION
## 概要
最近追加された vibrancy 機能 (Settings → Appearance → ウィンドウ透過) に関する2つの体感問題を修正します。

### 問題 1: Settings プレビューと実画面で透過度合いが違う
スライダーで「ちょうど良い」と思って Settings 画面を閉じると、メイン画面では**ずっと透明**に見える。ユーザーが想定する「設定値どおり」にならない。

### 問題 2: ダイアログ (TodoManager 等) の背景が透ける
TODO ボタンから開く Agent Manager をはじめ、 Dialog 系コンポーネントの背景が vibrancy ON 時に透けて、可読性が落ちていた。

## 原因

### 問題 1
- **Settings 画面**: 最外枠が \`bg-tertiary\` (vibrancy ON 時は \`alpha + 0.15\`) でラップされている
- **メイン画面 (DashboardLayout)**: 最外枠に \`bg-*\` 指定なし → ウィンドウの vibrancy が直接見える
- 同じスライダー値でも **Settings の方が約15ポイント不透明寄り**に表示される

### 問題 2
- \`apps/desktop/src/renderer/stores/vibrancy/store.ts\` で \`--background\` を \`transparent\` に強制
- \`globals.css\` のダイアログ override は \`var(--popover)\` (95% 不透明) を使用 → 5% 透ける
- さらに子要素の \`bg-background/*\` (例: TodoManager の sticky header / footer) は完全透明化していた

## 修正内容

### 1. \`apps/desktop/src/renderer/routes/_authenticated/_dashboard/layout.tsx\`
DashboardLayout の最外 \`div\` に \`bg-tertiary\` を追加。Settings と同じ二層構造 (\`bg-tertiary\` ラッパー + \`bg-background\` コンテンツ) にし、プレビューと実画面の見え方を揃える。

\`\`\`diff
- <div className="flex flex-col h-full w-full">
+ <div className="flex flex-col h-full w-full bg-tertiary">
\`\`\`

### 2. \`apps/desktop/src/renderer/globals.css\`
ダイアログ系の vibrancy override を \`var(--popover)\` → \`var(--background-solid)\` に変更。vibrancy ON / OFF どちらでもダイアログは完全不透明になる。

\`\`\`diff
:root[data-vibrancy="on"]
  :is(
    [data-slot="dialog-content"],
    [data-slot="alert-dialog-content"],
    [data-slot="sheet-content"],
    [data-slot="drawer-content"]
  ) {
- background-color: var(--popover);
+ background-color: var(--background-solid);
}
\`\`\`

調査の結果、アプリ内の全ダイアログ系UI (TodoManager / TodoModal / PresetsDialog / SearchDialog / NewWorkspaceModal / Alert helper など) はこの4種の \`data-slot\` のいずれかを経由しているため、これだけで全ダイアログが不透明になります。

## 影響範囲
- **対象**: vibrancy ON 時の Dialog / AlertDialog / Sheet / Drawer の Content 部分のみ
- **対象外** (意図的に半透明のまま): Popover / DropdownMenu / Select / Menubar / Tooltip / HoverCard
- vibrancy OFF 時の挙動は変化なし
- ダイアログの色味 (Dark/Monokai) はわずかに暗化、Light はほぼ同じ

## テスト
- [ ] Settings → Appearance → ウィンドウ透過 ON、不透明度を中間値に設定
- [ ] Settings 画面とメイン画面の見え方が**ほぼ揃う**ことを確認
- [ ] TODO ボタン → Agent Manager の背景が**完全に不透明**で、裏のデスクトップが見えないことを確認
- [ ] 新規ワークスペース作成モーダル / TodoModal も同様に不透明
- [ ] Tooltip / Popover / DropdownMenu は従来通り半透明のままであることを確認
- [ ] vibrancy OFF 状態でも見た目に変化がないことを確認 (light / dark / monokai)