### PR TITLE
fix(desktop): Agent Manager の タスク/スケジュール タブの UI 統一 (#222)

### DIFF
--- a/apps/desktop/src/renderer/features/todo-agent/TodoManager/SchedulesSection/SchedulesSection.tsx
+++ b/apps/desktop/src/renderer/features/todo-agent/TodoManager/SchedulesSection/SchedulesSection.tsx
@@ -1,5 +1,6 @@
 import type { SelectTodoSchedule } from "@superset/local-db";
 import { Button } from "@superset/ui/button";
+import { Input } from "@superset/ui/input";
 import { ScrollArea } from "@superset/ui/scroll-area";
 import { useMemo, useState } from "react";
 import { HiMiniPlus } from "react-icons/hi2";
@@ -15,6 +16,7 @@ import { ScheduleListRow } from "./components/ScheduleListRow";
 export function SchedulesSection() {
 	const [editorOpen, setEditorOpen] = useState(false);
 	const [editing, setEditing] = useState<SelectTodoSchedule | null>(null);
+	const [filter, setFilter] = useState("");
 
 	const { data: schedules } = electronTrpc.todoAgent.schedule.listAll.useQuery(
 		undefined,
@@ -36,6 +38,25 @@ export function SchedulesSection() {
 		for (const p of projects ?? []) map.set(p.id, p.name);
 		return map;
 	}, [projects]);
+
+	const filteredSchedules = useMemo(() => {
+		const list = schedules ?? [];
+		const needle = filter.trim().toLowerCase();
+		if (!needle) return list;
+		return list.filter((s) => {
+			const wsName = s.workspaceId
+				? (workspaceNameById.get(s.workspaceId) ?? "")
+				: "";
+			const projName = projectNameById.get(s.projectId) ?? "";
+			return (
+				s.name.toLowerCase().includes(needle) ||
+				s.title.toLowerCase().includes(needle) ||
+				s.description.toLowerCase().includes(needle) ||
+				wsName.toLowerCase().includes(needle) ||
+				projName.toLowerCase().includes(needle)
+			);
+		});
+	}, [schedules, filter, workspaceNameById, projectNameById]);
 
 	const openNew = () => {
 		setEditing(null);
@@ -65,9 +86,17 @@ export function SchedulesSection() {
 					新規
 				</Button>
 			</div>
+			<div className="p-2 border-b shrink-0">
+				<Input
+					value={filter}
+					onChange={(e) => setFilter(e.target.value)}
+					placeholder="絞り込み（名前 / タイトル / プロジェクト）"
+					className="h-8 text-xs rounded-md"
+				/>
+			</div>
 			<ScrollArea className="flex-1">
 				<div className="flex flex-col gap-1.5 p-2">
-					{(schedules?.length ?? 0) === 0 && (
+					{(schedules?.length ?? 0) === 0 ? (
 						<p className="text-xs text-muted-foreground px-1 py-4">
 							まだスケジュールはありません。「新規」ボタンから作成してください。
 							<br />
@@ -75,20 +104,25 @@ export function SchedulesSection() {
 								スケジュールはアプリ起動中のみ発火します。
 							</span>
 						</p>
+					) : filteredSchedules.length === 0 ? (
+						<p className="text-xs text-muted-foreground px-1 py-4">
+							条件に一致するスケジュールがありません。
+						</p>
+					) : (
+						filteredSchedules.map((schedule) => (
+							<ScheduleListRow
+								key={schedule.id}
+								schedule={schedule}
+								projectName={projectNameById.get(schedule.projectId) ?? null}
+								workspaceName={
+									schedule.workspaceId
+										? (workspaceNameById.get(schedule.workspaceId) ?? null)
+										: null
+								}
+								onEdit={() => openEdit(schedule)}
+							/>
+						))
 					)}
-					{(schedules ?? []).map((schedule) => (
-						<ScheduleListRow
-							key={schedule.id}
-							schedule={schedule}
-							projectName={projectNameById.get(schedule.projectId) ?? null}
-							workspaceName={
-								schedule.workspaceId
-									? (workspaceNameById.get(schedule.workspaceId) ?? null)
-									: null
-							}
-							onEdit={() => openEdit(schedule)}
-						/>
-					))}
 				</div>
 			</ScrollArea>
 

--- a/apps/desktop/src/renderer/features/todo-agent/TodoManager/TodoManager.tsx
+++ b/apps/desktop/src/renderer/features/todo-agent/TodoManager/TodoManager.tsx
@@ -490,6 +490,22 @@ export function TodoManager({
 							<SchedulesSection />
 						) : (
 							<>
+								<div className="p-2 border-b shrink-0 flex items-center justify-between gap-2">
+									<span className="text-xs text-muted-foreground">
+										{(sessions?.length ?? 0) > 0
+											? `${sessions?.length} 件のタスク`
+											: "タスクなし"}
+									</span>
+									<Button
+										type="button"
+										size="sm"
+										className="h-7 gap-1 px-2.5 text-xs rounded-md"
+										onClick={() => setComposerOpen(true)}
+									>
+										<HiMiniPlus className="size-4" />
+										新規
+									</Button>
+								</div>
 								<div className="p-2 border-b shrink-0">
 									<Input
 										value={filter}
@@ -502,7 +518,7 @@ export function TodoManager({
 									{grouped.length === 0 && (
 										<p className="text-xs text-muted-foreground px-3 py-6">
 											{(sessions?.length ?? 0) === 0
-												? "まだ TODO セッションはありません。右上の『新しい TODO』から作成してください。"
+												? "まだ TODO セッションはありません。『新規』から作成してください。"
 												: "条件に一致するセッションがありません。"}
 										</p>
 									)}
@@ -566,16 +582,7 @@ export function TodoManager({
 					</div>
 
 					<div className="flex-1 min-w-0 min-h-0 flex flex-col">
-						{composerOpen ? (
-							<TodoComposer
-								currentWorkspaceId={currentWorkspaceId}
-								onCreated={(id) => {
-									setComposerOpen(false);
-									setSelectedId(id);
-								}}
-								onCancel={() => setComposerOpen(false)}
-							/>
-						) : selected ? (
+						{selected ? (
 							<SessionDetail
 								session={selected}
 								onDeleted={() => setSelectedId(null)}
@@ -620,6 +627,24 @@ export function TodoManager({
 				open={presetsDialogOpen}
 				onOpenChange={setPresetsDialogOpen}
 			/>
+			<Dialog open={composerOpen} onOpenChange={setComposerOpen}>
+				<DialogContent
+					className="w-[1080px] max-w-[calc(100vw-3rem)] h-[84vh] max-h-[900px] p-0 gap-0 overflow-hidden flex flex-col rounded-xl"
+					showCloseButton={false}
+				>
+					<DialogTitle className="sr-only">新しい TODO</DialogTitle>
+					{composerOpen && (
+						<TodoComposer
+							currentWorkspaceId={currentWorkspaceId}
+							onCreated={(id) => {
+								setComposerOpen(false);
+								setSelectedId(id);
+							}}
+							onCancel={() => setComposerOpen(false)}
+						/>
+					)}
+				</DialogContent>
+			</Dialog>
 		</Dialog>
 	);
 }


### PR DESCRIPTION
## 概要

Closes #222

Agent Manager 左サイドバーの「タスク」タブと「スケジュール」タブの UI を揃え、新しい TODO の作成を Agent Manager 内のインライン表示ではなく Dialog で開くように変更しました。

## 変更点

- **スケジュールタブに検索機能を追加**: 名前 / TODO タイトル / プロジェクト / ワークスペース でフィルタできる検索欄をリストの上に追加。
- **タスクタブに「新規」ボタンを追加**: スケジュールと同じ行（件数表示 + 新規ボタン）をリストの上に追加し、両タブで同じレイアウトに統一。
- **TODO Composer を Dialog 化**: 右上の「新しい TODO」ボタンと、追加した「新規」ボタンの両方から、Agent Manager 内ではなく独立した Dialog として Composer が開くように変更（スケジュール編集 Dialog と同じ振る舞い）。
- 空状態メッセージの文言を「右上の『新しい TODO』」から「『新規』」に更新。

## スクリーンショット / 動作確認観点

- タスクタブ / スケジュールタブで、件数 + 新規ボタン + 検索欄 の並びが一致していること
- 「新しい TODO」「タスクタブの新規」両方のボタンが Dialog で Composer を開くこと
- スケジュールタブの検索欄で絞り込みが正しく動作すること
- 既存の右カラム（変更パネル）・セッション詳細の表示は変わらないこと

## 補足

- Composer 本体 (`TodoComposer`) のロジックには手を入れず、描画先だけを変更しました。
- `composerOpen` state は残したまま、インライン分岐を削除して Dialog でラップする形に変更。
- `onRequestNewTodo` prop（未使用の下線付き受け取り）も変更なし。