### PR TITLE
fix(desktop): TODO の ScheduleWakeup 再開時のゴリ押し解消と待機UI改善 (#240)

### DIFF
--- a/apps/desktop/src/main/todo-agent/scheduler.ts
+++ b/apps/desktop/src/main/todo-agent/scheduler.ts
@@ -227,12 +227,18 @@ class TodoScheduler {
 			if (this.isStopped) return;
 			const claimed = sessionStore.claimWaitingForResume(session.id);
 			if (!claimed) continue;
-			void supervisor.start(session.id).catch((err) => {
-				console.warn(
-					`[todo-scheduler] supervisor.start unexpectedly rejected for ${session.id}:`,
-					err,
-				);
-			});
+			// Tag this start as a scheduler-driven wakeup so the
+			// supervisor can skip the "再開" banner and use a short
+			// continuation prompt instead of re-replaying the goal
+			// (issue #240).
+			void supervisor
+				.start(session.id, { fromScheduledWakeup: true })
+				.catch((err) => {
+					console.warn(
+						`[todo-scheduler] supervisor.start unexpectedly rejected for ${session.id}:`,
+						err,
+					);
+				});
 		}
 	}
 

--- a/apps/desktop/src/main/todo-agent/supervisor.ts
+++ b/apps/desktop/src/main/todo-agent/supervisor.ts
@@ -472,8 +472,15 @@ class TodoSupervisor {
 					// Only the very first turn after the scheduler wakes us
 					// up is a "continuation" — subsequent iterations within
 					// the same runSession are normal verify-retry loops.
+					// Require an actual resumable session: if the parked
+					// turn never produced a parseable `session_id`,
+					// claudeSessionId is null and `--resume` will not be
+					// passed. In that edge case the continuation-only
+					// prompt would strand Claude in a fresh conversation
+					// with no task context — fall back to the full
+					// iteration-1 prompt instead.
 					isScheduledWakeupContinuation:
-						isFromScheduledWakeup && iteration === 1,
+						isFromScheduledWakeup && iteration === 1 && claudeSessionId != null,
 				});
 
 				appendUserEvent(sessionId, iteration, prompt);

--- a/apps/desktop/src/main/todo-agent/supervisor.ts
+++ b/apps/desktop/src/main/todo-agent/supervisor.ts
@@ -55,6 +55,15 @@ class TodoSupervisor {
 	 */
 	private readonly active = new Map<string, ActiveRun>();
 	private readonly queue: string[] = [];
+	/**
+	 * Sessions whose next queued start was triggered by `ScheduleWakeup`
+	 * firing (scheduler.resumeDueWaitingSessions), not by a user click or
+	 * a follow-up intervention. `runSession` consumes the marker to skip
+	 * the "セッションを再開します" banner and to send a short continuation
+	 * prompt instead of re-replaying the original goal — which Claude
+	 * has already been working on in the same `--resume`d session.
+	 */
+	private readonly wakeupResumeMarkers = new Set<string>();
 
 	/**
 	 * Pre-compute the artifact directory path for a not-yet-inserted
@@ -87,7 +96,19 @@ class TodoSupervisor {
 		return dir;
 	}
 
-	async start(sessionId: string): Promise<void> {
+	async start(
+		sessionId: string,
+		options?: { fromScheduledWakeup?: boolean },
+	): Promise<void> {
+		if (options?.fromScheduledWakeup) {
+			this.wakeupResumeMarkers.add(sessionId);
+		} else {
+			// A manual start (user click / follow-up intervention) always
+			// overrides a stale scheduler marker. Prevents a prior wakeup
+			// that never actually ran (e.g. abort landed between claim and
+			// drain) from silently relabeling the next manual resume.
+			this.wakeupResumeMarkers.delete(sessionId);
+		}
 		// Already pending another launch — coalesce repeat clicks.
 		if (this.queue.includes(sessionId)) return;
 		// If a previous run is still active AND has not been aborted,
@@ -171,6 +192,9 @@ class TodoSupervisor {
 		if (queueIdx !== -1) {
 			this.queue.splice(queueIdx, 1);
 		}
+		// Clear any wakeup-resume marker so a subsequent manual start
+		// cannot misinterpret this session as a scheduler wakeup.
+		this.wakeupResumeMarkers.delete(sessionId);
 		const activeRun = this.active.get(sessionId);
 		if (activeRun) {
 			activeRun.abortController.abort();
@@ -238,6 +262,13 @@ class TodoSupervisor {
 		const session0 = store.get(sessionId);
 		if (!session0) return;
 
+		// Consume the wakeup-resume marker (if any). A scheduler-driven
+		// resume from a `ScheduleWakeup`-paused session is not a new
+		// turn from Claude's perspective — Claude asked to be paged
+		// back later and is now continuing the same reasoning. Treat
+		// it differently from the user-driven done→follow-up resume.
+		const isFromScheduledWakeup = this.wakeupResumeMarkers.delete(sessionId);
+
 		// A session that already completed at least one run keeps its
 		// previous stream events so the user can scroll back to the
 		// prior turns after sending a follow-up message (done→resume).
@@ -251,7 +282,10 @@ class TodoSupervisor {
 		// Prime the artifact-path cache so the hot stream-persist path
 		// does not need to do a synchronous SQLite read per event.
 		store.setArtifactPathCache(sessionId, session0.artifactPath);
-		if (isResumingPastRun) {
+		// Scheduler-driven wakeup resumes skip the "再開" banner —
+		// Claude requested the pause itself, so the pause+wakeup is a
+		// single logical turn and does not warrant a new-session marker.
+		if (isResumingPastRun && !isFromScheduledWakeup) {
 			appendSetupEvent(
 				sessionId,
 				"再開",
@@ -341,11 +375,17 @@ class TodoSupervisor {
 				verdictPassed: null,
 				verdictReason: null,
 				verdictFailingTest: null,
-				// Keep the prior assistant text on resume so the Manager
-				// shows the last known answer while the new turn streams.
-				finalAssistantText: isResumingPastRun
-					? (session0.finalAssistantText ?? null)
-					: null,
+				// Keep the prior assistant text on a user-driven resume
+				// so the Manager shows the last known answer while the
+				// new turn streams. On a scheduler wakeup, clear it —
+				// the stale response has been visible the whole time
+				// under the "待機中" label and the user wants a clean
+				// slate under the "最終回答" label once the new turn
+				// starts producing output (issue #240).
+				finalAssistantText:
+					isResumingPastRun && !isFromScheduledWakeup
+						? (session0.finalAssistantText ?? null)
+						: null,
 				claudeSessionId: preservedClaudeSessionId,
 				totalCostUsd: isResumingPastRun
 					? (session0.totalCostUsd ?? null)
@@ -375,10 +415,14 @@ class TodoSupervisor {
 
 			// Same resume reasoning as above — seed the loop-local vars
 			// from the persisted row so `--resume` is actually issued.
+			// Wakeup resumes intentionally drop the prior assistant text
+			// so mid-turn failures do not resurface a stale answer as
+			// if it were the new turn's output.
 			let claudeSessionId: string | null = preservedClaudeSessionId;
-			let lastAssistantText: string | null = isResumingPastRun
-				? (session0.finalAssistantText ?? null)
-				: null;
+			let lastAssistantText: string | null =
+				isResumingPastRun && !isFromScheduledWakeup
+					? (session0.finalAssistantText ?? null)
+					: null;
 			let aggregatedCostUsd = isResumingPastRun
 				? (session0.totalCostUsd ?? 0)
 				: 0;
@@ -425,6 +469,11 @@ class TodoSupervisor {
 					iteration,
 					previousVerdictReason: currentSession.verdictReason ?? null,
 					intervention: pendingIntervention,
+					// Only the very first turn after the scheduler wakes us
+					// up is a "continuation" — subsequent iterations within
+					// the same runSession are normal verify-retry loops.
+					isScheduledWakeupContinuation:
+						isFromScheduledWakeup && iteration === 1,
 				});
 
 				appendUserEvent(sessionId, iteration, prompt);
@@ -995,15 +1044,33 @@ function buildIterationPrompt(params: {
 	iteration: number;
 	previousVerdictReason: string | null;
 	intervention: string | null;
+	isScheduledWakeupContinuation?: boolean;
 }): string {
-	const { session, iteration, previousVerdictReason, intervention } = params;
+	const {
+		session,
+		iteration,
+		previousVerdictReason,
+		intervention,
+		isScheduledWakeupContinuation,
+	} = params;
 	const goalPath = `.superset/todo/${session.id}/goal.md`;
 	const goalClause = session.goal?.trim()
 		? "ゴール（受け入れ条件）を達成することを目指してください"
 		: "『やって欲しいこと』が完了した時点で完了とみなしてください";
 
 	const sections: string[] = [];
-	if (iteration === 1) {
+	if (isScheduledWakeupContinuation) {
+		// Claude paused itself via `ScheduleWakeup` and the scheduler
+		// has now woken it up. The original goal and custom system
+		// prompt are already present in the resumed conversation — do
+		// not re-send them verbatim, that duplicate prompt is the
+		// "ゴリ押し" complaint in issue #240. A short continuation cue
+		// is enough; the user-visible intervention (if any) is still
+		// routed through the normal channel below.
+		sections.push(
+			"(予定時刻になりました。前回の続きから作業を再開してください。)",
+		);
+	} else if (iteration === 1) {
 		// Mirror the preset / custom system prompt into the first turn's
 		// user message. `--append-system-prompt` alone was not always
 		// visibly honored (users reported "気がする" that Claude never
@@ -1036,7 +1103,7 @@ function buildIterationPrompt(params: {
 	if (intervention) {
 		sections.push(`ユーザーからの介入指示（優先度: 高）:\n${intervention}`);
 	}
-	if (session.verifyCommand) {
+	if (session.verifyCommand && !isScheduledWakeupContinuation) {
 		sections.push(
 			`完了判定: 作業が終わったら、セッション終了後に supervisor が \`${session.verifyCommand}\` を実行して exit 0 を要求します。`,
 		);

--- a/apps/desktop/src/renderer/features/todo-agent/TodoManager/TodoManager.tsx
+++ b/apps/desktop/src/renderer/features/todo-agent/TodoManager/TodoManager.tsx
@@ -1492,13 +1492,32 @@ function SessionDetail({ session, onDeleted }: SessionDetailProps) {
 							</DetailBlock>
 						)}
 
+						{session.status === "waiting" && session.waitingUntil != null && (
+							<DetailBlock label="待機終了まで">
+								<div className="text-xs bg-muted/40 rounded-lg p-3 border border-border/40 flex flex-col gap-1">
+									<div className="font-mono text-sm">
+										{formatWaitingCountdown(session.waitingUntil)}
+									</div>
+									{session.waitingReason && (
+										<div className="text-[11px] text-muted-foreground break-words">
+											{session.waitingReason}
+										</div>
+									)}
+								</div>
+							</DetailBlock>
+						)}
+
 						{session.finalAssistantText && (
 							<DetailBlock
-								label="最終回答"
+								label={session.status === "waiting" ? "待機中" : "最終回答"}
 								action={
 									<CopyIconButton
 										value={session.finalAssistantText}
-										title="最終回答をコピー"
+										title={
+											session.status === "waiting"
+												? "待機前の応答をコピー"
+												: "最終回答をコピー"
+										}
 									/>
 								}
 							>
@@ -2251,6 +2270,24 @@ function formatWaitingRemaining(waitingUntil: number): string {
 	if (remainingMin < 60) return `${remainingMin}分後`;
 	const remainingHr = Math.round(remainingMin / 60);
 	return `${remainingHr}時間後`;
+}
+
+/**
+ * HH:MM:SS-ish countdown for the detail pane's "待機終了まで" block.
+ * More granular than `formatWaitingRemaining` because the detail view
+ * has room for a live-ticking clock, while the session list label
+ * only has room for a coarse "N分後" hint.
+ */
+function formatWaitingCountdown(waitingUntil: number): string {
+	const remainingMs = waitingUntil - Date.now();
+	if (remainingMs <= 0) return "まもなく再開します";
+	const totalSec = Math.floor(remainingMs / 1000);
+	const hours = Math.floor(totalSec / 3600);
+	const minutes = Math.floor((totalSec % 3600) / 60);
+	const seconds = totalSec % 60;
+	const pad = (n: number) => n.toString().padStart(2, "0");
+	if (hours > 0) return `${hours}:${pad(minutes)}:${pad(seconds)}`;
+	return `${pad(minutes)}:${pad(seconds)}`;
 }
 
 interface SessionGroup {


### PR DESCRIPTION
## 概要

[#240](https://github.com/MocA-Love/superset/issues/240) 対応。TODO 機能で Claude Code が `ScheduleWakeup` でセッションを自己休止したあと、スケジューラーが再開する際の挙動と UI をまとめて改善する。

### 背景

従来の動作には 3 つの課題があった。

1. **ゴリ押し再開**: 待機後の再開時に `runSession()` が iteration=1 から再スタートし、`buildIterationPrompt()` が元の goal.md パス / タイトル / 説明 / ゴールを**まるごと再送**していた。Claude 側から見ると `--resume` で同じ会話が続いているのに、ユーザーメッセージとして同じ指示が 2 回届く状態。加えてストリームに「セッションを再開します。これより下が新しいターンのストリームです。」のバナーが毎回挿入されていた。
2. **「最終回答」欄の表示**: `waiting` 中でも詳細ペインのラベルが「最終回答」のままで、待機前の応答が最終回答として誤読される。
3. **待機時間の見える化**: `waitingUntil` は保持しているのに詳細ペインにカウントダウンがなく、行ラベルの「N分後」しか手がかりがなかった。

### 変更点

#### バックエンド

- `TodoSupervisor.start(sessionId, { fromScheduledWakeup })` を追加。スケジューラー駆動の再開を識別する内部マーカー (`wakeupResumeMarkers`) を導入し、`runSession()` が 1 度だけ消費する設計。
- `TodoScheduler.resumeDueWaitingSessions()` は `fromScheduledWakeup: true` を付けて `start()` を呼ぶ。
- wakeup 再開時は:
  - `appendSetupEvent("再開", …)` をスキップ。
  - DB の `finalAssistantText` を **null にクリア**（「待機中」→「最終回答」への切替時にフィールドが空になる / 次ターンのストリームが前ターンの答えを上書きしない）。
  - `buildIterationPrompt()` の専用ブランチで短い継続キュー `"(予定時刻になりました。前回の続きから作業を再開してください。)"` のみを送る（元プロンプト / システムプロンプト / verify 注記は再送しない）。
- 手動 `start()`（ユーザー操作・フォローアップ介入）は常に stale なマーカーを先に削除して上書きする。`abort()` 時もマーカーを削除。

#### UI（`TodoManager.tsx`）

- `status === "waiting"` のとき「最終回答」ラベルを **「待機中」** に差し替え、コピーボタンのタイトルも「待機前の応答をコピー」に変更。
- 詳細ペインに **「待機終了まで」** ブロックを追加。MM:SS（1 時間超で HH:MM:SS）形式のカウントダウンと `waitingReason` を併記。既存の 1 秒 tick (`completedAt == null`) でライブ更新される。

## Test plan

- [ ] TODO セッションで Claude に `ScheduleWakeup` を発火させる
  - [ ] 「セッションを再開します」バナーが表示されないこと
  - [ ] 再開直後のユーザーメッセージが短い継続キューだけで、元プロンプトの再送がないこと
  - [ ] 待機中は「待機中」ラベルで前ターン応答が表示されること
  - [ ] 「待機終了まで」ブロックが MM:SS でライブカウントダウンされること
  - [ ] 再度 running に戻った時点で「最終回答」ラベルに戻り、前ターン応答が消えてから新しい応答がストリームされること
- [ ] 通常の done→フォローアップ再開では従来どおり「セッションを再開します」バナーと `finalAssistantText` の保持が効いていること
- [ ] abort 後に再度手動 start した場合、wakeup マーカーが残らず正常再開すること
- [ ] `bun run lint` / `bun run typecheck` 緑（ローカル確認済み）

Closes #240