### PR TITLE
fix(desktop): カスタム通知音の削除確認をカスタムダイアログ化

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/settings/ringtones/components/RingtonesSettings/RingtonesSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/ringtones/components/RingtonesSettings/RingtonesSettings.tsx
@@ -33,6 +33,7 @@ import {
 	SETTING_ITEM_ID,
 	type SettingItemId,
 } from "../../../utils/settings-search";
+import { DeleteRingtoneDialog } from "./components/DeleteRingtoneDialog";
 import { RenameRingtoneDialog } from "./components/RenameRingtoneDialog";
 import { VolumeDropdown } from "./components/VolumeDropdown";
 import { YouTubeImportDialog } from "./components/YouTubeImportDialog";
@@ -273,15 +274,19 @@ export function RingtonesSettings({ visibleItems }: RingtonesSettingsProps) {
 		},
 	});
 
+	const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+	const [deleteError, setDeleteError] = useState<string | null>(null);
 	const deleteCustomRingtone = electronTrpc.ringtone.deleteCustom.useMutation({
 		onSuccess: async () => {
 			if (selectedRingtoneId === CUSTOM_RINGTONE_ID) {
 				setRingtone(AVAILABLE_RINGTONES[0]?.id ?? "");
 			}
+			setDeleteError(null);
+			setDeleteDialogOpen(false);
 			await utils.ringtone.getCustom.invalidate();
 		},
 		onError: (error) => {
-			console.error("Failed to delete custom ringtone:", error);
+			setDeleteError(error.message);
 		},
 	});
 
@@ -299,11 +304,14 @@ export function RingtonesSettings({ visibleItems }: RingtonesSettingsProps) {
 	}, []);
 
 	const handleDeleteCustom = useCallback(() => {
-		const confirmed = window.confirm(
-			"Delete the custom notification sound? This cannot be undone.",
-		);
-		if (!confirmed) return;
-		deleteCustomRingtone.mutate();
+		setDeleteError(null);
+		setDeleteDialogOpen(true);
+	}, []);
+
+	const handleConfirmDelete = useCallback(async () => {
+		await deleteCustomRingtone.mutateAsync().catch(() => {
+			// Error surfaced via deleteError state.
+		});
 	}, [deleteCustomRingtone]);
 
 	// Clean up timer and stop any playing sound on unmount
@@ -487,6 +495,18 @@ export function RingtonesSettings({ visibleItems }: RingtonesSettingsProps) {
 				}}
 				isSubmitting={importFromYouTube.isPending}
 				errorMessage={youtubeError}
+			/>
+
+			<DeleteRingtoneDialog
+				open={deleteDialogOpen}
+				onOpenChange={(open) => {
+					setDeleteDialogOpen(open);
+					if (!open) setDeleteError(null);
+				}}
+				ringtoneName={customRingtone?.name ?? ""}
+				onConfirm={handleConfirmDelete}
+				isSubmitting={deleteCustomRingtone.isPending}
+				errorMessage={deleteError}
 			/>
 
 			<RenameRingtoneDialog

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/ringtones/components/RingtonesSettings/components/DeleteRingtoneDialog/DeleteRingtoneDialog.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/ringtones/components/RingtonesSettings/components/DeleteRingtoneDialog/DeleteRingtoneDialog.tsx
@@ -26,12 +26,14 @@ export function DeleteRingtoneDialog({
 	isSubmitting,
 	errorMessage,
 }: DeleteRingtoneDialogProps) {
-	const handleConfirm = async () => {
-		await onConfirm();
-	};
-
 	return (
-		<Dialog open={open} onOpenChange={onOpenChange}>
+		<Dialog
+			open={open}
+			onOpenChange={(next) => {
+				if (!next && isSubmitting) return;
+				onOpenChange(next);
+			}}
+		>
 			<DialogContent className="sm:max-w-sm">
 				<DialogHeader>
 					<DialogTitle>Delete custom audio</DialogTitle>
@@ -58,7 +60,9 @@ export function DeleteRingtoneDialog({
 					<Button
 						type="button"
 						variant="destructive"
-						onClick={handleConfirm}
+						onClick={() => {
+							void onConfirm();
+						}}
 						disabled={isSubmitting}
 					>
 						{isSubmitting && (

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/ringtones/components/RingtonesSettings/components/DeleteRingtoneDialog/DeleteRingtoneDialog.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/ringtones/components/RingtonesSettings/components/DeleteRingtoneDialog/DeleteRingtoneDialog.tsx
@@ -1,0 +1,73 @@
+import { Button } from "@superset/ui/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "@superset/ui/dialog";
+import { LuLoaderCircle } from "react-icons/lu";
+
+interface DeleteRingtoneDialogProps {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	ringtoneName: string;
+	onConfirm: () => Promise<void> | void;
+	isSubmitting: boolean;
+	errorMessage?: string | null;
+}
+
+export function DeleteRingtoneDialog({
+	open,
+	onOpenChange,
+	ringtoneName,
+	onConfirm,
+	isSubmitting,
+	errorMessage,
+}: DeleteRingtoneDialogProps) {
+	const handleConfirm = async () => {
+		await onConfirm();
+	};
+
+	return (
+		<Dialog open={open} onOpenChange={onOpenChange}>
+			<DialogContent className="sm:max-w-sm">
+				<DialogHeader>
+					<DialogTitle>Delete custom audio</DialogTitle>
+					<DialogDescription>
+						{ringtoneName
+							? `Delete “${ringtoneName}”? This cannot be undone.`
+							: "Delete the custom notification sound? This cannot be undone."}
+					</DialogDescription>
+				</DialogHeader>
+
+				{errorMessage && (
+					<p className="text-sm text-destructive break-words">{errorMessage}</p>
+				)}
+
+				<DialogFooter>
+					<Button
+						type="button"
+						variant="ghost"
+						onClick={() => onOpenChange(false)}
+						disabled={isSubmitting}
+					>
+						Cancel
+					</Button>
+					<Button
+						type="button"
+						variant="destructive"
+						onClick={handleConfirm}
+						disabled={isSubmitting}
+					>
+						{isSubmitting && (
+							<LuLoaderCircle className="mr-2 h-4 w-4 animate-spin" />
+						)}
+						Delete
+					</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/ringtones/components/RingtonesSettings/components/DeleteRingtoneDialog/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/ringtones/components/RingtonesSettings/components/DeleteRingtoneDialog/index.ts
@@ -1,0 +1,1 @@
+export { DeleteRingtoneDialog } from "./DeleteRingtoneDialog";


### PR DESCRIPTION
## 概要
Closes #262

カスタム通知音の削除時に表示されるダイアログが、OS / ブラウザのデフォルト確認ダイアログ (window.confirm) になっていたため、リネーム時と同じ shadcn の Dialog コンポーネントで統一する。

## 変更点
- `DeleteRingtoneDialog` を新規追加（Cancel / Delete ボタン構成、destructive バリアント）
- `RingtonesSettings` の `handleDeleteCustom` を window.confirm から新ダイアログ表示に置換
- 削除中はボタンをローダー付きで disable、エラー時はメッセージを表示

## テスト計画
- [ ] カスタム通知音カードのメニュー → Delete でアプリ内ダイアログが開く
- [ ] Cancel でダイアログが閉じ、削除されない
- [ ] Delete で削除され、選択中だった場合は別の通知音に切り替わる
- [ ] 削除中はボタンが disable になりローダーが表示される

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * カスタム着信音削除時の確認フローを改善。ブラウザの標準確認ダイアログから専用の確認ダイアログに変更し、削除エラーメッセージをダイアログ内に表示するようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->