### PR TITLE
feat(desktop): カスタム通知音の削除 / リネーム機能

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/ringtone/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/ringtone/index.ts
@@ -3,9 +3,11 @@ import { TRPCError } from "@trpc/server";
 import type { BrowserWindow, OpenDialogOptions } from "electron";
 import { dialog } from "electron";
 import {
+	deleteCustomRingtone,
 	getCustomRingtoneInfo,
 	getCustomRingtonePath,
 	importCustomRingtoneFromPath,
+	setCustomRingtoneDisplayName,
 } from "main/lib/custom-ringtones";
 import { playSoundFile } from "main/lib/play-sound";
 import { getSoundPath } from "main/lib/sound-paths";
@@ -175,6 +177,43 @@ export const createRingtoneRouter = (getWindow: () => BrowserWindow | null) => {
 				});
 			}
 		}),
+
+		/**
+		 * Deletes the imported custom ringtone (audio file + metadata).
+		 */
+		deleteCustom: publicProcedure.mutation(() => {
+			stopCurrentSound();
+			deleteCustomRingtone();
+			return { success: true as const };
+		}),
+
+		/**
+		 * Renames the custom ringtone's display name.
+		 */
+		renameCustom: publicProcedure
+			.input(z.object({ name: z.string().min(1).max(80) }))
+			.mutation(({ input }) => {
+				try {
+					setCustomRingtoneDisplayName(input.name);
+					const info = getCustomRingtoneInfo();
+					if (!info) {
+						throw new TRPCError({
+							code: "NOT_FOUND",
+							message: "No custom ringtone to rename.",
+						});
+					}
+					return { ringtone: info };
+				} catch (error) {
+					if (error instanceof TRPCError) throw error;
+					throw new TRPCError({
+						code: "BAD_REQUEST",
+						message:
+							error instanceof Error
+								? error.message
+								: "Failed to rename custom ringtone",
+					});
+				}
+			}),
 
 		/**
 		 * Imports a custom ringtone by clipping a section of a YouTube video.

--- a/apps/desktop/src/main/lib/custom-ringtones.ts
+++ b/apps/desktop/src/main/lib/custom-ringtones.ts
@@ -163,6 +163,20 @@ export function getCustomRingtonePath(): string | null {
 	return join(RINGTONES_ASSETS_DIR, filename);
 }
 
+export function deleteCustomRingtone(): void {
+	if (!existsSync(RINGTONES_ASSETS_DIR)) {
+		return;
+	}
+	removeExistingCustomRingtoneFiles();
+	if (existsSync(CUSTOM_RINGTONE_METADATA_PATH)) {
+		try {
+			unlinkSync(CUSTOM_RINGTONE_METADATA_PATH);
+		} catch {
+			// Best effort.
+		}
+	}
+}
+
 export function setCustomRingtoneDisplayName(name: string): void {
 	if (!hasCustomRingtone()) {
 		return;

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/ringtones/components/RingtonesSettings/RingtonesSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/ringtones/components/RingtonesSettings/RingtonesSettings.tsx
@@ -1,9 +1,23 @@
 import { Button } from "@superset/ui/button";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuTrigger,
+} from "@superset/ui/dropdown-menu";
 import { Label } from "@superset/ui/label";
 import { Switch } from "@superset/ui/switch";
 import { cn } from "@superset/ui/utils";
 import { useCallback, useEffect, useRef, useState } from "react";
-import { HiCheck, HiPlay, HiPlus, HiStop } from "react-icons/hi2";
+import {
+	HiCheck,
+	HiEllipsisHorizontal,
+	HiPencil,
+	HiPlay,
+	HiPlus,
+	HiStop,
+	HiTrash,
+} from "react-icons/hi2";
 import { SiYoutube } from "react-icons/si";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { electronTrpcClient } from "renderer/lib/trpc-client";
@@ -19,6 +33,7 @@ import {
 	SETTING_ITEM_ID,
 	type SettingItemId,
 } from "../../../utils/settings-search";
+import { RenameRingtoneDialog } from "./components/RenameRingtoneDialog";
 import { VolumeDropdown } from "./components/VolumeDropdown";
 import { YouTubeImportDialog } from "./components/YouTubeImportDialog";
 
@@ -32,6 +47,8 @@ interface RingtoneCardProps {
 	isPlaying: boolean;
 	onSelect: () => void;
 	onTogglePlay: () => void;
+	onRename?: () => void;
+	onDelete?: () => void;
 }
 
 function RingtoneCard({
@@ -40,7 +57,11 @@ function RingtoneCard({
 	isPlaying,
 	onSelect,
 	onTogglePlay,
+	onRename,
+	onDelete,
 }: RingtoneCardProps) {
+	const showActions = Boolean(onRename || onDelete);
+
 	return (
 		// biome-ignore lint/a11y/useSemanticElements: Using div with role="button" to allow nested play/stop button
 		<div
@@ -75,6 +96,45 @@ function RingtoneCard({
 					<span className="absolute top-2 right-2 text-xs text-muted-foreground bg-background/80 px-1.5 py-0.5 rounded">
 						{formatDuration(ringtone.duration)}
 					</span>
+				)}
+
+				{/* Actions menu (custom ringtones only) */}
+				{showActions && (
+					// biome-ignore lint/a11y/noStaticElementInteractions: wrapper exists only to stop click bubbling to the outer card button
+					<div
+						className="absolute top-1.5 left-1.5"
+						onClick={(e) => e.stopPropagation()}
+						onKeyDown={(e) => e.stopPropagation()}
+					>
+						<DropdownMenu>
+							<DropdownMenuTrigger asChild>
+								<button
+									type="button"
+									aria-label="Custom ringtone actions"
+									className="h-7 w-7 rounded-full flex items-center justify-center bg-background/80 text-foreground border border-border hover:bg-accent"
+								>
+									<HiEllipsisHorizontal className="h-4 w-4" />
+								</button>
+							</DropdownMenuTrigger>
+							<DropdownMenuContent align="start">
+								{onRename && (
+									<DropdownMenuItem onClick={onRename}>
+										<HiPencil className="mr-2 h-4 w-4" />
+										Rename
+									</DropdownMenuItem>
+								)}
+								{onDelete && (
+									<DropdownMenuItem
+										onClick={onDelete}
+										className="text-destructive focus:text-destructive"
+									>
+										<HiTrash className="mr-2 h-4 w-4" />
+										Delete
+									</DropdownMenuItem>
+								)}
+							</DropdownMenuContent>
+						</DropdownMenu>
+					</div>
 				)}
 
 				{/* Play/Stop button */}
@@ -200,6 +260,31 @@ export function RingtonesSettings({ visibleItems }: RingtonesSettingsProps) {
 		},
 	);
 
+	const [renameDialogOpen, setRenameDialogOpen] = useState(false);
+	const [renameError, setRenameError] = useState<string | null>(null);
+	const renameCustomRingtone = electronTrpc.ringtone.renameCustom.useMutation({
+		onSuccess: async () => {
+			setRenameError(null);
+			setRenameDialogOpen(false);
+			await utils.ringtone.getCustom.invalidate();
+		},
+		onError: (error) => {
+			setRenameError(error.message);
+		},
+	});
+
+	const deleteCustomRingtone = electronTrpc.ringtone.deleteCustom.useMutation({
+		onSuccess: async () => {
+			if (selectedRingtoneId === CUSTOM_RINGTONE_ID) {
+				setRingtone(AVAILABLE_RINGTONES[0]?.id ?? "");
+			}
+			await utils.ringtone.getCustom.invalidate();
+		},
+		onError: (error) => {
+			console.error("Failed to delete custom ringtone:", error);
+		},
+	});
+
 	const handleMutedToggle = (enabled: boolean) => {
 		setMuted.mutate({ muted: !enabled });
 	};
@@ -207,6 +292,19 @@ export function RingtonesSettings({ visibleItems }: RingtonesSettingsProps) {
 	const handleImportCustomRingtone = useCallback(() => {
 		importCustomRingtone.mutate();
 	}, [importCustomRingtone]);
+
+	const handleRenameCustom = useCallback(() => {
+		setRenameError(null);
+		setRenameDialogOpen(true);
+	}, []);
+
+	const handleDeleteCustom = useCallback(() => {
+		const confirmed = window.confirm(
+			"Delete the custom notification sound? This cannot be undone.",
+		);
+		if (!confirmed) return;
+		deleteCustomRingtone.mutate();
+	}, [deleteCustomRingtone]);
 
 	// Clean up timer and stop any playing sound on unmount
 	useEffect(() => {
@@ -345,16 +443,21 @@ export function RingtonesSettings({ visibleItems }: RingtonesSettingsProps) {
 							</div>
 						</div>
 						<div className="grid grid-cols-2 lg:grid-cols-3 gap-4">
-							{ringtoneOptions.map((ringtone) => (
-								<RingtoneCard
-									key={ringtone.id}
-									ringtone={ringtone}
-									isSelected={selectedRingtoneId === ringtone.id}
-									isPlaying={playingId === ringtone.id}
-									onSelect={() => handleSelect(ringtone.id)}
-									onTogglePlay={() => handleTogglePlay(ringtone)}
-								/>
-							))}
+							{ringtoneOptions.map((ringtone) => {
+								const isCustom = ringtone.id === CUSTOM_RINGTONE_ID;
+								return (
+									<RingtoneCard
+										key={ringtone.id}
+										ringtone={ringtone}
+										isSelected={selectedRingtoneId === ringtone.id}
+										isPlaying={playingId === ringtone.id}
+										onSelect={() => handleSelect(ringtone.id)}
+										onTogglePlay={() => handleTogglePlay(ringtone)}
+										onRename={isCustom ? handleRenameCustom : undefined}
+										onDelete={isCustom ? handleDeleteCustom : undefined}
+									/>
+								);
+							})}
 						</div>
 					</div>
 				)}
@@ -384,6 +487,22 @@ export function RingtonesSettings({ visibleItems }: RingtonesSettingsProps) {
 				}}
 				isSubmitting={importFromYouTube.isPending}
 				errorMessage={youtubeError}
+			/>
+
+			<RenameRingtoneDialog
+				open={renameDialogOpen}
+				onOpenChange={(open) => {
+					setRenameDialogOpen(open);
+					if (!open) setRenameError(null);
+				}}
+				currentName={customRingtone?.name ?? ""}
+				onSubmit={async (name) => {
+					await renameCustomRingtone.mutateAsync({ name }).catch(() => {
+						// Error surfaced via renameError state.
+					});
+				}}
+				isSubmitting={renameCustomRingtone.isPending}
+				errorMessage={renameError}
 			/>
 		</div>
 	);

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/ringtones/components/RingtonesSettings/components/RenameRingtoneDialog/RenameRingtoneDialog.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/ringtones/components/RingtonesSettings/components/RenameRingtoneDialog/RenameRingtoneDialog.tsx
@@ -1,0 +1,100 @@
+import { Button } from "@superset/ui/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "@superset/ui/dialog";
+import { Input } from "@superset/ui/input";
+import { Label } from "@superset/ui/label";
+import { useEffect, useId, useState } from "react";
+import { LuLoaderCircle } from "react-icons/lu";
+
+interface RenameRingtoneDialogProps {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	currentName: string;
+	onSubmit: (name: string) => Promise<void>;
+	isSubmitting: boolean;
+	errorMessage?: string | null;
+}
+
+export function RenameRingtoneDialog({
+	open,
+	onOpenChange,
+	currentName,
+	onSubmit,
+	isSubmitting,
+	errorMessage,
+}: RenameRingtoneDialogProps) {
+	const nameId = useId();
+	const [name, setName] = useState(currentName);
+
+	useEffect(() => {
+		if (open) {
+			setName(currentName);
+		}
+	}, [open, currentName]);
+
+	const trimmed = name.trim();
+	const canSubmit =
+		trimmed.length > 0 && trimmed !== currentName && !isSubmitting;
+
+	const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+		event.preventDefault();
+		if (!canSubmit) return;
+		await onSubmit(trimmed);
+	};
+
+	return (
+		<Dialog open={open} onOpenChange={onOpenChange}>
+			<DialogContent className="sm:max-w-sm">
+				<DialogHeader>
+					<DialogTitle>Rename custom audio</DialogTitle>
+					<DialogDescription>
+						Choose a new display name for this custom notification sound.
+					</DialogDescription>
+				</DialogHeader>
+
+				<form onSubmit={handleSubmit} className="space-y-4">
+					<div className="space-y-2">
+						<Label htmlFor={nameId}>Name</Label>
+						<Input
+							id={nameId}
+							value={name}
+							onChange={(event) => setName(event.target.value)}
+							maxLength={80}
+							autoFocus
+							disabled={isSubmitting}
+						/>
+					</div>
+
+					{errorMessage && (
+						<p className="text-sm text-destructive break-words">
+							{errorMessage}
+						</p>
+					)}
+
+					<DialogFooter>
+						<Button
+							type="button"
+							variant="ghost"
+							onClick={() => onOpenChange(false)}
+							disabled={isSubmitting}
+						>
+							Cancel
+						</Button>
+						<Button type="submit" disabled={!canSubmit}>
+							{isSubmitting && (
+								<LuLoaderCircle className="mr-2 h-4 w-4 animate-spin" />
+							)}
+							Save
+						</Button>
+					</DialogFooter>
+				</form>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/ringtones/components/RingtonesSettings/components/RenameRingtoneDialog/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/ringtones/components/RingtonesSettings/components/RenameRingtoneDialog/index.ts
@@ -1,0 +1,1 @@
+export { RenameRingtoneDialog } from "./RenameRingtoneDialog";


### PR DESCRIPTION
## 概要
カスタム通知音（YouTube クリップ含む）を削除・リネームできるようにします。Issue #258 の追加対応です。

## 実装内容
- `apps/desktop/src/main/lib/custom-ringtones.ts` に `deleteCustomRingtone()` を追加（オーディオファイル + メタデータを除去）
- tRPC ルーターに `ringtone.deleteCustom` と `ringtone.renameCustom` を追加
- `RingtoneCard` の左上に3点ドロップダウンを追加（カスタム通知音のみ表示）
- `RenameRingtoneDialog` を新規追加
- 削除時に `CUSTOM_RINGTONE_ID` が選択中だったらビルトイン1番目に自動切替

## テスト計画
- [ ] カスタム通知音カードのメニューから Rename → 名前が更新される
- [ ] カスタム通知音カードのメニューから Delete → ファイル + メタデータが削除される
- [ ] Delete 時に確認ダイアログが出る
- [ ] 削除後にカスタムカードが消える
- [ ] 削除時に選択中だった場合、別の通知音に切り替わる

Refs #258