### PR TITLE
feat(desktop): 右クリックで要素のCSSセレクターとXPathをコピー機能を追加 (#271)

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/browser/browser.ts
+++ b/apps/desktop/src/lib/trpc/routers/browser/browser.ts
@@ -3,7 +3,7 @@ import {
 	SITE_PERMISSION_VALUES,
 } from "@superset/local-db";
 import { observable } from "@trpc/server/observable";
-import { session } from "electron";
+import { session, webContents } from "electron";
 import { requestMediaAccess } from "lib/electron/request-media-access";
 import { browserManager } from "main/lib/browser/browser-manager";
 import { browserSitePermissionManager } from "main/lib/browser/browser-site-permission-manager";
@@ -347,6 +347,21 @@ export const createBrowserRouter = () => {
 						);
 					};
 				});
+			}),
+
+		showElementContextMenu: publicProcedure
+			.input(
+				z.object({
+					webContentsId: z.number(),
+					x: z.number(),
+					y: z.number(),
+				}),
+			)
+			.mutation(({ input }) => {
+				const wc = webContents.fromId(input.webContentsId);
+				if (!wc) return { success: false };
+				browserManager.showContextMenuForWebContents(wc, input.x, input.y);
+				return { success: true };
 			}),
 
 		clearBrowsingData: publicProcedure

--- a/apps/desktop/src/main/lib/browser/browser-manager.ts
+++ b/apps/desktop/src/main/lib/browser/browser-manager.ts
@@ -16,6 +16,55 @@ interface ConsoleEntry {
 
 const MAX_CONSOLE_ENTRIES = 500;
 
+function buildElementPathScript(x: number, y: number): string {
+	return `(function() {
+		var el = document.elementFromPoint(${x}, ${y});
+		if (!el) return null;
+		function getCssSelector(element) {
+			var parts = [];
+			var current = element;
+			while (current && current.nodeType === 1 && current !== document.documentElement) {
+				var sel = current.tagName.toLowerCase();
+				if (current.id) {
+					parts.unshift('#' + CSS.escape(current.id));
+					return parts.join(' > ');
+				}
+				var classes = Array.prototype.slice.call(current.classList, 0, 3).map(function(c) { return CSS.escape(c); });
+				if (classes.length > 0) sel += '.' + classes.join('.');
+				var parent = current.parentElement;
+				if (parent) {
+					var sameTag = Array.prototype.filter.call(parent.children, function(s) { return s.tagName === current.tagName; });
+					if (sameTag.length > 1) sel += ':nth-of-type(' + (Array.prototype.indexOf.call(sameTag, current) + 1) + ')';
+				}
+				parts.unshift(sel);
+				current = current.parentElement;
+				if (parts.length >= 5) break;
+			}
+			return parts.join(' > ');
+		}
+		function getXPath(element) {
+			if (element.id) return '//*[@id="' + element.id + '"]';
+			var parts = [];
+			var current = element;
+			while (current && current.nodeType === 1) {
+				var tag = current.tagName.toLowerCase();
+				var parent = current.parentElement;
+				if (!parent) { parts.unshift(tag); break; }
+				var sameTag = Array.prototype.filter.call(parent.children, function(s) { return s.tagName === current.tagName; });
+				if (sameTag.length > 1) {
+					parts.unshift(tag + '[' + (Array.prototype.indexOf.call(sameTag, current) + 1) + ']');
+				} else {
+					parts.unshift(tag);
+				}
+				current = parent;
+				if (parts.length >= 8) break;
+			}
+			return '/' + parts.join('/');
+		}
+		return { cssSelector: getCssSelector(el), xpath: getXPath(el) };
+	})()`;
+}
+
 function sanitizeUrl(url: string): string {
 	if (/^https?:\/\//i.test(url) || url.startsWith("about:")) {
 		return url;
@@ -440,6 +489,41 @@ class BrowserManager extends EventEmitter {
 			menuItems.push(
 				{ type: "separator" },
 				{
+					label: "Copy Element Selector",
+					submenu: [
+						{
+							label: "CSS Selector",
+							click: async () => {
+								try {
+									const result = (await wc.executeJavaScript(
+										buildElementPathScript(params.x, params.y),
+									)) as { cssSelector: string; xpath: string } | null;
+									if (result?.cssSelector) {
+										clipboard.writeText(result.cssSelector);
+									}
+								} catch {
+									// page may not support elementFromPoint
+								}
+							},
+						},
+						{
+							label: "XPath",
+							click: async () => {
+								try {
+									const result = (await wc.executeJavaScript(
+										buildElementPathScript(params.x, params.y),
+									)) as { cssSelector: string; xpath: string } | null;
+									if (result?.xpath) {
+										clipboard.writeText(result.xpath);
+									}
+								} catch {
+									// page may not support elementFromPoint
+								}
+							},
+						},
+					],
+				},
+				{
 					label: "Inspect Element",
 					click: () => wc.inspectElement(params.x, params.y),
 				},
@@ -493,6 +577,60 @@ class BrowserManager extends EventEmitter {
 				// webContents may be destroyed
 			}
 		});
+	}
+
+	showContextMenuForWebContents(
+		wc: Electron.WebContents,
+		x: number,
+		y: number,
+	): void {
+		const script = buildElementPathScript(x, y);
+		const menuItems: Electron.MenuItemConstructorOptions[] = [
+			{
+				label: "Copy Element Selector",
+				submenu: [
+					{
+						label: "CSS Selector",
+						click: async () => {
+							try {
+								const result = (await wc.executeJavaScript(script)) as {
+									cssSelector: string;
+									xpath: string;
+								} | null;
+								if (result?.cssSelector) {
+									clipboard.writeText(result.cssSelector);
+								}
+							} catch {
+								// page may not support elementFromPoint
+							}
+						},
+					},
+					{
+						label: "XPath",
+						click: async () => {
+							try {
+								const result = (await wc.executeJavaScript(script)) as {
+									cssSelector: string;
+									xpath: string;
+								} | null;
+								if (result?.xpath) {
+									clipboard.writeText(result.xpath);
+								}
+							} catch {
+								// page may not support elementFromPoint
+							}
+						},
+					},
+				],
+			},
+			{ type: "separator" },
+			{
+				label: "Inspect Element",
+				click: () => wc.inspectElement(x, y),
+			},
+		];
+		const menu = Menu.buildFromTemplate(menuItems);
+		menu.popup();
 	}
 }
 

--- a/apps/desktop/src/main/lib/browser/browser-manager.ts
+++ b/apps/desktop/src/main/lib/browser/browser-manager.ts
@@ -46,6 +46,7 @@ function buildElementPathScript(x: number, y: number): string {
 			if (element.id) return '//*[@id="' + element.id + '"]';
 			var parts = [];
 			var current = element;
+			var truncated = false;
 			while (current && current.nodeType === 1) {
 				var tag = current.tagName.toLowerCase();
 				var parent = current.parentElement;
@@ -57,9 +58,9 @@ function buildElementPathScript(x: number, y: number): string {
 					parts.unshift(tag);
 				}
 				current = parent;
-				if (parts.length >= 8) break;
+				if (parts.length >= 8) { truncated = true; break; }
 			}
-			return '/' + parts.join('/');
+			return (truncated ? '//' : '/') + parts.join('/');
 		}
 		return { cssSelector: getCssSelector(el), xpath: getXPath(el) };
 	})()`;

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/components/FileViewerContent/FileViewerContent.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/components/FileViewerContent/FileViewerContent.tsx
@@ -105,6 +105,19 @@ function HtmlPreviewWebview({
 			}
 		});
 
+		webview.addEventListener(
+			"context-menu",
+			(event: Electron.ContextMenuEvent) => {
+				event.preventDefault();
+				const { x, y } = event.params;
+				void electronTrpcClient.browser.showElementContextMenu.mutate({
+					webContentsId: webview.getWebContentsId(),
+					x,
+					y,
+				});
+			},
+		);
+
 		container.appendChild(webview);
 
 		return () => {


### PR DESCRIPTION
## 概要

Issue #271 の対応です。

HTMLビューアー（`.html`ファイルのプレビュー）と内蔵ブラウザタブで要素を右クリックした際に、その要素のパスをコピーできるコンテキストメニューを追加しました。

## 変更内容

- **内蔵ブラウザタブ**（BrowserPane）: `browser-manager.ts` のコンテキストメニューに「Copy Element Selector」サブメニューを追加
  - CSS Selector: IDや class名、:nth-of-type を組み合わせた最大5段階のセレクター
  - XPath: IDがあれば `//*[@id="..."]`、なければ階層パスを最大8段階で生成
- **HTMLファイルビューアー**（HtmlPreviewWebview）: `context-menu` イベントをハンドルし、tRPC経由でメインプロセスのコンテキストメニューを表示
- **tRPCルーター**（`browser.ts`）: `showElementContextMenu` mutation を追加（webContentsId, x, y を受け取る）

## ユースケース

「このボタンのスタイルを変えたい」「この要素の動作がおかしい」と思ったとき、要素を右クリックしてパスをコピーし、LLMに投げることで認識の齟齬なく指示できます。