### PR TITLE
fix(desktop): done タスクにメッセージ送信で再開できるようにする (#241)

### DIFF
--- a/apps/desktop/src/main/todo-agent/trpc-router.ts
+++ b/apps/desktop/src/main/todo-agent/trpc-router.ts
@@ -179,7 +179,12 @@ export const createTodoAgentRouter = () => {
 					// Allow manual "wake now" on a ScheduleWakeup-paused
 					// session — the user should not have to wait out the
 					// delay if they already have the context they wanted.
-					session.status !== "waiting"
+					session.status !== "waiting" &&
+					// Allow resuming a completed session so the user can send
+					// follow-up messages. The supervisor detects the existing
+					// `claudeSessionId` and issues `--resume` to continue the
+					// prior conversation rather than starting fresh.
+					session.status !== "done"
 				) {
 					throw new TRPCError({
 						code: "PRECONDITION_FAILED",
@@ -410,11 +415,43 @@ export const createTodoAgentRouter = () => {
 		 * Queue a user intervention for the next turn. Headless mode
 		 * cannot inject text mid-stream, so interventions land at the
 		 * next iteration boundary.
+		 *
+		 * Sending a message to a terminal session (done/failed/aborted/
+		 * escalated) that still has a `claudeSessionId` auto-resumes the
+		 * conversation: the message is buffered, the row flips to
+		 * `preparing`, and the supervisor reruns with `--resume <id>`.
+		 * Without this, the queued message would sit unread until the
+		 * user manually clicked Start — the exact friction #241 called
+		 * out for the `done` case.
 		 */
 		sendInput: publicProcedure
 			.input(todoSendInputSchema)
 			.mutation(({ input }) => {
-				getTodoSupervisor().queueIntervention(input.sessionId, input.data);
+				const store = getTodoSessionStore();
+				const session = store.get(input.sessionId);
+				if (!session) {
+					throw new TRPCError({
+						code: "NOT_FOUND",
+						message: "セッションが見つかりません",
+					});
+				}
+				const supervisor = getTodoSupervisor();
+				supervisor.queueIntervention(input.sessionId, input.data);
+
+				const isTerminal =
+					session.status === "done" ||
+					session.status === "failed" ||
+					session.status === "aborted" ||
+					session.status === "escalated";
+				if (isTerminal && session.claudeSessionId) {
+					store.update(input.sessionId, {
+						status: "preparing",
+						phase: "preparing",
+						waitingUntil: null,
+						waitingReason: null,
+					});
+					void supervisor.start(input.sessionId);
+				}
 				return { ok: true };
 			}),
 

--- a/apps/desktop/src/renderer/features/todo-agent/TodoManager/TodoManager.tsx
+++ b/apps/desktop/src/renderer/features/todo-agent/TodoManager/TodoManager.tsx
@@ -977,7 +977,10 @@ function SessionDetail({ session, onDeleted }: SessionDetailProps) {
 		session.status === "aborted" ||
 		session.status === "escalated" ||
 		// Manual "wake now" overrides the remaining ScheduleWakeup delay.
-		session.status === "waiting";
+		session.status === "waiting" ||
+		// Resume a completed session — supervisor issues `--resume` so the
+		// next turn continues the same Claude conversation.
+		(session.status === "done" && session.claudeSessionId != null);
 	const isRunning =
 		session.status === "preparing" ||
 		session.status === "running" ||
@@ -1581,7 +1584,7 @@ function SessionDetail({ session, onDeleted }: SessionDetailProps) {
 						) : (
 							<>
 								ヒント:
-								実行中でもメッセージを送ると、現在のターンを中断して即座に割り込みます。
+								実行中でもメッセージを送ると、現在のターンを中断して即座に割り込みます。完了済み/失敗のタスクに送ると、過去のセッションを再開して続きから対話します。
 							</>
 						)}
 					</p>


### PR DESCRIPTION
## 概要

Issue #241 の対応。完了済み (`done`) のタスクにメッセージを送信しても何も起きなかった挙動を、過去セッションを自動で再開して続きから対話できるように修正します。

> 一回最後まで走ったタスク(done)になっているものにメッセージを送信した時、再開できるようにできるか?

## 変更点

### バックエンド (`apps/desktop/src/main/todo-agent/trpc-router.ts`)
- `start` の許可ステータスに `done` を追加。手動 Start でも再開可能にした
- `sendInput` で現在のステータスが terminal (`done` / `failed` / `aborted` / `escalated`) かつ `claudeSessionId` が残っているとき、`preparing` へ遷移させて `supervisor.start()` を呼ぶようにした
  - これにより「メッセージを送る」だけで自動的に再開される
  - supervisor 側には既に `--resume <claudeSessionId>` で継続する仕組みがあるので、新規配線は不要

### UI (`apps/desktop/src/renderer/features/todo-agent/TodoManager/TodoManager.tsx`)
- `canStart` に `done && claudeSessionId != null` を追加し、Start ボタンを表示
- フッターのヒント文に「完了済み/失敗のタスクに送ると、過去のセッションを再開して続きから対話します」を追記

## 仕組み
1. ユーザーが done 済みタスクにメッセージ送信
2. `sendInput` が `queueIntervention` でメッセージをバッファ → ステータスを `preparing` に
3. `supervisor.start()` → `drain()` → `runSession()` が `isResumingPastRun = !!claudeSessionId` を検出
4. `claude -p --resume <id>` で実行され、ターン境界で `pendingIntervention` がプロンプトに反映される

## テスト計画
- [ ] `bun run typecheck` — 全 26 パッケージ成功
- [ ] `bun run lint` — clean
- [ ] 手動: done 済みセッションでメッセージ送信 → 自動で preparing → running に遷移し、「再開」イベントが表示されて過去の会話を継続する
- [ ] 手動: done 済みセッションで Start ボタンを押下 → 同様に再開する
- [ ] 手動: running 中のメッセージ送信 / queued の pendingIntervention 溜め込みなど既存動作に影響がないこと