### PR TITLE
feat(desktop): YouTubeインポートUXを全面改善

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/ringtone/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/ringtone/index.ts
@@ -11,9 +11,13 @@ import {
 } from "main/lib/custom-ringtones";
 import { playSoundFile } from "main/lib/play-sound";
 import { getSoundPath } from "main/lib/sound-paths";
+import { getTempAudioPath } from "main/lib/temp-audio-protocol";
 import {
+	checkMissingBinaries,
+	cleanupTempAudio,
+	downloadFullYouTubeAudio,
 	importRingtoneFromYouTube,
-	YOUTUBE_RINGTONE_LIMITS,
+	installMissingBinaries,
 	YouTubeRingtoneError,
 } from "main/lib/youtube-ringtone";
 import {
@@ -216,6 +220,77 @@ export const createRingtoneRouter = (getWindow: () => BrowserWindow | null) => {
 			}),
 
 		/**
+		 * Check which required binaries (yt-dlp, ffmpeg) are missing.
+		 */
+		checkBinaries: publicProcedure.query(async () => {
+			const missing = await checkMissingBinaries();
+			return { missing };
+		}),
+
+		/**
+		 * Install yt-dlp and ffmpeg via Homebrew (macOS only).
+		 */
+		installBinaries: publicProcedure.mutation(async () => {
+			try {
+				await installMissingBinaries();
+				return { success: true as const };
+			} catch (error) {
+				throw new TRPCError({
+					code: "INTERNAL_SERVER_ERROR",
+					message:
+						error instanceof Error
+							? error.message
+							: "Failed to install dependencies",
+				});
+			}
+		}),
+
+		/**
+		 * Download the full audio from a YouTube URL to a temp file.
+		 * Returns a tempId for use with the superset-temp-audio protocol and video metadata.
+		 */
+		downloadYouTubeAudio: publicProcedure
+			.input(z.object({ url: z.string().min(1) }))
+			.mutation(async ({ input }) => {
+				try {
+					const result = await downloadFullYouTubeAudio(input.url);
+					return {
+						tempId: result.tempId,
+						info: result.info,
+					};
+				} catch (error) {
+					if (error instanceof YouTubeRingtoneError) {
+						throw new TRPCError({
+							code:
+								error.code === "BINARY_MISSING" ||
+								error.code === "TIMEOUT" ||
+								error.code === "VIDEO_TOO_LONG"
+									? "PRECONDITION_FAILED"
+									: "BAD_REQUEST",
+							message: error.message,
+						});
+					}
+					throw new TRPCError({
+						code: "INTERNAL_SERVER_ERROR",
+						message:
+							error instanceof Error
+								? error.message
+								: "Failed to download YouTube audio",
+					});
+				}
+			}),
+
+		/**
+		 * Clean up a previously downloaded temp audio file.
+		 */
+		cleanupTempAudio: publicProcedure
+			.input(z.object({ tempId: z.string() }))
+			.mutation(async ({ input }) => {
+				await cleanupTempAudio(input.tempId);
+				return { success: true as const };
+			}),
+
+		/**
 		 * Imports a custom ringtone by clipping a section of a YouTube video.
 		 * Requires `yt-dlp` and `ffmpeg` to be installed on the user's machine.
 		 */
@@ -227,16 +302,28 @@ export const createRingtoneRouter = (getWindow: () => BrowserWindow | null) => {
 						.number()
 						.min(0)
 						.max(60 * 60 * 12),
-					durationSeconds: z
+					endSeconds: z
 						.number()
-						.min(1)
-						.max(YOUTUBE_RINGTONE_LIMITS.maxDurationSeconds),
+						.min(0)
+						.max(60 * 60 * 12),
 					displayName: z.string().max(120).optional(),
+					thumbnailUrl: z.string().max(2048).optional(),
+					fadeInSeconds: z.number().min(0).max(10).optional(),
+					fadeOutSeconds: z.number().min(0).max(10).optional(),
+					playbackRate: z.number().min(0.5).max(2.0).optional(),
+					/** Client-side tempId from downloadYouTubeAudio – resolved to path server-side */
+					tempId: z.string().optional(),
 				}),
 			)
 			.mutation(async ({ input }) => {
 				try {
-					const ringtone = await importRingtoneFromYouTube(input);
+					const tempFilePath = input.tempId
+						? (getTempAudioPath(input.tempId) ?? undefined)
+						: undefined;
+					const ringtone = await importRingtoneFromYouTube({
+						...input,
+						tempFilePath,
+					});
 					return { ringtone };
 				} catch (error) {
 					if (error instanceof YouTubeRingtoneError) {

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -44,6 +44,7 @@ import { closeLocalDb, localDb } from "./lib/local-db";
 import { ensureProjectIconsDir, getProjectIconPath } from "./lib/project-icons";
 import { initSentry } from "./lib/sentry";
 import { setupServiceStatusPolling } from "./lib/service-status";
+import { createTempAudioProtocolHandler } from "./lib/temp-audio-protocol";
 import {
 	prewarmTerminalRuntime,
 	reconcileDaemonSessions,
@@ -667,6 +668,13 @@ if (!gotTheLock) {
 		session
 			.fromPartition("persist:superset")
 			.protocol.handle("superset-ext-icon", extIconHandler);
+
+		// Serve temp audio files (for YouTube import waveform editor)
+		const tempAudioHandler = createTempAudioProtocolHandler();
+		protocol.handle("superset-temp-audio", tempAudioHandler);
+		session
+			.fromPartition("persist:superset")
+			.protocol.handle("superset-temp-audio", tempAudioHandler);
 
 		ensureProjectIconsDir();
 		setWorkspaceDockIcon();

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -511,6 +511,15 @@ protocol.registerSchemesAsPrivileged([
 		},
 	},
 	{
+		scheme: "superset-temp-audio",
+		privileges: {
+			standard: true,
+			secure: true,
+			bypassCSP: true,
+			supportFetchAPI: true,
+		},
+	},
+	{
 		scheme: "vscode-webview-resource",
 		privileges: {
 			standard: true,

--- a/apps/desktop/src/main/lib/custom-ringtones.ts
+++ b/apps/desktop/src/main/lib/custom-ringtones.ts
@@ -30,6 +30,7 @@ const ALLOWED_AUDIO_EXTENSIONS = new Set([".mp3", ".wav", ".ogg"]);
 interface CustomRingtoneMetadata {
 	name?: string;
 	importedAt?: number;
+	thumbnailUrl?: string;
 }
 
 export interface CustomRingtoneInfo {
@@ -37,6 +38,7 @@ export interface CustomRingtoneInfo {
 	name: string;
 	description: string;
 	emoji: string;
+	thumbnailUrl?: string;
 }
 
 function isAllowedAudioExtension(filePath: string): boolean {
@@ -119,12 +121,14 @@ function readCustomRingtoneMetadata(): CustomRingtoneMetadata {
 function writeCustomRingtoneMetadata(
 	name: string,
 	importedAt: number = Date.now(),
+	thumbnailUrl?: string,
 ): void {
 	writeFileSync(
 		CUSTOM_RINGTONE_METADATA_PATH,
 		JSON.stringify({
 			name,
 			importedAt,
+			...(thumbnailUrl ? { thumbnailUrl } : {}),
 		}),
 		"utf-8",
 	);
@@ -184,7 +188,11 @@ export function setCustomRingtoneDisplayName(name: string): void {
 	ensureCustomRingtonesDir();
 	const displayName = name.trim().slice(0, 80) || "Custom Audio";
 	const existing = readCustomRingtoneMetadata();
-	writeCustomRingtoneMetadata(displayName, existing.importedAt ?? Date.now());
+	writeCustomRingtoneMetadata(
+		displayName,
+		existing.importedAt ?? Date.now(),
+		existing.thumbnailUrl,
+	);
 }
 
 export function getCustomRingtoneInfo(): CustomRingtoneInfo | null {
@@ -199,11 +207,18 @@ export function getCustomRingtoneInfo(): CustomRingtoneInfo | null {
 		name: metadata.name?.trim() || "Custom Audio",
 		description: "Imported from your local machine",
 		emoji: "SFX",
+		...(metadata.thumbnailUrl ? { thumbnailUrl: metadata.thumbnailUrl } : {}),
 	};
+}
+
+export interface ImportOptions {
+	displayName?: string;
+	thumbnailUrl?: string;
 }
 
 export async function importCustomRingtoneFromPath(
 	sourcePath: string,
+	options?: ImportOptions,
 ): Promise<CustomRingtoneInfo> {
 	if (!isAllowedAudioExtension(sourcePath)) {
 		throw new Error("Only .mp3, .wav, and .ogg files are supported");
@@ -227,7 +242,10 @@ export async function importCustomRingtoneFromPath(
 		RINGTONES_ASSETS_DIR,
 		`${CUSTOM_RINGTONE_FILE_STEM}${ext}`,
 	);
-	const displayName = sanitizeDisplayName(basename(sourcePath));
+	const displayName =
+		options?.displayName?.trim().slice(0, 80) ||
+		sanitizeDisplayName(basename(sourcePath));
+	const thumbnailUrl = options?.thumbnailUrl;
 
 	// Re-importing the same file path should not delete the active ringtone.
 	if (areSamePath(sourcePath, destinationPath) && existsSync(destinationPath)) {
@@ -236,12 +254,13 @@ export async function importCustomRingtoneFromPath(
 		} catch {
 			// Best effort only.
 		}
-		writeCustomRingtoneMetadata(displayName);
+		writeCustomRingtoneMetadata(displayName, Date.now(), thumbnailUrl);
 		return {
 			id: CUSTOM_RINGTONE_ID,
 			name: displayName,
 			description: "Imported from your local machine",
 			emoji: "SFX",
+			...(thumbnailUrl ? { thumbnailUrl } : {}),
 		};
 	}
 
@@ -272,12 +291,13 @@ export async function importCustomRingtoneFromPath(
 		// Best effort only.
 	}
 
-	writeCustomRingtoneMetadata(displayName);
+	writeCustomRingtoneMetadata(displayName, Date.now(), thumbnailUrl);
 
 	return {
 		id: CUSTOM_RINGTONE_ID,
 		name: displayName,
 		description: "Imported from your local machine",
 		emoji: "SFX",
+		...(thumbnailUrl ? { thumbnailUrl } : {}),
 	};
 }

--- a/apps/desktop/src/main/lib/temp-audio-protocol.ts
+++ b/apps/desktop/src/main/lib/temp-audio-protocol.ts
@@ -1,0 +1,48 @@
+import { readFile } from "node:fs/promises";
+import { extname } from "node:path";
+
+const registry = new Map<string, string>();
+
+export function registerTempAudio(id: string, filePath: string): void {
+	registry.set(id, filePath);
+}
+
+export function unregisterTempAudio(id: string): void {
+	registry.delete(id);
+}
+
+export function getTempAudioPath(id: string): string | null {
+	return registry.get(id) ?? null;
+}
+
+function mimeForExt(ext: string): string {
+	if (ext === ".mp3") return "audio/mpeg";
+	if (ext === ".wav") return "audio/wav";
+	if (ext === ".ogg") return "audio/ogg";
+	return "audio/mpeg";
+}
+
+export function createTempAudioProtocolHandler() {
+	return async (request: Request): Promise<Response> => {
+		const url = new URL(request.url);
+		const id = url.hostname;
+		const filePath = registry.get(id);
+		if (!filePath) {
+			return new Response("Not found", { status: 404 });
+		}
+		try {
+			const data = await readFile(filePath);
+			const mime = mimeForExt(extname(filePath).toLowerCase());
+			return new Response(data, {
+				headers: {
+					"Content-Type": mime,
+					"Content-Length": String(data.length),
+					"Accept-Ranges": "bytes",
+					"Cache-Control": "no-store",
+				},
+			});
+		} catch {
+			return new Response("Error reading file", { status: 500 });
+		}
+	};
+}

--- a/apps/desktop/src/main/lib/youtube-ringtone.ts
+++ b/apps/desktop/src/main/lib/youtube-ringtone.ts
@@ -7,7 +7,7 @@ import {
 	readdirSync,
 	statSync,
 } from "node:fs";
-import { access, rm, unlink } from "node:fs/promises";
+import { access, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { delimiter, dirname, extname, join } from "node:path";
 import { getProcessEnvWithShellPath } from "lib/trpc/routers/workspaces/utils/shell-env";
@@ -16,9 +16,16 @@ import {
 	importCustomRingtoneFromPath,
 	setCustomRingtoneDisplayName,
 } from "./custom-ringtones";
+import {
+	getTempAudioPath,
+	registerTempAudio,
+	unregisterTempAudio,
+} from "./temp-audio-protocol";
 
 const MAX_CLIP_DURATION_SECONDS = 30;
 const YT_DLP_TIMEOUT_MS = 120_000;
+const FULL_DOWNLOAD_TIMEOUT_MS = 300_000;
+const MAX_FULL_DOWNLOAD_DURATION_SECONDS = 600;
 const REQUIRED_BINARIES = ["yt-dlp", "ffmpeg", "ffprobe"] as const;
 type RequiredBinary = (typeof REQUIRED_BINARIES)[number];
 const ALLOWED_OUTPUT_EXTENSIONS = new Set([".mp3", ".wav", ".ogg"]);
@@ -34,11 +41,29 @@ const FALLBACK_SEARCH_DIRS = [
 	"/sbin",
 ];
 
+export interface VideoInfo {
+	title: string;
+	thumbnailUrl: string;
+	durationSeconds: number;
+}
+
+export interface DownloadedAudio {
+	tempId: string;
+	tempPath: string;
+	info: VideoInfo;
+}
+
 export interface ImportFromYouTubeOptions {
 	url: string;
 	startSeconds: number;
-	durationSeconds: number;
+	endSeconds: number;
 	displayName?: string;
+	thumbnailUrl?: string;
+	fadeInSeconds?: number;
+	fadeOutSeconds?: number;
+	playbackRate?: number;
+	/** If provided, skip yt-dlp download and use this temp file instead */
+	tempFilePath?: string;
 }
 
 export class YouTubeRingtoneError extends Error {
@@ -49,7 +74,8 @@ export class YouTubeRingtoneError extends Error {
 			| "INVALID_URL"
 			| "INVALID_RANGE"
 			| "DOWNLOAD_FAILED"
-			| "TIMEOUT",
+			| "TIMEOUT"
+			| "VIDEO_TOO_LONG",
 	) {
 		super(message);
 		this.name = "YouTubeRingtoneError";
@@ -121,39 +147,100 @@ async function resolveRequiredBinaries(
 	return resolved;
 }
 
-function runYtDlp(
-	ytDlpPath: string,
-	args: string[],
-	cwd: string,
-	env: NodeJS.ProcessEnv,
-): Promise<void> {
-	return new Promise((resolve, reject) => {
-		const proc = spawn(ytDlpPath, args, {
-			cwd,
-			env,
+export async function checkMissingBinaries(): Promise<string[]> {
+	const shellEnv = await getProcessEnvWithShellPath();
+	const entries = await Promise.all(
+		REQUIRED_BINARIES.map(async (bin) => {
+			const path = await resolveBinaryPath(bin, shellEnv);
+			return [bin, path] as const;
+		}),
+	);
+	return entries.filter(([, p]) => !p).map(([name]) => name);
+}
+
+export async function installMissingBinaries(): Promise<void> {
+	if (process.platform !== "darwin") {
+		throw new Error(
+			"Auto-install is only supported on macOS. Please install yt-dlp and ffmpeg manually.",
+		);
+	}
+
+	const shellEnv = await getProcessEnvWithShellPath();
+	const brewPath = await resolveBinaryPath("brew", shellEnv);
+	if (!brewPath) {
+		throw new Error(
+			"Homebrew is not installed. Please install it from https://brew.sh and then install yt-dlp and ffmpeg.",
+		);
+	}
+
+	await new Promise<void>((resolve, reject) => {
+		const proc = spawn(brewPath, ["install", "yt-dlp", "ffmpeg"], {
+			env: shellEnv,
 			stdio: ["ignore", "pipe", "pipe"],
 		});
+
+		const timer = setTimeout(() => {
+			proc.kill("SIGKILL");
+			reject(new Error("Installation timed out after 10 minutes."));
+		}, 600_000);
 
 		let stderr = "";
 		proc.stderr?.on("data", (chunk: Buffer) => {
 			stderr += chunk.toString();
 		});
 
+		proc.on("error", (err) => {
+			clearTimeout(timer);
+			reject(new Error(`Failed to run brew: ${err.message}`));
+		});
+
+		proc.on("exit", (code) => {
+			clearTimeout(timer);
+			if (code === 0) {
+				resolve();
+			} else {
+				const msg = stderr.trim().split("\n").slice(-3).join("\n");
+				reject(
+					new Error(msg || `brew install exited with code ${code ?? "?"}`),
+				);
+			}
+		});
+	});
+}
+
+function runProcess(
+	binaryPath: string,
+	args: string[],
+	cwd: string,
+	env: NodeJS.ProcessEnv,
+	timeoutMs: number,
+): Promise<string> {
+	return new Promise((resolve, reject) => {
+		const proc = spawn(binaryPath, args, {
+			cwd,
+			env,
+			stdio: ["ignore", "pipe", "pipe"],
+		});
+
+		let stdout = "";
+		let stderr = "";
+		proc.stdout?.on("data", (chunk: Buffer) => {
+			stdout += chunk.toString();
+		});
+		proc.stderr?.on("data", (chunk: Buffer) => {
+			stderr += chunk.toString();
+		});
+
 		const timer = setTimeout(() => {
 			proc.kill("SIGKILL");
-			reject(
-				new YouTubeRingtoneError(
-					"yt-dlp timed out while downloading the audio.",
-					"TIMEOUT",
-				),
-			);
-		}, YT_DLP_TIMEOUT_MS);
+			reject(new YouTubeRingtoneError("Process timed out.", "TIMEOUT"));
+		}, timeoutMs);
 
 		proc.on("error", (error) => {
 			clearTimeout(timer);
 			reject(
 				new YouTubeRingtoneError(
-					`Failed to launch yt-dlp: ${error.message}`,
+					`Failed to launch process: ${error.message}`,
 					"DOWNLOAD_FAILED",
 				),
 			);
@@ -162,12 +249,12 @@ function runYtDlp(
 		proc.on("exit", (code) => {
 			clearTimeout(timer);
 			if (code === 0) {
-				resolve();
+				resolve(stdout);
 			} else {
 				const trimmed = stderr.trim().split("\n").slice(-3).join("\n");
 				reject(
 					new YouTubeRingtoneError(
-						trimmed || `yt-dlp exited with code ${code ?? "?"}`,
+						trimmed || `Process exited with code ${code ?? "?"}`,
 						"DOWNLOAD_FAILED",
 					),
 				);
@@ -196,28 +283,201 @@ function findProducedAudio(workDir: string): string | null {
 	return candidates[0] ?? null;
 }
 
-export async function importRingtoneFromYouTube(
-	options: ImportFromYouTubeOptions,
-): Promise<CustomRingtoneInfo> {
-	const url = options.url.trim();
-
-	if (!isLikelyYouTubeUrl(url)) {
+export async function fetchYouTubeVideoInfo(url: string): Promise<VideoInfo> {
+	const trimmedUrl = url.trim();
+	if (!isLikelyYouTubeUrl(trimmedUrl)) {
 		throw new YouTubeRingtoneError(
 			"Please enter a valid YouTube URL (youtube.com or youtu.be).",
 			"INVALID_URL",
 		);
 	}
 
-	const startSeconds = Math.max(0, Math.floor(options.startSeconds));
-	const durationSeconds = Math.floor(options.durationSeconds);
+	const shellEnv = await getProcessEnvWithShellPath();
+	const resolved = await resolveRequiredBinaries(shellEnv);
 
-	if (
-		!Number.isFinite(durationSeconds) ||
-		durationSeconds <= 0 ||
-		durationSeconds > MAX_CLIP_DURATION_SECONDS
-	) {
+	const workDir = join(tmpdir(), `superset-ytinfo-${randomUUID()}`);
+	mkdirSync(workDir, { recursive: true });
+
+	try {
+		const jsonOutput = await runProcess(
+			resolved["yt-dlp"],
+			["--dump-single-json", "--no-playlist", "--no-warnings", trimmedUrl],
+			workDir,
+			shellEnv,
+			YT_DLP_TIMEOUT_MS,
+		);
+
+		const data = JSON.parse(jsonOutput) as {
+			title?: string;
+			duration?: number;
+			thumbnail?: string;
+		};
+
+		return {
+			title: data.title?.trim() || "YouTube Video",
+			thumbnailUrl: data.thumbnail || "",
+			durationSeconds: data.duration ?? 0,
+		};
+	} finally {
+		await rm(workDir, { recursive: true, force: true }).catch(() => {});
+	}
+}
+
+export async function downloadFullYouTubeAudio(
+	url: string,
+): Promise<DownloadedAudio> {
+	const trimmedUrl = url.trim();
+	if (!isLikelyYouTubeUrl(trimmedUrl)) {
 		throw new YouTubeRingtoneError(
-			`Clip duration must be between 1 and ${MAX_CLIP_DURATION_SECONDS} seconds.`,
+			"Please enter a valid YouTube URL (youtube.com or youtu.be).",
+			"INVALID_URL",
+		);
+	}
+
+	const shellEnv = await getProcessEnvWithShellPath();
+	const resolved = await resolveRequiredBinaries(shellEnv);
+
+	const ffmpegDir = dirname(resolved.ffmpeg);
+	const existingPath = shellEnv.PATH ?? shellEnv.Path ?? "";
+	const pathEntries = existingPath.split(delimiter).filter(Boolean);
+	if (!pathEntries.includes(ffmpegDir)) {
+		pathEntries.unshift(ffmpegDir);
+	}
+	const spawnEnv: NodeJS.ProcessEnv = {
+		...shellEnv,
+		PATH: pathEntries.join(delimiter),
+	};
+
+	const workDir = join(tmpdir(), `superset-ytfull-${randomUUID()}`);
+	mkdirSync(workDir, { recursive: true });
+	const outputTemplate = join(workDir, "audio.%(ext)s");
+
+	const infoArgs = [
+		"--dump-single-json",
+		"--no-playlist",
+		"--no-warnings",
+		`--match-filter`,
+		`duration <= ${MAX_FULL_DOWNLOAD_DURATION_SECONDS}`,
+		trimmedUrl,
+	];
+
+	let info: VideoInfo;
+	try {
+		const jsonOutput = await runProcess(
+			resolved["yt-dlp"],
+			infoArgs,
+			workDir,
+			spawnEnv,
+			YT_DLP_TIMEOUT_MS,
+		);
+		const data = JSON.parse(jsonOutput) as {
+			title?: string;
+			duration?: number;
+			thumbnail?: string;
+		};
+		info = {
+			title: data.title?.trim() || "YouTube Video",
+			thumbnailUrl: data.thumbnail || "",
+			durationSeconds: data.duration ?? 0,
+		};
+	} catch (err) {
+		await rm(workDir, { recursive: true, force: true }).catch(() => {});
+		if (err instanceof YouTubeRingtoneError && err.code === "DOWNLOAD_FAILED") {
+			const msg = err.message.toLowerCase();
+			if (msg.includes("does not pass filter") || msg.includes("duration")) {
+				throw new YouTubeRingtoneError(
+					`Video is too long. Maximum supported duration is ${MAX_FULL_DOWNLOAD_DURATION_SECONDS / 60} minutes.`,
+					"VIDEO_TOO_LONG",
+				);
+			}
+		}
+		throw err;
+	}
+
+	const downloadArgs = [
+		"--no-playlist",
+		"--no-warnings",
+		"--quiet",
+		"-x",
+		"--audio-format",
+		"mp3",
+		"--audio-quality",
+		"5",
+		"--ffmpeg-location",
+		ffmpegDir,
+		"-o",
+		outputTemplate,
+		trimmedUrl,
+	];
+
+	try {
+		await runProcess(
+			resolved["yt-dlp"],
+			downloadArgs,
+			workDir,
+			spawnEnv,
+			FULL_DOWNLOAD_TIMEOUT_MS,
+		);
+	} catch (err) {
+		await rm(workDir, { recursive: true, force: true }).catch(() => {});
+		throw err;
+	}
+
+	const producedPath = findProducedAudio(workDir);
+	if (!producedPath) {
+		await rm(workDir, { recursive: true, force: true }).catch(() => {});
+		throw new YouTubeRingtoneError(
+			"yt-dlp did not produce an audio file. The video may be unavailable or restricted.",
+			"DOWNLOAD_FAILED",
+		);
+	}
+
+	const tempId = randomUUID();
+	registerTempAudio(tempId, producedPath);
+
+	return { tempId, tempPath: producedPath, info };
+}
+
+export async function cleanupTempAudio(tempId: string): Promise<void> {
+	const filePath = getTempAudioPath(tempId);
+	unregisterTempAudio(tempId);
+	if (filePath) {
+		const dir = dirname(filePath);
+		await rm(dir, { recursive: true, force: true }).catch(() => {});
+	}
+}
+
+export async function importRingtoneFromYouTube(
+	options: ImportFromYouTubeOptions,
+): Promise<CustomRingtoneInfo> {
+	const url = options.url.trim();
+
+	if (!options.tempFilePath && !isLikelyYouTubeUrl(url)) {
+		throw new YouTubeRingtoneError(
+			"Please enter a valid YouTube URL (youtube.com or youtu.be).",
+			"INVALID_URL",
+		);
+	}
+
+	const startSeconds = Math.max(0, options.startSeconds);
+	const endSeconds = options.endSeconds;
+	const playbackRate = Math.max(
+		0.5,
+		Math.min(2.0, options.playbackRate ?? 1.0),
+	);
+	const rawDuration = endSeconds - startSeconds;
+	const outputDuration = rawDuration / playbackRate;
+
+	if (!Number.isFinite(rawDuration) || rawDuration <= 0) {
+		throw new YouTubeRingtoneError(
+			"End time must be greater than start time.",
+			"INVALID_RANGE",
+		);
+	}
+
+	if (outputDuration > MAX_CLIP_DURATION_SECONDS) {
+		throw new YouTubeRingtoneError(
+			`Output clip duration (${outputDuration.toFixed(1)}s) exceeds the maximum of ${MAX_CLIP_DURATION_SECONDS} seconds.`,
 			"INVALID_RANGE",
 		);
 	}
@@ -225,8 +485,6 @@ export async function importRingtoneFromYouTube(
 	const shellEnv = await getProcessEnvWithShellPath();
 	const resolved = await resolveRequiredBinaries(shellEnv);
 
-	// Ensure the directory containing ffmpeg is on PATH for any child lookups
-	// yt-dlp may do internally (defense in depth — we also pass --ffmpeg-location).
 	const ffmpegDir = dirname(resolved.ffmpeg);
 	const existingPath = shellEnv.PATH ?? shellEnv.Path ?? "";
 	const pathEntries = existingPath.split(delimiter).filter(Boolean);
@@ -240,66 +498,105 @@ export async function importRingtoneFromYouTube(
 
 	const workDir = join(tmpdir(), `superset-yt-${randomUUID()}`);
 	mkdirSync(workDir, { recursive: true });
-	const outputTemplate = join(workDir, "clip.%(ext)s");
-
-	const endSeconds = startSeconds + durationSeconds;
-	const sectionSpec = `*${startSeconds}-${endSeconds}`;
-
-	const args = [
-		"--no-playlist",
-		"--no-warnings",
-		"--quiet",
-		"-x",
-		"--audio-format",
-		"mp3",
-		"--audio-quality",
-		"5",
-		"--download-sections",
-		sectionSpec,
-		"--force-keyframes-at-cuts",
-		"--ffmpeg-location",
-		ffmpegDir,
-		"-o",
-		outputTemplate,
-		url,
-	];
 
 	try {
-		await runYtDlp(resolved["yt-dlp"], args, workDir, spawnEnv);
+		let inputPath: string;
 
-		const producedPath = findProducedAudio(workDir);
-		if (!producedPath) {
-			throw new YouTubeRingtoneError(
-				"yt-dlp did not produce an audio file. The video may be unavailable or restricted.",
-				"DOWNLOAD_FAILED",
+		if (options.tempFilePath) {
+			inputPath = options.tempFilePath;
+		} else {
+			// Legacy: download section via yt-dlp
+			const outputTemplate = join(workDir, "clip.%(ext)s");
+
+			const sectionSpec = `*${startSeconds}-${endSeconds}`;
+			const ytArgs = [
+				"--no-playlist",
+				"--no-warnings",
+				"--quiet",
+				"-x",
+				"--audio-format",
+				"mp3",
+				"--audio-quality",
+				"5",
+				"--download-sections",
+				sectionSpec,
+				"--force-keyframes-at-cuts",
+				"--ffmpeg-location",
+				ffmpegDir,
+				"-o",
+				outputTemplate,
+				url,
+			];
+
+			await runProcess(
+				resolved["yt-dlp"],
+				ytArgs,
+				workDir,
+				spawnEnv,
+				YT_DLP_TIMEOUT_MS,
+			);
+
+			const downloaded = findProducedAudio(workDir);
+			if (!downloaded) {
+				throw new YouTubeRingtoneError(
+					"yt-dlp did not produce an audio file. The video may be unavailable or restricted.",
+					"DOWNLOAD_FAILED",
+				);
+			}
+			inputPath = downloaded;
+		}
+
+		// Build ffmpeg filter chain
+		const filters: string[] = [];
+		if (playbackRate !== 1.0) {
+			filters.push(`atempo=${playbackRate.toFixed(3)}`);
+		}
+		const fadeIn = options.fadeInSeconds ?? 0;
+		const fadeOut = options.fadeOutSeconds ?? 0;
+		if (fadeIn > 0) {
+			filters.push(`afade=t=in:st=0:d=${fadeIn.toFixed(3)}`);
+		}
+		if (fadeOut > 0) {
+			const fadeOutStart = Math.max(0, outputDuration - fadeOut);
+			filters.push(
+				`afade=t=out:st=${fadeOutStart.toFixed(3)}:d=${fadeOut.toFixed(3)}`,
 			);
 		}
 
-		const info = await importCustomRingtoneFromPath(producedPath);
+		const outputPath = join(workDir, `output_${randomUUID()}.mp3`);
+		const ffmpegArgs: string[] = ["-i", inputPath];
 
-		const displayName = options.displayName?.trim();
-		if (displayName) {
-			setCustomRingtoneDisplayName(displayName);
-			return { ...info, name: displayName.slice(0, 80) };
+		if (options.tempFilePath) {
+			// Trim from the full downloaded file
+			ffmpegArgs.push("-ss", String(startSeconds), "-to", String(endSeconds));
 		}
 
-		return info;
-	} finally {
-		await safeUnlink(join(workDir, "clip.mp3"));
-		await rm(workDir, { recursive: true, force: true }).catch(() => {
-			// Best-effort cleanup.
+		if (filters.length > 0) {
+			ffmpegArgs.push("-af", filters.join(","));
+		}
+
+		ffmpegArgs.push("-acodec", "libmp3lame", "-q:a", "5", "-y", outputPath);
+
+		await runProcess(
+			resolved.ffmpeg,
+			ffmpegArgs,
+			workDir,
+			spawnEnv,
+			YT_DLP_TIMEOUT_MS,
+		);
+
+		return await importCustomRingtoneFromPath(outputPath, {
+			displayName: options.displayName?.trim() || undefined,
+			thumbnailUrl: options.thumbnailUrl,
 		});
+	} finally {
+		await rm(workDir, { recursive: true, force: true }).catch(() => {});
 	}
 }
 
-async function safeUnlink(path: string): Promise<void> {
-	try {
-		await unlink(path);
-	} catch {
-		// Best-effort cleanup.
-	}
-}
+export { setCustomRingtoneDisplayName };
 
 export const YOUTUBE_RINGTONE_LIMITS = {
 	maxDurationSeconds: MAX_CLIP_DURATION_SECONDS,
+	maxFullDownloadDurationSeconds: MAX_FULL_DOWNLOAD_DURATION_SECONDS,
 };

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/ringtones/components/RingtonesSettings/RingtonesSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/ringtones/components/RingtonesSettings/RingtonesSettings.tsx
@@ -89,12 +89,20 @@ function RingtoneCard({
 					isSelected ? "bg-accent/50" : "bg-muted/30",
 				)}
 			>
-				{/* Emoji */}
-				<span className="text-4xl">{ringtone.emoji}</span>
+				{/* Thumbnail or Emoji */}
+				{ringtone.thumbnailUrl ? (
+					<img
+						src={ringtone.thumbnailUrl}
+						alt=""
+						className="w-full h-full object-cover absolute inset-0"
+					/>
+				) : (
+					<span className="text-4xl">{ringtone.emoji}</span>
+				)}
 
 				{/* Duration badge */}
 				{ringtone.duration && (
-					<span className="absolute top-2 right-2 text-xs text-muted-foreground bg-background/80 px-1.5 py-0.5 rounded">
+					<span className="absolute top-2 right-2 text-xs text-muted-foreground bg-background/80 px-1.5 py-0.5 rounded z-10">
 						{formatDuration(ringtone.duration)}
 					</span>
 				)}
@@ -103,7 +111,7 @@ function RingtoneCard({
 				{showActions && (
 					// biome-ignore lint/a11y/noStaticElementInteractions: wrapper exists only to stop click bubbling to the outer card button
 					<div
-						className="absolute top-1.5 left-1.5"
+						className="absolute top-1.5 left-1.5 z-10"
 						onClick={(e) => e.stopPropagation()}
 						onKeyDown={(e) => e.stopPropagation()}
 					>
@@ -146,7 +154,7 @@ function RingtoneCard({
 						onTogglePlay();
 					}}
 					className={cn(
-						"absolute bottom-2 right-2 h-8 w-8 rounded-full flex items-center justify-center",
+						"absolute bottom-2 right-2 h-8 w-8 rounded-full flex items-center justify-center z-10",
 						"transition-colors border",
 						isPlaying
 							? "bg-destructive text-destructive-foreground border-destructive hover:bg-destructive/90"
@@ -246,20 +254,11 @@ export function RingtonesSettings({ visibleItems }: RingtonesSettingsProps) {
 	});
 
 	const [youtubeDialogOpen, setYoutubeDialogOpen] = useState(false);
-	const [youtubeError, setYoutubeError] = useState<string | null>(null);
-	const importFromYouTube = electronTrpc.ringtone.importFromYouTube.useMutation(
-		{
-			onSuccess: async () => {
-				setYoutubeError(null);
-				setYoutubeDialogOpen(false);
-				await utils.ringtone.getCustom.invalidate();
-				setRingtone(CUSTOM_RINGTONE_ID);
-			},
-			onError: (error) => {
-				setYoutubeError(error.message);
-			},
-		},
-	);
+
+	const handleYouTubeImportSuccess = useCallback(async () => {
+		await utils.ringtone.getCustom.invalidate();
+		setRingtone(CUSTOM_RINGTONE_ID);
+	}, [utils, setRingtone]);
 
 	const [renameDialogOpen, setRenameDialogOpen] = useState(false);
 	const [renameError, setRenameError] = useState<string | null>(null);
@@ -429,11 +428,7 @@ export function RingtonesSettings({ visibleItems }: RingtonesSettingsProps) {
 									type="button"
 									size="sm"
 									variant="outline"
-									onClick={() => {
-										setYoutubeError(null);
-										setYoutubeDialogOpen(true);
-									}}
-									disabled={importFromYouTube.isPending}
+									onClick={() => setYoutubeDialogOpen(true)}
 								>
 									<SiYoutube className="mr-1.5 h-3.5 w-3.5" />
 									From YouTube
@@ -484,17 +479,8 @@ export function RingtonesSettings({ visibleItems }: RingtonesSettingsProps) {
 
 			<YouTubeImportDialog
 				open={youtubeDialogOpen}
-				onOpenChange={(open) => {
-					setYoutubeDialogOpen(open);
-					if (!open) setYoutubeError(null);
-				}}
-				onSubmit={async (input) => {
-					await importFromYouTube.mutateAsync(input).catch(() => {
-						// Error surfaced via youtubeError state.
-					});
-				}}
-				isSubmitting={importFromYouTube.isPending}
-				errorMessage={youtubeError}
+				onOpenChange={setYoutubeDialogOpen}
+				onImportSuccess={handleYouTubeImportSuccess}
 			/>
 
 			<DeleteRingtoneDialog

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/ringtones/components/RingtonesSettings/components/YouTubeImportDialog/YouTubeImportDialog.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/ringtones/components/RingtonesSettings/components/YouTubeImportDialog/YouTubeImportDialog.tsx
@@ -9,194 +9,322 @@ import {
 } from "@superset/ui/dialog";
 import { Input } from "@superset/ui/input";
 import { Label } from "@superset/ui/label";
-import { useEffect, useId, useMemo, useState } from "react";
+import { useCallback, useEffect, useId, useMemo, useState } from "react";
 import { LuLoaderCircle } from "react-icons/lu";
-
-const MAX_DURATION_SECONDS = 30;
-
-interface YouTubeImportDialogProps {
-	open: boolean;
-	onOpenChange: (open: boolean) => void;
-	onSubmit: (input: {
-		url: string;
-		startSeconds: number;
-		durationSeconds: number;
-		displayName?: string;
-	}) => Promise<void>;
-	isSubmitting: boolean;
-	errorMessage?: string | null;
-}
+import { SiYoutube } from "react-icons/si";
+import { electronTrpc } from "renderer/lib/electron-trpc";
+import { AudioEditor } from "./components/AudioEditor";
 
 const YOUTUBE_URL_HINT =
 	/^https?:\/\/(?:www\.|m\.|music\.)?(?:youtube\.com|youtu\.be)\//i;
 
-function clampNonNegativeInt(value: string, max?: number): number {
-	const parsed = Number.parseInt(value, 10);
-	if (!Number.isFinite(parsed) || parsed < 0) return 0;
-	return max !== undefined ? Math.min(parsed, max) : parsed;
+type Step = "url" | "installing" | "downloading" | "editor";
+
+interface DownloadedAudioState {
+	tempId: string;
+	tempPath: string;
+	info: {
+		title: string;
+		thumbnailUrl: string;
+		durationSeconds: number;
+	};
+}
+
+interface YouTubeImportDialogProps {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	onImportSuccess: () => void;
 }
 
 export function YouTubeImportDialog({
 	open,
 	onOpenChange,
-	onSubmit,
-	isSubmitting,
-	errorMessage,
+	onImportSuccess,
 }: YouTubeImportDialogProps) {
 	const urlId = useId();
-	const startId = useId();
-	const durationId = useId();
-	const nameId = useId();
 
+	const [step, setStep] = useState<Step>("url");
 	const [url, setUrl] = useState("");
-	const [startMin, setStartMin] = useState("0");
-	const [startSec, setStartSec] = useState("0");
-	const [duration, setDuration] = useState("5");
+	const [errorMessage, setErrorMessage] = useState<string | null>(null);
+	const [downloaded, setDownloaded] = useState<DownloadedAudioState | null>(
+		null,
+	);
 	const [displayName, setDisplayName] = useState("");
+
+	// Binary check
+	const { data: binariesData, refetch: refetchBinaries } =
+		electronTrpc.ringtone.checkBinaries.useQuery(undefined, {
+			enabled: open,
+			staleTime: 10_000,
+		});
+	const missingBinaries = binariesData?.missing ?? [];
+	const hasMissingBinaries = missingBinaries.length > 0;
+
+	const installBinaries = electronTrpc.ringtone.installBinaries.useMutation({
+		onSuccess: async () => {
+			await refetchBinaries();
+			setStep("url");
+			setErrorMessage(null);
+		},
+		onError: (err) => {
+			setErrorMessage(err.message);
+			setStep("url");
+		},
+	});
+
+	const downloadAudio = electronTrpc.ringtone.downloadYouTubeAudio.useMutation({
+		onSuccess: (result) => {
+			setDownloaded({
+				tempId: result.tempId,
+				tempPath: result.tempId,
+				info: result.info,
+			});
+			setDisplayName(result.info.title.slice(0, 80));
+			setStep("editor");
+			setErrorMessage(null);
+		},
+		onError: (err) => {
+			setErrorMessage(err.message);
+			setStep("url");
+		},
+	});
+
+	const cleanupTempAudio = electronTrpc.ringtone.cleanupTempAudio.useMutation();
+
+	const importFromYouTube = electronTrpc.ringtone.importFromYouTube.useMutation(
+		{
+			onSuccess: async () => {
+				if (downloaded) {
+					cleanupTempAudio.mutate({ tempId: downloaded.tempId });
+				}
+				setErrorMessage(null);
+				onImportSuccess();
+				onOpenChange(false);
+			},
+			onError: (err) => {
+				setErrorMessage(err.message);
+			},
+		},
+	);
+
+	const resetState = useCallback(() => {
+		setStep("url");
+		setUrl("");
+		setErrorMessage(null);
+		setDisplayName("");
+		if (downloaded) {
+			cleanupTempAudio.mutate({ tempId: downloaded.tempId });
+			setDownloaded(null);
+		}
+	}, [downloaded, cleanupTempAudio]);
 
 	useEffect(() => {
 		if (!open) {
-			setUrl("");
-			setStartMin("0");
-			setStartSec("0");
-			setDuration("5");
-			setDisplayName("");
+			resetState();
 		}
-	}, [open]);
-
-	const startSeconds =
-		clampNonNegativeInt(startMin) * 60 + clampNonNegativeInt(startSec, 59);
-	const durationSeconds = clampNonNegativeInt(duration, MAX_DURATION_SECONDS);
+	}, [open, resetState]);
 
 	const urlLooksValid = useMemo(() => YOUTUBE_URL_HINT.test(url.trim()), [url]);
-	const durationValid =
-		durationSeconds >= 1 && durationSeconds <= MAX_DURATION_SECONDS;
-	const canSubmit =
-		urlLooksValid && durationValid && !isSubmitting && url.trim().length > 0;
 
-	const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
-		event.preventDefault();
-		if (!canSubmit) return;
-		await onSubmit({
-			url: url.trim(),
-			startSeconds,
-			durationSeconds,
-			displayName: displayName.trim() || undefined,
-		});
+	const handleInstall = () => {
+		setStep("installing");
+		setErrorMessage(null);
+		installBinaries.mutate();
 	};
 
+	const handleLoad = () => {
+		if (!urlLooksValid) return;
+		setStep("downloading");
+		setErrorMessage(null);
+		downloadAudio.mutate({ url: url.trim() });
+	};
+
+	const handleImport = useCallback(
+		async (params: {
+			startSeconds: number;
+			endSeconds: number;
+			fadeInSeconds: number;
+			fadeOutSeconds: number;
+			playbackRate: number;
+		}) => {
+			if (!downloaded) return;
+			await importFromYouTube.mutateAsync({
+				url: url.trim(),
+				startSeconds: params.startSeconds,
+				endSeconds: params.endSeconds,
+				displayName: displayName.trim() || undefined,
+				thumbnailUrl: downloaded.info.thumbnailUrl || undefined,
+				fadeInSeconds:
+					params.fadeInSeconds > 0 ? params.fadeInSeconds : undefined,
+				fadeOutSeconds:
+					params.fadeOutSeconds > 0 ? params.fadeOutSeconds : undefined,
+				playbackRate:
+					params.playbackRate !== 1.0 ? params.playbackRate : undefined,
+				tempId: downloaded.tempId,
+			});
+		},
+		[downloaded, url, displayName, importFromYouTube],
+	);
+
+	const isLoading = step === "downloading" || step === "installing";
+
+	const dialogTitle = step === "editor" ? "Edit Clip" : "Import from YouTube";
+	const dialogDescription =
+		step === "editor"
+			? "Set the clip range, fade, and speed, then import."
+			: step === "downloading"
+				? "Downloading audio…"
+				: step === "installing"
+					? "Installing dependencies…"
+					: hasMissingBinaries
+						? "Required tools are not installed."
+						: "Paste a YouTube URL and load the audio to edit.";
+
 	return (
-		<Dialog open={open} onOpenChange={onOpenChange}>
-			<DialogContent className="sm:max-w-md">
+		<Dialog
+			open={open}
+			onOpenChange={(o) => {
+				if (!isLoading && !importFromYouTube.isPending) onOpenChange(o);
+			}}
+		>
+			<DialogContent className="!max-w-lg sm:!max-w-2xl">
 				<DialogHeader>
-					<DialogTitle>Import from YouTube</DialogTitle>
-					<DialogDescription>
-						Paste a YouTube URL and choose a clip range. Requires{" "}
-						<code className="rounded bg-muted px-1 text-xs">yt-dlp</code> and{" "}
-						<code className="rounded bg-muted px-1 text-xs">ffmpeg</code> to be
-						installed locally.
-					</DialogDescription>
+					<DialogTitle className="flex items-center gap-2">
+						<SiYoutube className="h-4 w-4 text-red-500" />
+						{dialogTitle}
+					</DialogTitle>
+					<DialogDescription>{dialogDescription}</DialogDescription>
 				</DialogHeader>
 
-				<form onSubmit={handleSubmit} className="space-y-4">
-					<div className="space-y-2">
-						<Label htmlFor={urlId}>YouTube URL</Label>
-						<Input
-							id={urlId}
-							type="url"
-							placeholder="https://www.youtube.com/watch?v=..."
-							value={url}
-							onChange={(event) => setUrl(event.target.value)}
-							autoFocus
-							disabled={isSubmitting}
-						/>
-						{url.length > 0 && !urlLooksValid && (
-							<p className="text-xs text-destructive">
-								Enter a youtube.com or youtu.be URL.
+				{/* Step: installing */}
+				{step === "installing" && (
+					<div className="flex flex-col items-center gap-4 py-6">
+						<LuLoaderCircle className="h-8 w-8 animate-spin text-muted-foreground" />
+						<p className="text-sm text-center text-muted-foreground">
+							Running{" "}
+							<code className="rounded bg-muted px-1">
+								brew install yt-dlp ffmpeg
+							</code>
+							<br />
+							This may take a few minutes…
+						</p>
+						{errorMessage && (
+							<p className="text-sm text-destructive break-words text-center">
+								{errorMessage}
 							</p>
 						)}
 					</div>
+				)}
 
-					<div className="grid grid-cols-2 gap-4">
-						<div className="space-y-2">
-							<Label htmlFor={startId}>Start time</Label>
-							<div className="flex items-center gap-2">
-								<Input
-									id={startId}
-									type="number"
-									min={0}
-									value={startMin}
-									onChange={(event) => setStartMin(event.target.value)}
-									disabled={isSubmitting}
-									className="w-16"
-								/>
-								<span className="text-xs text-muted-foreground">min</span>
-								<Input
-									type="number"
-									min={0}
-									max={59}
-									value={startSec}
-									onChange={(event) => setStartSec(event.target.value)}
-									disabled={isSubmitting}
-									className="w-16"
-								/>
-								<span className="text-xs text-muted-foreground">sec</span>
-							</div>
-						</div>
-
-						<div className="space-y-2">
-							<Label htmlFor={durationId}>Duration (sec)</Label>
-							<Input
-								id={durationId}
-								type="number"
-								min={1}
-								max={MAX_DURATION_SECONDS}
-								value={duration}
-								onChange={(event) => setDuration(event.target.value)}
-								disabled={isSubmitting}
-							/>
-							<p className="text-xs text-muted-foreground">
-								Max {MAX_DURATION_SECONDS} seconds.
-							</p>
-						</div>
-					</div>
-
-					<div className="space-y-2">
-						<Label htmlFor={nameId}>Display name (optional)</Label>
-						<Input
-							id={nameId}
-							type="text"
-							placeholder="My YouTube clip"
-							value={displayName}
-							onChange={(event) => setDisplayName(event.target.value)}
-							disabled={isSubmitting}
-							maxLength={80}
-						/>
-					</div>
-
-					{errorMessage && (
-						<p className="text-sm text-destructive break-words">
-							{errorMessage}
+				{/* Step: downloading */}
+				{step === "downloading" && (
+					<div className="flex flex-col items-center gap-4 py-6">
+						<LuLoaderCircle className="h-8 w-8 animate-spin text-muted-foreground" />
+						<p className="text-sm text-muted-foreground">
+							Downloading audio from YouTube…
 						</p>
-					)}
+					</div>
+				)}
 
-					<DialogFooter>
-						<Button
-							type="button"
-							variant="ghost"
-							onClick={() => onOpenChange(false)}
-							disabled={isSubmitting}
-						>
-							Cancel
-						</Button>
-						<Button type="submit" disabled={!canSubmit}>
-							{isSubmitting && (
-								<LuLoaderCircle className="mr-2 h-4 w-4 animate-spin" />
+				{/* Step: url */}
+				{step === "url" && (
+					<div className="space-y-4">
+						{/* Missing binaries notice */}
+						{hasMissingBinaries && (
+							<div className="rounded-md border border-amber-500/40 bg-amber-500/10 p-3 space-y-2">
+								<p className="text-sm text-amber-700 dark:text-amber-400">
+									Required tools not found:{" "}
+									<code className="rounded bg-muted px-1 text-xs">
+										{missingBinaries.join(", ")}
+									</code>
+								</p>
+								{process.platform === "darwin" ? (
+									<Button
+										type="button"
+										size="sm"
+										variant="outline"
+										onClick={handleInstall}
+										className="gap-1.5"
+									>
+										Install with Homebrew
+									</Button>
+								) : (
+									<p className="text-xs text-muted-foreground">
+										Please install{" "}
+										<code className="rounded bg-muted px-1">yt-dlp</code> and{" "}
+										<code className="rounded bg-muted px-1">ffmpeg</code> via
+										your package manager.
+									</p>
+								)}
+							</div>
+						)}
+
+						<div className="space-y-2">
+							<Label htmlFor={urlId}>YouTube URL</Label>
+							<Input
+								id={urlId}
+								type="url"
+								placeholder="https://www.youtube.com/watch?v=..."
+								value={url}
+								onChange={(e) => setUrl(e.target.value)}
+								autoFocus
+								disabled={hasMissingBinaries}
+								onKeyDown={(e) => {
+									if (
+										e.key === "Enter" &&
+										urlLooksValid &&
+										!hasMissingBinaries
+									) {
+										handleLoad();
+									}
+								}}
+							/>
+							{url.length > 0 && !urlLooksValid && (
+								<p className="text-xs text-destructive">
+									Enter a youtube.com or youtu.be URL.
+								</p>
 							)}
-							{isSubmitting ? "Importing..." : "Import"}
-						</Button>
-					</DialogFooter>
-				</form>
+						</div>
+
+						{errorMessage && (
+							<p className="text-sm text-destructive break-words">
+								{errorMessage}
+							</p>
+						)}
+
+						<DialogFooter>
+							<Button
+								type="button"
+								variant="ghost"
+								onClick={() => onOpenChange(false)}
+							>
+								Cancel
+							</Button>
+							<Button
+								type="button"
+								disabled={!urlLooksValid || hasMissingBinaries}
+								onClick={handleLoad}
+							>
+								Load Audio
+							</Button>
+						</DialogFooter>
+					</div>
+				)}
+
+				{/* Step: editor */}
+				{step === "editor" && downloaded && (
+					<AudioEditor
+						tempId={downloaded.tempId}
+						videoTitle={downloaded.info.title}
+						thumbnailUrl={downloaded.info.thumbnailUrl}
+						totalDuration={downloaded.info.durationSeconds}
+						displayName={displayName}
+						onDisplayNameChange={setDisplayName}
+						onImport={handleImport}
+						isImporting={importFromYouTube.isPending}
+						errorMessage={errorMessage}
+					/>
+				)}
 			</DialogContent>
 		</Dialog>
 	);

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/ringtones/components/RingtonesSettings/components/YouTubeImportDialog/components/AudioEditor/AudioEditor.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/ringtones/components/RingtonesSettings/components/YouTubeImportDialog/components/AudioEditor/AudioEditor.tsx
@@ -301,9 +301,12 @@ export function AudioEditor({
 	}, [isPlaying, startSeconds, endSeconds, playbackRate, stopPreview]);
 
 	// Stop preview when selection changes
+	const isPlayingRef = useRef(isPlaying);
+	isPlayingRef.current = isPlaying;
+	// biome-ignore lint/correctness/useExhaustiveDependencies: isPlaying tracked via ref to avoid stopping on play-start
 	useEffect(() => {
-		if (isPlaying) stopPreview();
-	}, [isPlaying, stopPreview]);
+		if (isPlayingRef.current) stopPreview();
+	}, [startSeconds, endSeconds, stopPreview]);
 
 	const handleCanvasMouseDown = useCallback(
 		(e: React.MouseEvent<HTMLCanvasElement>) => {

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/ringtones/components/RingtonesSettings/components/YouTubeImportDialog/components/AudioEditor/AudioEditor.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/ringtones/components/RingtonesSettings/components/YouTubeImportDialog/components/AudioEditor/AudioEditor.tsx
@@ -1,0 +1,603 @@
+import { Button } from "@superset/ui/button";
+import { Input } from "@superset/ui/input";
+import { Label } from "@superset/ui/label";
+import { Slider } from "@superset/ui/slider";
+import { cn } from "@superset/ui/utils";
+import { useCallback, useEffect, useId, useRef, useState } from "react";
+import { HiPlay, HiStop } from "react-icons/hi2";
+import { LuLoaderCircle } from "react-icons/lu";
+
+const MAX_OUTPUT_DURATION = 30;
+
+interface AudioEditorProps {
+	tempId: string;
+	videoTitle: string;
+	thumbnailUrl: string;
+	totalDuration: number;
+	displayName: string;
+	onDisplayNameChange: (name: string) => void;
+	onImport: (params: {
+		startSeconds: number;
+		endSeconds: number;
+		fadeInSeconds: number;
+		fadeOutSeconds: number;
+		playbackRate: number;
+	}) => Promise<void>;
+	isImporting: boolean;
+	errorMessage?: string | null;
+}
+
+interface WaveformPeaks {
+	peaks: number[];
+	duration: number;
+}
+
+function formatTime(seconds: number): string {
+	const m = Math.floor(seconds / 60);
+	const s = Math.floor(seconds % 60);
+	const ms = Math.floor((seconds % 1) * 10);
+	return `${m}:${String(s).padStart(2, "0")}.${ms}`;
+}
+
+function clampValue(val: number, min: number, max: number): number {
+	return Math.max(min, Math.min(max, val));
+}
+
+async function decodeWaveformPeaks(
+	audioUrl: string,
+	numPeaks: number,
+): Promise<WaveformPeaks> {
+	const response = await fetch(audioUrl);
+	const arrayBuffer = await response.arrayBuffer();
+	const audioContext = new AudioContext();
+	try {
+		const audioBuffer = await audioContext.decodeAudioData(arrayBuffer);
+		const channelData = audioBuffer.getChannelData(0);
+		const totalSamples = channelData.length;
+		const blockSize = Math.max(1, Math.floor(totalSamples / numPeaks));
+		const peaks: number[] = [];
+		for (let i = 0; i < numPeaks; i++) {
+			let max = 0;
+			const start = i * blockSize;
+			const end = Math.min(start + blockSize, totalSamples);
+			for (let j = start; j < end; j++) {
+				const abs = Math.abs(channelData[j] ?? 0);
+				if (abs > max) max = abs;
+			}
+			peaks.push(max);
+		}
+		return { peaks, duration: audioBuffer.duration };
+	} finally {
+		await audioContext.close();
+	}
+}
+
+function drawWaveform(
+	canvas: HTMLCanvasElement,
+	peaks: number[],
+	startFrac: number,
+	endFrac: number,
+	playFrac: number,
+	isDark: boolean,
+) {
+	const ctx = canvas.getContext("2d");
+	if (!ctx) return;
+
+	const { width, height } = canvas;
+	ctx.clearRect(0, 0, width, height);
+
+	const midY = height / 2;
+	const barWidth = width / peaks.length;
+
+	// Draw bars
+	for (let i = 0; i < peaks.length; i++) {
+		const x = i * barWidth;
+		const frac = i / peaks.length;
+		const barH = Math.max(2, (peaks[i] ?? 0) * height * 0.85);
+
+		let color: string;
+		if (frac >= startFrac && frac < endFrac) {
+			color = isDark ? "rgba(99,102,241,0.9)" : "rgba(79,70,229,0.85)";
+		} else {
+			color = isDark ? "rgba(255,255,255,0.2)" : "rgba(0,0,0,0.15)";
+		}
+
+		ctx.fillStyle = color;
+		ctx.fillRect(x, midY - barH / 2, Math.max(1, barWidth - 0.5), barH);
+	}
+
+	// Draw playhead
+	if (playFrac >= 0 && playFrac <= 1) {
+		const px = playFrac * width;
+		ctx.strokeStyle = isDark ? "rgba(255,255,255,0.8)" : "rgba(0,0,0,0.6)";
+		ctx.lineWidth = 1.5;
+		ctx.beginPath();
+		ctx.moveTo(px, 0);
+		ctx.lineTo(px, height);
+		ctx.stroke();
+	}
+
+	// Draw start handle
+	const sx = startFrac * width;
+	ctx.fillStyle = "rgb(34,197,94)";
+	ctx.fillRect(sx - 1, 0, 2, height);
+	ctx.fillStyle = "rgb(34,197,94)";
+	ctx.beginPath();
+	ctx.moveTo(sx, 0);
+	ctx.lineTo(sx + 8, 0);
+	ctx.lineTo(sx, 10);
+	ctx.closePath();
+	ctx.fill();
+
+	// Draw end handle
+	const ex = endFrac * width;
+	ctx.fillStyle = "rgb(239,68,68)";
+	ctx.fillRect(ex - 1, 0, 2, height);
+	ctx.fillStyle = "rgb(239,68,68)";
+	ctx.beginPath();
+	ctx.moveTo(ex, 0);
+	ctx.lineTo(ex - 8, 0);
+	ctx.lineTo(ex, 10);
+	ctx.closePath();
+	ctx.fill();
+}
+
+export function AudioEditor({
+	tempId,
+	videoTitle,
+	thumbnailUrl,
+	totalDuration,
+	displayName,
+	onDisplayNameChange,
+	onImport,
+	isImporting,
+	errorMessage,
+}: AudioEditorProps) {
+	const audioRef = useRef<HTMLAudioElement>(null);
+	const canvasRef = useRef<HTMLCanvasElement>(null);
+	const animFrameRef = useRef<number | null>(null);
+	const previewStopRef = useRef<number | null>(null);
+	const draggingRef = useRef<"start" | "end" | null>(null);
+
+	const [waveform, setWaveform] = useState<WaveformPeaks | null>(null);
+	const [waveformError, setWaveformError] = useState<string | null>(null);
+	const [isLoadingWaveform, setIsLoadingWaveform] = useState(true);
+
+	const [startSeconds, setStartSeconds] = useState(0);
+	const [endSeconds, setEndSeconds] = useState(Math.min(10, totalDuration));
+	const [playFrac, setPlayFrac] = useState(-1);
+	const [isPlaying, setIsPlaying] = useState(false);
+	const [fadeIn, setFadeIn] = useState(0);
+	const [fadeOut, setFadeOut] = useState(0);
+	const [playbackRate, setPlaybackRate] = useState(1.0);
+
+	const nameId = useId();
+
+	const audioUrl = `superset-temp-audio://${tempId}`;
+
+	const rawDuration = endSeconds - startSeconds;
+	const outputDuration = rawDuration / playbackRate;
+	const outputValid = rawDuration > 0 && outputDuration <= MAX_OUTPUT_DURATION;
+
+	const isDark =
+		document.documentElement.classList.contains("dark") ||
+		window.matchMedia("(prefers-color-scheme: dark)").matches;
+
+	// Load waveform on mount
+	useEffect(() => {
+		let cancelled = false;
+		setIsLoadingWaveform(true);
+		setWaveformError(null);
+
+		decodeWaveformPeaks(audioUrl, 400)
+			.then((data) => {
+				if (!cancelled) {
+					setWaveform(data);
+					setStartSeconds(0);
+					setEndSeconds(Math.min(10, data.duration));
+				}
+			})
+			.catch((err) => {
+				if (!cancelled) {
+					setWaveformError(
+						err instanceof Error ? err.message : "Failed to load audio",
+					);
+				}
+			})
+			.finally(() => {
+				if (!cancelled) setIsLoadingWaveform(false);
+			});
+
+		return () => {
+			cancelled = true;
+		};
+	}, [audioUrl]);
+
+	// Draw waveform whenever relevant state changes
+	const redrawWaveform = useCallback(() => {
+		if (!canvasRef.current || !waveform) return;
+		const duration = waveform.duration || totalDuration;
+		drawWaveform(
+			canvasRef.current,
+			waveform.peaks,
+			startSeconds / duration,
+			endSeconds / duration,
+			playFrac,
+			isDark,
+		);
+	}, [waveform, startSeconds, endSeconds, playFrac, totalDuration, isDark]);
+
+	useEffect(() => {
+		redrawWaveform();
+	}, [redrawWaveform]);
+
+	// Animate playhead
+	useEffect(() => {
+		if (!isPlaying) {
+			if (animFrameRef.current !== null) {
+				cancelAnimationFrame(animFrameRef.current);
+				animFrameRef.current = null;
+			}
+			return;
+		}
+		const duration = waveform?.duration || totalDuration;
+		const tick = () => {
+			const audio = audioRef.current;
+			if (audio && duration > 0) {
+				setPlayFrac(audio.currentTime / duration);
+			}
+			animFrameRef.current = requestAnimationFrame(tick);
+		};
+		animFrameRef.current = requestAnimationFrame(tick);
+		return () => {
+			if (animFrameRef.current !== null) {
+				cancelAnimationFrame(animFrameRef.current);
+				animFrameRef.current = null;
+			}
+		};
+	}, [isPlaying, waveform, totalDuration]);
+
+	const stopPreview = useCallback(() => {
+		if (previewStopRef.current !== null) {
+			clearInterval(previewStopRef.current);
+			previewStopRef.current = null;
+		}
+		const audio = audioRef.current;
+		if (audio) {
+			audio.pause();
+			audio.currentTime = startSeconds;
+		}
+		setIsPlaying(false);
+		setPlayFrac(startSeconds / (waveform?.duration || totalDuration));
+	}, [startSeconds, waveform, totalDuration]);
+
+	const handleTogglePreview = useCallback(() => {
+		const audio = audioRef.current;
+		if (!audio) return;
+
+		if (isPlaying) {
+			stopPreview();
+			return;
+		}
+
+		// Apply playback rate for preview
+		audio.playbackRate = playbackRate;
+		audio.currentTime = startSeconds;
+		audio.play().catch(() => setIsPlaying(false));
+		setIsPlaying(true);
+
+		// Stop at end time
+		if (previewStopRef.current !== null) {
+			clearInterval(previewStopRef.current);
+		}
+		previewStopRef.current = window.setInterval(() => {
+			const a = audioRef.current;
+			if (!a) return;
+			// currentTime in the source maps to effective time / playbackRate
+			if (a.currentTime >= endSeconds) {
+				stopPreview();
+			}
+		}, 50);
+	}, [isPlaying, startSeconds, endSeconds, playbackRate, stopPreview]);
+
+	// Stop preview when selection changes
+	useEffect(() => {
+		if (isPlaying) stopPreview();
+	}, [isPlaying, stopPreview]);
+
+	const handleCanvasMouseDown = useCallback(
+		(e: React.MouseEvent<HTMLCanvasElement>) => {
+			const canvas = canvasRef.current;
+			if (!canvas || !waveform) return;
+			const rect = canvas.getBoundingClientRect();
+			const x = e.clientX - rect.left;
+			const duration = waveform.duration || totalDuration;
+			const totalWidth = rect.width;
+
+			const sx = (startSeconds / duration) * totalWidth;
+			const ex = (endSeconds / duration) * totalWidth;
+
+			const distStart = Math.abs(x - sx);
+			const distEnd = Math.abs(x - ex);
+
+			if (distStart <= 10 && distStart <= distEnd) {
+				draggingRef.current = "start";
+			} else if (distEnd <= 10) {
+				draggingRef.current = "end";
+			} else {
+				// Click to seek
+				const time = clampValue((x / totalWidth) * duration, 0, duration);
+				if (audioRef.current) audioRef.current.currentTime = time;
+				setPlayFrac(time / duration);
+			}
+		},
+		[waveform, startSeconds, endSeconds, totalDuration],
+	);
+
+	const handleCanvasMouseMove = useCallback(
+		(e: React.MouseEvent<HTMLCanvasElement>) => {
+			if (!draggingRef.current || !waveform) return;
+			const canvas = canvasRef.current;
+			if (!canvas) return;
+			const rect = canvas.getBoundingClientRect();
+			const x = e.clientX - rect.left;
+			const duration = waveform.duration || totalDuration;
+			const time = clampValue((x / rect.width) * duration, 0, duration);
+
+			if (draggingRef.current === "start") {
+				setStartSeconds(Math.min(time, endSeconds - 0.5));
+			} else {
+				setEndSeconds(Math.max(time, startSeconds + 0.5));
+			}
+		},
+		[waveform, startSeconds, endSeconds, totalDuration],
+	);
+
+	const handleCanvasMouseUp = useCallback(() => {
+		draggingRef.current = null;
+	}, []);
+
+	// Cleanup on unmount
+	useEffect(() => {
+		return () => {
+			if (previewStopRef.current !== null) {
+				clearInterval(previewStopRef.current);
+			}
+			if (animFrameRef.current !== null) {
+				cancelAnimationFrame(animFrameRef.current);
+			}
+			audioRef.current?.pause();
+		};
+	}, []);
+
+	const handleStartInput = (val: string) => {
+		const n = Number.parseFloat(val);
+		if (!Number.isNaN(n)) {
+			const duration = waveform?.duration || totalDuration;
+			setStartSeconds(clampValue(n, 0, Math.min(endSeconds - 0.5, duration)));
+		}
+	};
+
+	const handleEndInput = (val: string) => {
+		const n = Number.parseFloat(val);
+		if (!Number.isNaN(n)) {
+			const duration = waveform?.duration || totalDuration;
+			setEndSeconds(clampValue(n, Math.max(startSeconds + 0.5, 0), duration));
+		}
+	};
+
+	const handleImport = async () => {
+		await onImport({
+			startSeconds,
+			endSeconds,
+			fadeInSeconds: fadeIn,
+			fadeOutSeconds: fadeOut,
+			playbackRate,
+		});
+	};
+
+	const duration = waveform?.duration || totalDuration;
+
+	return (
+		<div className="space-y-4">
+			{/* Video info */}
+			<div className="flex items-center gap-3">
+				{thumbnailUrl && (
+					<img
+						src={thumbnailUrl}
+						alt=""
+						className="w-16 h-10 object-cover rounded shrink-0"
+					/>
+				)}
+				<div className="min-w-0">
+					<p className="text-sm font-medium truncate">{videoTitle}</p>
+					<p className="text-xs text-muted-foreground">
+						{formatTime(duration)}
+					</p>
+				</div>
+			</div>
+
+			{/* Waveform */}
+			<div className="space-y-1">
+				{isLoadingWaveform ? (
+					<div className="h-20 flex items-center justify-center bg-muted/30 rounded">
+						<LuLoaderCircle className="h-5 w-5 animate-spin text-muted-foreground" />
+					</div>
+				) : waveformError ? (
+					<div className="h-20 flex items-center justify-center bg-muted/30 rounded">
+						<p className="text-xs text-destructive">{waveformError}</p>
+					</div>
+				) : (
+					<canvas
+						ref={canvasRef}
+						width={600}
+						height={80}
+						className="w-full h-20 rounded cursor-col-resize select-none"
+						onMouseDown={handleCanvasMouseDown}
+						onMouseMove={handleCanvasMouseMove}
+						onMouseUp={handleCanvasMouseUp}
+						onMouseLeave={handleCanvasMouseUp}
+					/>
+				)}
+				<div className="flex justify-between text-xs text-muted-foreground">
+					<span>{formatTime(0)}</span>
+					<span className="text-primary text-xs font-medium">
+						{formatTime(startSeconds)} → {formatTime(endSeconds)}
+					</span>
+					<span>{formatTime(duration)}</span>
+				</div>
+			</div>
+
+			{/* Start / End time inputs */}
+			<div className="grid grid-cols-2 gap-3">
+				<div className="space-y-1">
+					<Label className="text-xs">Start (sec)</Label>
+					<Input
+						type="number"
+						min={0}
+						max={duration}
+						step={0.1}
+						value={startSeconds.toFixed(1)}
+						onChange={(e) => handleStartInput(e.target.value)}
+						className="h-8 text-sm"
+					/>
+				</div>
+				<div className="space-y-1">
+					<Label className="text-xs">End (sec)</Label>
+					<Input
+						type="number"
+						min={0}
+						max={duration}
+						step={0.1}
+						value={endSeconds.toFixed(1)}
+						onChange={(e) => handleEndInput(e.target.value)}
+						className="h-8 text-sm"
+					/>
+				</div>
+			</div>
+
+			{/* Preview button */}
+			<div className="flex items-center gap-2">
+				<Button
+					type="button"
+					size="sm"
+					variant={isPlaying ? "destructive" : "outline"}
+					onClick={handleTogglePreview}
+					disabled={isLoadingWaveform || !waveform}
+					className="gap-1.5"
+				>
+					{isPlaying ? (
+						<>
+							<HiStop className="h-3.5 w-3.5" />
+							Stop
+						</>
+					) : (
+						<>
+							<HiPlay className="h-3.5 w-3.5 ml-0.5" />
+							Preview
+						</>
+					)}
+				</Button>
+				<span
+					className={cn(
+						"text-xs",
+						outputValid ? "text-muted-foreground" : "text-destructive",
+					)}
+				>
+					Output: {outputDuration.toFixed(1)}s / {MAX_OUTPUT_DURATION}s max
+				</span>
+			</div>
+
+			{/* Fade in/out */}
+			<div className="grid grid-cols-2 gap-4">
+				<div className="space-y-2">
+					<Label className="text-xs">Fade In: {fadeIn.toFixed(1)}s</Label>
+					<Slider
+						min={0}
+						max={Math.min(5, rawDuration / 2)}
+						step={0.1}
+						value={[fadeIn]}
+						onValueChange={([v]) => setFadeIn(v ?? 0)}
+					/>
+				</div>
+				<div className="space-y-2">
+					<Label className="text-xs">Fade Out: {fadeOut.toFixed(1)}s</Label>
+					<Slider
+						min={0}
+						max={Math.min(5, rawDuration / 2)}
+						step={0.1}
+						value={[fadeOut]}
+						onValueChange={([v]) => setFadeOut(v ?? 0)}
+					/>
+				</div>
+			</div>
+
+			{/* Playback speed */}
+			<div className="space-y-2">
+				<Label className="text-xs">
+					Playback Speed: {playbackRate.toFixed(2)}x
+					{playbackRate !== 1.0 && (
+						<span className="text-muted-foreground ml-2">
+							(notification will play at this speed)
+						</span>
+					)}
+				</Label>
+				<Slider
+					min={0.5}
+					max={2.0}
+					step={0.05}
+					value={[playbackRate]}
+					onValueChange={([v]) => setPlaybackRate(v ?? 1.0)}
+				/>
+				<div className="flex justify-between text-xs text-muted-foreground">
+					<span>0.5x</span>
+					<span>1x</span>
+					<span>2x</span>
+				</div>
+			</div>
+
+			{/* Display name */}
+			<div className="space-y-1">
+				<Label htmlFor={nameId} className="text-xs">
+					Display name
+				</Label>
+				<Input
+					id={nameId}
+					type="text"
+					placeholder={videoTitle}
+					value={displayName}
+					onChange={(e) => onDisplayNameChange(e.target.value)}
+					maxLength={80}
+					className="h-8 text-sm"
+				/>
+			</div>
+
+			{errorMessage && (
+				<p className="text-sm text-destructive break-words">{errorMessage}</p>
+			)}
+
+			{!outputValid && rawDuration > 0 && (
+				<p className="text-xs text-destructive">
+					Output duration ({outputDuration.toFixed(1)}s) exceeds{" "}
+					{MAX_OUTPUT_DURATION}s. Shorten the selection or increase playback
+					speed.
+				</p>
+			)}
+
+			<Button
+				type="button"
+				className="w-full"
+				disabled={!outputValid || isImporting || isLoadingWaveform}
+				onClick={handleImport}
+			>
+				{isImporting && (
+					<LuLoaderCircle className="mr-2 h-4 w-4 animate-spin" />
+				)}
+				{isImporting ? "Importing..." : "Import"}
+			</Button>
+
+			{/* biome-ignore lint/a11y/useMediaCaption: programmatic preview player, no dialogue content */}
+			<audio ref={audioRef} src={audioUrl} preload="none" />
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/ringtones/components/RingtonesSettings/components/YouTubeImportDialog/components/AudioEditor/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/ringtones/components/RingtonesSettings/components/YouTubeImportDialog/components/AudioEditor/index.ts
@@ -1,0 +1,1 @@
+export { AudioEditor } from "./AudioEditor";

--- a/apps/desktop/src/shared/ringtones.ts
+++ b/apps/desktop/src/shared/ringtones.ts
@@ -12,6 +12,8 @@ export interface RingtoneData {
 	color: string;
 	/** Duration in seconds */
 	duration?: number;
+	/** Optional thumbnail URL (used for YouTube imports) */
+	thumbnailUrl?: string;
 }
 
 export const CUSTOM_RINGTONE_ID = "custom";


### PR DESCRIPTION
## 概要 (Issue #276)

- YouTubeのフル音声を先行ダウンロードし、波形ビジュアライザで範囲をビジュアルトリムできるようにした
- フェードイン/アウト・再生速度設定を追加（ffmpegのatempo/afadeフィルタで通知音ファイルに反映）
- yt-dlp/ffmpeg未インストール時にHomebrewインストールボタンを表示（macOS）
- YouTubeのタイトル・サムネイルを着信音カードに表示

## 変更内容

### 新規ファイル
- `src/main/lib/temp-audio-protocol.ts` - `superset-temp-audio://` カスタムプロトコル（一時音声ファイルをレンダラーに安全に提供）
- `src/renderer/.../AudioEditor/AudioEditor.tsx` - 波形ビジュアライザ、トリムハンドル、フェード/スピードコントロール

### 主な変更
- `youtube-ringtone.ts`: `downloadFullYouTubeAudio()` を追加、ffmpegフィルタチェーン（atempo/afade）対応、workDirクリーンアップをtry/finallyで確実に実行
- `ringtone/index.ts`: `checkBinaries`, `installBinaries`, `downloadYouTubeAudio`, `cleanupTempAudio` 手続き追加
- `YouTubeImportDialog.tsx`: マルチステップUI（url → downloading → editor）に刷新
- `RingtonesSettings.tsx`: サムネイル表示対応
- `custom-ringtones.ts` / `shared/ringtones.ts`: `thumbnailUrl` フィールド追加

## テスト計画

- [ ] YouTubeのURLを貼り付けてLoad Audioを押す
- [ ] 波形が表示され、トリムハンドルが動くことを確認
- [ ] フェードイン/アウト・速度を変更してインポート
- [ ] 通知音カードにサムネイルが表示されることを確認
- [ ] yt-dlp未インストール環境で「Install with Homebrew」ボタンが表示されることを確認