### PR TITLE
fix(desktop): AgentManager の preparing 状態でも description/goal を編集可能に

### DIFF
--- a/apps/desktop/src/main/todo-agent/trpc-router.ts
+++ b/apps/desktop/src/main/todo-agent/trpc-router.ts
@@ -220,11 +220,12 @@ export const createTodoAgentRouter = () => {
 
 		/**
 		 * Edit the user-authored fields (description / goal) of a TODO
-		 * session that has not started yet. Allowed only in pre-start
-		 * states (queued / failed / aborted / escalated) so a running
-		 * worker's prompt can never mutate under its feet. When the
-		 * description / goal changes we rewrite the session's goal.md
-		 * so the next run picks up the edit.
+		 * session. Allowed in queued / preparing / failed / aborted /
+		 * escalated. `preparing` is safe because the supervisor has
+		 * not spawned Claude yet and `prepareArtifacts` will rewrite
+		 * goal.md before it is read. Refused once the session is
+		 * running / verifying so the worker's prompt never mutates
+		 * under its feet.
 		 */
 		updateFields: publicProcedure
 			.input(
@@ -251,6 +252,7 @@ export const createTodoAgentRouter = () => {
 				}
 				if (
 					session.status !== "queued" &&
+					session.status !== "preparing" &&
 					session.status !== "failed" &&
 					session.status !== "aborted" &&
 					session.status !== "escalated"
@@ -258,7 +260,7 @@ export const createTodoAgentRouter = () => {
 					throw new TRPCError({
 						code: "PRECONDITION_FAILED",
 						message:
-							"実行中またはキュー済みでないセッションは編集できません。中断してから再度お試しください。",
+							"実行中のセッションは編集できません。中断してから再度お試しください。",
 					});
 				}
 				const patch: {

--- a/apps/desktop/src/renderer/features/todo-agent/TodoManager/TodoManager.tsx
+++ b/apps/desktop/src/renderer/features/todo-agent/TodoManager/TodoManager.tsx
@@ -1030,7 +1030,25 @@ function SessionDetail({ session, onDeleted }: SessionDetailProps) {
 		}
 	}, [invalidate, rerunMut, session.id]);
 
-	const canEditFields = canStart && !isRunning;
+	// `preparing` is still editable: the supervisor has not spawned
+	// Claude yet, and prepareArtifacts rewrites goal.md before Claude
+	// reads it, so an edit during preparing still takes effect.
+	const canEditFields = canStart || session.status === "preparing";
+
+	// Bail out of any in-flight edit the moment the session starts
+	// actually running — e.g. a queued session whose turn arrived
+	// mid-edit — so the user doesn't hit Save only to get rejected by
+	// the backend guard. Only cancel on running/verifying; terminal
+	// states stay editable (rerun path).
+	useEffect(() => {
+		if (!editingField) return;
+		if (session.status !== "running" && session.status !== "verifying") return;
+		setEditingField(null);
+		setEditDraft("");
+		toast.warning(
+			"タスクの実行が開始されたため編集を中止しました。中断してから再度編集してください。",
+		);
+	}, [editingField, session.status]);
 
 	const startEditField = useCallback(
 		(field: "description" | "goal") => {


### PR DESCRIPTION
## 概要

AgentManager（TODO Agent Manager）でタスクの「やって欲しいこと」「ゴール」を編集できる状態を拡張し、`preparing` ステータスでも編集可能にした。併せて、編集中に他セッションの終了を受けて `running` に遷移した場合のレースに対処した。

Closes #232

## 背景

- これまで `preparing` ステータス（`start` 後〜Claude プロセス起動前）ではフロント側・バック側ともに編集が不可だった。
- 実際には `preparing` はキュー待ちの間も留まり得るステータスで、Claude はまだ goal.md を読んでいないため、編集を許容しても安全。
- `preparing` 中の `updateFields` は既存の `prepareArtifacts` によって goal.md を書き直すため、その後に Claude が読み込む段階で最新内容が反映される。

## 変更点

### `apps/desktop/src/main/todo-agent/trpc-router.ts`
- `updateFields` の許可ステータスに `preparing` を追加。
- エラーメッセージとドキュメントコメントを実態に合わせて更新。

### `apps/desktop/src/renderer/features/todo-agent/TodoManager/TodoManager.tsx`
- `canEditFields` に `session.status === \"preparing\"` を追加。
- 編集中にセッションが `running` / `verifying` に遷移した場合、`useEffect` で編集モードを自動キャンセルし、toast.warning で通知する。これにより、ユーザーが保存ボタンを押してから backend の `PRECONDITION_FAILED` を踏む体験を避ける。

### 編集中に running に遷移するケースの扱い

キュー待ちの別セッションが終わって自分の番が回ってくるタイミングで編集していると、`preparing → running` へ遷移し得る。その際の挙動:

1. フロント側で `status` を監視し、`running` / `verifying` に遷移したら編集を自動キャンセル + 下書きを破棄 + toast 警告。
2. 万一 1 をすり抜けて保存ミューテーションが走っても、バックエンドの `updateFields` が `running` / `verifying` を拒否するガードを維持しているため安全。
3. `preparing` 中の保存は `prepareArtifacts` による goal.md 書き直しを通じて Claude 起動前に反映される。

## 動作確認

- `bun run lint` ✅
- `bun run typecheck` ✅

## Test plan
- [ ] AgentManager で `preparing` 状態のセッション詳細を開き、「やって欲しいこと」「ゴール」の「編集」ボタンが表示されること
- [ ] `preparing` 中に編集 → 保存で goal.md が書き換わり、次の iteration に反映されること
- [ ] キュー待ちの `preparing` セッションで編集中に `running` に遷移すると、編集モードが自動解除され toast 警告が出ること
- [ ] `running` / `verifying` / `done` / `paused` のセッションは編集ボタンが出ないこと（回帰なし）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 改善

* セッション準備中でもフィールドの編集が可能になり、より長い時間編集できるようになりました
* セッション実行中に編集中の操作が自動的にキャンセルされ、その旨が警告通知として表示されるようになりました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->