### PR TITLE
fix(desktop): TODO の maxConcurrentTasks を尊重しキュー消化する (#220)

### DIFF
--- a/apps/desktop/src/main/todo-agent/supervisor.ts
+++ b/apps/desktop/src/main/todo-agent/supervisor.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import type { SelectTodoSession } from "@superset/local-db";
 import { getCurrentHeadSha } from "./git-status";
 import { getTodoSessionStore, resolveWorktreePath } from "./session-store";
+import { getTodoSettings } from "./settings";
 import type { TodoStreamEventKind } from "./types";
 import { TODO_ARTIFACT_SUBDIR } from "./types";
 
@@ -46,7 +47,13 @@ interface ActiveRun {
 }
 
 class TodoSupervisor {
-	private active: ActiveRun | undefined;
+	/**
+	 * Currently executing sessions keyed by sessionId. The size of this map
+	 * is compared against `maxConcurrentTasks` in `drain()` to decide whether
+	 * the next pending session can start. Keyed storage (as opposed to a
+	 * single slot) lets `abort()` target a specific run without scanning.
+	 */
+	private readonly active = new Map<string, ActiveRun>();
 	private readonly queue: string[] = [];
 
 	/**
@@ -81,12 +88,38 @@ class TodoSupervisor {
 	}
 
 	async start(sessionId: string): Promise<void> {
-		if (this.active) {
-			if (!this.queue.includes(sessionId)) this.queue.push(sessionId);
-			return;
-		}
-		await this.runSession(sessionId);
-		while (this.queue.length > 0) {
+		// Already executing or queued — no-op so repeated `start` calls
+		// from the UI do not create duplicate work.
+		if (this.active.has(sessionId)) return;
+		if (this.queue.includes(sessionId)) return;
+		this.queue.push(sessionId);
+		this.drain();
+	}
+
+	/**
+	 * Called by the settings mutation after `maxConcurrentTasks` changes.
+	 * When the user raises the concurrency cap we need to pull the next
+	 * pending sessions from the queue immediately — otherwise they sit
+	 * idle until the currently active session completes, which is the
+	 * exact symptom reported in issue #220. Lowering the cap is handled
+	 * passively (new starts are blocked until capacity frees up; already
+	 * running sessions keep running).
+	 */
+	handleSettingsChanged(): void {
+		this.drain();
+	}
+
+	/**
+	 * Launch as many queued sessions as `maxConcurrentTasks` permits.
+	 * Synchronous: each launch kicks off `runSession` as a fire-and-
+	 * forget Promise whose `finally` loops back into `drain()` so the
+	 * next slot fills as soon as a session finishes. The settings value
+	 * is re-read on every call so live setting updates take effect
+	 * without restart.
+	 */
+	private drain(): void {
+		const capacity = getTodoSettings().maxConcurrentTasks;
+		while (this.active.size < capacity && this.queue.length > 0) {
 			const next = this.queue.shift();
 			if (!next) continue;
 			// A session can be aborted / deleted / rerun while still
@@ -103,7 +136,20 @@ class TodoSupervisor {
 			) {
 				continue;
 			}
-			await this.runSession(next);
+			// `runSession` sets `this.active[sessionId]` synchronously
+			// before its first `await`, so by the time control returns
+			// here the slot count reflects the new run and the while
+			// loop's capacity check stays accurate.
+			void this.runSession(next)
+				.catch((err) => {
+					console.warn(
+						`[todo-supervisor] runSession crashed for ${next}:`,
+						err,
+					);
+				})
+				.finally(() => {
+					this.drain();
+				});
 		}
 	}
 
@@ -116,8 +162,9 @@ class TodoSupervisor {
 		if (queueIdx !== -1) {
 			this.queue.splice(queueIdx, 1);
 		}
-		if (this.active?.sessionId === sessionId) {
-			this.active.abortController.abort();
+		const activeRun = this.active.get(sessionId);
+		if (activeRun) {
+			activeRun.abortController.abort();
 			// Kill the whole process group, not just the direct child.
 			// `claude -p` spawns its own children (the Node-side agent
 			// loop, MCP servers, tool helpers). A plain `child.kill()`
@@ -127,7 +174,7 @@ class TodoSupervisor {
 			// actually stop. We `spawn` with `detached: true` so the
 			// child becomes a session leader; here we signal the
 			// negative PID to reach every descendant.
-			const child = this.active.currentChild;
+			const child = activeRun.currentChild;
 			if (child?.pid) {
 				const pid = child.pid;
 				killProcessTree(pid, "SIGINT");
@@ -211,7 +258,7 @@ class TodoSupervisor {
 			startedAt: Date.now(),
 			currentChild: null,
 		};
-		this.active = run;
+		this.active.set(sessionId, run);
 
 		try {
 			appendSetupEvent(
@@ -550,7 +597,7 @@ class TodoSupervisor {
 				});
 			}
 		} finally {
-			this.active = undefined;
+			this.active.delete(sessionId);
 		}
 	}
 

--- a/apps/desktop/src/main/todo-agent/trpc-router.ts
+++ b/apps/desktop/src/main/todo-agent/trpc-router.ts
@@ -649,7 +649,15 @@ export const createTodoAgentRouter = () => {
 			get: publicProcedure.query(() => getTodoSettings()),
 			update: publicProcedure
 				.input(todoSettingsUpdateSchema)
-				.mutation(({ input }) => updateTodoSettings(input)),
+				.mutation(({ input }) => {
+					const next = updateTodoSettings(input);
+					// Nudge the supervisor so a raised `maxConcurrentTasks`
+					// immediately releases queued sessions. Without this, a
+					// bump from 1 → N leaves already-pending tasks waiting
+					// until the currently running session finishes.
+					getTodoSupervisor().handleSettingsChanged();
+					return next;
+				}),
 		}),
 
 		schedule: router({


### PR DESCRIPTION
## Summary

Issue #220 の修正。TODO 機能の最大同時実行数設定が実質未実装で、常に 1 セッションずつ順次実行されていた。また設定変更時に supervisor に通知が届かないため、1→2 への引き上げ後も pending タスクが動き出さなかった。

## 原因

- `TodoSupervisor.active` が `ActiveRun | undefined` で、シングルスロット実装だった
- `start()` は `if (this.active) { queue.push(); return; }` とするだけで、`maxConcurrentTasks` をどこからも参照していなかった
- `updateTodoSettings()` は JSON を書き換えるだけで、supervisor へ通知する経路がなかった

## 修正内容

- `apps/desktop/src/main/todo-agent/supervisor.ts`
  - `active` を `Map<string, ActiveRun>` に変更（keyed storage）
  - `start()` を「キューへ追加して `drain()` を呼ぶ」形に変更
  - `drain()` メソッドを追加。毎回 `getTodoSettings().maxConcurrentTasks` を読み直し、容量が空いていて終端状態でないセッションを順次起動する
  - 各 `runSession` を fire-and-forget にし、`finally` でスロット解放 + `drain()` 再実行
  - `handleSettingsChanged()` を追加。設定変更直後に drain して詰まっていたタスクを即起動する
  - `abort()` を Map ベースに書き換え、対象セッションだけ停止
- `apps/desktop/src/main/todo-agent/trpc-router.ts`
  - `todoAgent.settings.update` ミューテーション内で `updateTodoSettings` 後に `getTodoSupervisor().handleSettingsChanged()` を呼ぶ

## 動作

- maxConcurrentTasks=1 の状態で 2 タスク作成 → 従来通り 1 つずつ順次
- maxConcurrentTasks=2 に上げた瞬間 → 残りの pending タスクが即 running に
- 実行中に減らした場合 → 走っているセッションはそのまま継続、以後の新規 start は容量空きまで待機
- start() 重複呼び出しは `active.has() || queue.includes()` でガード

## Test plan

- [ ] `bun run lint` 通過
- [ ] `bun run typecheck` 通過
- [ ] 手動: maxConcurrentTasks=1 で 2 タスク作成 → 1 つだけ running、もう 1 つは queued
- [ ] 手動: 上記の状態で maxConcurrentTasks を 2 に変更 → 2 つ目も running に切り替わる
- [ ] 手動: maxConcurrentTasks=3 で 3 タスク同時起動 → 3 つとも running

Closes #220