### PR TITLE
feat(desktop): TODOタスク名を任意化し、Claude Codeへのタイトル送信を廃止

### DIFF
--- a/apps/desktop/src/main/todo-agent/supervisor.ts
+++ b/apps/desktop/src/main/todo-agent/supervisor.ts
@@ -118,7 +118,7 @@ export function getTodoSupervisor(): TodoSupervisor {
 
 function renderGoalDoc(session: SelectTodoSession): string {
 	const lines: string[] = [
-		`# TODO: ${session.title}`,
+		session.title ? `# TODO: ${session.title}` : "# TODO",
 		"",
 		"## やって欲しいこと",
 		session.description,

--- a/apps/desktop/src/main/todo-agent/trpc-router.ts
+++ b/apps/desktop/src/main/todo-agent/trpc-router.ts
@@ -121,7 +121,7 @@ export const createTodoAgentRouter = () => {
 					id: sessionId,
 					projectId: input.projectId ?? null,
 					workspaceId: input.workspaceId,
-					title: input.title,
+					title: input.title ?? "",
 					description: input.description,
 					goal: input.goal,
 					verifyCommand: input.verifyCommand,

--- a/apps/desktop/src/main/todo-agent/types.ts
+++ b/apps/desktop/src/main/todo-agent/types.ts
@@ -64,7 +64,7 @@ export const todoClaudeEffortSchema = z.enum(CLAUDE_EFFORT_OPTIONS);
 export const todoCreateInputSchema = z.object({
 	workspaceId: z.string().min(1),
 	projectId: z.string().optional(),
-	title: z.string().min(1).max(200),
+	title: z.string().trim().max(200).optional(),
 	description: z.string().min(1).max(10_000),
 	// Optional: when omitted, the session treats "やって欲しいこと
 	// (description) が完了したとき" as the implicit goal.

--- a/apps/desktop/src/main/todo-daemon/supervisor-engine.ts
+++ b/apps/desktop/src/main/todo-daemon/supervisor-engine.ts
@@ -923,9 +923,7 @@ function buildIterationPrompt(params: {
 		sections.push(
 			`${goalPath} を読んで、${goalClause}。作業ディレクトリは worktree のルートです。`,
 		);
-		sections.push(
-			`タスクのタイトル: ${session.title}\n説明: ${session.description}`,
-		);
+		sections.push(`説明: ${session.description}`);
 		if (session.goal?.trim()) {
 			sections.push(`ゴール:\n${session.goal.trim()}`);
 		}

--- a/apps/desktop/src/renderer/features/todo-agent/TodoManager/TodoManager.tsx
+++ b/apps/desktop/src/renderer/features/todo-agent/TodoManager/TodoManager.tsx
@@ -854,7 +854,7 @@ function SessionRow({
 								/>
 							) : (
 								<span className="text-xs font-medium line-clamp-1 flex-1 min-w-0">
-									{session.title}
+									{session.title || session.description}
 								</span>
 							)}
 						</div>
@@ -872,7 +872,7 @@ function SessionRow({
 					<TooltipContent side="right" align="start" className="max-w-[360px]">
 						<div className="flex flex-col gap-0.5">
 							<span className="text-[11px] font-medium break-words">
-								{session.title}
+								{session.title || session.description}
 							</span>
 							<span className="text-[10px] opacity-70 break-words">
 								{status}
@@ -1272,7 +1272,7 @@ function SessionDetail({ session, onDeleted }: SessionDetailProps) {
 							)}
 						</div>
 						<h2 className="text-lg font-semibold mt-1 leading-tight break-words">
-							{session.title}
+							{session.title || session.description}
 						</h2>
 					</div>
 					<div className="flex items-center gap-2 shrink-0">

--- a/apps/desktop/src/renderer/features/todo-agent/TodoManager/TodoManager.tsx
+++ b/apps/desktop/src/renderer/features/todo-agent/TodoManager/TodoManager.tsx
@@ -2535,7 +2535,6 @@ function TodoComposer({
 
 	const canSubmit =
 		projectId.length > 0 &&
-		title.trim().length > 0 &&
 		description.trim().length > 0 &&
 		!submitting &&
 		(createWorktree || workspaceId.length > 0);
@@ -2709,14 +2708,13 @@ function TodoComposer({
 						)}
 
 						<div className="flex flex-col gap-1.5">
-							<Label htmlFor="composer-title">タイトル</Label>
+							<Label htmlFor="composer-title">タイトル（省略可）</Label>
 							<Input
 								id="composer-title"
 								value={title}
 								onChange={(e) => setTitle(e.target.value)}
 								placeholder="例: Issue #123 を修正"
 								maxLength={200}
-								autoFocus
 							/>
 						</div>
 
@@ -2735,6 +2733,7 @@ function TodoComposer({
 								onAttachmentsChange={setDescAttachments}
 								placeholder="やってほしい作業を書く（右のテンプレートから挿入可・画像貼り付け可）"
 								rows={5}
+								autoFocus
 							/>
 						</div>
 

--- a/apps/desktop/src/renderer/features/todo-agent/TodoModal/TodoModal.tsx
+++ b/apps/desktop/src/renderer/features/todo-agent/TodoModal/TodoModal.tsx
@@ -149,7 +149,6 @@ export function TodoModal({
 
 	const canUseNewWorktree = Boolean(projectId);
 	const canSubmit =
-		title.trim().length > 0 &&
 		description.trim().length > 0 &&
 		maxIterations >= 1 &&
 		maxMinutes >= 1 &&
@@ -244,14 +243,13 @@ export function TodoModal({
 
 				<div className="flex flex-col gap-4">
 					<div className="flex flex-col gap-1.5">
-						<Label htmlFor="todo-title">タイトル</Label>
+						<Label htmlFor="todo-title">タイトル（省略可）</Label>
 						<Input
 							id="todo-title"
 							value={title}
 							onChange={(e) => setTitle(e.target.value)}
 							placeholder="例: Issue #123 を修正"
 							maxLength={200}
-							autoFocus
 							className="rounded-md"
 						/>
 					</div>
@@ -293,6 +291,7 @@ export function TodoModal({
 							onChange={(e) => setDescription(e.target.value)}
 							placeholder="やってほしい作業を書く"
 							rows={4}
+							autoFocus
 							className="rounded-md"
 						/>
 					</div>


### PR DESCRIPTION
## 概要

Issue #277 の対応。Agent ManagerのTODO機能でタスク名（タイトル）を必須から任意に変更し、Claude Codeへの不要なタイトル送信を廃止する。

## 変更内容

- **タイトル任意化**: `todoCreateInputSchema`の`title`フィールドから`min(1)`を削除してオプショナル化
- **代替表示**: タイトルが空の場合、リスト・ツールチップ・右パネルの見出しでdescriptionを代わりに表示
- **UIラベル変更**: フォームのタイトルラベルを「タイトル（省略可）」に変更、autoFocusをdescription欄へ移動
- **Claude Code送信の改善**: `buildIterationPrompt`からタイトル行を削除し、descriptionのみを送信（ノイズ削減）
- **goal.md**: タイトルが空の場合は `# TODO` と表示

## テスト手順

- [ ] タイトルなしでTODOを作成できること
- [ ] リスト表示でdescriptionが代替表示されること
- [ ] タイトルありの場合は従来通り表示されること
- [ ] Claude Codeへのプロンプトにタイトルが含まれないこと

Closes #277