### PR TITLE
fix(desktop): TODO 新規作成ダイアログの幅 / truncate / model&effort ピッカー

### DIFF
--- a/apps/desktop/src/renderer/features/todo-agent/ClaudeRuntimePicker/ClaudeRuntimePicker.tsx
+++ b/apps/desktop/src/renderer/features/todo-agent/ClaudeRuntimePicker/ClaudeRuntimePicker.tsx
@@ -20,21 +20,7 @@ interface ClaudeRuntimePickerProps {
 	onModelChange: (value: ClaudeModelPick) => void;
 	onEffortChange: (value: ClaudeEffortPick) => void;
 	disabled?: boolean;
-	/**
-	 * Layout variant. `stacked` labels above, `row` puts model + effort
-	 * side by side. Defaults to `row`.
-	 */
 	layout?: "stacked" | "row";
-	/**
-	 * Shows the "デフォルト = 〜" hint line under the row. Hidden when the
-	 * caller has its own explanation nearby (e.g. the Settings tab).
-	 */
-	showHint?: boolean;
-	/**
-	 * Compact mode shrinks the control height + label size so the picker
-	 * slots into tight dialog grids. Default matches the TodoModal form
-	 * density.
-	 */
 	compact?: boolean;
 }
 
@@ -52,7 +38,6 @@ export function ClaudeRuntimePicker({
 	onEffortChange,
 	disabled,
 	layout = "row",
-	showHint = true,
 	compact = true,
 }: ClaudeRuntimePickerProps) {
 	const labelClass = compact ? "text-xs" : "text-sm";
@@ -79,12 +64,7 @@ export function ClaudeRuntimePicker({
 						<SelectContent>
 							{CLAUDE_MODEL_SELECT_OPTIONS.map((opt) => (
 								<SelectItem key={opt.value} value={opt.value}>
-									<div className="flex flex-col gap-0.5 py-0.5">
-										<span className="text-xs font-medium">{opt.label}</span>
-										<span className="text-[10px] text-muted-foreground leading-tight">
-											{opt.description}
-										</span>
-									</div>
+									<span className="text-xs font-medium">{opt.label}</span>
 								</SelectItem>
 							))}
 						</SelectContent>
@@ -103,26 +83,13 @@ export function ClaudeRuntimePicker({
 						<SelectContent>
 							{CLAUDE_EFFORT_SELECT_OPTIONS.map((opt) => (
 								<SelectItem key={opt.value} value={opt.value}>
-									<div className="flex flex-col gap-0.5 py-0.5">
-										<span className="text-xs font-medium">{opt.label}</span>
-										<span className="text-[10px] text-muted-foreground leading-tight">
-											{opt.description}
-										</span>
-									</div>
+									<span className="text-xs font-medium">{opt.label}</span>
 								</SelectItem>
 							))}
 						</SelectContent>
 					</Select>
 				</div>
 			</div>
-			{showHint && (
-				<p className="text-[10px] text-muted-foreground leading-relaxed">
-					デフォルト は --model / --effort を渡さないため、CLI
-					側の設定（ユーザ設定や既定値）が優先される。 モデルと effort
-					の組み合わせによっては Claude Code
-					が対応していない場合があり、その時はセッションが即座にエラー終了する。
-				</p>
-			)}
 		</div>
 	);
 }

--- a/apps/desktop/src/renderer/features/todo-agent/TodoManager/TodoManager.tsx
+++ b/apps/desktop/src/renderer/features/todo-agent/TodoManager/TodoManager.tsx
@@ -68,6 +68,16 @@ import {
 } from "react-icons/lu";
 import { MarkdownRenderer } from "renderer/components/MarkdownRenderer";
 import { electronTrpc } from "renderer/lib/electron-trpc";
+import {
+	type ClaudeEffortPick,
+	type ClaudeModelPick,
+	ClaudeRuntimePicker,
+	DEFAULT_SENTINEL,
+	fromPersistedEffort,
+	fromPersistedModel,
+	toPersistedEffort,
+	toPersistedModel,
+} from "../ClaudeRuntimePicker";
 import { ChangesSidebar } from "./ChangesSidebar";
 import { AttachmentChips } from "./components/AttachmentChips";
 import { AttachmentPreviewDialog } from "./components/AttachmentPreviewDialog";
@@ -552,7 +562,7 @@ export function TodoManager({
 									{grouped.map((group) => {
 										const collapsed = collapsedGroups.has(group.key);
 										return (
-											<div key={group.key} className="pb-1">
+											<div key={group.key} className="pb-1 min-w-0 w-full">
 												<Tooltip delayDuration={300}>
 													<TooltipTrigger asChild>
 														<button
@@ -674,7 +684,7 @@ export function TodoManager({
 				/>
 				<Dialog open={composerOpen} onOpenChange={setComposerOpen}>
 					<DialogContent
-						className="w-[1080px] max-w-[calc(100vw-3rem)] h-[84vh] max-h-[900px] p-0 gap-0 overflow-hidden flex flex-col rounded-xl"
+						className="!w-[min(1080px,calc(100vw-3rem))] !max-w-[min(1080px,calc(100vw-3rem))] sm:!max-w-[min(1080px,calc(100vw-3rem))] h-[84vh] max-h-[900px] p-0 gap-0 overflow-hidden flex flex-col rounded-xl"
 						showCloseButton={false}
 					>
 						<DialogTitle className="sr-only">新しい TODO</DialogTitle>
@@ -2431,11 +2441,29 @@ function TodoComposer({
 	const [goalAttachments, setGoalAttachments] = useState<ImageAttachment[]>([]);
 	const [verifyCommand, setVerifyCommand] = useState("");
 	const [selectedPresetId, setSelectedPresetId] = useState<string | null>(null);
+	const [claudeModel, setClaudeModel] =
+		useState<ClaudeModelPick>(DEFAULT_SENTINEL);
+	const [claudeEffort, setClaudeEffort] =
+		useState<ClaudeEffortPick>(DEFAULT_SENTINEL);
 	const [submitting, setSubmitting] = useState(false);
 
 	useEffect(() => {
 		if (!projectId && defaultProjectId) setProjectId(defaultProjectId);
 	}, [projectId, defaultProjectId]);
+
+	// Seed model/effort pickers from the global defaults once the settings
+	// query resolves. Only runs until the user touches a picker — after
+	// that any manual pick is preserved even if a refetch comes in.
+	const claudeSeededRef = useRef(false);
+	useEffect(() => {
+		if (claudeSeededRef.current) return;
+		if (!todoSettings) return;
+		setClaudeModel(fromPersistedModel(todoSettings.defaultClaudeModel ?? null));
+		setClaudeEffort(
+			fromPersistedEffort(todoSettings.defaultClaudeEffort ?? null),
+		);
+		claudeSeededRef.current = true;
+	}, [todoSettings]);
 
 	// Workspaces scoped to the picked project, excluding the ones
 	// scheduled for deletion.
@@ -2532,6 +2560,8 @@ function TodoComposer({
 				maxIterations,
 				maxWallClockSec,
 				customSystemPrompt: selected?.content ?? undefined,
+				claudeModel: toPersistedModel(claudeModel),
+				claudeEffort: toPersistedEffort(claudeEffort),
 			});
 			await utils.todoAgent.listAll.invalidate();
 			toast.success(
@@ -2554,6 +2584,8 @@ function TodoComposer({
 		}
 	}, [
 		canSubmit,
+		claudeEffort,
+		claudeModel,
 		createMut,
 		createWorkspaceMut,
 		createWorktree,
@@ -2715,6 +2747,14 @@ function TodoComposer({
 								placeholder="例: bun test"
 							/>
 						</div>
+
+						<ClaudeRuntimePicker
+							model={claudeModel}
+							effort={claudeEffort}
+							onModelChange={setClaudeModel}
+							onEffortChange={setClaudeEffort}
+							disabled={submitting}
+						/>
 
 						{selectedPresetId && (
 							<div className="flex flex-col gap-1.5">

--- a/packages/ui/src/components/ui/scroll-area.tsx
+++ b/packages/ui/src/components/ui/scroll-area.tsx
@@ -18,7 +18,7 @@ function ScrollArea({
 		>
 			<ScrollAreaPrimitive.Viewport
 				data-slot="scroll-area-viewport"
-				className="focus-visible:ring-ring/50 size-full rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:outline-1"
+				className="focus-visible:ring-ring/50 size-full rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:outline-1 [&>div]:!block [&>div]:!w-full"
 			>
 				{children}
 			</ScrollAreaPrimitive.Viewport>


### PR DESCRIPTION
## 概要

直前リリース (`v1.5.5-fork.4`) 後に見つかった 3 件の UI 問題を一括修正し、併せて「新しい TODO」ダイアログにも model / effort 指定を追加。

## 修正内容

### 1. 新規 TODO ダイアログの幅が広がらない
- 症状: `新規` ボタンで開く TodoComposer の Dialog が `sm:max-w-lg` (512px) に制限されて狭かった
- 原因: PR #255 で `!important` 化されたのは TodoModal 側 (TodoButton 経由) で、TodoManager 内のインライン Dialog (TodoComposer) は別物だった
- 修正: `TodoManager.tsx` の Dialog に `!w-[min(1080px,calc(100vw-3rem))] !max-w-[...] sm:!max-w-[...]` を適用 (DockerView / ScheduleEditorDialog と同じパターン)

### 2. サイドバー見出しの truncate が効かない
- 症状: 左サイドバーのグループ見出しや ChangesSidebar のブランチ名・ファイルパスが、長文だと単に右端でクリップされて `...` が出なかった
- 原因: Radix ScrollArea の Viewport が内部で `display: table` のラッパを挿入するため、中の `w-full` が親幅 (固定 320px) ではなく content 幅に従い、子の `truncate` が効かない
- 修正: 共通 `ScrollArea` (`packages/ui/src/components/ui/scroll-area.tsx`) に `[&>div]:!block [&>div]:!w-full` を付与して block layout を強制

### 3. 新規 TODO ダイアログにも model / effort 指定を追加
- ScheduleEditorDialog と同じ `ClaudeRuntimePicker` を TodoComposer に配置
- 初期値はユーザ設定の `defaultClaudeModel` / `defaultClaudeEffort` から seed
- 未タッチなら `--model` / `--effort` を CLI に渡さない (既定挙動を維持)

### 4. ClaudeRuntimePicker のシンプル化
- Select Item の副説明 (opt.description) と下部のヒント段落を削除
- 表示は model 名 / effort 名のみ (使うユーザはわかっている前提)

## Test plan

- [ ] Dev で「新規」を押すと TodoComposer が 1080px 幅で開くこと
- [ ] サイドバーのグループ見出しが長いと `...` で省略されること (hover で Tooltip 全文表示)
- [ ] ChangesSidebar のブランチ名 / ファイルパスも同様
- [ ] 新規 TODO ダイアログで model / effort を選べること。初期値が設定の既定値と一致すること
- [ ] 他の Radix ScrollArea を使う画面で回帰していないこと

Refs: #238, #252, #254, #255

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * TODOコンポーザーにClaudeのモデルと努力レベルを選択する機能を追加しました。

* **UI/UX改善**
  * ランタイムピッカーの表示をシンプル化し、不要な説明文を削除しました。
  * スクロールエリアのスタイリングを改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->