### PR TITLE
fix(desktop): Agent Manager 設定ダイアログでマネージャが閉じる問題を修正 (#217)

### DIFF
--- a/apps/desktop/src/renderer/features/todo-agent/TodoManager/TodoManager.tsx
+++ b/apps/desktop/src/renderer/features/todo-agent/TodoManager/TodoManager.tsx
@@ -615,11 +615,17 @@ export function TodoManager({
 						)}
 					</div>
 				</div>
+				{/*
+				  Rendered inside DialogContent (same pattern as
+				  ScheduleEditorDialog in SchedulesSection) so the
+				  settings dialog stacks on top of the Manager without
+				  causing the outer Dialog to close. See Issue #217.
+				*/}
+				<PresetsDialog
+					open={presetsDialogOpen}
+					onOpenChange={setPresetsDialogOpen}
+				/>
 			</DialogContent>
-			<PresetsDialog
-				open={presetsDialogOpen}
-				onOpenChange={setPresetsDialogOpen}
-			/>
 		</Dialog>
 	);
 }


### PR DESCRIPTION
## 概要

Issue #217 の修正。Agent Manager の「設定 / プリセット」ボタンで開く設定ダイアログが、
**開くたびに Agent Manager 自体を閉じてしまう** 問題を修正した。

## 原因

`TodoManager.tsx` では `PresetsDialog` を次のように `DialogContent` の外側・`Dialog` の
兄弟として配置していた:

\`\`\`tsx
<Dialog open={open} onOpenChange={onOpenChange}>
  <DialogContent>
    ...
  </DialogContent>
  <PresetsDialog ... />   // ← DialogContent の外
</Dialog>
\`\`\`

この配置だと Radix UI の DismissableLayer 側で **兄弟関係のネストを「ネスト」として
認識できない**。結果、設定ダイアログ内のクリックが親 `DialogContent` から見て
「外側クリック」と判定され、`onOpenChange(false)` が発火して Agent Manager が
閉じてしまっていた。

スケジュールタブの「新規」ボタンで開く `ScheduleEditorDialog` は
`SchedulesSection` の中（= `DialogContent` の内側）で描画されているため、
Radix が正しく入れ子と認識して親は閉じない。これが挙動差の原因だった。

## 修正

`PresetsDialog` を `DialogContent` の内側へ移動し、`ScheduleEditorDialog` と
同じ配置パターンに揃えた。

## テスト手順

- [ ] Agent Manager を開く
- [ ] 左下の「設定 / プリセット」をクリック
- [ ] 設定ダイアログが Agent Manager の **上** に重ねて開き、Agent Manager は
      閉じないことを確認
- [ ] 設定ダイアログを閉じると Agent Manager だけが残ることを確認
- [ ] スケジュールタブ → 「新規」ボタンの従来挙動に変化がないことを確認

Closes #217