### PR TITLE
fix(desktop): Cmd+Q でティアオフウィンドウのタブが消えない問題を修正

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -49,6 +49,7 @@ import {
 	reconcileDaemonSessions,
 } from "./lib/terminal";
 import { disposeTray, initTray } from "./lib/tray";
+import { windowManager } from "./lib/window-manager";
 
 // Lazy import to avoid module resolution issues during Vite build
 const loadVscodeShim = () =>
@@ -437,6 +438,39 @@ app.on("before-quit", async (event) => {
 		manager.releaseAll();
 	}
 	disposeTray();
+
+	// app.exit() bypasses beforeunload in renderer processes, so tearoff windows
+	// never return their tabs via the normal beforeunload path. Collect them here
+	// and merge into persisted tabsState before the process exits.
+	try {
+		const { appState } = await import("./lib/app-state");
+		const tearoffTabs = await windowManager.collectAllTearoffTabs(1500);
+		if (tearoffTabs.length > 0) {
+			const current = appState.data.tabsState;
+			const existingIds = new Set(current.tabs.map((t) => t.id));
+			const newEntries = tearoffTabs.filter(
+				({ tab }) => !existingIds.has((tab as { id: string }).id),
+			);
+			if (newEntries.length > 0) {
+				const newPanes: Record<string, unknown> = {};
+				for (const { panes } of newEntries) {
+					Object.assign(newPanes, panes);
+				}
+				appState.data.tabsState = {
+					...current,
+					tabs: [
+						...current.tabs,
+						...newEntries.map(({ tab }) => tab as (typeof current.tabs)[0]),
+					],
+					panes: { ...current.panes, ...newPanes } as typeof current.panes,
+				};
+				await appState.write();
+			}
+		}
+	} catch (error) {
+		console.error("[main] Failed to collect tearoff tabs before quit:", error);
+	}
+
 	app.exit(0);
 });
 

--- a/apps/desktop/src/main/lib/window-manager/index.ts
+++ b/apps/desktop/src/main/lib/window-manager/index.ts
@@ -192,6 +192,58 @@ export class WindowManager {
 		return { windowId, window };
 	}
 
+	/**
+	 * Collect tabs from all open tearoff windows before the app quits.
+	 * app.exit() bypasses beforeunload in renderers, so we must explicitly
+	 * request state from each tearoff window via IPC.
+	 */
+	async collectAllTearoffTabs(
+		timeoutMs = 1500,
+	): Promise<Array<{ tab: unknown; panes: Record<string, unknown> }>> {
+		const tearoffEntries = Array.from(this.windows.entries()).filter(
+			([id, win]) => id !== "main" && !win.isDestroyed(),
+		);
+
+		if (tearoffEntries.length === 0) return [];
+
+		const promises = tearoffEntries.map(
+			([windowId, win]) =>
+				new Promise<Array<{ tab: unknown; panes: Record<string, unknown> }>>(
+					(resolve) => {
+						const timer = setTimeout(() => {
+							ipcMain.removeAllListeners(`tearoff-state-collected-${windowId}`);
+							resolve([]);
+						}, timeoutMs);
+
+						ipcMain.once(
+							`tearoff-state-collected-${windowId}`,
+							(
+								_event,
+								data: Array<{
+									tab: unknown;
+									panes: Record<string, unknown>;
+								}>,
+							) => {
+								clearTimeout(timer);
+								resolve(Array.isArray(data) ? data : []);
+							},
+						);
+
+						if (!win.isDestroyed()) {
+							win.webContents.send("collect-tearoff-state", windowId);
+						} else {
+							clearTimeout(timer);
+							ipcMain.removeAllListeners(`tearoff-state-collected-${windowId}`);
+							resolve([]);
+						}
+					},
+				),
+		);
+
+		const results = await Promise.all(promises);
+		return results.flat();
+	}
+
 	broadcast(channel: string, ...args: unknown[]): void {
 		for (const window of this.windows.values()) {
 			if (!window.isDestroyed()) {

--- a/apps/desktop/src/renderer/hooks/useTearoffInit/useTearoffInit.ts
+++ b/apps/desktop/src/renderer/hooks/useTearoffInit/useTearoffInit.ts
@@ -29,6 +29,31 @@ export function useTearoffInit() {
 		navigate({ to: `/workspace/${tab.workspaceId}`, replace: true });
 	}, [tabs, navigate]);
 
+	// Respond to main-process request for state before app.exit() (Cmd+Q path)
+	useEffect(() => {
+		if (!_cachedWindowId) return;
+		const handleCollect = (windowId: string) => {
+			if (windowId !== _cachedWindowId) return;
+			const state = useTabsStore.getState();
+			if (state.tabs.length === 0) return;
+			const tabsWithPanes = state.tabs.map((tab) => {
+				const panes: Record<string, Pane> = {};
+				for (const [id, pane] of Object.entries(state.panes)) {
+					if (pane.tabId === tab.id) {
+						panes[id] = pane;
+					}
+				}
+				return { tab, panes };
+			});
+			window.ipcRenderer.send(
+				`tearoff-state-collected-${windowId}`,
+				tabsWithPanes,
+			);
+		};
+		window.ipcRenderer.on("collect-tearoff-state", handleCollect);
+		return () => window.ipcRenderer.off("collect-tearoff-state", handleCollect);
+	}, []);
+
 	// Return ALL tabs to main window when this tearoff window closes
 	useEffect(() => {
 		if (!_cachedWindowId) return;


### PR DESCRIPTION
## 概要

Issue #274 の修正です。

ティアオフウィンドウが開いたまま Cmd+Q でアプリを終了すると、再起動後にそのタブが復元されない問題を修正しました。

## 原因

`app.exit(0)` はレンダラープロセスの `beforeunload` イベントを発火させません。そのため、通常のウィンドウクローズ時に走る「ティアオフタブをメインウィンドウに返す」処理が実行されず、タブが `appState` に保存されないまま終了していました。

## 修正内容

- **`window-manager/index.ts`** — `collectAllTearoffTabs()` メソッドを追加。  
  各ティアオフウィンドウに `collect-tearoff-state` IPC を送り、1.5秒以内の応答を待って tabs/panes を収集する。

- **`useTearoffInit.ts`** — `collect-tearoff-state` IPC リスナーを追加。  
  受信時に Zustand ストアから現在の tabs/panes を収集して `tearoff-state-collected-<windowId>` で返す。

- **`main/index.ts`** — `before-quit` ハンドラの `app.exit(0)` 直前に tearoff タブ収集処理を追加。  
  収集したタブを `appState.data.tabsState` にマージして `appState.write()` で永続化する。

## テスト方法

1. ターミナルなどをティアオフして別ウィンドウとして開く
2. そのまま Cmd+Q でアプリを終了
3. アプリを再起動
4. ティアオフしていたタブが復元されることを確認