### PR TITLE
feat(desktop): YouTube URL から通知音を作成 (#258)

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/ringtone/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/ringtone/index.ts
@@ -10,6 +10,11 @@ import {
 import { playSoundFile } from "main/lib/play-sound";
 import { getSoundPath } from "main/lib/sound-paths";
 import {
+	importRingtoneFromYouTube,
+	YOUTUBE_RINGTONE_LIMITS,
+	YouTubeRingtoneError,
+} from "main/lib/youtube-ringtone";
+import {
 	CUSTOM_RINGTONE_ID,
 	getRingtoneFilename,
 	isBuiltInRingtoneId,
@@ -170,6 +175,49 @@ export const createRingtoneRouter = (getWindow: () => BrowserWindow | null) => {
 				});
 			}
 		}),
+
+		/**
+		 * Imports a custom ringtone by clipping a section of a YouTube video.
+		 * Requires `yt-dlp` and `ffmpeg` to be installed on the user's machine.
+		 */
+		importFromYouTube: publicProcedure
+			.input(
+				z.object({
+					url: z.string().min(1),
+					startSeconds: z
+						.number()
+						.min(0)
+						.max(60 * 60 * 12),
+					durationSeconds: z
+						.number()
+						.min(1)
+						.max(YOUTUBE_RINGTONE_LIMITS.maxDurationSeconds),
+					displayName: z.string().max(120).optional(),
+				}),
+			)
+			.mutation(async ({ input }) => {
+				try {
+					const ringtone = await importRingtoneFromYouTube(input);
+					return { ringtone };
+				} catch (error) {
+					if (error instanceof YouTubeRingtoneError) {
+						throw new TRPCError({
+							code:
+								error.code === "BINARY_MISSING" || error.code === "TIMEOUT"
+									? "PRECONDITION_FAILED"
+									: "BAD_REQUEST",
+							message: error.message,
+						});
+					}
+					throw new TRPCError({
+						code: "INTERNAL_SERVER_ERROR",
+						message:
+							error instanceof Error
+								? error.message
+								: "Failed to import YouTube ringtone",
+					});
+				}
+			}),
 	});
 };
 

--- a/apps/desktop/src/main/lib/custom-ringtones.ts
+++ b/apps/desktop/src/main/lib/custom-ringtones.ts
@@ -116,12 +116,15 @@ function readCustomRingtoneMetadata(): CustomRingtoneMetadata {
 	}
 }
 
-function writeCustomRingtoneMetadata(name: string): void {
+function writeCustomRingtoneMetadata(
+	name: string,
+	importedAt: number = Date.now(),
+): void {
 	writeFileSync(
 		CUSTOM_RINGTONE_METADATA_PATH,
 		JSON.stringify({
 			name,
-			importedAt: Date.now(),
+			importedAt,
 		}),
 		"utf-8",
 	);
@@ -165,7 +168,9 @@ export function setCustomRingtoneDisplayName(name: string): void {
 		return;
 	}
 	ensureCustomRingtonesDir();
-	writeCustomRingtoneMetadata(name.trim().slice(0, 80) || "Custom Audio");
+	const displayName = name.trim().slice(0, 80) || "Custom Audio";
+	const existing = readCustomRingtoneMetadata();
+	writeCustomRingtoneMetadata(displayName, existing.importedAt ?? Date.now());
 }
 
 export function getCustomRingtoneInfo(): CustomRingtoneInfo | null {

--- a/apps/desktop/src/main/lib/custom-ringtones.ts
+++ b/apps/desktop/src/main/lib/custom-ringtones.ts
@@ -160,6 +160,14 @@ export function getCustomRingtonePath(): string | null {
 	return join(RINGTONES_ASSETS_DIR, filename);
 }
 
+export function setCustomRingtoneDisplayName(name: string): void {
+	if (!hasCustomRingtone()) {
+		return;
+	}
+	ensureCustomRingtonesDir();
+	writeCustomRingtoneMetadata(name.trim().slice(0, 80) || "Custom Audio");
+}
+
 export function getCustomRingtoneInfo(): CustomRingtoneInfo | null {
 	if (!hasCustomRingtone()) {
 		return null;

--- a/apps/desktop/src/main/lib/youtube-ringtone.ts
+++ b/apps/desktop/src/main/lib/youtube-ringtone.ts
@@ -1,0 +1,208 @@
+import { spawn } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { existsSync, mkdirSync, statSync } from "node:fs";
+import { rm, unlink } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+	type CustomRingtoneInfo,
+	importCustomRingtoneFromPath,
+	setCustomRingtoneDisplayName,
+} from "./custom-ringtones";
+
+const MAX_CLIP_DURATION_SECONDS = 30;
+const YT_DLP_TIMEOUT_MS = 120_000;
+
+export interface ImportFromYouTubeOptions {
+	url: string;
+	startSeconds: number;
+	durationSeconds: number;
+	displayName?: string;
+}
+
+export class YouTubeRingtoneError extends Error {
+	constructor(
+		message: string,
+		public readonly code:
+			| "BINARY_MISSING"
+			| "INVALID_URL"
+			| "INVALID_RANGE"
+			| "DOWNLOAD_FAILED"
+			| "TIMEOUT",
+	) {
+		super(message);
+		this.name = "YouTubeRingtoneError";
+	}
+}
+
+const YOUTUBE_URL_PATTERN =
+	/^https?:\/\/(?:www\.|m\.|music\.)?(?:youtube\.com\/(?:watch\?v=|shorts\/|embed\/|live\/)[\w-]+|youtu\.be\/[\w-]+)/i;
+
+export function isLikelyYouTubeUrl(url: string): boolean {
+	return YOUTUBE_URL_PATTERN.test(url.trim());
+}
+
+function checkBinary(binary: string): Promise<boolean> {
+	return new Promise((resolve) => {
+		const proc = spawn(binary, ["--version"], { stdio: "ignore" });
+		proc.on("error", () => resolve(false));
+		proc.on("exit", (code) => resolve(code === 0));
+	});
+}
+
+async function ensureBinariesInstalled(): Promise<void> {
+	const [hasYtDlp, hasFfmpeg] = await Promise.all([
+		checkBinary("yt-dlp"),
+		checkBinary("ffmpeg"),
+	]);
+
+	if (!hasYtDlp || !hasFfmpeg) {
+		const missing: string[] = [];
+		if (!hasYtDlp) missing.push("yt-dlp");
+		if (!hasFfmpeg) missing.push("ffmpeg");
+		throw new YouTubeRingtoneError(
+			`Missing required tool(s): ${missing.join(", ")}. Install with \`brew install ${missing.join(" ")}\` (macOS) or your platform's package manager.`,
+			"BINARY_MISSING",
+		);
+	}
+}
+
+function runYtDlp(args: string[], cwd: string): Promise<void> {
+	return new Promise((resolve, reject) => {
+		const proc = spawn("yt-dlp", args, {
+			cwd,
+			stdio: ["ignore", "pipe", "pipe"],
+		});
+
+		let stderr = "";
+		proc.stderr?.on("data", (chunk: Buffer) => {
+			stderr += chunk.toString();
+		});
+
+		const timer = setTimeout(() => {
+			proc.kill("SIGKILL");
+			reject(
+				new YouTubeRingtoneError(
+					"yt-dlp timed out while downloading the audio.",
+					"TIMEOUT",
+				),
+			);
+		}, YT_DLP_TIMEOUT_MS);
+
+		proc.on("error", (error) => {
+			clearTimeout(timer);
+			reject(
+				new YouTubeRingtoneError(
+					`Failed to launch yt-dlp: ${error.message}`,
+					"DOWNLOAD_FAILED",
+				),
+			);
+		});
+
+		proc.on("exit", (code) => {
+			clearTimeout(timer);
+			if (code === 0) {
+				resolve();
+			} else {
+				const trimmed = stderr.trim().split("\n").slice(-3).join("\n");
+				reject(
+					new YouTubeRingtoneError(
+						trimmed || `yt-dlp exited with code ${code ?? "?"}`,
+						"DOWNLOAD_FAILED",
+					),
+				);
+			}
+		});
+	});
+}
+
+export async function importRingtoneFromYouTube(
+	options: ImportFromYouTubeOptions,
+): Promise<CustomRingtoneInfo> {
+	const url = options.url.trim();
+
+	if (!isLikelyYouTubeUrl(url)) {
+		throw new YouTubeRingtoneError(
+			"Please enter a valid YouTube URL (youtube.com or youtu.be).",
+			"INVALID_URL",
+		);
+	}
+
+	const startSeconds = Math.max(0, Math.floor(options.startSeconds));
+	const durationSeconds = Math.floor(options.durationSeconds);
+
+	if (
+		!Number.isFinite(durationSeconds) ||
+		durationSeconds <= 0 ||
+		durationSeconds > MAX_CLIP_DURATION_SECONDS
+	) {
+		throw new YouTubeRingtoneError(
+			`Clip duration must be between 1 and ${MAX_CLIP_DURATION_SECONDS} seconds.`,
+			"INVALID_RANGE",
+		);
+	}
+
+	await ensureBinariesInstalled();
+
+	const workDir = join(tmpdir(), `superset-yt-${randomUUID()}`);
+	mkdirSync(workDir, { recursive: true });
+	const outputPath = join(workDir, "clip.mp3");
+
+	const endSeconds = startSeconds + durationSeconds;
+	const sectionSpec = `*${startSeconds}-${endSeconds}`;
+
+	const args = [
+		"--no-playlist",
+		"--no-warnings",
+		"--quiet",
+		"-x",
+		"--audio-format",
+		"mp3",
+		"--audio-quality",
+		"5",
+		"--download-sections",
+		sectionSpec,
+		"--force-keyframes-at-cuts",
+		"-o",
+		outputPath,
+		url,
+	];
+
+	try {
+		await runYtDlp(args, workDir);
+
+		if (!existsSync(outputPath) || statSync(outputPath).size === 0) {
+			throw new YouTubeRingtoneError(
+				"yt-dlp did not produce an audio file. The video may be unavailable or restricted.",
+				"DOWNLOAD_FAILED",
+			);
+		}
+
+		const info = await importCustomRingtoneFromPath(outputPath);
+
+		const displayName = options.displayName?.trim();
+		if (displayName) {
+			setCustomRingtoneDisplayName(displayName);
+			return { ...info, name: displayName.slice(0, 80) };
+		}
+
+		return info;
+	} finally {
+		await safeUnlink(outputPath);
+		await rm(workDir, { recursive: true, force: true }).catch(() => {
+			// Best-effort cleanup.
+		});
+	}
+}
+
+async function safeUnlink(path: string): Promise<void> {
+	try {
+		await unlink(path);
+	} catch {
+		// Best-effort cleanup.
+	}
+}
+
+export const YOUTUBE_RINGTONE_LIMITS = {
+	maxDurationSeconds: MAX_CLIP_DURATION_SECONDS,
+};

--- a/apps/desktop/src/main/lib/youtube-ringtone.ts
+++ b/apps/desktop/src/main/lib/youtube-ringtone.ts
@@ -1,9 +1,10 @@
 import { spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
-import { existsSync, mkdirSync, statSync } from "node:fs";
+import { existsSync, mkdirSync, readdirSync, statSync } from "node:fs";
 import { rm, unlink } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { extname, join } from "node:path";
+import { getProcessEnvWithShellPath } from "lib/trpc/routers/workspaces/utils/shell-env";
 import {
 	type CustomRingtoneInfo,
 	importCustomRingtoneFromPath,
@@ -12,6 +13,8 @@ import {
 
 const MAX_CLIP_DURATION_SECONDS = 30;
 const YT_DLP_TIMEOUT_MS = 120_000;
+const REQUIRED_BINARIES = ["yt-dlp", "ffmpeg", "ffprobe"] as const;
+const ALLOWED_OUTPUT_EXTENSIONS = new Set([".mp3", ".wav", ".ogg"]);
 
 export interface ImportFromYouTubeOptions {
 	url: string;
@@ -42,35 +45,39 @@ export function isLikelyYouTubeUrl(url: string): boolean {
 	return YOUTUBE_URL_PATTERN.test(url.trim());
 }
 
-function checkBinary(binary: string): Promise<boolean> {
+function checkBinary(binary: string, env: NodeJS.ProcessEnv): Promise<boolean> {
 	return new Promise((resolve) => {
-		const proc = spawn(binary, ["--version"], { stdio: "ignore" });
+		const proc = spawn(binary, ["--version"], { stdio: "ignore", env });
 		proc.on("error", () => resolve(false));
 		proc.on("exit", (code) => resolve(code === 0));
 	});
 }
 
-async function ensureBinariesInstalled(): Promise<void> {
-	const [hasYtDlp, hasFfmpeg] = await Promise.all([
-		checkBinary("yt-dlp"),
-		checkBinary("ffmpeg"),
-	]);
+async function ensureBinariesInstalled(env: NodeJS.ProcessEnv): Promise<void> {
+	const results = await Promise.all(
+		REQUIRED_BINARIES.map((bin) => checkBinary(bin, env)),
+	);
+	const missing = REQUIRED_BINARIES.filter((_, idx) => !results[idx]);
 
-	if (!hasYtDlp || !hasFfmpeg) {
-		const missing: string[] = [];
-		if (!hasYtDlp) missing.push("yt-dlp");
-		if (!hasFfmpeg) missing.push("ffmpeg");
+	if (missing.length > 0) {
 		throw new YouTubeRingtoneError(
-			`Missing required tool(s): ${missing.join(", ")}. Install with \`brew install ${missing.join(" ")}\` (macOS) or your platform's package manager.`,
+			`Missing required tool(s): ${missing.join(", ")}. Install with \`brew install ${
+				missing.filter((b) => b !== "ffprobe").join(" ") || "yt-dlp ffmpeg"
+			}\` (macOS, ffprobe ships with ffmpeg) or your platform's package manager.`,
 			"BINARY_MISSING",
 		);
 	}
 }
 
-function runYtDlp(args: string[], cwd: string): Promise<void> {
+function runYtDlp(
+	args: string[],
+	cwd: string,
+	env: NodeJS.ProcessEnv,
+): Promise<void> {
 	return new Promise((resolve, reject) => {
 		const proc = spawn("yt-dlp", args, {
 			cwd,
+			env,
 			stdio: ["ignore", "pipe", "pipe"],
 		});
 
@@ -116,6 +123,26 @@ function runYtDlp(args: string[], cwd: string): Promise<void> {
 	});
 }
 
+function findProducedAudio(workDir: string): string | null {
+	if (!existsSync(workDir)) return null;
+	const candidates = readdirSync(workDir)
+		.filter((name) =>
+			ALLOWED_OUTPUT_EXTENSIONS.has(extname(name).toLowerCase()),
+		)
+		.map((name) => join(workDir, name))
+		.filter((p) => {
+			try {
+				return statSync(p).isFile() && statSync(p).size > 0;
+			} catch {
+				return false;
+			}
+		});
+
+	if (candidates.length === 0) return null;
+	candidates.sort((a, b) => statSync(b).mtimeMs - statSync(a).mtimeMs);
+	return candidates[0] ?? null;
+}
+
 export async function importRingtoneFromYouTube(
 	options: ImportFromYouTubeOptions,
 ): Promise<CustomRingtoneInfo> {
@@ -142,11 +169,12 @@ export async function importRingtoneFromYouTube(
 		);
 	}
 
-	await ensureBinariesInstalled();
+	const env = await getProcessEnvWithShellPath();
+	await ensureBinariesInstalled(env);
 
 	const workDir = join(tmpdir(), `superset-yt-${randomUUID()}`);
 	mkdirSync(workDir, { recursive: true });
-	const outputPath = join(workDir, "clip.mp3");
+	const outputTemplate = join(workDir, "clip.%(ext)s");
 
 	const endSeconds = startSeconds + durationSeconds;
 	const sectionSpec = `*${startSeconds}-${endSeconds}`;
@@ -164,21 +192,22 @@ export async function importRingtoneFromYouTube(
 		sectionSpec,
 		"--force-keyframes-at-cuts",
 		"-o",
-		outputPath,
+		outputTemplate,
 		url,
 	];
 
 	try {
-		await runYtDlp(args, workDir);
+		await runYtDlp(args, workDir, env);
 
-		if (!existsSync(outputPath) || statSync(outputPath).size === 0) {
+		const producedPath = findProducedAudio(workDir);
+		if (!producedPath) {
 			throw new YouTubeRingtoneError(
 				"yt-dlp did not produce an audio file. The video may be unavailable or restricted.",
 				"DOWNLOAD_FAILED",
 			);
 		}
 
-		const info = await importCustomRingtoneFromPath(outputPath);
+		const info = await importCustomRingtoneFromPath(producedPath);
 
 		const displayName = options.displayName?.trim();
 		if (displayName) {
@@ -188,7 +217,7 @@ export async function importRingtoneFromYouTube(
 
 		return info;
 	} finally {
-		await safeUnlink(outputPath);
+		await safeUnlink(join(workDir, "clip.mp3"));
 		await rm(workDir, { recursive: true, force: true }).catch(() => {
 			// Best-effort cleanup.
 		});

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/ringtones/components/RingtonesSettings/RingtonesSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/ringtones/components/RingtonesSettings/RingtonesSettings.tsx
@@ -4,6 +4,7 @@ import { Switch } from "@superset/ui/switch";
 import { cn } from "@superset/ui/utils";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { HiCheck, HiPlay, HiPlus, HiStop } from "react-icons/hi2";
+import { SiYoutube } from "react-icons/si";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { electronTrpcClient } from "renderer/lib/trpc-client";
 import {
@@ -19,6 +20,7 @@ import {
 	type SettingItemId,
 } from "../../../utils/settings-search";
 import { VolumeDropdown } from "./components/VolumeDropdown";
+import { YouTubeImportDialog } from "./components/YouTubeImportDialog";
 
 function formatDuration(seconds: number): string {
 	return `${seconds}s`;
@@ -182,6 +184,22 @@ export function RingtonesSettings({ visibleItems }: RingtonesSettingsProps) {
 		},
 	});
 
+	const [youtubeDialogOpen, setYoutubeDialogOpen] = useState(false);
+	const [youtubeError, setYoutubeError] = useState<string | null>(null);
+	const importFromYouTube = electronTrpc.ringtone.importFromYouTube.useMutation(
+		{
+			onSuccess: async () => {
+				setYoutubeError(null);
+				setYoutubeDialogOpen(false);
+				await utils.ringtone.getCustom.invalidate();
+				setRingtone(CUSTOM_RINGTONE_ID);
+			},
+			onError: (error) => {
+				setYoutubeError(error.message);
+			},
+		},
+	);
+
 	const handleMutedToggle = (enabled: boolean) => {
 		setMuted.mutate({ muted: !enabled });
 	};
@@ -300,16 +318,31 @@ export function RingtonesSettings({ visibleItems }: RingtonesSettingsProps) {
 					<div>
 						<div className="mb-4 flex items-center justify-between gap-2">
 							<h3 className="text-sm font-medium">Notification Sound</h3>
-							<Button
-								type="button"
-								size="sm"
-								variant="outline"
-								onClick={handleImportCustomRingtone}
-								disabled={importCustomRingtone.isPending}
-							>
-								<HiPlus className="mr-1.5 h-3.5 w-3.5" />
-								{customRingtone ? "Replace Custom Audio" : "Add Custom Audio"}
-							</Button>
+							<div className="flex items-center gap-2">
+								<Button
+									type="button"
+									size="sm"
+									variant="outline"
+									onClick={() => {
+										setYoutubeError(null);
+										setYoutubeDialogOpen(true);
+									}}
+									disabled={importFromYouTube.isPending}
+								>
+									<SiYoutube className="mr-1.5 h-3.5 w-3.5" />
+									From YouTube
+								</Button>
+								<Button
+									type="button"
+									size="sm"
+									variant="outline"
+									onClick={handleImportCustomRingtone}
+									disabled={importCustomRingtone.isPending}
+								>
+									<HiPlus className="mr-1.5 h-3.5 w-3.5" />
+									{customRingtone ? "Replace Custom Audio" : "Add Custom Audio"}
+								</Button>
+							</div>
 						</div>
 						<div className="grid grid-cols-2 lg:grid-cols-3 gap-4">
 							{ringtoneOptions.map((ringtone) => (
@@ -331,11 +364,27 @@ export function RingtonesSettings({ visibleItems }: RingtonesSettingsProps) {
 					<div className="pt-6 border-t">
 						<p className="text-sm text-muted-foreground">
 							Click the play button to preview a sound. Use Add Custom Audio to
-							import your own .mp3, .wav, or .ogg file.
+							import your own .mp3, .wav, or .ogg file, or From YouTube to clip
+							a section from a YouTube video.
 						</p>
 					</div>
 				)}
 			</div>
+
+			<YouTubeImportDialog
+				open={youtubeDialogOpen}
+				onOpenChange={(open) => {
+					setYoutubeDialogOpen(open);
+					if (!open) setYoutubeError(null);
+				}}
+				onSubmit={async (input) => {
+					await importFromYouTube.mutateAsync(input).catch(() => {
+						// Error surfaced via youtubeError state.
+					});
+				}}
+				isSubmitting={importFromYouTube.isPending}
+				errorMessage={youtubeError}
+			/>
 		</div>
 	);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/ringtones/components/RingtonesSettings/components/YouTubeImportDialog/YouTubeImportDialog.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/ringtones/components/RingtonesSettings/components/YouTubeImportDialog/YouTubeImportDialog.tsx
@@ -1,0 +1,203 @@
+import { Button } from "@superset/ui/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "@superset/ui/dialog";
+import { Input } from "@superset/ui/input";
+import { Label } from "@superset/ui/label";
+import { useEffect, useId, useMemo, useState } from "react";
+import { LuLoaderCircle } from "react-icons/lu";
+
+const MAX_DURATION_SECONDS = 30;
+
+interface YouTubeImportDialogProps {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	onSubmit: (input: {
+		url: string;
+		startSeconds: number;
+		durationSeconds: number;
+		displayName?: string;
+	}) => Promise<void>;
+	isSubmitting: boolean;
+	errorMessage?: string | null;
+}
+
+const YOUTUBE_URL_HINT =
+	/^https?:\/\/(?:www\.|m\.|music\.)?(?:youtube\.com|youtu\.be)\//i;
+
+function clampNonNegativeInt(value: string): number {
+	const parsed = Number.parseInt(value, 10);
+	if (!Number.isFinite(parsed) || parsed < 0) return 0;
+	return parsed;
+}
+
+export function YouTubeImportDialog({
+	open,
+	onOpenChange,
+	onSubmit,
+	isSubmitting,
+	errorMessage,
+}: YouTubeImportDialogProps) {
+	const urlId = useId();
+	const startId = useId();
+	const durationId = useId();
+	const nameId = useId();
+
+	const [url, setUrl] = useState("");
+	const [startMin, setStartMin] = useState("0");
+	const [startSec, setStartSec] = useState("0");
+	const [duration, setDuration] = useState("5");
+	const [displayName, setDisplayName] = useState("");
+
+	useEffect(() => {
+		if (!open) {
+			setUrl("");
+			setStartMin("0");
+			setStartSec("0");
+			setDuration("5");
+			setDisplayName("");
+		}
+	}, [open]);
+
+	const startSeconds =
+		clampNonNegativeInt(startMin) * 60 + clampNonNegativeInt(startSec);
+	const durationSeconds = clampNonNegativeInt(duration);
+
+	const urlLooksValid = useMemo(() => YOUTUBE_URL_HINT.test(url.trim()), [url]);
+	const durationValid =
+		durationSeconds >= 1 && durationSeconds <= MAX_DURATION_SECONDS;
+	const canSubmit =
+		urlLooksValid && durationValid && !isSubmitting && url.trim().length > 0;
+
+	const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+		event.preventDefault();
+		if (!canSubmit) return;
+		await onSubmit({
+			url: url.trim(),
+			startSeconds,
+			durationSeconds,
+			displayName: displayName.trim() || undefined,
+		});
+	};
+
+	return (
+		<Dialog open={open} onOpenChange={onOpenChange}>
+			<DialogContent className="sm:max-w-md">
+				<DialogHeader>
+					<DialogTitle>Import from YouTube</DialogTitle>
+					<DialogDescription>
+						Paste a YouTube URL and choose a clip range. Requires{" "}
+						<code className="rounded bg-muted px-1 text-xs">yt-dlp</code> and{" "}
+						<code className="rounded bg-muted px-1 text-xs">ffmpeg</code> to be
+						installed locally.
+					</DialogDescription>
+				</DialogHeader>
+
+				<form onSubmit={handleSubmit} className="space-y-4">
+					<div className="space-y-2">
+						<Label htmlFor={urlId}>YouTube URL</Label>
+						<Input
+							id={urlId}
+							type="url"
+							placeholder="https://www.youtube.com/watch?v=..."
+							value={url}
+							onChange={(event) => setUrl(event.target.value)}
+							autoFocus
+							disabled={isSubmitting}
+						/>
+						{url.length > 0 && !urlLooksValid && (
+							<p className="text-xs text-destructive">
+								Enter a youtube.com or youtu.be URL.
+							</p>
+						)}
+					</div>
+
+					<div className="grid grid-cols-2 gap-4">
+						<div className="space-y-2">
+							<Label htmlFor={startId}>Start time</Label>
+							<div className="flex items-center gap-2">
+								<Input
+									id={startId}
+									type="number"
+									min={0}
+									value={startMin}
+									onChange={(event) => setStartMin(event.target.value)}
+									disabled={isSubmitting}
+									className="w-16"
+								/>
+								<span className="text-xs text-muted-foreground">min</span>
+								<Input
+									type="number"
+									min={0}
+									max={59}
+									value={startSec}
+									onChange={(event) => setStartSec(event.target.value)}
+									disabled={isSubmitting}
+									className="w-16"
+								/>
+								<span className="text-xs text-muted-foreground">sec</span>
+							</div>
+						</div>
+
+						<div className="space-y-2">
+							<Label htmlFor={durationId}>Duration (sec)</Label>
+							<Input
+								id={durationId}
+								type="number"
+								min={1}
+								max={MAX_DURATION_SECONDS}
+								value={duration}
+								onChange={(event) => setDuration(event.target.value)}
+								disabled={isSubmitting}
+							/>
+							<p className="text-xs text-muted-foreground">
+								Max {MAX_DURATION_SECONDS} seconds.
+							</p>
+						</div>
+					</div>
+
+					<div className="space-y-2">
+						<Label htmlFor={nameId}>Display name (optional)</Label>
+						<Input
+							id={nameId}
+							type="text"
+							placeholder="My YouTube clip"
+							value={displayName}
+							onChange={(event) => setDisplayName(event.target.value)}
+							disabled={isSubmitting}
+							maxLength={80}
+						/>
+					</div>
+
+					{errorMessage && (
+						<p className="text-sm text-destructive break-words">
+							{errorMessage}
+						</p>
+					)}
+
+					<DialogFooter>
+						<Button
+							type="button"
+							variant="ghost"
+							onClick={() => onOpenChange(false)}
+							disabled={isSubmitting}
+						>
+							Cancel
+						</Button>
+						<Button type="submit" disabled={!canSubmit}>
+							{isSubmitting && (
+								<LuLoaderCircle className="mr-2 h-4 w-4 animate-spin" />
+							)}
+							{isSubmitting ? "Importing..." : "Import"}
+						</Button>
+					</DialogFooter>
+				</form>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/ringtones/components/RingtonesSettings/components/YouTubeImportDialog/YouTubeImportDialog.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/ringtones/components/RingtonesSettings/components/YouTubeImportDialog/YouTubeImportDialog.tsx
@@ -30,10 +30,10 @@ interface YouTubeImportDialogProps {
 const YOUTUBE_URL_HINT =
 	/^https?:\/\/(?:www\.|m\.|music\.)?(?:youtube\.com|youtu\.be)\//i;
 
-function clampNonNegativeInt(value: string): number {
+function clampNonNegativeInt(value: string, max?: number): number {
 	const parsed = Number.parseInt(value, 10);
 	if (!Number.isFinite(parsed) || parsed < 0) return 0;
-	return parsed;
+	return max !== undefined ? Math.min(parsed, max) : parsed;
 }
 
 export function YouTubeImportDialog({
@@ -65,8 +65,8 @@ export function YouTubeImportDialog({
 	}, [open]);
 
 	const startSeconds =
-		clampNonNegativeInt(startMin) * 60 + clampNonNegativeInt(startSec);
-	const durationSeconds = clampNonNegativeInt(duration);
+		clampNonNegativeInt(startMin) * 60 + clampNonNegativeInt(startSec, 59);
+	const durationSeconds = clampNonNegativeInt(duration, MAX_DURATION_SECONDS);
 
 	const urlLooksValid = useMemo(() => YOUTUBE_URL_HINT.test(url.trim()), [url]);
 	const durationValid =

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/ringtones/components/RingtonesSettings/components/YouTubeImportDialog/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/ringtones/components/RingtonesSettings/components/YouTubeImportDialog/index.ts
@@ -1,0 +1,1 @@
+export { YouTubeImportDialog } from "./YouTubeImportDialog";


### PR DESCRIPTION
## 概要
Settings > Notifications に **From YouTube** ボタンを追加し、YouTube の URL を貼って区間を指定するとカスタム通知音として取り込めるようにします。Issue #258 の対応です。

## 実装内容
- `apps/desktop/src/main/lib/youtube-ringtone.ts` を新規追加。`yt-dlp` の `--download-sections` で指定区間だけを mp3 として抽出し、既存の `importCustomRingtoneFromPath` に渡してカスタム通知音として登録。
- `apps/desktop/src/main/lib/custom-ringtones.ts` に `setCustomRingtoneDisplayName` を追加し、ユーザーが任意で付けたラベルをメタデータに保存できるように。
- tRPC ルーター `ringtone.importFromYouTube` を追加（URL / 開始秒 / 長さ秒 / 任意の表示名）。
- `RingtonesSettings.tsx` に `From YouTube` ボタンとモーダルを追加。
- `YouTubeImportDialog` を新規追加。URL / 開始時刻 (分・秒) / 長さ (最大30秒) / 表示名（任意）を入力。

## 動作要件
- ローカルに `yt-dlp` と `ffmpeg` がインストールされていること（macOS なら `brew install yt-dlp ffmpeg`）。
- 未インストール時はエラーメッセージで案内します。

## テスト計画
- [ ] Settings > Notifications で「From YouTube」ボタンが表示される
- [ ] YouTube URL を入力し開始時刻 / 長さを指定して取り込みできる
- [ ] 取り込んだクリップがプレビュー再生できる
- [ ] yt-dlp / ffmpeg が無い環境でわかりやすいエラーが出る
- [ ] 不正な URL で送信を弾く

Closes #258

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * YouTube動画からの通知音インポート機能を追加
  * 動画の特定区間（最大30秒）をクリップして通知音として設定可能に
  * カスタム通知音の表示名を設定・編集可能に

<!-- end of auto-generated comment: release notes by coderabbit.ai -->