### PR TITLE
fix(desktop): TODO 画像添付が「実行中…」のまま止まる問題を修正 (#247)

### DIFF
--- a/apps/desktop/src/main/todo-agent/supervisor.ts
+++ b/apps/desktop/src/main/todo-agent/supervisor.ts
@@ -990,6 +990,34 @@ function renderGoalDoc(session: SelectTodoSession): string {
 	return lines.join("\n");
 }
 
+/**
+ * Pull attachment file paths out of description/goal markdown. Mirrors
+ * the renderer regex in `TodoManager/utils/attachmentRefs` so the same
+ * `todo-agent/attachments/` references the UI renders as chips are the
+ * ones we surface to Claude as "please Read this". The regex is
+ * duplicated intentionally — the renderer module lives in the web
+ * bundle and we don't want a cross-bundle import here in main.
+ */
+const ATTACHMENT_PATH_RE =
+	/!\[[^\]]*\]\(([^()\s]*[/\\]todo-agent[/\\]attachments[/\\][^)\s]+)\)/g;
+
+function extractAttachmentPaths(
+	texts: (string | null | undefined)[],
+): string[] {
+	const seen = new Set<string>();
+	const out: string[] = [];
+	for (const text of texts) {
+		if (!text) continue;
+		for (const m of text.matchAll(ATTACHMENT_PATH_RE)) {
+			const p = m[1];
+			if (!p || seen.has(p)) continue;
+			seen.add(p);
+			out.push(p);
+		}
+	}
+	return out;
+}
+
 function buildIterationPrompt(params: {
 	session: SelectTodoSession;
 	iteration: number;
@@ -1023,6 +1051,24 @@ function buildIterationPrompt(params: {
 		);
 		if (session.goal?.trim()) {
 			sections.push(`ゴール:\n${session.goal.trim()}`);
+		}
+		// Hoist attachment file paths out of the markdown so Claude
+		// doesn't have to decide on its own whether `![](…)` inside the
+		// description is decorative or a real artifact it should load.
+		// Before this nudge, image attachments were frequently ignored —
+		// the file was saved and the path was correct, but Claude would
+		// proceed without ever calling Read on it. See #247.
+		const attachments = extractAttachmentPaths([
+			session.description,
+			session.goal,
+		]);
+		if (attachments.length > 0) {
+			sections.push(
+				[
+					"添付ファイル（作業開始前に Read で内容を確認してください）:",
+					...attachments.map((p) => `- ${p}`),
+				].join("\n"),
+			);
 		}
 	} else {
 		sections.push(
@@ -1382,10 +1428,14 @@ function extractToolResultDetails(
 	if (!Array.isArray(content)) return null;
 	const parts: string[] = [];
 	let toolUseId: string | undefined;
+	let sawToolResult = false;
+	let imageCount = 0;
+	let otherBlockCount = 0;
 	for (const part of content) {
 		if (typeof part !== "object" || part === null) continue;
 		const rec = part as Record<string, unknown>;
 		if (rec.type === "tool_result") {
+			sawToolResult = true;
 			if (!toolUseId && typeof rec.tool_use_id === "string") {
 				toolUseId = rec.tool_use_id as string;
 			}
@@ -1398,14 +1448,35 @@ function extractToolResultDetails(
 					const pr = p as Record<string, unknown>;
 					if (pr.type === "text" && typeof pr.text === "string") {
 						parts.push(pr.text as string);
+					} else if (pr.type === "image") {
+						imageCount += 1;
+					} else if (typeof pr.type === "string") {
+						otherBlockCount += 1;
 					}
 				}
 			}
 		}
 	}
+	// Bail only when the message didn't contain a tool_result block at
+	// all. If it did, emit the result even when it carried no text so
+	// the UI can pair it with its tool_use — otherwise e.g. Read on an
+	// image file (which returns only `image` blocks) leaves the card
+	// spinning "実行中…" forever even though Claude already processed
+	// the result and moved on to subsequent tool calls. See #247.
+	if (!sawToolResult) return null;
 	const joined = parts.join("\n").trim();
-	if (joined.length === 0) return null;
-	return { text: joined, toolUseId };
+	if (joined.length > 0) return { text: joined, toolUseId };
+	const summary: string[] = [];
+	if (imageCount > 0) {
+		summary.push(imageCount === 1 ? "[画像 1 件]" : `[画像 ${imageCount} 件]`);
+	}
+	if (otherBlockCount > 0) {
+		summary.push(`[非テキストブロック ${otherBlockCount} 件]`);
+	}
+	return {
+		text: summary.length > 0 ? summary.join(" ") : "(空の結果)",
+		toolUseId,
+	};
 }
 
 function summarizeToolInput(name: string, input: unknown): string {


### PR DESCRIPTION
## 概要

Issue #247 対応。TODO 依頼で画像を添付したとき、ツールカードが永遠に「実行中…」のままになる問題を修正する。

## 原因

`apps/desktop/src/main/todo-agent/supervisor.ts` の `extractToolResultDetails` は、Claude Code から来る `tool_result` の `content` を走査してテキスト部分だけを組み立て、テキストが空なら `null` を返す実装になっていた。

Read ツールを画像ファイルに対して呼び出すと、`tool_result.content` には `text` ブロックが無く `image` ブロックだけが入る。このため `extractToolResultDetails` は `null` を返し、`classifyStreamJson` は `tool_result` イベント自体を emit しなかった。

結果として UI 側の `buildStreamTree` は該当 `tool_use` に対応する `tool_result` を見つけられず、`StreamNode` は `toolResult` が falsy な間ずっと `実行中…` のシマーを表示し続ける。Claude 自身は画像を受け取って後続ツール呼び出しへ進んでいるため、Issue の記述 (「後続のツールとかは呼び出されている」) とも一致する。

## 修正内容

### 1. `extractToolResultDetails` を常にイベントを emit する実装に変更

- `tool_result` ブロックが 1 つでも存在したら、テキストが空でも `toolUseId` 付きの結果を返す
- テキストが無い場合は `image` / 非テキストブロックの件数を集計して `[画像 1 件]` 等のプレースホルダに差し替える
- これにより UI の `buildStreamTree` が `tool_use ↔ tool_result` をペアリングでき、「実行中…」が解消する

### 2. 添付ファイルパスを 1 周目プロンプトに明示列挙

- `description` / `goal` 内の `![](.../todo-agent/attachments/...)` markdown を正規表現で抽出し、「添付ファイル（作業開始前に Read で内容を確認してください）」として箇条書きで添える
- Claude がマークダウンを装飾として無視して画像ファイルを読まずに進めるケースを減らす
- 正規表現はレンダラ側の `TodoManager/utils/attachmentRefs` と同じものを意図的にコピーしている（main / renderer でバンドルが分かれているため共有できない）

## テスト観点

- [ ] TODO に画像を添付して依頼し、Read ツールカードが `実行中…` ではなく `[画像 1 件]` 等に置き換わること
- [ ] 画像なしの通常タスクでリグレッションが無いこと（テキスト tool_result は従来通り表示される）
- [ ] `description` に 2 枚以上の画像を貼った場合、プロンプトに全パスが列挙されること
- [ ] `lint` / `typecheck` が通ること

Fixes #247