### PR TITLE
fix(desktop): コンフリクトファイルを ConflictViewer で開くよう viewMode を強制 (#248)

### DIFF
--- a/apps/desktop/src/renderer/stores/tabs/store.ts
+++ b/apps/desktop/src/renderer/stores/tabs/store.ts
@@ -966,8 +966,13 @@ export const useTabsStore = create<TabsStore>()(
 
 						// If clicking the same file that's already in preview, just focus it
 						if (isSameFile) {
-							const nextViewMode =
-								options.viewMode ?? existingFileViewer.viewMode;
+							// Conflicted files must default to the conflict viewer even
+							// when callers do not pass an explicit viewMode.
+							const conflictFallbackViewMode =
+								options.diffCategory === "conflicted"
+									? "conflict"
+									: existingFileViewer.viewMode;
+							const nextViewMode = options.viewMode ?? conflictFallbackViewMode;
 							const shouldUpdateViewerState =
 								nextViewMode !== existingFileViewer.viewMode ||
 								options.line !== undefined ||

--- a/apps/desktop/src/renderer/stores/tabs/utils.test.ts
+++ b/apps/desktop/src/renderer/stores/tabs/utils.test.ts
@@ -595,6 +595,53 @@ describe("applyFileViewerOpenOptionsToPane", () => {
 			initialColumn: 7,
 		});
 	});
+
+	it("forces conflict viewer for conflicted files when no explicit viewMode is provided", () => {
+		const pane: Pane = {
+			id: "pane-a",
+			tabId: "tab-a",
+			type: "file-viewer",
+			name: "file.ts",
+			fileViewer: {
+				filePath: "/repo/file.ts",
+				viewMode: "raw",
+				isPinned: false,
+				diffLayout: "inline",
+				diffCategory: "conflicted",
+			},
+		};
+
+		const result = applyFileViewerOpenOptionsToPane(pane, {
+			filePath: "/repo/file.ts",
+			diffCategory: "conflicted",
+		});
+
+		expect(result.fileViewer?.viewMode).toBe("conflict");
+	});
+
+	it("preserves explicit viewMode for conflicted files", () => {
+		const pane: Pane = {
+			id: "pane-a",
+			tabId: "tab-a",
+			type: "file-viewer",
+			name: "file.ts",
+			fileViewer: {
+				filePath: "/repo/file.ts",
+				viewMode: "raw",
+				isPinned: false,
+				diffLayout: "inline",
+				diffCategory: "conflicted",
+			},
+		};
+
+		const result = applyFileViewerOpenOptionsToPane(pane, {
+			filePath: "/repo/file.ts",
+			diffCategory: "conflicted",
+			viewMode: "raw",
+		});
+
+		expect(result.fileViewer?.viewMode).toBe("raw");
+	});
 });
 
 describe("activatePaneInWorkspace", () => {

--- a/apps/desktop/src/renderer/stores/tabs/utils.ts
+++ b/apps/desktop/src/renderer/stores/tabs/utils.ts
@@ -980,9 +980,17 @@ export const applyFileViewerOpenOptionsToPane = (
 		return pane;
 	}
 
+	// Conflicted files must render in the conflict viewer. If the reused pane
+	// has a stale non-conflict viewMode (e.g. was opened as raw before the
+	// merge marked the file as conflicted), force it back to "conflict" when
+	// no explicit override is provided.
+	const fallbackViewMode =
+		options.diffCategory === "conflicted"
+			? "conflict"
+			: pane.fileViewer.viewMode;
 	const nextFileViewer: FileViewerState = {
 		...pane.fileViewer,
-		viewMode: options.viewMode ?? pane.fileViewer.viewMode,
+		viewMode: options.viewMode ?? fallbackViewMode,
 		isPinned: pane.fileViewer.isPinned || (options.isPinned ?? false),
 		oldPath: options.oldPath ?? pane.fileViewer.oldPath,
 		initialLine: options.line ?? pane.fileViewer.initialLine,


### PR DESCRIPTION
## 概要

Issue #248 の修正。Git タブの Conflicts セクションからコンフリクトファイルを開いたときに、通常のファイルビュワー(raw)ではなく ConflictViewer が確実に表示されるようにする。

## 原因

`addFileViewerPane` で既存ペインを再利用するとき、`options.viewMode` が未指定だとペインの既存 viewMode を保持するロジックになっていた。そのため次のような順序だと raw viewer のまま表示されてしまう:

1. ユーザーがファイルエクスプローラ経由で `file.txt` を raw で開く (viewMode: \"raw\"、diffCategory: undefined)。
2. マージ操作で `file.txt` がコンフリクト状態になる。
3. Git タブ → Conflicts から `file.txt` をクリック。
4. `handleFileOpenPane` は viewMode: \"conflict\" を渡すが、プレビューペイン再利用パス(`store.ts` の `isSameFile` 判定)では diffCategory 不一致で \"different file - replace\" に進むケースと進まないケースがあり、キャッシュされた viewMode が残る経路があった。

さらに `applyFileViewerOpenOptionsToPane` も同様の問題を持っており、`diffCategory: \"conflicted\"` なのに viewMode が raw のままで据え置かれるケースが発生しうる。

## 修正内容

- `applyFileViewerOpenOptionsToPane` (`apps/desktop/src/renderer/stores/tabs/utils.ts`): `options.diffCategory === \"conflicted\"` のときのフォールバック viewMode を \"conflict\" にする。`options.viewMode` が明示指定されていればそれを優先する。
- プレビューペイン再利用(`apps/desktop/src/renderer/stores/tabs/store.ts` の isSameFile 分岐): 同様に conflicted のフォールバックを \"conflict\" に変更。
- `applyFileViewerOpenOptionsToPane` のユニットテストを2件追加(フォールバックで conflict に戻ること、明示 viewMode が尊重されること)。

`createFileViewerPane` は既に `resolveFileViewerMode` 経由で conflicted → \"conflict\" を解決しているため変更不要。

## テスト計画

- [x] `bun test apps/desktop/src/renderer/stores/tabs/utils.test.ts` — 49 tests pass
- [x] `bun run lint`
- [x] `bun run typecheck`
- [ ] Desktop アプリを立ち上げて手動検証(マージコンフリクトを発生させ、Git タブから該当ファイルをクリックして ConflictViewer が開くこと)

## 関連

Closes #248

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * コンフリクトされたファイルを開く際、ビューモードが明示的に指定されていない場合、自動的に「コンフリクト」モードで表示されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->