### PR TITLE
feat(desktop): TODO詳細とスケジュール一覧にモデル/Effortを表示

### DIFF
--- a/apps/desktop/src/renderer/features/todo-agent/ClaudeRuntimePicker/claudeRuntimeOptions.ts
+++ b/apps/desktop/src/renderer/features/todo-agent/ClaudeRuntimePicker/claudeRuntimeOptions.ts
@@ -161,3 +161,28 @@ export function fromPersistedEffort(
 	);
 	return DEFAULT_SENTINEL;
 }
+
+/**
+ * Resolve a DB-persisted model/effort value to the human-readable label
+ * the picker shows. Used by read-only views (session detail, schedule
+ * list) so the label matches what the user originally selected.
+ */
+export function getClaudeModelLabel(
+	persisted: string | null | undefined,
+): string {
+	const pick = fromPersistedModel(persisted);
+	return (
+		CLAUDE_MODEL_SELECT_OPTIONS.find((o) => o.value === pick)?.label ??
+		String(persisted)
+	);
+}
+
+export function getClaudeEffortLabel(
+	persisted: string | null | undefined,
+): string {
+	const pick = fromPersistedEffort(persisted);
+	return (
+		CLAUDE_EFFORT_SELECT_OPTIONS.find((o) => o.value === pick)?.label ??
+		String(persisted)
+	);
+}

--- a/apps/desktop/src/renderer/features/todo-agent/ClaudeRuntimePicker/claudeRuntimeOptions.ts
+++ b/apps/desktop/src/renderer/features/todo-agent/ClaudeRuntimePicker/claudeRuntimeOptions.ts
@@ -166,23 +166,39 @@ export function fromPersistedEffort(
  * Resolve a DB-persisted model/effort value to the human-readable label
  * the picker shows. Used by read-only views (session detail, schedule
  * list) so the label matches what the user originally selected.
+ *
+ * null/undefined → "デフォルト" (matches the sentinel's label).
+ * Unknown values (persisted from an older build with a wider allowed set)
+ * surface the raw string so detail views don't silently lie about what is
+ * actually configured — we fall back to `fromPersisted*` only for the
+ * `DEFAULT_SENTINEL` case.
  */
 export function getClaudeModelLabel(
 	persisted: string | null | undefined,
 ): string {
-	const pick = fromPersistedModel(persisted);
+	if (persisted == null) {
+		return (
+			CLAUDE_MODEL_SELECT_OPTIONS.find((o) => o.value === DEFAULT_SENTINEL)
+				?.label ?? "デフォルト"
+		);
+	}
 	return (
-		CLAUDE_MODEL_SELECT_OPTIONS.find((o) => o.value === pick)?.label ??
-		String(persisted)
+		CLAUDE_MODEL_SELECT_OPTIONS.find((o) => o.value === persisted)?.label ??
+		persisted
 	);
 }
 
 export function getClaudeEffortLabel(
 	persisted: string | null | undefined,
 ): string {
-	const pick = fromPersistedEffort(persisted);
+	if (persisted == null) {
+		return (
+			CLAUDE_EFFORT_SELECT_OPTIONS.find((o) => o.value === DEFAULT_SENTINEL)
+				?.label ?? "デフォルト"
+		);
+	}
 	return (
-		CLAUDE_EFFORT_SELECT_OPTIONS.find((o) => o.value === pick)?.label ??
-		String(persisted)
+		CLAUDE_EFFORT_SELECT_OPTIONS.find((o) => o.value === persisted)?.label ??
+		persisted
 	);
 }

--- a/apps/desktop/src/renderer/features/todo-agent/ClaudeRuntimePicker/index.ts
+++ b/apps/desktop/src/renderer/features/todo-agent/ClaudeRuntimePicker/index.ts
@@ -7,6 +7,8 @@ export {
 	DEFAULT_SENTINEL,
 	fromPersistedEffort,
 	fromPersistedModel,
+	getClaudeEffortLabel,
+	getClaudeModelLabel,
 	toPersistedEffort,
 	toPersistedModel,
 } from "./claudeRuntimeOptions";

--- a/apps/desktop/src/renderer/features/todo-agent/TodoManager/SchedulesSection/components/ScheduleListRow/ScheduleListRow.tsx
+++ b/apps/desktop/src/renderer/features/todo-agent/TodoManager/SchedulesSection/components/ScheduleListRow/ScheduleListRow.tsx
@@ -14,6 +14,10 @@ import {
 	HiMiniPencil,
 	HiMiniTrash,
 } from "react-icons/hi2";
+import {
+	getClaudeEffortLabel,
+	getClaudeModelLabel,
+} from "renderer/features/todo-agent/ClaudeRuntimePicker";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { describeSchedule } from "../../utils/describeSchedule";
 import { formatNextRun } from "../../utils/formatNextRun";
@@ -86,6 +90,10 @@ export function ScheduleListRow({
 						{projectName ?? "(不明なプロジェクト)"}
 						{workspaceName ? ` / ${workspaceName}` : " / main"}
 					</span>
+				</div>
+				<div className="text-[10px] text-muted-foreground mt-0.5 flex flex-wrap gap-x-2">
+					<span>モデル: {getClaudeModelLabel(schedule.claudeModel)}</span>
+					<span>effort: {getClaudeEffortLabel(schedule.claudeEffort)}</span>
 				</div>
 				{schedule.lastRunAt && (
 					<div className="text-[10px] text-muted-foreground mt-0.5">

--- a/apps/desktop/src/renderer/features/todo-agent/TodoManager/TodoManager.tsx
+++ b/apps/desktop/src/renderer/features/todo-agent/TodoManager/TodoManager.tsx
@@ -75,6 +75,8 @@ import {
 	DEFAULT_SENTINEL,
 	fromPersistedEffort,
 	fromPersistedModel,
+	getClaudeEffortLabel,
+	getClaudeModelLabel,
 	toPersistedEffort,
 	toPersistedModel,
 } from "../ClaudeRuntimePicker";
@@ -1519,6 +1521,19 @@ function SessionDetail({ session, onDeleted }: SessionDetailProps) {
 									{session.verifyCommand
 										? `${session.iteration}/${session.maxIterations} iter · ${Math.round(session.maxWallClockSec / 60)}分`
 										: `${Math.round(session.maxWallClockSec / 60)}分`}
+								</div>
+							</DetailBlock>
+						</div>
+
+						<div className="grid grid-cols-2 gap-4">
+							<DetailBlock label="Claude モデル">
+								<div className="text-xs">
+									{getClaudeModelLabel(session.claudeModel)}
+								</div>
+							</DetailBlock>
+							<DetailBlock label="思考 effort">
+								<div className="text-xs">
+									{getClaudeEffortLabel(session.claudeEffort)}
 								</div>
 							</DetailBlock>
 						</div>


### PR DESCRIPTION
## Summary
- Issue #264 対応。AgentManager の TODO セッション詳細と、スケジュール一覧で使用中の Claude モデル／思考 effort が確認できるようにした。
- DB (`todoSessions.claudeModel/claudeEffort`, `todoSchedules.claudeModel/claudeEffort`) には元々保存されていたが、作成/編集時の `ClaudeRuntimePicker` 以外からは見えない状態だった。
- `ClaudeRuntimePicker` に `getClaudeModelLabel` / `getClaudeEffortLabel` ヘルパーを追加し、DB 永続値（null含む）からピッカー上のラベルに解決して表示する。

## Changes
- `ClaudeRuntimePicker/claudeRuntimeOptions.ts`: ラベル解決ヘルパーを追加（null → 「デフォルト」、不明値も安全にフォールバック）
- `TodoManager.tsx` SessionDetail: 「Verify / 予算」ブロックの下に「Claude モデル / 思考 effort」を 2 カラムで表示
- `ScheduleListRow.tsx`: 頻度行の下にモデル/effort のミニ表示を追加

## Test plan
- [ ] TODO を新規作成し、SessionDetail に選択したモデル/effort が表示されることを確認
- [ ] モデル/effort を指定せず作成したセッションで「デフォルト」と表示されることを確認
- [ ] スケジュールの一覧行にモデル/effort が表示されることを確認
- [ ] typecheck / lint ともにグリーン

Closes #264