### PR TITLE
fix(desktop): AgentManager 右サイドバーにセッション全体の差分を表示

### DIFF
--- a/apps/desktop/src/main/todo-agent/git-status.ts
+++ b/apps/desktop/src/main/todo-agent/git-status.ts
@@ -20,6 +20,23 @@ async function gitOut(args: string[], cwd: string): Promise<string> {
 	}
 }
 
+/**
+ * Does `sha` resolve to a commit object in `cwd`'s git dir? Used to
+ * distinguish "no new commits" from "startHeadSha was orphaned by a
+ * reset/rebase" — otherwise both look identical in the sidebar.
+ */
+async function gitRevExists(sha: string, cwd: string): Promise<boolean> {
+	try {
+		await execGitWithShellPath(
+			["rev-parse", "--verify", "--quiet", `${sha}^{commit}`],
+			{ cwd },
+		);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
 export async function getCurrentHeadSha(cwd: string): Promise<string | null> {
 	const out = (await gitOut(["rev-parse", "HEAD"], cwd)).trim();
 	return out || null;
@@ -42,12 +59,34 @@ export interface SessionGitFile {
 	code: string;
 }
 
+export interface SessionGitChangedFile {
+	path: string;
+	/** First letter of git's name-status code: A / M / D / R / C / T */
+	code: string;
+}
+
 export interface SessionGitSnapshot {
 	branch: string | null;
 	startHeadSha: string | null;
 	currentHeadSha: string | null;
 	commits: SessionGitCommit[];
 	workingTree: SessionGitFile[];
+	/**
+	 * Files whose contents differ between `startHeadSha` and HEAD
+	 * (two-dot `git diff`). Populated regardless of whether HEAD is a
+	 * descendant of startHeadSha, so branch switches / rebases still
+	 * surface the cumulative session delta instead of silently
+	 * rendering an empty sidebar.
+	 */
+	sessionFiles: SessionGitChangedFile[];
+	/**
+	 * True when `startHeadSha` is set but its commit object is no
+	 * longer reachable (e.g. the branch was reset and the object was
+	 * pruned, or a different repo was swapped in under the worktree).
+	 * The UI uses this to show an explanatory message rather than a
+	 * silently empty panel.
+	 */
+	startHeadUnreachable: boolean;
 	ahead: number;
 	behind: number;
 }
@@ -68,32 +107,53 @@ export async function getSessionGitSnapshot(params: {
 	const branch = branchOut.trim() || null;
 	const currentHeadSha = currentOut.trim() || null;
 
-	// Commits produced since the session started. If start and current
-	// are the same (no new commits yet) this returns an empty list.
+	// Commits produced since the session started. Scoped to the range
+	// `startHeadSha..HEAD`; when HEAD is not a descendant of
+	// startHeadSha (branch switch / reset / rebase), this can validly
+	// return an empty list, and we surface cumulative file-level
+	// changes via `sessionFiles` below so the sidebar isn't empty.
 	let commits: SessionGitCommit[] = [];
+	let sessionFiles: SessionGitChangedFile[] = [];
+	let startHeadUnreachable = false;
 	if (startHeadSha && currentHeadSha && startHeadSha !== currentHeadSha) {
-		const logOut = await gitOut(
-			[
-				"log",
-				`${startHeadSha}..${currentHeadSha}`,
-				`--format=${COMMIT_FORMAT}`,
-			],
-			cwd,
-		);
-		commits = logOut
-			.split("\n")
-			.filter((l) => l.length > 0)
-			.map((line) => {
-				const [sha, shortSha, subject, authorName, authorDate] =
-					line.split(COMMIT_DELIM);
-				return {
-					sha: sha ?? "",
-					shortSha: shortSha ?? "",
-					subject: subject ?? "",
-					authorName: authorName ?? "",
-					authorDate: authorDate ?? "",
-				};
-			});
+		const reachable = await gitRevExists(startHeadSha, cwd);
+		if (!reachable) {
+			startHeadUnreachable = true;
+		} else {
+			const logOut = await gitOut(
+				[
+					"log",
+					`${startHeadSha}..${currentHeadSha}`,
+					`--format=${COMMIT_FORMAT}`,
+				],
+				cwd,
+			);
+			commits = logOut
+				.split("\n")
+				.filter((l) => l.length > 0)
+				.map((line) => {
+					const [sha, shortSha, subject, authorName, authorDate] =
+						line.split(COMMIT_DELIM);
+					return {
+						sha: sha ?? "",
+						shortSha: shortSha ?? "",
+						subject: subject ?? "",
+						authorName: authorName ?? "",
+						authorDate: authorDate ?? "",
+					};
+				});
+
+			// `git diff --name-status -z A B` compares the two commits
+			// directly (two-dot in diff has no range semantics), so it
+			// works even when A and B are on divergent histories. This
+			// is what lets the sidebar show the real session delta
+			// when commits are zero but files were touched.
+			const diffOut = await gitOut(
+				["diff", "--name-status", "-z", startHeadSha, currentHeadSha],
+				cwd,
+			);
+			sessionFiles = parseNameStatusNul(diffOut);
+		}
 	}
 
 	// Working tree state via porcelain v1 for stable parsing.
@@ -152,9 +212,43 @@ export async function getSessionGitSnapshot(params: {
 		currentHeadSha,
 		commits,
 		workingTree,
+		sessionFiles,
+		startHeadUnreachable,
 		ahead,
 		behind,
 	};
+}
+
+/**
+ * Parse `git diff --name-status -z` output.
+ *
+ * Standard entries are `<CODE>\0<path>\0`; rename/copy entries are
+ * `<CODE><score>\0<oldPath>\0<newPath>\0` — we keep only the new path
+ * and collapse the code to its first letter so the UI can render a
+ * single badge per file.
+ */
+function parseNameStatusNul(raw: string): SessionGitChangedFile[] {
+	const files: SessionGitChangedFile[] = [];
+	const parts = raw.split("\0");
+	let i = 0;
+	while (i < parts.length) {
+		const token = parts[i];
+		if (!token) {
+			i += 1;
+			continue;
+		}
+		const letter = token[0] ?? "";
+		if (letter === "R" || letter === "C") {
+			const newPath = parts[i + 2];
+			if (newPath) files.push({ path: newPath, code: letter });
+			i += 3;
+			continue;
+		}
+		const p = parts[i + 1];
+		if (p) files.push({ path: p, code: letter || token });
+		i += 2;
+	}
+	return files;
 }
 
 export type SessionDiffScope = "session" | "staged" | "unstaged" | "commit";

--- a/apps/desktop/src/main/todo-agent/supervisor.ts
+++ b/apps/desktop/src/main/todo-agent/supervisor.ts
@@ -224,12 +224,16 @@ class TodoSupervisor {
 			// sidebar can show exactly what this session produced via
 			// `git log <startHeadSha>..HEAD` — user commits made before
 			// the session are excluded from attribution.
+			//
+			// On resume (follow-up intervention), keep the ORIGINAL
+			// starting point. Overwriting it on every run moved the
+			// goalpost forward and hid earlier commits from the sidebar.
 			if (worktreePath) {
 				appendSetupEvent(sessionId, "worktree", worktreePath);
 			}
-			const startHeadSha = worktreePath
-				? await getCurrentHeadSha(worktreePath)
-				: null;
+			const startHeadSha =
+				session0.startHeadSha ??
+				(worktreePath ? await getCurrentHeadSha(worktreePath) : null);
 			if (startHeadSha) {
 				appendSetupEvent(
 					sessionId,

--- a/apps/desktop/src/renderer/features/todo-agent/TodoManager/ChangesSidebar/ChangesSidebar.tsx
+++ b/apps/desktop/src/renderer/features/todo-agent/TodoManager/ChangesSidebar/ChangesSidebar.tsx
@@ -188,12 +188,16 @@ export function ChangesSidebar({ sessionId, active }: ChangesSidebarProps) {
 								) : (
 									sessionFiles.map((file) => {
 										const key = `session:${file.path}`;
-										const canDiff = file.code !== "D";
+										// Deletions ARE the diff at session scope —
+										// `git diff <start>..HEAD -- <path>` still emits
+										// a valid deletion patch, so keep every entry
+										// clickable. The working-tree section below
+										// rightly disables `D`, because there the file
+										// is already gone from the worktree.
 										return (
 											<button
 												key={key}
 												type="button"
-												disabled={!canDiff}
 												onClick={() =>
 													setSelected({
 														key,
@@ -206,7 +210,6 @@ export function ChangesSidebar({ sessionId, active }: ChangesSidebarProps) {
 													"text-left rounded-md px-2 py-1 border border-transparent hover:bg-accent/50 hover:border-border/40 transition flex items-center gap-2",
 													selected?.key === key &&
 														"bg-accent border-primary/40",
-													!canDiff && "opacity-60 cursor-default",
 												)}
 											>
 												<StatusBadge code={file.code} stage="session" />

--- a/apps/desktop/src/renderer/features/todo-agent/TodoManager/ChangesSidebar/ChangesSidebar.tsx
+++ b/apps/desktop/src/renderer/features/todo-agent/TodoManager/ChangesSidebar/ChangesSidebar.tsx
@@ -33,6 +33,7 @@ export function ChangesSidebar({ sessionId, active }: ChangesSidebarProps) {
 	const [selected, setSelected] = useState<SelectedDiff | null>(null);
 	const [commitsOpen, setCommitsOpen] = useState(true);
 	const [workingTreeOpen, setWorkingTreeOpen] = useState(true);
+	const [sessionFilesOpen, setSessionFilesOpen] = useState(true);
 
 	const snapshot = electronTrpc.todoAgent.gitSnapshot.useQuery(
 		{ sessionId },
@@ -70,6 +71,8 @@ export function ChangesSidebar({ sessionId, active }: ChangesSidebarProps) {
 	const data = snapshot.data;
 	const commits = data?.commits ?? [];
 	const workingTree = data?.workingTree ?? [];
+	const sessionFiles = data?.sessionFiles ?? [];
+	const startHeadUnreachable = data?.startHeadUnreachable ?? false;
 
 	const stagedCount = useMemo(
 		() => workingTree.filter((f) => f.stage === "staged").length,
@@ -144,6 +147,79 @@ export function ChangesSidebar({ sessionId, active }: ChangesSidebarProps) {
 							このパネルに差分とコミット履歴が表示されます。
 						</div>
 					)}
+
+					{startHeadUnreachable && (
+						<div className="rounded-md border border-amber-500/40 bg-amber-500/10 px-2 py-1.5 text-[11px] text-amber-500">
+							開始時 HEAD
+							のコミットが見つかりません。ブランチがリセットされたか、
+							オブジェクトが失われている可能性があります。
+						</div>
+					)}
+
+					{/* Cumulative session delta (startHeadSha ↔ HEAD), shown
+					    even when no new commits exist so branch switches /
+					    rebases don't leave the sidebar looking empty. */}
+					<section>
+						<button
+							type="button"
+							onClick={() => setSessionFilesOpen((v) => !v)}
+							className="w-full flex items-center gap-1 text-[10px] uppercase tracking-wide text-muted-foreground font-semibold mb-1 hover:text-foreground transition"
+						>
+							{sessionFilesOpen ? (
+								<HiMiniChevronDown className="size-3" />
+							) : (
+								<HiMiniChevronRight className="size-3" />
+							)}
+							セッション全体
+							<span className="ml-1 text-muted-foreground/70">
+								({sessionFiles.length})
+							</span>
+						</button>
+						{sessionFilesOpen && (
+							<div className="flex flex-col gap-0.5">
+								{!data?.startHeadSha ? (
+									<p className="text-[11px] text-muted-foreground px-1 py-2">
+										開始時 HEAD が未記録のため、差分を算出できません。
+									</p>
+								) : sessionFiles.length === 0 ? (
+									<p className="text-[11px] text-muted-foreground px-1 py-2">
+										開始時からの差分はありません。
+									</p>
+								) : (
+									sessionFiles.map((file) => {
+										const key = `session:${file.path}`;
+										const canDiff = file.code !== "D";
+										return (
+											<button
+												key={key}
+												type="button"
+												disabled={!canDiff}
+												onClick={() =>
+													setSelected({
+														key,
+														path: file.path,
+														scope: "session",
+														label: file.path,
+													})
+												}
+												className={cn(
+													"text-left rounded-md px-2 py-1 border border-transparent hover:bg-accent/50 hover:border-border/40 transition flex items-center gap-2",
+													selected?.key === key &&
+														"bg-accent border-primary/40",
+													!canDiff && "opacity-60 cursor-default",
+												)}
+											>
+												<StatusBadge code={file.code} stage="session" />
+												<span className="text-[11px] font-mono truncate flex-1">
+													{file.path}
+												</span>
+											</button>
+										);
+									})
+								)}
+							</div>
+						)}
+					</section>
 
 					{/* Commits since session start */}
 					<section>
@@ -284,7 +360,7 @@ export function ChangesSidebar({ sessionId, active }: ChangesSidebarProps) {
 								<div className="text-[10px] uppercase tracking-wide text-muted-foreground font-semibold truncate">
 									{selected.scope === "commit"
 										? `コミット ${selected.label}`
-										: `${selected.scope === "staged" ? "staged" : "unstaged"} · ${selected.label}`}
+										: `${scopeLabel(selected.scope)} · ${selected.label}`}
 								</div>
 								<button
 									type="button"
@@ -393,4 +469,17 @@ function formatShortDate(iso: string): string {
 	if (Number.isNaN(d.getTime())) return iso;
 	const pad = (n: number) => n.toString().padStart(2, "0");
 	return `${pad(d.getMonth() + 1)}/${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+function scopeLabel(scope: DiffScope): string {
+	switch (scope) {
+		case "staged":
+			return "staged";
+		case "unstaged":
+			return "unstaged";
+		case "session":
+			return "セッション全体";
+		case "commit":
+			return "commit";
+	}
 }


### PR DESCRIPTION
Closes #226

## Summary
- AgentManager 右サイドバー「変更」パネルで、セッション中のコミット・ワーキングツリー差分が 0 件と表示されていた問題を修正。
- `git log startHeadSha..HEAD` は HEAD が startHeadSha の子孫でないと（ブランチ切替・reset・rebase）無音で 0 件を返すため、**「セッション全体」セクション**を新設して `git diff --name-status -z startHeadSha HEAD` で二コミット間のファイル差分をそのまま表示する。
- 開始HEAD が git オブジェクトから失われているケース（reset 等）を `gitRevExists` で検出し、UI にはアンバー色の注意バナーを出す。
- supervisor: resume のたびに `startHeadSha` が上書きされ初回ランの履歴が埋もれていた問題を修正。既に記録済みならそのまま維持する。

## 再現手順（修正前）
1. AgentManager で TODO タスクを作成して実行
2. タスク内でブランチを切替 or reset するなど、HEAD が startHeadSha の子孫にならない挙動を含ませる
3. 右サイドバーで「開始時 HEAD: A → B」と表示されるのに「コミット (0)」「ワーキングツリー (0)」で差分が一切見えない

## 修正後の挙動
- 右サイドバーに「セッション全体」セクションが追加され、開始HEAD と現在 HEAD の間のファイル差分が一覧される。
- ファイルをクリックすると `scope=session` で diff ビューアに展開される。
- 開始HEAD が reset 等で失われた場合は専用の注意バナーを表示。
- resume を繰り返しても最初に記録した開始HEAD が維持され、セッション全体のコミット履歴が見える。

## 変更ファイル
- \`apps/desktop/src/main/todo-agent/git-status.ts\`
- \`apps/desktop/src/main/todo-agent/supervisor.ts\`
- \`apps/desktop/src/renderer/features/todo-agent/TodoManager/ChangesSidebar/ChangesSidebar.tsx\`

## Test plan
- [ ] \`bun run lint\` / \`bun run typecheck\` ともに green（CIで確認）
- [ ] Electron を起動し、TODO セッションで実際に複数コミット→ブランチ切替→resume を行い、右サイドバーに
      - 「セッション全体」セクションが表示される
      - 「コミット」「ワーキングツリー」「セッション全体」それぞれのファイルクリックで差分が開く
      - 開始HEAD を `git reset` で失わせた場合に注意バナーが出る
      ことを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * セッション全体の変更ファイルをサイドバーで表示可能に。ファイルごとのdiff参照ができるようになりました。
  * セッション開始時点のコミットが到達不可能な場合に警告を表示。
  * 変更内容の閲覧範囲をセッションレベルで拡張し、より詳細なgit差分追跡が可能に。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->