### PR TITLE
fix(desktop): AgentManager 左サイドバー下部の設定ボタンを固定 (#249)

### DIFF
--- a/apps/desktop/src/renderer/features/todo-agent/TodoManager/SchedulesSection/SchedulesSection.tsx
+++ b/apps/desktop/src/renderer/features/todo-agent/TodoManager/SchedulesSection/SchedulesSection.tsx
@@ -69,7 +69,7 @@ export function SchedulesSection() {
 	};
 
 	return (
-		<div className="flex flex-col h-full min-h-0">
+		<div className="flex flex-col flex-1 min-h-0">
 			<div className="p-2 border-b shrink-0 flex items-center justify-between gap-2">
 				<span className="text-xs text-muted-foreground">
 					{(schedules?.length ?? 0) > 0
@@ -94,7 +94,7 @@ export function SchedulesSection() {
 					className="h-8 text-xs rounded-md"
 				/>
 			</div>
-			<ScrollArea className="flex-1">
+			<ScrollArea className="flex-1 min-h-0">
 				<div className="flex flex-col gap-1.5 p-2">
 					{(schedules?.length ?? 0) === 0 ? (
 						<p className="text-xs text-muted-foreground px-1 py-4">

--- a/apps/desktop/src/renderer/features/todo-agent/TodoManager/TodoManager.tsx
+++ b/apps/desktop/src/renderer/features/todo-agent/TodoManager/TodoManager.tsx
@@ -539,7 +539,7 @@ export function TodoManager({
 										className="h-8 text-xs rounded-md"
 									/>
 								</div>
-								<ScrollArea className="flex-1">
+								<ScrollArea className="flex-1 min-h-0">
 									{grouped.length === 0 && (
 										<p className="text-xs text-muted-foreground px-3 py-6">
 											{(sessions?.length ?? 0) === 0


### PR DESCRIPTION
## 概要

Fixes #249

Agent Manager の左サイドバー下部にある「設定 / プリセット」ボタンが、TODO タスクやスケジュールが増えて一覧が長くなると押し出されて見えなくなる問題を修正。

## 原因

flex-col コンテナ内で `flex-1` だけを指定した ScrollArea は、子コンテンツの `min-content` が `min-height: auto` として効いてしまい、flex-grow で膨らんだまま兄弟要素 (shrink-0 の設定ボタン) を押し出す、flexbox の典型的な落とし穴。親は `overflow-hidden` なので、押し出された設定ボタンは視覚的に消える。

## 変更点

- `TodoManager.tsx`: タスクタブの `ScrollArea` に `min-h-0` を追加
- `SchedulesSection.tsx`: 
  - `ScrollArea` に `min-h-0` を追加
  - 外側コンテナを `h-full` → `flex-1` に変更（flex-col 内では `flex-1 min-h-0` のほうが兄弟を押し出さない正しい書き方）

## 動作確認

- lint: ok
- typecheck: ok
- タスクが多い状態でも「設定 / プリセット」ボタンが常に下部に固定表示されること
- スケジュールタブでも同様