### PR TITLE
fix(desktop): AgentManager の見切れ項目を truncate + tooltip で救済 (#252)

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Works with any CLI agent. Built for local worktree-based development.
 | **PR コメント返信** | Review タブのコメント右上に Reply ボタンを追加。ダイアログから直接返信を投稿できる。レビュースレッドへの返信と通常 PR コメントの両方に対応 | [#206](https://github.com/MocA-Love/superset/pull/206) | 2026-04-16 |
 | **TODO Agent スケジュール実行** | 毎日デプロイ / 毎時 lint のような定型 TODO を UI ビルダー (毎時/毎日/毎週/毎月/cron) で登録可能。アプリ起動中に時刻が来ると TODO セッションが自動作成され発火トーストを表示。前回未完了時は skip / queue 選択可 | [#211](https://github.com/MocA-Love/superset/pull/211) | 2026-04-16 |
 | **TODO 詳細の添付画像 chip 化＋プレビュー** | TODO 作成時に「やってほしいこと」「ゴール」へ貼り付けた画像を、タスク詳細画面でクリップマーク + ファイル名の chip として表示。クリックでネスト Dialog の画像プレビューを開ける（AgentManager は閉じない）。`todo-agent/attachments/` 配下のみを許可するパス検証付き `readAttachment` tRPC を追加 | [#229](https://github.com/MocA-Love/superset/pull/229) | 2026-04-16 |
+| **AgentManager 見切れ救済** | AgentManager 左サイドバーのワークスペース見出し・セッションタイトル、右 ChangesSidebar のブランチ/ファイルパス/コミット subject/選択ヘッダーが狭幅で見切れていた問題を修正。`truncate` + ホバー時 `Tooltip` で全文表示 | [#254](https://github.com/MocA-Love/superset/pull/254) | 2026-04-17 |
 
 ## Fork のビルド方法 (macOS)
 

--- a/apps/desktop/src/renderer/features/todo-agent/TodoManager/ChangesSidebar/ChangesSidebar.tsx
+++ b/apps/desktop/src/renderer/features/todo-agent/TodoManager/ChangesSidebar/ChangesSidebar.tsx
@@ -367,15 +367,16 @@ export function ChangesSidebar({ sessionId, active }: ChangesSidebarProps) {
 												<TooltipTrigger asChild>
 													<button
 														type="button"
-														disabled={!canDiff}
-														onClick={() =>
+														aria-disabled={!canDiff}
+														onClick={() => {
+															if (!canDiff) return;
 															setSelected({
 																key,
 																path: file.path,
 																scope,
 																label: file.path,
-															})
-														}
+															});
+														}}
 														className={cn(
 															"text-left rounded-md px-2 py-1 border border-transparent hover:bg-accent/50 hover:border-border/40 transition flex items-center gap-2 min-w-0",
 															selected?.key === key &&

--- a/apps/desktop/src/renderer/features/todo-agent/TodoManager/ChangesSidebar/ChangesSidebar.tsx
+++ b/apps/desktop/src/renderer/features/todo-agent/TodoManager/ChangesSidebar/ChangesSidebar.tsx
@@ -1,4 +1,5 @@
 import { ScrollArea } from "@superset/ui/scroll-area";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { cn } from "@superset/ui/utils";
 import { useMemo, useState } from "react";
 import {
@@ -94,13 +95,22 @@ export function ChangesSidebar({ sessionId, active }: ChangesSidebarProps) {
 					<div className="text-[10px] uppercase tracking-wide text-muted-foreground font-semibold">
 						変更
 					</div>
-					<div className="text-xs truncate">
-						{data?.branch ? (
-							<span className="font-mono">{data.branch}</span>
-						) : (
+					{data?.branch ? (
+						<Tooltip delayDuration={300}>
+							<TooltipTrigger asChild>
+								<div className="text-xs truncate">
+									<span className="font-mono">{data.branch}</span>
+								</div>
+							</TooltipTrigger>
+							<TooltipContent side="bottom" align="start">
+								<span className="font-mono text-xs">{data.branch}</span>
+							</TooltipContent>
+						</Tooltip>
+					) : (
+						<div className="text-xs truncate">
 							<span className="text-muted-foreground">（ブランチ取得中…）</span>
-						)}
-					</div>
+						</div>
+					)}
 				</div>
 				<button
 					type="button"
@@ -195,28 +205,36 @@ export function ChangesSidebar({ sessionId, active }: ChangesSidebarProps) {
 										// rightly disables `D`, because there the file
 										// is already gone from the worktree.
 										return (
-											<button
-												key={key}
-												type="button"
-												onClick={() =>
-													setSelected({
-														key,
-														path: file.path,
-														scope: "session",
-														label: file.path,
-													})
-												}
-												className={cn(
-													"text-left rounded-md px-2 py-1 border border-transparent hover:bg-accent/50 hover:border-border/40 transition flex items-center gap-2",
-													selected?.key === key &&
-														"bg-accent border-primary/40",
-												)}
-											>
-												<StatusBadge code={file.code} stage="session" />
-												<span className="text-[11px] font-mono truncate flex-1">
-													{file.path}
-												</span>
-											</button>
+											<Tooltip key={key} delayDuration={300}>
+												<TooltipTrigger asChild>
+													<button
+														type="button"
+														onClick={() =>
+															setSelected({
+																key,
+																path: file.path,
+																scope: "session",
+																label: file.path,
+															})
+														}
+														className={cn(
+															"text-left rounded-md px-2 py-1 border border-transparent hover:bg-accent/50 hover:border-border/40 transition flex items-center gap-2 min-w-0",
+															selected?.key === key &&
+																"bg-accent border-primary/40",
+														)}
+													>
+														<StatusBadge code={file.code} stage="session" />
+														<span className="text-[11px] font-mono truncate flex-1">
+															{file.path}
+														</span>
+													</button>
+												</TooltipTrigger>
+												<TooltipContent side="left" align="start">
+													<span className="font-mono text-[11px] break-all">
+														{file.path}
+													</span>
+												</TooltipContent>
+											</Tooltip>
 										);
 									})
 								)}
@@ -249,39 +267,59 @@ export function ChangesSidebar({ sessionId, active }: ChangesSidebarProps) {
 									</p>
 								) : (
 									commits.map((commit) => (
-										<button
-											key={commit.sha}
-											type="button"
-											onClick={() =>
-												setSelected({
-													key: `commit:${commit.sha}`,
-													path: "",
-													scope: "commit",
-													commitSha: commit.sha,
-													label: commit.shortSha,
-												})
-											}
-											className={cn(
-												"text-left rounded-md px-2 py-1.5 border border-border/30 hover:bg-accent/50 transition",
-												selected?.key === `commit:${commit.sha}` &&
-													"bg-accent border-primary/40",
-											)}
-										>
-											<div className="flex items-center gap-2">
-												<span className="font-mono text-[10px] text-muted-foreground shrink-0">
-													{commit.shortSha}
-												</span>
-												<span className="line-clamp-1 flex-1 text-[11px]">
-													{commit.subject}
-												</span>
-											</div>
-											<div className="text-[10px] text-muted-foreground pl-[3.25rem] mt-0.5">
-												{commit.authorName}
-												{commit.authorDate
-													? ` · ${formatShortDate(commit.authorDate)}`
-													: ""}
-											</div>
-										</button>
+										<Tooltip key={commit.sha} delayDuration={300}>
+											<TooltipTrigger asChild>
+												<button
+													type="button"
+													onClick={() =>
+														setSelected({
+															key: `commit:${commit.sha}`,
+															path: "",
+															scope: "commit",
+															commitSha: commit.sha,
+															label: commit.shortSha,
+														})
+													}
+													className={cn(
+														"text-left rounded-md px-2 py-1.5 border border-border/30 hover:bg-accent/50 transition min-w-0",
+														selected?.key === `commit:${commit.sha}` &&
+															"bg-accent border-primary/40",
+													)}
+												>
+													<div className="flex items-center gap-2">
+														<span className="font-mono text-[10px] text-muted-foreground shrink-0">
+															{commit.shortSha}
+														</span>
+														<span className="line-clamp-1 flex-1 text-[11px]">
+															{commit.subject}
+														</span>
+													</div>
+													<div className="text-[10px] text-muted-foreground pl-[3.25rem] mt-0.5 truncate">
+														{commit.authorName}
+														{commit.authorDate
+															? ` · ${formatShortDate(commit.authorDate)}`
+															: ""}
+													</div>
+												</button>
+											</TooltipTrigger>
+											<TooltipContent
+												side="left"
+												align="start"
+												className="max-w-[360px]"
+											>
+												<div className="flex flex-col gap-0.5">
+													<span className="text-[11px] break-words">
+														{commit.subject}
+													</span>
+													<span className="text-[10px] opacity-70">
+														{commit.shortSha} · {commit.authorName}
+														{commit.authorDate
+															? ` · ${formatShortDate(commit.authorDate)}`
+															: ""}
+													</span>
+												</div>
+											</TooltipContent>
+										</Tooltip>
 									))
 								)}
 							</div>
@@ -325,30 +363,38 @@ export function ChangesSidebar({ sessionId, active }: ChangesSidebarProps) {
 										const canDiff =
 											file.stage !== "untracked" && file.code !== "D";
 										return (
-											<button
-												key={key}
-												type="button"
-												disabled={!canDiff}
-												onClick={() =>
-													setSelected({
-														key,
-														path: file.path,
-														scope,
-														label: file.path,
-													})
-												}
-												className={cn(
-													"text-left rounded-md px-2 py-1 border border-transparent hover:bg-accent/50 hover:border-border/40 transition flex items-center gap-2",
-													selected?.key === key &&
-														"bg-accent border-primary/40",
-													!canDiff && "opacity-60 cursor-default",
-												)}
-											>
-												<StatusBadge code={file.code} stage={file.stage} />
-												<span className="text-[11px] font-mono truncate flex-1">
-													{file.path}
-												</span>
-											</button>
+											<Tooltip key={key} delayDuration={300}>
+												<TooltipTrigger asChild>
+													<button
+														type="button"
+														disabled={!canDiff}
+														onClick={() =>
+															setSelected({
+																key,
+																path: file.path,
+																scope,
+																label: file.path,
+															})
+														}
+														className={cn(
+															"text-left rounded-md px-2 py-1 border border-transparent hover:bg-accent/50 hover:border-border/40 transition flex items-center gap-2 min-w-0",
+															selected?.key === key &&
+																"bg-accent border-primary/40",
+															!canDiff && "opacity-60 cursor-default",
+														)}
+													>
+														<StatusBadge code={file.code} stage={file.stage} />
+														<span className="text-[11px] font-mono truncate flex-1">
+															{file.path}
+														</span>
+													</button>
+												</TooltipTrigger>
+												<TooltipContent side="left" align="start">
+													<span className="font-mono text-[11px] break-all">
+														{file.path}
+													</span>
+												</TooltipContent>
+											</Tooltip>
 										);
 									})
 								)}
@@ -359,12 +405,27 @@ export function ChangesSidebar({ sessionId, active }: ChangesSidebarProps) {
 					{/* Diff viewer for the currently selected file/commit */}
 					{selected && (
 						<section className="rounded-lg border border-border/40 bg-muted/20 overflow-hidden">
-							<div className="flex items-center justify-between px-2.5 py-1.5 border-b border-border/30">
-								<div className="text-[10px] uppercase tracking-wide text-muted-foreground font-semibold truncate">
-									{selected.scope === "commit"
-										? `コミット ${selected.label}`
-										: `${scopeLabel(selected.scope)} · ${selected.label}`}
-								</div>
+							<div className="flex items-center justify-between px-2.5 py-1.5 border-b border-border/30 gap-2">
+								<Tooltip delayDuration={300}>
+									<TooltipTrigger asChild>
+										<div className="text-[10px] uppercase tracking-wide text-muted-foreground font-semibold truncate min-w-0 flex-1">
+											{selected.scope === "commit"
+												? `コミット ${selected.label}`
+												: `${scopeLabel(selected.scope)} · ${selected.label}`}
+										</div>
+									</TooltipTrigger>
+									<TooltipContent
+										side="top"
+										align="start"
+										className="max-w-[360px]"
+									>
+										<span className="text-[11px] break-all">
+											{selected.scope === "commit"
+												? `コミット ${selected.label}`
+												: `${scopeLabel(selected.scope)} · ${selected.label}`}
+										</span>
+									</TooltipContent>
+								</Tooltip>
 								<button
 									type="button"
 									className="text-[10px] text-muted-foreground hover:text-foreground transition"

--- a/apps/desktop/src/renderer/features/todo-agent/TodoManager/TodoManager.tsx
+++ b/apps/desktop/src/renderer/features/todo-agent/TodoManager/TodoManager.tsx
@@ -13,6 +13,7 @@ import { Label } from "@superset/ui/label";
 import { ScrollArea } from "@superset/ui/scroll-area";
 import { toast } from "@superset/ui/sonner";
 import { Textarea } from "@superset/ui/textarea";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { cn } from "@superset/ui/utils";
 import {
 	Bot,
@@ -551,23 +552,36 @@ export function TodoManager({
 										const collapsed = collapsedGroups.has(group.key);
 										return (
 											<div key={group.key} className="pb-1">
-												<button
-													type="button"
-													onClick={() => toggleGroup(group.key)}
-													className="sticky top-0 z-10 bg-background/95 backdrop-blur w-full flex items-center gap-1 px-2 py-1.5 text-[10px] uppercase tracking-wide text-muted-foreground font-semibold border-b hover:bg-accent/40 transition"
-												>
-													{collapsed ? (
-														<HiMiniChevronRight className="size-3" />
-													) : (
-														<HiMiniChevronDown className="size-3" />
-													)}
-													<span className="flex-1 text-left truncate">
-														{group.label}
-													</span>
-													<span className="text-muted-foreground/60">
-														{group.sessions.length}
-													</span>
-												</button>
+												<Tooltip delayDuration={300}>
+													<TooltipTrigger asChild>
+														<button
+															type="button"
+															onClick={() => toggleGroup(group.key)}
+															className="sticky top-0 z-10 bg-background/95 backdrop-blur w-full flex items-center gap-1 px-2 py-1.5 text-[10px] uppercase tracking-wide text-muted-foreground font-semibold border-b hover:bg-accent/40 transition min-w-0"
+														>
+															{collapsed ? (
+																<HiMiniChevronRight className="size-3 shrink-0" />
+															) : (
+																<HiMiniChevronDown className="size-3 shrink-0" />
+															)}
+															<span className="flex-1 text-left truncate min-w-0">
+																{group.label}
+															</span>
+															<span className="text-muted-foreground/60 shrink-0">
+																{group.sessions.length}
+															</span>
+														</button>
+													</TooltipTrigger>
+													<TooltipContent
+														side="right"
+														align="start"
+														className="max-w-[360px]"
+													>
+														<span className="text-[11px] break-all">
+															{group.label}
+														</span>
+													</TooltipContent>
+												</Tooltip>
 												{!collapsed && (
 													<div className="flex flex-col px-1.5 py-1 gap-0.5">
 														{group.sessions.map((session) => (
@@ -797,6 +811,8 @@ function SessionRow({
 		void copyToClipboard(session.title, "タイトルをコピーしました");
 	}, [session.title]);
 
+	const status = statusLabel(session);
+
 	return (
 		<div
 			className={cn(
@@ -804,38 +820,54 @@ function SessionRow({
 				isSelected ? "bg-accent" : "hover:bg-accent/50",
 			)}
 		>
-			<button
-				type="button"
-				onClick={onSelect}
-				className="text-left flex-1 min-w-0 pl-2.5 pr-1 py-2"
-			>
-				<div className="flex items-center gap-2">
-					<StatusDot status={session.status} />
-					{renaming ? (
-						<Input
-							autoFocus
-							value={renameValue}
-							onChange={(e) => setRenameValue(e.target.value)}
-							onKeyDown={handleRenameKey}
-							onBlur={() => void commitRename()}
-							onClick={(e) => e.stopPropagation()}
-							className="h-6 text-xs rounded-md"
-						/>
-					) : (
-						<span className="text-xs font-medium line-clamp-1 flex-1">
-							{session.title}
-						</span>
-					)}
-				</div>
-				<div className="flex items-center justify-between gap-2 pl-4 mt-0.5">
-					<span className="text-[10px] text-muted-foreground line-clamp-1 flex-1">
-						{statusLabel(session)}
-					</span>
-					<span className="text-[10px] text-muted-foreground tabular-nums shrink-0">
-						{formatRelativeTime(session.createdAt)}
-					</span>
-				</div>
-			</button>
+			<Tooltip delayDuration={500}>
+				<TooltipTrigger asChild>
+					<button
+						type="button"
+						onClick={onSelect}
+						className="text-left flex-1 min-w-0 pl-2.5 pr-1 py-2"
+					>
+						<div className="flex items-center gap-2 min-w-0">
+							<StatusDot status={session.status} />
+							{renaming ? (
+								<Input
+									autoFocus
+									value={renameValue}
+									onChange={(e) => setRenameValue(e.target.value)}
+									onKeyDown={handleRenameKey}
+									onBlur={() => void commitRename()}
+									onClick={(e) => e.stopPropagation()}
+									className="h-6 text-xs rounded-md"
+								/>
+							) : (
+								<span className="text-xs font-medium line-clamp-1 flex-1 min-w-0">
+									{session.title}
+								</span>
+							)}
+						</div>
+						<div className="flex items-center justify-between gap-2 pl-4 mt-0.5 min-w-0">
+							<span className="text-[10px] text-muted-foreground line-clamp-1 flex-1 min-w-0">
+								{status}
+							</span>
+							<span className="text-[10px] text-muted-foreground tabular-nums shrink-0">
+								{formatRelativeTime(session.createdAt)}
+							</span>
+						</div>
+					</button>
+				</TooltipTrigger>
+				{!renaming && (
+					<TooltipContent side="right" align="start" className="max-w-[360px]">
+						<div className="flex flex-col gap-0.5">
+							<span className="text-[11px] font-medium break-words">
+								{session.title}
+							</span>
+							<span className="text-[10px] opacity-70 break-words">
+								{status}
+							</span>
+						</div>
+					</TooltipContent>
+				)}
+			</Tooltip>
 			<div className="flex items-center pr-1">
 				<DropdownMenu open={menuOpen} onOpenChange={setMenuOpen}>
 					<DropdownMenuTrigger asChild>


### PR DESCRIPTION
## Summary

Issue #252 対応。`apps/desktop` の AgentManager で一部テキストが見切れていた箇所を、省略 (`truncate` / `line-clamp`) + ホバー時ツールチップで全文表示できるように改善。

### 左サイドバー
- ワークスペースグループ見出し (プロジェクト名 / ワークツリー名) をツールチップ化
- セッションカードのタイトルとステータス行をホバーで全文表示
- `min-w-0` を補強して flex 親による押し出しが起きても綺麗に `...` に収束する様にした

### 右サイドバー (ChangesSidebar)
- ブランチ名ヘッダー
- 「セッション全体」「ワーキングツリー」のファイルパス一覧
- コミット subject + メタ情報 (short sha / author / date)
- 選択中の diff ヘッダーラベル

いずれも `Tooltip` (`@superset/ui/tooltip`, 既存で使われているもの) でラップし、リネーム中はタイトルが `Input` になるのでその間だけツールチップを出さない様ガードしている。

## Test plan
- [ ] AgentManager を開き、狭い左サイドバー幅でワークスペース名 / セッションタイトルが `...` で省略されること
- [ ] それぞれにマウスホバーし、ツールチップで全文が表示されること
- [ ] 右サイドバー (ChangesSidebar) のブランチ名 / ファイルパス / コミット subject / 選択ヘッダーでも同様にツールチップが出ること
- [ ] セッションのリネーム中 (入力中) はツールチップが出ない事
- [ ] `bun run lint` / `bun run typecheck` がグリーン

Closes #252