### PR TITLE
fix(desktop): ラベル統一 + スケジュール編集干渉 + IME Enter + ステータスPopover

### DIFF
--- a/apps/desktop/src/renderer/features/todo-agent/ClaudeRuntimePicker/ClaudeRuntimePicker.tsx
+++ b/apps/desktop/src/renderer/features/todo-agent/ClaudeRuntimePicker/ClaudeRuntimePicker.tsx
@@ -52,7 +52,7 @@ export function ClaudeRuntimePicker({
 				)}
 			>
 				<div className="flex flex-col gap-1.5">
-					<Label className={labelClass}>Claude モデル</Label>
+					<Label className={labelClass}>Model</Label>
 					<Select
 						value={model}
 						onValueChange={(v) => onModelChange(v as ClaudeModelPick)}
@@ -71,7 +71,7 @@ export function ClaudeRuntimePicker({
 					</Select>
 				</div>
 				<div className="flex flex-col gap-1.5">
-					<Label className={labelClass}>思考 effort</Label>
+					<Label className={labelClass}>Effort</Label>
 					<Select
 						value={effort}
 						onValueChange={(v) => onEffortChange(v as ClaudeEffortPick)}

--- a/apps/desktop/src/renderer/features/todo-agent/TodoManager/SchedulesSection/components/ScheduleListRow/ScheduleListRow.tsx
+++ b/apps/desktop/src/renderer/features/todo-agent/TodoManager/SchedulesSection/components/ScheduleListRow/ScheduleListRow.tsx
@@ -92,8 +92,8 @@ export function ScheduleListRow({
 					</span>
 				</div>
 				<div className="text-[10px] text-muted-foreground mt-0.5 flex flex-wrap gap-x-2">
-					<span>モデル: {getClaudeModelLabel(schedule.claudeModel)}</span>
-					<span>effort: {getClaudeEffortLabel(schedule.claudeEffort)}</span>
+					<span>Model: {getClaudeModelLabel(schedule.claudeModel)}</span>
+					<span>Effort: {getClaudeEffortLabel(schedule.claudeEffort)}</span>
 				</div>
 				{schedule.lastRunAt && (
 					<div className="text-[10px] text-muted-foreground mt-0.5">

--- a/apps/desktop/src/renderer/features/todo-agent/TodoManager/SchedulesSection/components/ScheduleListRow/ScheduleListRow.tsx
+++ b/apps/desktop/src/renderer/features/todo-agent/TodoManager/SchedulesSection/components/ScheduleListRow/ScheduleListRow.tsx
@@ -114,11 +114,10 @@ export function ScheduleListRow({
 				</DropdownMenuTrigger>
 				<DropdownMenuContent align="end">
 					<DropdownMenuItem
-						onSelect={(e) => {
+						onSelect={() => {
 							// Defer opening the editor Dialog so the dropdown's own
 							// pointer-up / focus-return doesn't race with Dialog's
 							// outside-click detection and immediately close it.
-							e.preventDefault();
 							setTimeout(onEdit, 0);
 						}}
 					>
@@ -126,8 +125,7 @@ export function ScheduleListRow({
 						編集
 					</DropdownMenuItem>
 					<DropdownMenuItem
-						onSelect={(e) => {
-							e.preventDefault();
+						onSelect={() => {
 							setTimeout(() => void handleDelete(), 0);
 						}}
 						className="text-destructive focus:text-destructive"

--- a/apps/desktop/src/renderer/features/todo-agent/TodoManager/SchedulesSection/components/ScheduleListRow/ScheduleListRow.tsx
+++ b/apps/desktop/src/renderer/features/todo-agent/TodoManager/SchedulesSection/components/ScheduleListRow/ScheduleListRow.tsx
@@ -101,7 +101,7 @@ export function ScheduleListRow({
 					</div>
 				)}
 			</button>
-			<DropdownMenu>
+			<DropdownMenu modal={false}>
 				<DropdownMenuTrigger asChild>
 					<Button
 						type="button"
@@ -113,12 +113,23 @@ export function ScheduleListRow({
 					</Button>
 				</DropdownMenuTrigger>
 				<DropdownMenuContent align="end">
-					<DropdownMenuItem onClick={onEdit}>
+					<DropdownMenuItem
+						onSelect={(e) => {
+							// Defer opening the editor Dialog so the dropdown's own
+							// pointer-up / focus-return doesn't race with Dialog's
+							// outside-click detection and immediately close it.
+							e.preventDefault();
+							setTimeout(onEdit, 0);
+						}}
+					>
 						<HiMiniPencil className="mr-2 size-4" />
 						編集
 					</DropdownMenuItem>
 					<DropdownMenuItem
-						onClick={() => void handleDelete()}
+						onSelect={(e) => {
+							e.preventDefault();
+							setTimeout(() => void handleDelete(), 0);
+						}}
 						className="text-destructive focus:text-destructive"
 					>
 						<HiMiniTrash className="mr-2 size-4" />

--- a/apps/desktop/src/renderer/features/todo-agent/TodoManager/TodoManager.tsx
+++ b/apps/desktop/src/renderer/features/todo-agent/TodoManager/TodoManager.tsx
@@ -1526,12 +1526,12 @@ function SessionDetail({ session, onDeleted }: SessionDetailProps) {
 						</div>
 
 						<div className="grid grid-cols-2 gap-4">
-							<DetailBlock label="Claude モデル">
+							<DetailBlock label="Model">
 								<div className="text-xs">
 									{getClaudeModelLabel(session.claudeModel)}
 								</div>
 							</DetailBlock>
-							<DetailBlock label="思考 effort">
+							<DetailBlock label="Effort">
 								<div className="text-xs">
 									{getClaudeEffortLabel(session.claudeEffort)}
 								</div>

--- a/apps/desktop/src/renderer/features/todo-agent/TodoManager/TodoManager.tsx
+++ b/apps/desktop/src/renderer/features/todo-agent/TodoManager/TodoManager.tsx
@@ -771,7 +771,7 @@ function SessionRow({
 
 	const handleRenameKey = useCallback(
 		(e: ReactKeyboardEvent<HTMLInputElement>) => {
-			if (e.key === "Enter") {
+			if (e.key === "Enter" && !e.nativeEvent.isComposing) {
 				e.preventDefault();
 				e.stopPropagation();
 				void commitRename();
@@ -1634,7 +1634,11 @@ function SessionDetail({ session, onDeleted }: SessionDetailProps) {
 							rows={2}
 							className="resize-none min-h-[44px] max-h-40 text-xs leading-relaxed"
 							onKeyDown={(e) => {
-								if (e.key === "Enter" && !e.shiftKey) {
+								if (
+									e.key === "Enter" &&
+									!e.shiftKey &&
+									!e.nativeEvent.isComposing
+								) {
 									e.preventDefault();
 									void handleSendInput();
 								}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/ServiceStatusIndicators/ServiceStatusIndicators.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/ServiceStatusIndicators/ServiceStatusIndicators.tsx
@@ -1,4 +1,4 @@
-import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
+import { Popover, PopoverContent, PopoverTrigger } from "@superset/ui/popover";
 import { useMemo, useState } from "react";
 import type { IconType } from "react-icons";
 import { SiClaude, SiOpenai } from "react-icons/si";
@@ -53,12 +53,12 @@ function hostOrFallback(statusUrl: string, fallback: string): string {
 
 interface ServiceStatusIndicatorProps {
 	snapshot: ServiceStatusSnapshot;
-	onClick: () => void;
+	onOpenStatusPage: () => void;
 }
 
 function ServiceStatusIndicator({
 	snapshot,
-	onClick,
+	onOpenStatusPage,
 }: ServiceStatusIndicatorProps) {
 	const dotClass = LEVEL_DOT_CLASS[snapshot.level];
 	const levelLabel = LEVEL_LABEL[snapshot.level];
@@ -66,11 +66,10 @@ function ServiceStatusIndicator({
 	const Icon = SERVICE_ICON[snapshot.id];
 
 	return (
-		<Tooltip delayDuration={300}>
-			<TooltipTrigger asChild>
+		<Popover>
+			<PopoverTrigger asChild>
 				<button
 					type="button"
-					onClick={onClick}
 					aria-label={`${snapshot.label} status: ${levelLabel}`}
 					className="no-drag relative flex items-center justify-center size-7 rounded-md text-foreground/80 hover:text-foreground hover:bg-accent/60 transition-colors"
 				>
@@ -79,17 +78,10 @@ function ServiceStatusIndicator({
 						className={`absolute -bottom-0.5 -right-0.5 size-2 rounded-full ring-2 ring-background ${dotClass}`}
 					/>
 				</button>
-			</TooltipTrigger>
-			{/* Project's TooltipContent defaults to an inverted color pair
-			 *  (`bg-foreground` + `text-[var(--background)]`). For this
-			 *  multi-line status card we want the regular popover surface
-			 *  instead so description / meta colors (muted-foreground, etc.)
-			 *  work normally. `!` prefix forces the override past the
-			 *  component defaults. */}
-			<TooltipContent
+			</PopoverTrigger>
+			<PopoverContent
 				side="bottom"
-				showArrow={false}
-				className="!bg-popover !text-popover-foreground border shadow-md p-3 max-w-[280px] space-y-1.5 text-sm"
+				className="p-3 max-w-[280px] w-auto space-y-1.5 text-sm"
 			>
 				<div className="flex items-center gap-1.5 font-semibold">
 					<Icon className="size-3.5 shrink-0" />
@@ -102,11 +94,15 @@ function ServiceStatusIndicator({
 					{formatCheckedAt(snapshot.checkedAt)}
 					{snapshot.fetchError ? ` · ${snapshot.fetchError}` : ""}
 				</div>
-				<div className="text-xs text-muted-foreground">
-					クリックで {displayHost} を開く
-				</div>
-			</TooltipContent>
-		</Tooltip>
+				<button
+					type="button"
+					onClick={onOpenStatusPage}
+					className="text-xs text-primary hover:underline focus:outline-none focus-visible:underline"
+				>
+					{displayHost} を開く
+				</button>
+			</PopoverContent>
+		</Popover>
 	);
 }
 
@@ -147,7 +143,7 @@ export function ServiceStatusIndicators() {
 				<ServiceStatusIndicator
 					key={snapshot.id}
 					snapshot={snapshot}
-					onClick={() => openUrl.mutate(snapshot.statusUrl)}
+					onOpenStatusPage={() => openUrl.mutate(snapshot.statusUrl)}
 				/>
 			))}
 		</div>


### PR DESCRIPTION
## 概要
- Issue #268 の対応（ラベル「Claude モデル」「思考 effort」「モデル/effort」を Model/Effort に統一）
- 追加で以下 3 バグも同じ PR で修正

## 変更点
1. **ラベル統一 (#268)**: `ClaudeRuntimePicker`, `TodoManager`, `ScheduleListRow` の表示を Model / Effort に
2. **スケジュール一覧の編集メニュー干渉**: `ScheduleListRow` で 3 点メニュー → 編集を押すとダイアログが一瞬で閉じる / 動作が不安定な問題を修正
   - `DropdownMenu` の `modal={false}` + `DropdownMenuItem` の `onSelect` で `e.preventDefault()` + `setTimeout(onEdit, 0)` で Dialog オープンを次 tick に遅延
3. **IME 変換確定 Enter の誤送信**: `TodoManager.tsx` の送信入力欄とリネーム入力で、`e.nativeEvent.isComposing` を見て IME 変換中は Enter を無視
4. **ヘッダーサービスステータスの UX 改善**: Claude / Codex アイコンを Tooltip (hover) から Popover (click) に置換。ポップ内の `status.claude.com を開く` 等のリンクをクリックで外部ブラウザオープン

## 確認
- [x] `bun run lint:fix`
- [x] `cd apps/desktop && bun run typecheck`

Closes #268