### PR TITLE
fix(desktop): Excel diff/raw viewer を vibrancy でも不透明に戻す (#263)

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Works with any CLI agent. Built for local worktree-based development.
 | **TODO Agent スケジュール実行** | 毎日デプロイ / 毎時 lint のような定型 TODO を UI ビルダー (毎時/毎日/毎週/毎月/cron) で登録可能。アプリ起動中に時刻が来ると TODO セッションが自動作成され発火トーストを表示。前回未完了時は skip / queue 選択可 | [#211](https://github.com/MocA-Love/superset/pull/211) | 2026-04-16 |
 | **TODO 詳細の添付画像 chip 化＋プレビュー** | TODO 作成時に「やってほしいこと」「ゴール」へ貼り付けた画像を、タスク詳細画面でクリップマーク + ファイル名の chip として表示。クリックでネスト Dialog の画像プレビューを開ける（AgentManager は閉じない）。`todo-agent/attachments/` 配下のみを許可するパス検証付き `readAttachment` tRPC を追加 | [#229](https://github.com/MocA-Love/superset/pull/229) | 2026-04-16 |
 | **AgentManager 見切れ救済** | AgentManager 左サイドバーのワークスペース見出し・セッションタイトル、右 ChangesSidebar のブランチ/ファイルパス/コミット subject/選択ヘッダーが狭幅で見切れていた問題を修正。`truncate` + ホバー時 `Tooltip` で全文表示 | [#254](https://github.com/MocA-Love/superset/pull/254) | 2026-04-17 |
+| **Excel diff / raw viewer の透過抑止** | Appearance の透過設定 (vibrancy) ON 時に Excel ビューア / Excel diff / 画像プレビュー / HTML プレビューの背景まで透けていた問題を修正。これらの読み取り専用サーフェスは `bg-background-solid` に差し替えてダイアログと同様に不透明で維持 | [#266](https://github.com/MocA-Love/superset/pull/266) | 2026-04-17 |
 
 ## Fork のビルド方法 (macOS)
 

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/components/FileViewerContent/FileViewerContent.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/components/FileViewerContent/FileViewerContent.tsx
@@ -130,7 +130,9 @@ function HtmlPreviewWebview({
 		}
 	}, [zoomLevel]);
 
-	return <div ref={containerRef} className="h-full w-full bg-background" />;
+	return (
+		<div ref={containerRef} className="h-full w-full bg-background-solid" />
+	);
 }
 
 interface RawFileData {
@@ -838,7 +840,7 @@ export function FileViewerContent({
 		}
 
 		return (
-			<div className="flex h-full items-center justify-center overflow-auto bg-background p-4">
+			<div className="flex h-full items-center justify-center overflow-auto bg-background-solid p-4">
 				<img
 					src={imageData.dataUrl}
 					alt={filePath.split("/").pop() || "Image"}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/components/SpreadsheetViewer/SpreadsheetDiffViewer.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/components/SpreadsheetViewer/SpreadsheetDiffViewer.tsx
@@ -266,7 +266,7 @@ function DiffTable({
 	return (
 		<div
 			ref={setRefs}
-			className="min-h-0 flex-1 overflow-auto bg-background"
+			className="min-h-0 flex-1 overflow-auto bg-background-solid"
 			onScroll={handleScroll}
 		>
 			<div

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/components/SpreadsheetViewer/SpreadsheetViewer.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/components/SpreadsheetViewer/SpreadsheetViewer.tsx
@@ -343,7 +343,7 @@ export function SpreadsheetViewer({
 			</div>
 			<div
 				ref={containerRef}
-				className="min-h-0 flex-1 overflow-auto bg-background"
+				className="min-h-0 flex-1 overflow-auto bg-background-solid"
 			>
 				{/* Outer wrapper: clips to container width */}
 				<div


### PR DESCRIPTION
## 概要

Issue #263 の修正。Appearance 設定のウィンドウ透過 (vibrancy) を ON にすると、Excel ビューア / Excel diff / 画像プレビュー / HTML プレビューの背景まで透過し、下のウィンドウが透けて見えていた問題を修正する。

## 原因

6066d72f3 ("make FileViewer + CodeMirror + terminal honour vibrancy") で、FileViewer 系サーフェスの背景を `bg-white` / `bg-[#0d0d0d]` から `bg-background` に揃えた。vibrancy ON 時は `--background` が `rgba(..., var(--vibrancy-alpha))` に差し替わるため、これらのサーフェスも巻き込まれて透過してしまっていた。

コードエディタ / diff / ターミナル側はこのまま vibrancy の恩恵を受けさせたい一方、Excel / 画像 / HTML プレビューは読み取り専用の内容表示サーフェスなので、ダイアログと同様に不透明で保ちたい。

## 変更点

`bg-background` を `bg-background-solid` に差し替え。`--background-solid` はテーマ切替には追従するが vibrancy alpha の影響を受けないため、ダイアログ等と同じ扱いになる。

| ファイル | 対象 |
|---|---|
| `FileViewerContent.tsx` | `HtmlPreviewWebview` / 画像プレビュー コンテナ |
| `SpreadsheetViewer.tsx` | シート本体のスクロールコンテナ |
| `SpreadsheetDiffViewer.tsx` | 左右 `DiffTable` のスクロールコンテナ |

## 動作確認

- `bun run lint:fix` / `bun run typecheck` ともに pass
- vibrancy OFF / ON の双方で、画像 / HTML / Excel / Excel diff の背景が不透明のままであること
- vibrancy ON で他のサーフェス (チャット・サイドバー・コードエディタ) は従来通り半透明維持

Closes #263