### PR TITLE
fix(desktop): 通知音ボリュームをドロップダウンからスライダーに変更

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/settings/ringtones/components/RingtonesSettings/components/VolumeDropdown/VolumeDropdown.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/ringtones/components/RingtonesSettings/components/VolumeDropdown/VolumeDropdown.tsx
@@ -1,27 +1,8 @@
 import { Label } from "@superset/ui/label";
-import {
-	Select,
-	SelectContent,
-	SelectItem,
-	SelectTrigger,
-	SelectValue,
-} from "@superset/ui/select";
-import { useCallback } from "react";
+import { Slider } from "@superset/ui/slider";
+import { useState } from "react";
 import { HiSpeakerWave } from "react-icons/hi2";
 import { electronTrpc } from "renderer/lib/electron-trpc";
-
-const VOLUME_LEVELS = [
-	{ value: 20, label: "Quiet" },
-	{ value: 40, label: "Low" },
-	{ value: 60, label: "Medium" },
-	{ value: 80, label: "High" },
-	{ value: 100, label: "Maximum" },
-] as const;
-
-function getVolumeLabel(volume: number): string {
-	const level = VOLUME_LEVELS.find((l) => l.value === volume);
-	return level ? level.label : "Custom";
-}
 
 export function VolumeDropdown() {
 	const utils = electronTrpc.useUtils();
@@ -29,11 +10,14 @@ export function VolumeDropdown() {
 		electronTrpc.settings.getNotificationVolume.useQuery();
 	const volume = volumeData ?? 100;
 
+	const [draftVolume, setDraftVolume] = useState<number | null>(null);
+	const displayVolume = draftVolume ?? volume;
+
 	const setVolume = electronTrpc.settings.setNotificationVolume.useMutation({
-		onMutate: async ({ volume }) => {
+		onMutate: async ({ volume: newVolume }) => {
 			await utils.settings.getNotificationVolume.cancel();
 			const previous = utils.settings.getNotificationVolume.getData();
-			utils.settings.getNotificationVolume.setData(undefined, volume);
+			utils.settings.getNotificationVolume.setData(undefined, newVolume);
 			return { previous };
 		},
 		onError: (_err, _vars, context) => {
@@ -49,14 +33,6 @@ export function VolumeDropdown() {
 		},
 	});
 
-	const handleVolumeChange = useCallback(
-		(value: string) => {
-			const newVolume = Number.parseInt(value, 10);
-			setVolume.mutate({ volume: newVolume });
-		},
-		[setVolume],
-	);
-
 	return (
 		<div className="space-y-3">
 			<div className="flex items-center justify-between gap-4">
@@ -64,35 +40,31 @@ export function VolumeDropdown() {
 					<HiSpeakerWave className="h-5 w-5 text-muted-foreground flex-shrink-0" />
 					<Label htmlFor="notification-volume" className="text-sm font-medium">
 						Volume
+						<span className="ml-2 text-xs text-muted-foreground">
+							{displayVolume}%
+						</span>
 					</Label>
 				</div>
-				<Select
-					value={volume.toString()}
-					onValueChange={handleVolumeChange}
-					disabled={volumeLoading}
-				>
-					<SelectTrigger id="notification-volume" className="w-[200px]">
-						<SelectValue>
-							<span className="flex items-center gap-2">
-								<span className="font-medium">{getVolumeLabel(volume)}</span>
-								<span className="text-muted-foreground">({volume}%)</span>
-							</span>
-						</SelectValue>
-					</SelectTrigger>
-					<SelectContent>
-						{VOLUME_LEVELS.map((level) => (
-							<SelectItem key={level.value} value={level.value.toString()}>
-								<div className="flex items-center gap-2">
-									<span className="font-medium">{level.label}</span>
-									<span className="text-muted-foreground text-xs">
-										({level.value}%)
-									</span>
-								</div>
-							</SelectItem>
-						))}
-					</SelectContent>
-				</Select>
 			</div>
+			<Slider
+				id="notification-volume"
+				value={[displayVolume]}
+				min={0}
+				max={100}
+				step={1}
+				disabled={volumeLoading}
+				onValueChange={(values) => {
+					const value = values[0];
+					if (typeof value !== "number") return;
+					setDraftVolume(value);
+				}}
+				onValueCommit={(values) => {
+					const value = values[0];
+					if (typeof value !== "number") return;
+					setDraftVolume(null);
+					setVolume.mutate({ volume: value });
+				}}
+			/>
 		</div>
 	);
 }


### PR DESCRIPTION
## 概要

- Issue #283 対応
- 通知音のボリューム設定を5段階のドロップダウンから、0〜100%の連続スライダーに変更

## 変更内容

- `VolumeDropdown` コンポーネントの `Select` を `Slider` に置き換え
- ドラッグ中はローカルの `draftVolume` で即時反映し、ドラッグ確定時（`onValueCommit`）にサーバーへ保存するパターンを採用（`VibrancySection` と同じ実装パターン）
- ラベル横に現在値（`XX%`）を表示

## テスト手順

- [ ] Settings > Ringtones を開く
- [ ] Volume スライダーをドラッグして値が変化することを確認
- [ ] ドラッグ離した後に設定が保存されることを確認（再起動後も維持される）
- [ ] 通知音が設定したボリュームで再生されることを確認