### PR TITLE
fix(desktop): TODO/Schedule ダイアログの横幅が狭い不具合を修正 (#238)

### DIFF
--- a/apps/desktop/src/renderer/features/todo-agent/TodoManager/SchedulesSection/components/ScheduleEditorDialog/ScheduleEditorDialog.tsx
+++ b/apps/desktop/src/renderer/features/todo-agent/TodoManager/SchedulesSection/components/ScheduleEditorDialog/ScheduleEditorDialog.tsx
@@ -218,7 +218,7 @@ export function ScheduleEditorDialog({
 
 	return (
 		<Dialog open={open} onOpenChange={onOpenChange}>
-			<DialogContent className="max-w-5xl w-[92vw] max-h-[90vh] overflow-y-auto">
+			<DialogContent className="max-w-5xl sm:max-w-5xl w-[92vw] max-h-[90vh] overflow-y-auto">
 				<DialogHeader>
 					<DialogTitle>
 						{initial ? "スケジュールを編集" : "新しいスケジュール"}

--- a/apps/desktop/src/renderer/features/todo-agent/TodoModal/TodoModal.tsx
+++ b/apps/desktop/src/renderer/features/todo-agent/TodoModal/TodoModal.tsx
@@ -190,7 +190,7 @@ export function TodoModal({
 
 	return (
 		<Dialog open={open} onOpenChange={handleOpenChange}>
-			<DialogContent className="max-w-xl rounded-xl">
+			<DialogContent className="max-w-xl sm:max-w-xl rounded-xl">
 				<DialogHeader>
 					<DialogTitle>新しい自律 TODO</DialogTitle>
 				</DialogHeader>


### PR DESCRIPTION
## 概要

Issue #238 の修正です。

新しい TODO ダイアログ (`TodoModal`) と新しいスケジュールダイアログ (`ScheduleEditorDialog`) が、意図したサイズよりかなり狭く表示されていた不具合を直します。

## 原因

`packages/ui` の `DialogContent` のデフォルトクラスに `sm:max-w-lg` (512px) が含まれています。`tailwind-merge` は **responsive variant を別スコープで扱う** ため、ユーザーが `max-w-5xl` / `max-w-xl` のような **非 variant** のクラスだけを渡しても `sm:max-w-lg` は打ち消されず、`sm` ブレークポイント以上（＝デスクトップ表示）では常に 512px にキャップされていました。

結果として、Issue の添付スクリーンショット (約 547px 幅) のように Agent Manager ダイアログの 1/5 程度の横幅になっていました。

## 修正

各ダイアログに `sm:` プレフィックス付きの max-width を追加し、sm 以上のビューポートでも意図したサイズを維持するようにします。

| ダイアログ | 修正前 | 修正後 |
|---|---|---|
| `ScheduleEditorDialog` | `max-w-5xl w-[92vw]` | `max-w-5xl sm:max-w-5xl w-[92vw]` |
| `TodoModal` | `max-w-xl rounded-xl` | `max-w-xl sm:max-w-xl rounded-xl` |

他の広幅ダイアログ（`TodoManager`, `PresetsDialog`, `FileSaveConflictDialog`, `CreateTaskDialog` 等）は既に `sm:max-w-*` または `!max-w-*` を明示しており、同じバグは発生していないことを確認済みです。

## 動作確認

- `bun run lint:fix`：追加修正なし
- `cd apps/desktop && bun run typecheck`：エラーなし

## Test plan

- [ ] Desktop アプリを起動
- [ ] Agent Manager を開く
- [ ] 「新しいスケジュール」ダイアログを開き、横幅が広がっていることを確認
- [ ] 「新しい TODO」ダイアログを開き、横幅が広がっていることを確認

Closes #238