### PR TITLE
fix(desktop): TODO/Schedule ダイアログ横幅を !important で確実に広げる (再対応 #238)

### DIFF
--- a/apps/desktop/src/renderer/features/todo-agent/TodoManager/SchedulesSection/components/ScheduleEditorDialog/ScheduleEditorDialog.tsx
+++ b/apps/desktop/src/renderer/features/todo-agent/TodoManager/SchedulesSection/components/ScheduleEditorDialog/ScheduleEditorDialog.tsx
@@ -264,7 +264,7 @@ export function ScheduleEditorDialog({
 
 	return (
 		<Dialog open={open} onOpenChange={onOpenChange}>
-			<DialogContent className="max-w-5xl sm:max-w-5xl w-[92vw] max-h-[90vh] overflow-y-auto">
+			<DialogContent className="!w-[min(1280px,92vw)] !max-w-[min(1280px,92vw)] sm:!max-w-[min(1280px,92vw)] max-h-[90vh] overflow-y-auto">
 				<DialogHeader>
 					<DialogTitle>
 						{initial ? "スケジュールを編集" : "新しいスケジュール"}

--- a/apps/desktop/src/renderer/features/todo-agent/TodoModal/TodoModal.tsx
+++ b/apps/desktop/src/renderer/features/todo-agent/TodoModal/TodoModal.tsx
@@ -237,7 +237,7 @@ export function TodoModal({
 
 	return (
 		<Dialog open={open} onOpenChange={handleOpenChange}>
-			<DialogContent className="max-w-xl sm:max-w-xl rounded-xl">
+			<DialogContent className="!max-w-[min(640px,calc(100vw-2rem))] sm:!max-w-[min(640px,calc(100vw-2rem))] rounded-xl">
 				<DialogHeader>
 					<DialogTitle>新しい自律 TODO</DialogTitle>
 				</DialogHeader>


### PR DESCRIPTION
## 概要

Issue #238 は PR #242 でクラスを `sm:max-w-xl` / `sm:max-w-5xl` に差し替えたが、ユーザー報告によるとビルド後も依然として狭いままだった（`sm:max-w-lg` 相当の 512px）。

## 原因の仮説

`packages/ui` の `DialogContent` の base className には `sm:max-w-lg` が入っている。twMerge は理屈上これを剥がせるはずなのに、ビルド済み CSS のルール順で `sm:max-w-5xl` が `sm:max-w-lg` より **前** に配置されるため、@media の specificity 引き分けが発生した場合に `lg` が勝ってしまう余地がある。

実際、リポジトリの他の広幅ダイアログ（`DockerView` / `DatabasesView` / `TeardownLogsDialog`）は揃って `!max-w-...` の important パターンを採用している。

## 変更点

| ダイアログ | before | after |
|---|---|---|
| `TodoModal` | `max-w-xl sm:max-w-xl rounded-xl` | `!max-w-[min(640px,calc(100vw-2rem))] sm:!max-w-[min(640px,calc(100vw-2rem))] rounded-xl` |
| `ScheduleEditorDialog` | `max-w-5xl sm:max-w-5xl w-[92vw] ...` | `!w-[min(1280px,92vw)] !max-w-[min(1280px,92vw)] sm:!max-w-[min(1280px,92vw)] max-h-[90vh] overflow-y-auto` |

- `!` (important) でベースの `sm:max-w-lg` を確実に勝ち切る
- `min(固定幅, vw)` で画面が狭い時はビューポート基準で縮む
- `sm:!max-w-...` も併記して @media 由来の順序問題を完全に排除

## Test plan

- [ ] Desktop アプリを起動
- [ ] Agent Manager で「新しい TODO」ダイアログ → 640px 幅で表示されること
- [ ] 「新しいスケジュール」ダイアログ → 92vw（最大 1280px）で表示されること
- [ ] ウィンドウ幅を狭めた時に `min()` で画面内に収まること
- [ ] 既存の他ダイアログに影響していないこと（横幅を変えていないので影響なし）

Closes #238

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * スケジュール編集ダイアログとタスクモーダルが、さまざまな画面サイズに対して最適に表示されるようにレイアウトが調整されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->