### PR TITLE
fix(desktop): PR返信ダイアログの返信元をMarkdownレンダリング対応 (#214)

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/ReviewPanel/ReviewPanel.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/ReviewPanel/ReviewPanel.tsx
@@ -19,7 +19,7 @@ import { Skeleton } from "@superset/ui/skeleton";
 import { toast } from "@superset/ui/sonner";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { cn } from "@superset/ui/utils";
-import { memo, useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import {
 	LuArrowUpRight,
 	LuCheck,
@@ -33,18 +33,13 @@ import {
 	LuX,
 } from "react-icons/lu";
 import { VscChevronRight } from "react-icons/vsc";
-import ReactMarkdown from "react-markdown";
-import rehypeRaw from "rehype-raw";
-import rehypeSanitize from "rehype-sanitize";
-import remarkGfm from "remark-gfm";
-import { remarkAlert } from "remark-github-blockquote-alert";
-import { CodeBlock } from "renderer/components/MarkdownRenderer/components/CodeBlock";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { showGitConfirmDialog } from "renderer/lib/git/gitConfirmDialog";
 import { PRIcon } from "renderer/screens/main/components/PRIcon";
 import { useWorkspaceId } from "renderer/screens/main/components/WorkspaceView/WorkspaceIdContext";
 import { useTabsStore } from "renderer/stores/tabs";
 import { CheckSteps } from "./components/CheckSteps";
+import { CommentBody } from "./components/CommentBody";
 import { ReplyDialog } from "./components/ReplyDialog";
 import {
 	ALL_COMMENTS_COPY_ACTION_KEY,
@@ -60,44 +55,7 @@ import {
 	resolveCheckDestinationUrl,
 	reviewDecisionConfig,
 	splitPullRequestComments,
-	stripHtmlComments,
 } from "./utils";
-
-const CommentBody = memo(function CommentBody({
-	body,
-	onOpenUrl,
-}: {
-	body: string;
-	onOpenUrl: (url: string, e: React.MouseEvent) => void;
-}) {
-	return (
-		<ReactMarkdown
-			remarkPlugins={[remarkGfm, remarkAlert]}
-			rehypePlugins={[rehypeRaw, rehypeSanitize]}
-			components={{
-				a: ({ href, children }) =>
-					href ? (
-						<a
-							href={href}
-							className="text-primary underline"
-							onClick={(e) => onOpenUrl(href, e)}
-						>
-							{children}
-						</a>
-					) : (
-						<span>{children}</span>
-					),
-				code: ({ className, children, node }) => (
-					<CodeBlock className={className} node={node}>
-						{children}
-					</CodeBlock>
-				),
-			}}
-		>
-			{stripHtmlComments(body)}
-		</ReactMarkdown>
-	);
-});
 
 function buildIdentitySummary(items: string[]): string {
 	if (items.length === 0) {
@@ -1464,6 +1422,7 @@ export function ReviewPanel({
 				onOpenChange={handleReplyDialogOpenChange}
 				onSubmit={handleSubmitReply}
 				isSubmitting={isReplySubmitting}
+				onOpenUrl={handleOpenUrl}
 			/>
 		</div>
 	);

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/ReviewPanel/components/CommentBody/CommentBody.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/ReviewPanel/components/CommentBody/CommentBody.tsx
@@ -1,0 +1,46 @@
+import { memo } from "react";
+import ReactMarkdown from "react-markdown";
+import rehypeRaw from "rehype-raw";
+import rehypeSanitize from "rehype-sanitize";
+import remarkGfm from "remark-gfm";
+import { remarkAlert } from "remark-github-blockquote-alert";
+import { CodeBlock } from "renderer/components/MarkdownRenderer/components/CodeBlock";
+import { stripHtmlComments } from "../../utils";
+
+interface CommentBodyProps {
+	body: string;
+	onOpenUrl?: (url: string, e: React.MouseEvent) => void;
+}
+
+export const CommentBody = memo(function CommentBody({
+	body,
+	onOpenUrl,
+}: CommentBodyProps) {
+	return (
+		<ReactMarkdown
+			remarkPlugins={[remarkGfm, remarkAlert]}
+			rehypePlugins={[rehypeRaw, rehypeSanitize]}
+			components={{
+				a: ({ href, children }) =>
+					href ? (
+						<a
+							href={href}
+							className="text-primary underline"
+							onClick={(e) => onOpenUrl?.(href, e)}
+						>
+							{children}
+						</a>
+					) : (
+						<span>{children}</span>
+					),
+				code: ({ className, children, node }) => (
+					<CodeBlock className={className} node={node}>
+						{children}
+					</CodeBlock>
+				),
+			}}
+		>
+			{stripHtmlComments(body)}
+		</ReactMarkdown>
+	);
+});

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/ReviewPanel/components/CommentBody/index.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/ReviewPanel/components/CommentBody/index.ts
@@ -1,0 +1,1 @@
+export { CommentBody } from "./CommentBody";

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/ReviewPanel/components/ReplyDialog/ReplyDialog.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/ReviewPanel/components/ReplyDialog/ReplyDialog.tsx
@@ -12,7 +12,8 @@ import {
 import { Textarea } from "@superset/ui/textarea";
 import { useEffect, useRef, useState } from "react";
 import { LuLoaderCircle } from "react-icons/lu";
-import { getCommentAvatarFallback, getCommentPreviewText } from "../../utils";
+import { getCommentAvatarFallback } from "../../utils";
+import { CommentBody } from "../CommentBody";
 
 interface ReplyDialogProps {
 	comment: PullRequestComment | null;
@@ -20,6 +21,7 @@ interface ReplyDialogProps {
 	onOpenChange: (open: boolean) => void;
 	onSubmit: (body: string) => Promise<void> | void;
 	isSubmitting: boolean;
+	onOpenUrl?: (url: string, e: React.MouseEvent) => void;
 }
 
 export function ReplyDialog({
@@ -28,6 +30,7 @@ export function ReplyDialog({
 	onOpenChange,
 	onSubmit,
 	isSubmitting,
+	onOpenUrl,
 }: ReplyDialogProps) {
 	const [body, setBody] = useState("");
 	const inFlightRef = useRef(false);
@@ -87,7 +90,7 @@ export function ReplyDialog({
 					</DialogDescription>
 				</DialogHeader>
 
-				<div className="max-h-32 overflow-y-auto rounded-md border border-border/60 bg-muted/30 p-2 text-xs">
+				<div className="max-h-48 overflow-y-auto rounded-md border border-border/60 bg-muted/30 p-2 text-xs">
 					<div className="mb-1 flex items-center gap-1.5">
 						<Avatar className="size-4">
 							{comment.avatarUrl ? (
@@ -110,9 +113,9 @@ export function ReplyDialog({
 							</span>
 						) : null}
 					</div>
-					<p className="whitespace-pre-wrap text-muted-foreground">
-						{getCommentPreviewText(comment.body)}
-					</p>
+					<div className="review-comment-body break-words text-xs leading-5 text-muted-foreground">
+						<CommentBody body={comment.body} onOpenUrl={onOpenUrl} />
+					</div>
 				</div>
 
 				<form className="space-y-3" onSubmit={handleSubmit}>


### PR DESCRIPTION
## 概要

Issue #214 対応。PR コメント返信ダイアログ (`ReplyDialog`) の「返信元コメント」表示が `getCommentPreviewText` によってプレーンテキスト化されており、画像・リンク・コードブロックなど Markdown 要素がレンダリングされていなかった問題を修正する。

## 変更内容

- `ReviewPanel` 内にインライン定義されていた `CommentBody` コンポーネントを `components/CommentBody/` に切り出し、`ReviewPanel` と `ReplyDialog` の両方から再利用できるようにした
- `ReplyDialog` の返信元プレビュー表示を `getCommentPreviewText` による1行プレーンテキストから `CommentBody` によるフル Markdown レンダリング (GFM / rehype-sanitize / blockquote alert / コードブロック) に差し替え
- 返信元の高さ上限を `max-h-32` → `max-h-48` に拡張し、複数行/画像入りの本文でもスクロールで読めるように調整
- `ReviewPanel` から `ReplyDialog` へ `onOpenUrl` を渡し、返信元内リンクも既存のブラウザタブで開く挙動に統一

## 関連 Issue

Closes #214

## テスト観点

- [ ] PR の通常コメントに画像/リンク/コードブロックが含まれる状態で返信ダイアログを開き、Markdown が正しくレンダリングされること
- [ ] レビュースレッドへの返信ダイアログでも同様に Markdown が表示されること
- [ ] 返信元内のリンクをクリックすると既存のブラウザタブで開くこと
- [ ] 返信投稿自体の動作に回帰がないこと