### PR TITLE
feat(desktop): ライブストリームのMCPツール名を "server tool" 形式で表示

### DIFF
--- a/apps/desktop/src/renderer/features/todo-agent/TodoManager/TodoManager.tsx
+++ b/apps/desktop/src/renderer/features/todo-agent/TodoManager/TodoManager.tsx
@@ -27,6 +27,7 @@ import {
 	Globe,
 	ListTree,
 	type LucideIcon,
+	Plug,
 	Search,
 	Sparkles,
 	SquareTerminal,
@@ -1892,6 +1893,11 @@ function ToolCallCard({
 }) {
 	const { toolUse, toolResult, children } = item;
 	const toolName = toolUse.label;
+	// Claude Code emits MCP tool names as `mcp__<server>__<tool>`. That
+	// raw form is fine for routing but ugly in the stream UI. Render as
+	// `server tool` instead; the palette also uses a dedicated MCP icon
+	// so it still visually separates from built-in tools.
+	const displayName = formatToolDisplayName(toolName);
 	const secondary = extractSecondaryInfo(toolName, toolUse.text);
 	const hasResult = toolResult != null;
 	const isRunning = !hasResult;
@@ -1937,11 +1943,11 @@ function ToolCallCard({
 				</span>
 				{isRunning ? (
 					<ShinyText className={cn("font-semibold shrink-0", palette.name)}>
-						{toolName}
+						{displayName}
 					</ShinyText>
 				) : (
 					<span className={cn("font-semibold shrink-0", palette.name)}>
-						{toolName}
+						{displayName}
 					</span>
 				)}
 				{secondary && (
@@ -2034,6 +2040,20 @@ function ShinyText({
 	);
 }
 
+/**
+ * Render tool names for the stream UI. Claude Code emits MCP tools as
+ * `mcp__<server>__<tool>`; the `mcp__` prefix is an internal routing
+ * marker that adds no signal for the human reading the stream, so we
+ * strip it and render `<server> <tool>` space-separated. Built-in tools
+ * (Read, Bash, …) fall through untouched.
+ */
+function formatToolDisplayName(rawName: string): string {
+	if (!rawName.startsWith("mcp__")) return rawName;
+	const parts = rawName.slice("mcp__".length).split("__");
+	if (parts.length < 2) return rawName;
+	return parts.join(" ");
+}
+
 interface ToolPalette {
 	icon: LucideIcon;
 	iconBg: string;
@@ -2057,6 +2077,18 @@ function getToolPalette(toolName: string): ToolPalette {
 		name: "text-foreground",
 		accent: "hover:bg-accent/20",
 	};
+	// All MCP tools share one palette so a run that uses a chain of
+	// `mcp__<server>__<tool>` calls doesn't explode into unique colors.
+	// The server name is already surfaced via `formatToolDisplayName`.
+	if (toolName.startsWith("mcp__")) {
+		return {
+			icon: Plug,
+			iconBg: "bg-indigo-500/15",
+			iconColor: "text-indigo-400",
+			name: "text-indigo-300",
+			accent: "hover:bg-indigo-500/10",
+		};
+	}
 	const palettes: Record<string, ToolPalette> = {
 		Agent: {
 			icon: Bot,


### PR DESCRIPTION
## 概要

Agent Manager タスク詳細の「Claude の応答 / ライブストリーム」で、MCP ツール呼び出しが生の `mcp__<server>__<tool>` 形式で表示されていたのを、`<server> <tool>` のスッキリした見た目に変更。

Before: \`mcp__aivis__talk\` (Wrench グレーでそのまま)
After: \`aivis talk\` (Plug アイコン + indigo)

## 変更点

- `formatToolDisplayName` を追加。`mcp__` で始まるツール名を `__` で分割し、プレフィックスを外して空白区切りで結合（`mcp__aivis__talk` → \`aivis talk\`、`mcp__github__create_issue` → \`github create_issue\`）。それ以外 (`Read` / `Bash` 等) は素通し
- ToolCallCard の label 描画 (`summary` 内の `ShinyText` / `span`) で `displayName` を使う
- `getToolPalette` は `mcp__` 始まりなら全て `Plug` + indigo の共通 palette を返す。サーバー別に色を散らさず、フォールバック Wrench グレーより識別しやすい見た目に
- 生イベントは触らないので履歴 stream ログの形式は不変（安全な表示層だけの変更）

## Test plan

- [ ] `bun run typecheck` pass（ローカルで確認済み）
- [ ] `bun run lint` clean（ローカルで確認済み）
- [ ] 実機: MCP ツール (`mcp__aivis__talk` 等) が \`aivis talk\` + Plug アイコン + indigo で表示されること
- [ ] 実機: ネイティブツール (`Read`, `Bash`, `Task`) の表示が従来通りであること

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能・改善**
  * ツール名の表示形式を改善し、より読みやすいフォーマットで表示するようにしました。
  * MCP対応ツールの表示に統一されたアイコンを使用するようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->