### PR TITLE
fix(desktop): スケジュール作成ダイアログの横幅を広げる (#215)

### DIFF
--- a/apps/desktop/src/renderer/features/todo-agent/TodoManager/SchedulesSection/components/ScheduleEditorDialog/ScheduleEditorDialog.tsx
+++ b/apps/desktop/src/renderer/features/todo-agent/TodoManager/SchedulesSection/components/ScheduleEditorDialog/ScheduleEditorDialog.tsx
@@ -218,7 +218,7 @@ export function ScheduleEditorDialog({
 
 	return (
 		<Dialog open={open} onOpenChange={onOpenChange}>
-			<DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
+			<DialogContent className="max-w-5xl w-[92vw] max-h-[90vh] overflow-y-auto">
 				<DialogHeader>
 					<DialogTitle>
 						{initial ? "スケジュールを編集" : "新しいスケジュール"}


### PR DESCRIPTION
## Summary
- スケジュール作成/編集ダイアログの `DialogContent` を `max-w-2xl` (672px) から `max-w-5xl` (1024px) に拡大
- 小画面での見切れ防止に `w-[92vw]` を併用
- 2カラムレイアウトの各列がフォーム入力・textarea に十分な幅を確保できるようにする

Closes #215

## Screenshot

Before: `max-w-2xl` (672px) — 2カラム時に入力欄が狭く窮屈
After: `max-w-5xl` (1024px, 画面が狭ければ92vw) — 余裕を持って入力できる

## Test plan
- [ ] アプリ起動後、TODOスケジュール管理からダイアログを開き横幅が広がっていること
- [ ] ウィンドウを縮めたときにもダイアログがはみ出ないこと（92vw で追従）
- [ ] 既存のフォーム挙動・保存動作が変わらないこと