### PR TITLE
feat(desktop): Aivis ユーザー辞書 + 日別使用量ダッシュボード

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/aivis/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/aivis/index.ts
@@ -1,0 +1,342 @@
+import { randomUUID } from "node:crypto";
+import { TRPCError } from "@trpc/server";
+import {
+	AivisApiError,
+	AivisApiKeyMissingError,
+	aivisFetch,
+	aivisJson,
+} from "main/lib/aivis/client";
+import { z } from "zod";
+import { publicProcedure, router } from "../..";
+
+const WORD_TYPES = [
+	"PROPER_NOUN",
+	"COMMON_NOUN",
+	"VERB",
+	"ADJECTIVE",
+	"SUFFIX",
+] as const;
+
+function wrapApiError(err: unknown): TRPCError {
+	if (err instanceof AivisApiKeyMissingError) {
+		return new TRPCError({
+			code: "PRECONDITION_FAILED",
+			message: "Aivis API key is not configured",
+		});
+	}
+	if (err instanceof AivisApiError) {
+		return new TRPCError({
+			code: err.status === 401 ? "UNAUTHORIZED" : "BAD_REQUEST",
+			message: err.message,
+		});
+	}
+	return new TRPCError({
+		code: "INTERNAL_SERVER_ERROR",
+		message: err instanceof Error ? err.message : String(err),
+	});
+}
+
+const wordSchema = z.object({
+	uuid: z.string().uuid(),
+	surface: z.array(z.string().min(1)).min(1),
+	pronunciation: z.array(z.string().min(1)).min(1),
+	accent_type: z.array(z.number().int().min(0)),
+	word_type: z.enum(WORD_TYPES).default("PROPER_NOUN"),
+	priority: z.number().int().min(0).max(10).default(5),
+});
+
+interface DictionaryListItem {
+	uuid: string;
+	name: string;
+	description: string;
+	word_count: number;
+	created_at: string;
+	updated_at: string;
+}
+
+interface DictionaryDetail {
+	name: string;
+	description: string;
+	word_properties: Array<{
+		uuid: string;
+		surface: string[];
+		normalized_surface?: string[] | null;
+		pronunciation: string[];
+		accent_type: number[];
+		word_type: (typeof WORD_TYPES)[number];
+		priority: number;
+	}>;
+	created_at: string;
+	updated_at: string;
+}
+
+interface UsageSummary {
+	api_key_id: string;
+	api_key_name: string;
+	summary_date: string;
+	summary_hour: number;
+	request_count: number;
+	character_count: number;
+	credit_consumed: number;
+}
+
+interface UserMeResponse {
+	handle?: string;
+	name?: string;
+	email?: string;
+	credit_balance?: number;
+	// Additional fields are ignored; we only surface balance + identity.
+	[key: string]: unknown;
+}
+
+export const createAivisRouter = () => {
+	return router({
+		/** Validate the key without persisting it; returns basic user info. */
+		validateKey: publicProcedure
+			.input(z.object({ apiKey: z.string().min(1).optional() }))
+			.mutation(async ({ input }) => {
+				try {
+					const me = await aivisJson<UserMeResponse>("/v1/users/me", {
+						apiKey: input.apiKey ?? undefined,
+					});
+					return {
+						ok: true as const,
+						handle: typeof me.handle === "string" ? me.handle : null,
+						name: typeof me.name === "string" ? me.name : null,
+						creditBalance:
+							typeof me.credit_balance === "number" ? me.credit_balance : null,
+					};
+				} catch (err) {
+					if (err instanceof AivisApiKeyMissingError) {
+						return { ok: false as const, reason: "missing" as const };
+					}
+					if (err instanceof AivisApiError) {
+						return {
+							ok: false as const,
+							reason: err.status === 401 ? "unauthorized" : "api",
+							message: err.message,
+						} as const;
+					}
+					throw wrapApiError(err);
+				}
+			}),
+
+		dictionary: router({
+			list: publicProcedure.query(async () => {
+				try {
+					const json = await aivisJson<{
+						user_dictionaries: DictionaryListItem[];
+					}>("/v1/user-dictionaries");
+					return json.user_dictionaries;
+				} catch (err) {
+					throw wrapApiError(err);
+				}
+			}),
+
+			get: publicProcedure
+				.input(z.object({ uuid: z.string().uuid() }))
+				.query(async ({ input }) => {
+					try {
+						return await aivisJson<DictionaryDetail>(
+							`/v1/user-dictionaries/${input.uuid}`,
+						);
+					} catch (err) {
+						throw wrapApiError(err);
+					}
+				}),
+
+			create: publicProcedure
+				.input(
+					z.object({
+						name: z.string().min(1).max(100),
+						description: z.string().max(500).default(""),
+					}),
+				)
+				.mutation(async ({ input }) => {
+					const uuid = randomUUID();
+					try {
+						await aivisFetch(`/v1/user-dictionaries/${uuid}`, {
+							method: "PUT",
+							json: {
+								name: input.name,
+								description: input.description,
+								word_properties: [],
+							},
+						});
+						return { uuid };
+					} catch (err) {
+						throw wrapApiError(err);
+					}
+				}),
+
+			update: publicProcedure
+				.input(
+					z.object({
+						uuid: z.string().uuid(),
+						name: z.string().min(1).max(100),
+						description: z.string().max(500).default(""),
+						words: z.array(wordSchema),
+					}),
+				)
+				.mutation(async ({ input }) => {
+					try {
+						await aivisFetch(`/v1/user-dictionaries/${input.uuid}`, {
+							method: "PUT",
+							json: {
+								name: input.name,
+								description: input.description,
+								word_properties: input.words,
+							},
+						});
+						return { success: true };
+					} catch (err) {
+						throw wrapApiError(err);
+					}
+				}),
+
+			delete: publicProcedure
+				.input(z.object({ uuid: z.string().uuid() }))
+				.mutation(async ({ input }) => {
+					try {
+						await aivisFetch(`/v1/user-dictionaries/${input.uuid}`, {
+							method: "DELETE",
+						});
+						return { success: true };
+					} catch (err) {
+						throw wrapApiError(err);
+					}
+				}),
+
+			export: publicProcedure
+				.input(z.object({ uuid: z.string().uuid() }))
+				.query(async ({ input }) => {
+					try {
+						return await aivisJson<Record<string, unknown>>(
+							`/v1/user-dictionaries/${input.uuid}/export`,
+						);
+					} catch (err) {
+						throw wrapApiError(err);
+					}
+				}),
+
+			import: publicProcedure
+				.input(
+					z.object({
+						uuid: z.string().uuid(),
+						data: z.record(z.string(), z.unknown()),
+						override: z.boolean().default(false),
+					}),
+				)
+				.mutation(async ({ input }) => {
+					try {
+						await aivisFetch(`/v1/user-dictionaries/${input.uuid}/import`, {
+							method: "POST",
+							query: { override: input.override },
+							json: input.data,
+						});
+						return { success: true };
+					} catch (err) {
+						throw wrapApiError(err);
+					}
+				}),
+		}),
+
+		usage: router({
+			daily: publicProcedure
+				.input(
+					z.object({
+						startDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+						endDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+					}),
+				)
+				.query(async ({ input }) => {
+					try {
+						const json = await aivisJson<{ summaries: UsageSummary[] }>(
+							"/v1/payment/usage-summaries",
+							{
+								query: {
+									start_date: input.startDate,
+									end_date: input.endDate,
+								},
+							},
+						);
+
+						const byDate = new Map<
+							string,
+							{
+								date: string;
+								requestCount: number;
+								characterCount: number;
+								creditConsumed: number;
+								byApiKey: Record<
+									string,
+									{
+										name: string;
+										requestCount: number;
+										characterCount: number;
+										creditConsumed: number;
+									}
+								>;
+							}
+						>();
+
+						for (const s of json.summaries) {
+							const entry = byDate.get(s.summary_date) ?? {
+								date: s.summary_date,
+								requestCount: 0,
+								characterCount: 0,
+								creditConsumed: 0,
+								byApiKey: {},
+							};
+							entry.requestCount += s.request_count;
+							entry.characterCount += s.character_count;
+							entry.creditConsumed += s.credit_consumed;
+
+							const bucket = entry.byApiKey[s.api_key_id] ?? {
+								name: s.api_key_name,
+								requestCount: 0,
+								characterCount: 0,
+								creditConsumed: 0,
+							};
+							bucket.requestCount += s.request_count;
+							bucket.characterCount += s.character_count;
+							bucket.creditConsumed += s.credit_consumed;
+							entry.byApiKey[s.api_key_id] = bucket;
+
+							byDate.set(s.summary_date, entry);
+						}
+
+						const days = [...byDate.values()].sort((a, b) =>
+							a.date.localeCompare(b.date),
+						);
+						const total = days.reduce(
+							(acc, d) => ({
+								requestCount: acc.requestCount + d.requestCount,
+								characterCount: acc.characterCount + d.characterCount,
+								creditConsumed: acc.creditConsumed + d.creditConsumed,
+							}),
+							{ requestCount: 0, characterCount: 0, creditConsumed: 0 },
+						);
+
+						return { days, total };
+					} catch (err) {
+						throw wrapApiError(err);
+					}
+				}),
+
+			me: publicProcedure.query(async () => {
+				try {
+					const me = await aivisJson<UserMeResponse>("/v1/users/me");
+					return {
+						handle: typeof me.handle === "string" ? me.handle : null,
+						name: typeof me.name === "string" ? me.name : null,
+						creditBalance:
+							typeof me.credit_balance === "number" ? me.credit_balance : null,
+					};
+				} catch (err) {
+					throw wrapApiError(err);
+				}
+			}),
+		}),
+	});
+};

--- a/apps/desktop/src/lib/trpc/routers/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/index.ts
@@ -3,6 +3,7 @@ import type { WindowManager } from "main/lib/window-manager";
 // Fork-local: TODO autonomous agent feature.
 import { createTodoAgentRouter } from "main/todo-agent";
 import { router } from "..";
+import { createAivisRouter } from "./aivis";
 import { createAnalyticsRouter } from "./analytics";
 import { createAuthRouter } from "./auth";
 import { createAutoUpdateRouter } from "./auto-update";
@@ -48,6 +49,7 @@ export const createAppRouter = (
 	return router({
 		chatRuntimeService: createChatRuntimeServiceRouter(),
 		chatService: createChatServiceRouter(),
+		aivis: createAivisRouter(),
 		analytics: createAnalyticsRouter(),
 		browser: createBrowserRouter(),
 		browserHistory: createBrowserHistoryRouter(),

--- a/apps/desktop/src/lib/trpc/routers/settings/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/settings/index.ts
@@ -1046,6 +1046,7 @@ export const createSettingsRouter = () => {
 				enabled: row.aivisEnabled ?? false,
 				apiKey: row.aivisApiKey ?? "",
 				modelUuid: row.aivisModelUuid ?? "",
+				userDictionaryUuid: row.aivisUserDictionaryUuid ?? "",
 				format: row.aivisFormat ?? "ワークスペース、{{workspace}}、です",
 				formatPermission:
 					row.aivisFormatPermission ?? "{{branch}}で対応が必要です",
@@ -1058,6 +1059,7 @@ export const createSettingsRouter = () => {
 					enabled: z.boolean().optional(),
 					apiKey: z.string().optional(),
 					modelUuid: z.string().optional(),
+					userDictionaryUuid: z.string().optional(),
 					format: z.string().optional(),
 					formatPermission: z.string().optional(),
 				}),
@@ -1076,6 +1078,10 @@ export const createSettingsRouter = () => {
 				if (input.modelUuid !== undefined) {
 					values.aivisModelUuid = input.modelUuid;
 					set.aivisModelUuid = input.modelUuid;
+				}
+				if (input.userDictionaryUuid !== undefined) {
+					values.aivisUserDictionaryUuid = input.userDictionaryUuid;
+					set.aivisUserDictionaryUuid = input.userDictionaryUuid;
 				}
 				if (input.format !== undefined) {
 					values.aivisFormat = input.format;
@@ -1099,6 +1105,7 @@ export const createSettingsRouter = () => {
 					apiKey: z.string(),
 					modelUuid: z.string(),
 					text: z.string().min(1).max(3000),
+					userDictionaryUuid: z.string().uuid().optional(),
 				}),
 			)
 			.mutation(async ({ input }) => {
@@ -1109,6 +1116,7 @@ export const createSettingsRouter = () => {
 					apiKey: input.apiKey,
 					modelUuid: input.modelUuid,
 					text: input.text,
+					userDictionaryUuid: input.userDictionaryUuid,
 				});
 				return { success: true };
 			}),

--- a/apps/desktop/src/main/lib/aivis/client.ts
+++ b/apps/desktop/src/main/lib/aivis/client.ts
@@ -1,0 +1,89 @@
+import { settings } from "@superset/local-db";
+import { localDb } from "../local-db";
+
+const BASE_URL = "https://api.aivis-project.com";
+
+export class AivisApiKeyMissingError extends Error {
+	constructor() {
+		super("Aivis API key is not configured");
+		this.name = "AivisApiKeyMissingError";
+	}
+}
+
+export class AivisApiError extends Error {
+	constructor(
+		readonly status: number,
+		readonly bodyText: string,
+	) {
+		super(`Aivis API error ${status}: ${bodyText.slice(0, 300)}`);
+		this.name = "AivisApiError";
+	}
+}
+
+function readApiKey(): string | null {
+	try {
+		const row = localDb.select().from(settings).get();
+		const key = row?.aivisApiKey?.trim();
+		return key || null;
+	} catch {
+		return null;
+	}
+}
+
+export interface AivisFetchInit extends Omit<RequestInit, "body"> {
+	query?: Record<string, string | number | boolean | undefined>;
+	json?: unknown;
+	/** Override the stored API key (used for validation from a form). */
+	apiKey?: string | null;
+}
+
+/**
+ * Authorized fetch wrapper for the Aivis Cloud API.
+ * Throws AivisApiKeyMissingError if no key is configured, and AivisApiError
+ * on non-2xx responses.
+ */
+export async function aivisFetch(
+	path: string,
+	init: AivisFetchInit = {},
+): Promise<Response> {
+	const key = init.apiKey ?? readApiKey();
+	if (!key) throw new AivisApiKeyMissingError();
+
+	const url = new URL(path, BASE_URL);
+	for (const [k, v] of Object.entries(init.query ?? {})) {
+		if (v !== undefined && v !== null) url.searchParams.set(k, String(v));
+	}
+
+	const headers: Record<string, string> = {
+		Authorization: `Bearer ${key}`,
+		Accept: "application/json",
+		...(init.headers as Record<string, string> | undefined),
+	};
+
+	let body: BodyInit | undefined;
+	if (init.json !== undefined) {
+		headers["Content-Type"] = "application/json";
+		body = JSON.stringify(init.json);
+	}
+
+	const res = await fetch(url, {
+		...init,
+		headers,
+		body,
+	});
+
+	if (!res.ok) {
+		const text = await res.text().catch(() => "");
+		throw new AivisApiError(res.status, text);
+	}
+
+	return res;
+}
+
+export async function aivisJson<T>(
+	path: string,
+	init: AivisFetchInit = {},
+): Promise<T> {
+	const res = await aivisFetch(path, init);
+	return (await res.json()) as T;
+}

--- a/apps/desktop/src/main/lib/notifications/aivis-tts.ts
+++ b/apps/desktop/src/main/lib/notifications/aivis-tts.ts
@@ -45,6 +45,7 @@ function readAivisSettings() {
 			enabled: row?.aivisEnabled ?? false,
 			apiKey: row?.aivisApiKey ?? "",
 			modelUuid: row?.aivisModelUuid ?? "",
+			userDictionaryUuid: row?.aivisUserDictionaryUuid ?? "",
 			format: row?.aivisFormat ?? "ワークスペース、{{workspace}}、です",
 			formatPermission:
 				row?.aivisFormatPermission ?? "{{branch}}で対応が必要です",
@@ -63,7 +64,15 @@ async function synthesize(
 	apiKey: string,
 	modelUuid: string,
 	text: string,
+	userDictionaryUuid?: string,
 ): Promise<Buffer> {
+	const body: Record<string, unknown> = {
+		model_uuid: modelUuid,
+		text,
+		output_format: "mp3",
+	};
+	if (userDictionaryUuid) body.user_dictionary_uuid = userDictionaryUuid;
+
 	const res = await fetch(AIVIS_ENDPOINT, {
 		method: "POST",
 		headers: {
@@ -71,11 +80,7 @@ async function synthesize(
 			"Content-Type": "application/json",
 			Accept: "audio/mpeg",
 		},
-		body: JSON.stringify({
-			model_uuid: modelUuid,
-			text,
-			output_format: "mp3",
-		}),
+		body: JSON.stringify(body),
 	});
 
 	if (!res.ok) {
@@ -112,6 +117,7 @@ export async function playAivisTts(options: {
 	modelUuid: string;
 	text: string;
 	volume?: number;
+	userDictionaryUuid?: string;
 }): Promise<void> {
 	const trimmed = options.text.trim();
 	if (!trimmed) return;
@@ -119,7 +125,12 @@ export async function playAivisTts(options: {
 		throw new Error("Aivis API key and model UUID are required");
 	}
 
-	const audio = await synthesize(options.apiKey, options.modelUuid, trimmed);
+	const audio = await synthesize(
+		options.apiKey,
+		options.modelUuid,
+		trimmed,
+		options.userDictionaryUuid,
+	);
 	const path = uniqueTmpPath();
 	await writeFile(path, audio);
 
@@ -150,6 +161,7 @@ export async function playAivisNotification(
 			modelUuid: cfg.modelUuid,
 			text,
 			volume: cfg.volume,
+			userDictionaryUuid: cfg.userDictionaryUuid || undefined,
 		});
 	} catch (err) {
 		console.warn("[aivis-tts] playback failed", err);

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/ringtones/components/AivisDictionary/AivisDictionary.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/ringtones/components/AivisDictionary/AivisDictionary.tsx
@@ -1,0 +1,280 @@
+import { Button } from "@superset/ui/button";
+import { useRef, useState } from "react";
+import {
+	HiArrowDownTray,
+	HiArrowUpTray,
+	HiCheck,
+	HiPencil,
+	HiPlus,
+	HiTrash,
+} from "react-icons/hi2";
+import { electronTrpc } from "renderer/lib/electron-trpc";
+import { electronTrpcClient } from "renderer/lib/trpc-client";
+import {
+	isItemVisible,
+	SETTING_ITEM_ID,
+	type SettingItemId,
+} from "../../../utils/settings-search";
+import { CreateDictionaryDialog } from "./CreateDictionaryDialog";
+import { DictionaryEditorDialog } from "./DictionaryEditorDialog";
+
+interface Props {
+	visibleItems?: SettingItemId[] | null;
+}
+
+function formatDate(iso: string): string {
+	return iso.slice(0, 10);
+}
+
+export function AivisDictionary({ visibleItems }: Props) {
+	const visible = isItemVisible(
+		SETTING_ITEM_ID.RINGTONES_AIVIS_DICTIONARY,
+		visibleItems,
+	);
+
+	const utils = electronTrpc.useUtils();
+	const { data: aivisSettings } =
+		electronTrpc.settings.getAivisSettings.useQuery();
+	const apiKey = aivisSettings?.apiKey ?? "";
+	const activeUuid = aivisSettings?.userDictionaryUuid ?? "";
+
+	const list = electronTrpc.aivis.dictionary.list.useQuery(undefined, {
+		enabled: Boolean(apiKey),
+		retry: false,
+	});
+
+	const saveSettings = electronTrpc.settings.setAivisSettings.useMutation({
+		onSuccess: () => utils.settings.getAivisSettings.invalidate(),
+	});
+	const remove = electronTrpc.aivis.dictionary.delete.useMutation({
+		onSuccess: () => utils.aivis.dictionary.list.invalidate(),
+	});
+	const importMutation = electronTrpc.aivis.dictionary.import.useMutation({
+		onSuccess: () => utils.aivis.dictionary.list.invalidate(),
+	});
+
+	const [createOpen, setCreateOpen] = useState(false);
+	const [editUuid, setEditUuid] = useState<string | null>(null);
+	const [error, setError] = useState<string | null>(null);
+	const fileInputRef = useRef<HTMLInputElement | null>(null);
+	const [importTargetUuid, setImportTargetUuid] = useState<string | null>(null);
+
+	if (!visible) return null;
+
+	const handleSelectActive = (uuid: string) => {
+		saveSettings.mutate({
+			userDictionaryUuid: uuid === activeUuid ? "" : uuid,
+		});
+	};
+
+	const handleDelete = (uuid: string, name: string) => {
+		if (!confirm(`辞書「${name}」を削除します。よろしいですか？`)) return;
+		remove.mutate({ uuid });
+		if (uuid === activeUuid) saveSettings.mutate({ userDictionaryUuid: "" });
+	};
+
+	const handleExport = async (uuid: string, name: string) => {
+		try {
+			setError(null);
+			const data = await electronTrpcClient.aivis.dictionary.export.query({
+				uuid,
+			});
+			const blob = new Blob([JSON.stringify(data, null, 2)], {
+				type: "application/json",
+			});
+			const url = URL.createObjectURL(blob);
+			const a = document.createElement("a");
+			a.href = url;
+			a.download = `${name || "dictionary"}.aivisspeech.json`;
+			a.click();
+			URL.revokeObjectURL(url);
+		} catch (err) {
+			setError(err instanceof Error ? err.message : String(err));
+		}
+	};
+
+	const triggerImport = (uuid: string) => {
+		setImportTargetUuid(uuid);
+		fileInputRef.current?.click();
+	};
+
+	const handleImportFile = async (e: React.ChangeEvent<HTMLInputElement>) => {
+		const file = e.target.files?.[0];
+		e.target.value = "";
+		if (!file || !importTargetUuid) return;
+		try {
+			setError(null);
+			const text = await file.text();
+			const data = JSON.parse(text);
+			if (typeof data !== "object" || Array.isArray(data) || data === null) {
+				throw new Error(
+					"AivisSpeech 互換の JSON オブジェクトを選択してください",
+				);
+			}
+			await importMutation.mutateAsync({
+				uuid: importTargetUuid,
+				data,
+				override: false,
+			});
+		} catch (err) {
+			setError(err instanceof Error ? err.message : String(err));
+		} finally {
+			setImportTargetUuid(null);
+		}
+	};
+
+	return (
+		<div className="pt-6 border-t space-y-6">
+			<div className="flex items-start justify-between gap-4">
+				<div>
+					<h3 className="text-base font-semibold">ユーザー辞書</h3>
+					<p className="text-sm text-muted-foreground mt-1">
+						固有名詞・英略語・ブランチ名など特殊な読み方をする単語を登録します。
+						AivisSpeech 互換 JSON の import / export に対応。
+					</p>
+				</div>
+				<div className="shrink-0 flex items-center gap-2">
+					<Button
+						type="button"
+						size="sm"
+						variant="outline"
+						onClick={() => setCreateOpen(true)}
+						disabled={!apiKey}
+					>
+						<HiPlus className="mr-1.5 h-3.5 w-3.5" />
+						新規辞書
+					</Button>
+				</div>
+			</div>
+
+			{!apiKey && (
+				<div className="rounded-md border border-dashed px-4 py-6 text-center text-sm text-muted-foreground">
+					Aivis API キーを設定すると辞書を管理できます。
+				</div>
+			)}
+
+			{apiKey && list.isLoading && (
+				<div className="text-sm text-muted-foreground">読み込み中…</div>
+			)}
+
+			{apiKey && list.error && (
+				<div className="text-sm text-destructive">
+					辞書の取得に失敗しました: {list.error.message}
+				</div>
+			)}
+
+			{apiKey && list.data && list.data.length === 0 && (
+				<div className="rounded-md border border-dashed px-4 py-8 text-center text-sm text-muted-foreground">
+					まだ辞書がありません。「新規辞書」から作成してください。
+				</div>
+			)}
+
+			<div className="space-y-2">
+				{list.data?.map((d) => {
+					const isActive = d.uuid === activeUuid;
+					return (
+						<div
+							key={d.uuid}
+							className={`rounded-lg border p-4 ${
+								isActive ? "border-emerald-500/40 bg-emerald-500/5" : "bg-card"
+							}`}
+						>
+							<div className="flex items-center justify-between gap-3">
+								<div className="flex items-center gap-3 min-w-0">
+									<span
+										className={`h-2 w-2 rounded-full ${
+											isActive ? "bg-emerald-400" : "bg-muted-foreground/30"
+										}`}
+									/>
+									<div className="min-w-0">
+										<div className="text-sm font-medium flex items-center gap-2">
+											<span className="truncate">{d.name}</span>
+											{isActive && (
+												<span className="text-[10px] font-semibold px-1.5 py-0.5 rounded border border-emerald-500/40 bg-emerald-500/10 text-emerald-500">
+													ACTIVE
+												</span>
+											)}
+										</div>
+										<div className="text-xs text-muted-foreground mt-0.5 truncate">
+											{d.description || "—"} · {d.word_count} words · Updated{" "}
+											{formatDate(d.updated_at)}
+										</div>
+									</div>
+								</div>
+								<div className="flex items-center gap-1.5 shrink-0">
+									{!isActive && (
+										<Button
+											size="sm"
+											variant="outline"
+											onClick={() => handleSelectActive(d.uuid)}
+											disabled={saveSettings.isPending}
+										>
+											<HiCheck className="mr-1 h-3.5 w-3.5" />
+											適用
+										</Button>
+									)}
+									<Button
+										size="sm"
+										variant="outline"
+										onClick={() => setEditUuid(d.uuid)}
+									>
+										<HiPencil className="mr-1 h-3.5 w-3.5" />
+										編集
+									</Button>
+									<Button
+										size="sm"
+										variant="outline"
+										onClick={() => triggerImport(d.uuid)}
+										disabled={importMutation.isPending}
+										title="AivisSpeech JSON を取り込み"
+									>
+										<HiArrowUpTray className="h-3.5 w-3.5" />
+									</Button>
+									<Button
+										size="sm"
+										variant="outline"
+										onClick={() => handleExport(d.uuid, d.name)}
+										title="AivisSpeech JSON をエクスポート"
+									>
+										<HiArrowDownTray className="h-3.5 w-3.5" />
+									</Button>
+									<Button
+										size="sm"
+										variant="outline"
+										onClick={() => handleDelete(d.uuid, d.name)}
+										disabled={remove.isPending}
+										className="hover:bg-destructive/10 hover:text-destructive hover:border-destructive/40"
+									>
+										<HiTrash className="h-3.5 w-3.5" />
+									</Button>
+								</div>
+							</div>
+						</div>
+					);
+				})}
+			</div>
+
+			{error && <p className="text-sm text-destructive">{error}</p>}
+
+			<input
+				ref={fileInputRef}
+				type="file"
+				accept="application/json,.json"
+				className="hidden"
+				onChange={handleImportFile}
+			/>
+
+			<CreateDictionaryDialog
+				open={createOpen}
+				onOpenChange={setCreateOpen}
+				onCreated={(uuid) => setEditUuid(uuid)}
+			/>
+
+			<DictionaryEditorDialog
+				uuid={editUuid}
+				open={Boolean(editUuid)}
+				onOpenChange={(open) => !open && setEditUuid(null)}
+			/>
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/ringtones/components/AivisDictionary/AivisDictionary.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/ringtones/components/AivisDictionary/AivisDictionary.tsx
@@ -69,8 +69,16 @@ export function AivisDictionary({ visibleItems }: Props) {
 
 	const handleDelete = (uuid: string, name: string) => {
 		if (!confirm(`辞書「${name}」を削除します。よろしいですか？`)) return;
-		remove.mutate({ uuid });
-		if (uuid === activeUuid) saveSettings.mutate({ userDictionaryUuid: "" });
+		remove.mutate(
+			{ uuid },
+			{
+				onSuccess: () => {
+					if (uuid === activeUuid) {
+						saveSettings.mutate({ userDictionaryUuid: "" });
+					}
+				},
+			},
+		);
 	};
 
 	const handleExport = async (uuid: string, name: string) => {

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/ringtones/components/AivisDictionary/CreateDictionaryDialog.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/ringtones/components/AivisDictionary/CreateDictionaryDialog.tsx
@@ -1,0 +1,97 @@
+import { Button } from "@superset/ui/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "@superset/ui/dialog";
+import { Input } from "@superset/ui/input";
+import { Label } from "@superset/ui/label";
+import { useState } from "react";
+import { electronTrpc } from "renderer/lib/electron-trpc";
+
+interface Props {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	onCreated?: (uuid: string) => void;
+}
+
+export function CreateDictionaryDialog({
+	open,
+	onOpenChange,
+	onCreated,
+}: Props) {
+	const utils = electronTrpc.useUtils();
+	const create = electronTrpc.aivis.dictionary.create.useMutation({
+		onSuccess: async ({ uuid }) => {
+			await utils.aivis.dictionary.list.invalidate();
+			onCreated?.(uuid);
+			onOpenChange(false);
+			setName("");
+			setDescription("");
+		},
+	});
+
+	const [name, setName] = useState("");
+	const [description, setDescription] = useState("");
+
+	return (
+		<Dialog open={open} onOpenChange={onOpenChange}>
+			<DialogContent>
+				<DialogHeader>
+					<DialogTitle>新規ユーザー辞書</DialogTitle>
+					<DialogDescription>
+						空の辞書を作成します。作成後に単語を追加してください。
+					</DialogDescription>
+				</DialogHeader>
+				<div className="space-y-3">
+					<div className="space-y-1.5">
+						<Label htmlFor="new-dict-name">名前</Label>
+						<Input
+							id="new-dict-name"
+							value={name}
+							onChange={(e) => setName(e.target.value)}
+							maxLength={100}
+							placeholder="project-terms"
+						/>
+					</div>
+					<div className="space-y-1.5">
+						<Label htmlFor="new-dict-desc">説明 (任意)</Label>
+						<Input
+							id="new-dict-desc"
+							value={description}
+							onChange={(e) => setDescription(e.target.value)}
+							maxLength={500}
+							placeholder="プロジェクト固有名詞"
+						/>
+					</div>
+					{create.error && (
+						<p className="text-sm text-destructive">{create.error.message}</p>
+					)}
+				</div>
+				<DialogFooter>
+					<Button
+						variant="outline"
+						onClick={() => onOpenChange(false)}
+						disabled={create.isPending}
+					>
+						キャンセル
+					</Button>
+					<Button
+						onClick={() =>
+							create.mutate({
+								name: name.trim(),
+								description: description.trim(),
+							})
+						}
+						disabled={create.isPending || !name.trim()}
+					>
+						{create.isPending ? "作成中…" : "作成"}
+					</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/ringtones/components/AivisDictionary/DictionaryEditorDialog.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/ringtones/components/AivisDictionary/DictionaryEditorDialog.tsx
@@ -1,0 +1,312 @@
+import { Button } from "@superset/ui/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "@superset/ui/dialog";
+import { Input } from "@superset/ui/input";
+import { Label } from "@superset/ui/label";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@superset/ui/select";
+import { useEffect, useState } from "react";
+import { HiPlus, HiXMark } from "react-icons/hi2";
+import { electronTrpc } from "renderer/lib/electron-trpc";
+
+const WORD_TYPES = [
+	{ value: "PROPER_NOUN", label: "固有名詞" },
+	{ value: "COMMON_NOUN", label: "一般名詞" },
+	{ value: "VERB", label: "動詞" },
+	{ value: "ADJECTIVE", label: "形容詞" },
+	{ value: "SUFFIX", label: "接尾辞" },
+] as const;
+
+type WordType = (typeof WORD_TYPES)[number]["value"];
+
+interface WordRow {
+	uuid: string;
+	surface: string;
+	pronunciation: string;
+	accentType: number;
+	wordType: WordType;
+	priority: number;
+}
+
+interface Props {
+	uuid: string | null;
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+}
+
+const KATAKANA_RE = /^[\u30A0-\u30FFー\s]+$/;
+
+export function DictionaryEditorDialog({ uuid, open, onOpenChange }: Props) {
+	const utils = electronTrpc.useUtils();
+	const detail = electronTrpc.aivis.dictionary.get.useQuery(
+		{ uuid: uuid ?? "" },
+		{ enabled: Boolean(uuid) && open, staleTime: 0 },
+	);
+	const update = electronTrpc.aivis.dictionary.update.useMutation({
+		onSuccess: async () => {
+			await utils.aivis.dictionary.list.invalidate();
+			if (uuid) await utils.aivis.dictionary.get.invalidate({ uuid });
+			onOpenChange(false);
+		},
+	});
+
+	const [name, setName] = useState("");
+	const [description, setDescription] = useState("");
+	const [words, setWords] = useState<WordRow[]>([]);
+	const [error, setError] = useState<string | null>(null);
+
+	useEffect(() => {
+		if (!detail.data) return;
+		setName(detail.data.name);
+		setDescription(detail.data.description);
+		setWords(
+			detail.data.word_properties.map((w) => ({
+				uuid: w.uuid,
+				surface: w.surface[0] ?? "",
+				pronunciation: w.pronunciation[0] ?? "",
+				accentType: w.accent_type[0] ?? 0,
+				wordType: w.word_type,
+				priority: w.priority,
+			})),
+		);
+		setError(null);
+	}, [detail.data]);
+
+	const addRow = () => {
+		setWords((rows) => [
+			...rows,
+			{
+				uuid: crypto.randomUUID(),
+				surface: "",
+				pronunciation: "",
+				accentType: 0,
+				wordType: "PROPER_NOUN",
+				priority: 5,
+			},
+		]);
+	};
+
+	const patchRow = (idx: number, patch: Partial<WordRow>) => {
+		setWords((rows) =>
+			rows.map((r, i) => (i === idx ? { ...r, ...patch } : r)),
+		);
+	};
+
+	const removeRow = (idx: number) => {
+		setWords((rows) => rows.filter((_, i) => i !== idx));
+	};
+
+	const handleSave = () => {
+		setError(null);
+		if (!uuid) return;
+		if (!name.trim()) {
+			setError("辞書名を入力してください");
+			return;
+		}
+		for (const [i, w] of words.entries()) {
+			if (!w.surface.trim()) {
+				setError(`行 ${i + 1}: 表記が空です`);
+				return;
+			}
+			if (!w.pronunciation.trim()) {
+				setError(`行 ${i + 1}: 読みが空です`);
+				return;
+			}
+			if (!KATAKANA_RE.test(w.pronunciation.trim())) {
+				setError(`行 ${i + 1}: 読みはカタカナで入力してください`);
+				return;
+			}
+		}
+		update.mutate({
+			uuid,
+			name: name.trim(),
+			description: description.trim(),
+			words: words.map((w) => ({
+				uuid: w.uuid,
+				surface: [w.surface.trim()],
+				pronunciation: [w.pronunciation.trim()],
+				accent_type: [Math.max(0, Math.floor(w.accentType))],
+				word_type: w.wordType,
+				priority: Math.max(0, Math.min(10, Math.floor(w.priority))),
+			})),
+		});
+	};
+
+	return (
+		<Dialog open={open} onOpenChange={onOpenChange}>
+			<DialogContent className="!max-w-[900px] sm:!max-w-[900px]">
+				<DialogHeader>
+					<DialogTitle>ユーザー辞書を編集</DialogTitle>
+					<DialogDescription>
+						Aivis
+						の音声合成時に適用される読み方を登録します。読みはカタカナで入力してください。
+					</DialogDescription>
+				</DialogHeader>
+
+				{detail.isLoading ? (
+					<div className="py-12 text-center text-sm text-muted-foreground">
+						読み込み中…
+					</div>
+				) : detail.error ? (
+					<div className="py-8 text-sm text-destructive">
+						読み込みに失敗しました: {detail.error.message}
+					</div>
+				) : (
+					<div className="space-y-4">
+						<div className="grid grid-cols-2 gap-3">
+							<div className="space-y-1.5">
+								<Label htmlFor="dict-name">名前</Label>
+								<Input
+									id="dict-name"
+									value={name}
+									onChange={(e) => setName(e.target.value)}
+									maxLength={100}
+								/>
+							</div>
+							<div className="space-y-1.5">
+								<Label htmlFor="dict-desc">説明</Label>
+								<Input
+									id="dict-desc"
+									value={description}
+									onChange={(e) => setDescription(e.target.value)}
+									maxLength={500}
+								/>
+							</div>
+						</div>
+
+						<div className="rounded-md border overflow-hidden">
+							<div className="grid grid-cols-[24%_26%_12%_14%_18%_auto] bg-muted text-xs font-medium text-muted-foreground px-3 py-2">
+								<div>表記</div>
+								<div>読み (カタカナ)</div>
+								<div>アクセント</div>
+								<div>優先度 (0-10)</div>
+								<div>品詞</div>
+								<div />
+							</div>
+							<div className="max-h-[360px] overflow-y-auto divide-y">
+								{words.length === 0 && (
+									<div className="px-3 py-6 text-center text-xs text-muted-foreground">
+										まだ単語がありません。右下の「行を追加」から開始してください。
+									</div>
+								)}
+								{words.map((w, i) => (
+									<div
+										key={w.uuid}
+										className="grid grid-cols-[24%_26%_12%_14%_18%_auto] items-center px-3 py-1.5 gap-2 text-xs"
+									>
+										<Input
+											className="h-7 text-xs font-mono"
+											value={w.surface}
+											onChange={(e) => patchRow(i, { surface: e.target.value })}
+											placeholder="Superset"
+										/>
+										<Input
+											className="h-7 text-xs font-mono"
+											value={w.pronunciation}
+											onChange={(e) =>
+												patchRow(i, { pronunciation: e.target.value })
+											}
+											placeholder="スーパーセット"
+										/>
+										<Input
+											className="h-7 text-xs tabular-nums"
+											type="number"
+											min={0}
+											value={w.accentType}
+											onChange={(e) =>
+												patchRow(i, {
+													accentType: Number(e.target.value) || 0,
+												})
+											}
+										/>
+										<Input
+											className="h-7 text-xs tabular-nums"
+											type="number"
+											min={0}
+											max={10}
+											value={w.priority}
+											onChange={(e) =>
+												patchRow(i, { priority: Number(e.target.value) || 0 })
+											}
+										/>
+										<Select
+											value={w.wordType}
+											onValueChange={(v) =>
+												patchRow(i, { wordType: v as WordType })
+											}
+										>
+											<SelectTrigger className="h-7 text-xs">
+												<SelectValue />
+											</SelectTrigger>
+											<SelectContent>
+												{WORD_TYPES.map((t) => (
+													<SelectItem key={t.value} value={t.value}>
+														{t.label}
+													</SelectItem>
+												))}
+											</SelectContent>
+										</Select>
+										<button
+											type="button"
+											onClick={() => removeRow(i)}
+											className="p-1 text-muted-foreground hover:text-destructive"
+											aria-label="削除"
+										>
+											<HiXMark className="h-4 w-4" />
+										</button>
+									</div>
+								))}
+							</div>
+						</div>
+
+						<div className="flex items-center justify-between">
+							<Button
+								type="button"
+								size="sm"
+								variant="outline"
+								onClick={addRow}
+							>
+								<HiPlus className="mr-1.5 h-3.5 w-3.5" />
+								行を追加
+							</Button>
+							<p className="text-[11px] text-muted-foreground">
+								アクセント核は 0 始まりの整数 (0 = 平板型)。
+							</p>
+						</div>
+
+						{error && <p className="text-sm text-destructive">{error}</p>}
+					</div>
+				)}
+
+				<DialogFooter>
+					<Button
+						type="button"
+						variant="outline"
+						onClick={() => onOpenChange(false)}
+						disabled={update.isPending}
+					>
+						キャンセル
+					</Button>
+					<Button
+						type="button"
+						onClick={handleSave}
+						disabled={update.isPending || detail.isLoading || !uuid}
+					>
+						{update.isPending ? "保存中…" : "保存"}
+					</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/ringtones/components/AivisDictionary/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/ringtones/components/AivisDictionary/index.ts
@@ -1,0 +1,1 @@
+export { AivisDictionary } from "./AivisDictionary";

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/ringtones/components/AivisSettings/AivisSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/ringtones/components/AivisSettings/AivisSettings.tsx
@@ -1,6 +1,13 @@
 import { Button } from "@superset/ui/button";
 import { Input } from "@superset/ui/input";
 import { Label } from "@superset/ui/label";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@superset/ui/select";
 import { Switch } from "@superset/ui/switch";
 import { Textarea } from "@superset/ui/textarea";
 import { useEffect, useRef, useState } from "react";
@@ -163,6 +170,8 @@ export function AivisSettings({ visibleItems }: AivisSettingsProps) {
 				/>
 			</div>
 
+			<AivisDictionarySelector apiKey={apiKey} enabled={enabled} />
+
 			<div className="space-y-2">
 				<div className="flex items-center justify-between">
 					<Label>プレースホルダ</Label>
@@ -244,6 +253,64 @@ export function AivisSettings({ visibleItems }: AivisSettingsProps) {
 			</div>
 
 			{testError && <p className="text-sm text-destructive">{testError}</p>}
+		</div>
+	);
+}
+
+function AivisDictionarySelector({
+	apiKey,
+	enabled,
+}: {
+	apiKey: string;
+	enabled: boolean;
+}) {
+	const utils = electronTrpc.useUtils();
+	const { data: settingsData } =
+		electronTrpc.settings.getAivisSettings.useQuery();
+	const list = electronTrpc.aivis.dictionary.list.useQuery(undefined, {
+		enabled: Boolean(apiKey),
+		retry: false,
+	});
+	const save = electronTrpc.settings.setAivisSettings.useMutation({
+		onSuccess: () => utils.settings.getAivisSettings.invalidate(),
+	});
+
+	const selected = settingsData?.userDictionaryUuid || "__none__";
+
+	const options = list.data ?? [];
+
+	return (
+		<div className="space-y-2">
+			<div className="flex items-center justify-between">
+				<Label>適用するユーザー辞書</Label>
+				{list.error && (
+					<span className="text-xs text-muted-foreground">
+						辞書の取得に失敗
+					</span>
+				)}
+			</div>
+			<Select
+				value={selected}
+				onValueChange={(v) =>
+					save.mutate({ userDictionaryUuid: v === "__none__" ? "" : v })
+				}
+				disabled={!enabled || !apiKey || list.isLoading}
+			>
+				<SelectTrigger>
+					<SelectValue placeholder="— 辞書なし —" />
+				</SelectTrigger>
+				<SelectContent>
+					<SelectItem value="__none__">— 辞書なし —</SelectItem>
+					{options.map((d) => (
+						<SelectItem key={d.uuid} value={d.uuid}>
+							{d.name} ({d.word_count} 語)
+						</SelectItem>
+					))}
+				</SelectContent>
+			</Select>
+			<p className="text-[11px] text-muted-foreground">
+				下の「ユーザー辞書」セクションで辞書の作成・編集ができます。
+			</p>
 		</div>
 	);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/ringtones/components/AivisUsage/AivisUsage.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/ringtones/components/AivisUsage/AivisUsage.tsx
@@ -163,13 +163,17 @@ export function AivisUsage({ visibleItems }: Props) {
 				</div>
 			)}
 
-			{apiKey && usage.error && (
+			{apiKey && usage.error && !usage.data && (
 				<div className="text-sm text-destructive">
 					使用量の取得に失敗しました: {usage.error.message}
 				</div>
 			)}
 
-			{apiKey && (
+			{apiKey && usage.isLoading && !usage.data && (
+				<div className="text-sm text-muted-foreground">読み込み中…</div>
+			)}
+
+			{apiKey && usage.data && (
 				<>
 					<div className="grid grid-cols-3 gap-3">
 						<StatCard

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/ringtones/components/AivisUsage/AivisUsage.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/ringtones/components/AivisUsage/AivisUsage.tsx
@@ -1,0 +1,414 @@
+import { useMemo, useState } from "react";
+import { electronTrpc } from "renderer/lib/electron-trpc";
+import {
+	isItemVisible,
+	SETTING_ITEM_ID,
+	type SettingItemId,
+} from "../../../utils/settings-search";
+
+interface Props {
+	visibleItems?: SettingItemId[] | null;
+}
+
+type Period = "7" | "30" | "custom";
+
+function toISODate(d: Date): string {
+	const y = d.getFullYear();
+	const m = String(d.getMonth() + 1).padStart(2, "0");
+	const day = String(d.getDate()).padStart(2, "0");
+	return `${y}-${m}-${day}`;
+}
+
+function rangeFor(period: Period): {
+	start: string;
+	end: string;
+	days: number;
+} {
+	const end = new Date();
+	const start = new Date();
+	const days = period === "7" ? 7 : 30;
+	start.setDate(end.getDate() - (days - 1));
+	return { start: toISODate(start), end: toISODate(end), days };
+}
+
+function fillMissingDates(
+	days: Array<{
+		date: string;
+		requestCount: number;
+		characterCount: number;
+		creditConsumed: number;
+	}>,
+	start: string,
+	end: string,
+) {
+	const result: typeof days = [];
+	const map = new Map(days.map((d) => [d.date, d]));
+	const s = new Date(`${start}T00:00:00`);
+	const e = new Date(`${end}T00:00:00`);
+	for (let d = new Date(s); d <= e; d.setDate(d.getDate() + 1)) {
+		const key = toISODate(d);
+		result.push(
+			map.get(key) ?? {
+				date: key,
+				requestCount: 0,
+				characterCount: 0,
+				creditConsumed: 0,
+			},
+		);
+	}
+	return result;
+}
+
+type Metric = "credits" | "requests" | "chars";
+
+export function AivisUsage({ visibleItems }: Props) {
+	const visible = isItemVisible(
+		SETTING_ITEM_ID.RINGTONES_AIVIS_USAGE,
+		visibleItems,
+	);
+
+	const { data: aivisSettings } =
+		electronTrpc.settings.getAivisSettings.useQuery();
+	const apiKey = aivisSettings?.apiKey ?? "";
+
+	const [period, setPeriod] = useState<Period>("30");
+	const [metric, setMetric] = useState<Metric>("credits");
+	const range = useMemo(
+		() => rangeFor(period === "custom" ? "30" : period),
+		[period],
+	);
+
+	const usage = electronTrpc.aivis.usage.daily.useQuery(
+		{ startDate: range.start, endDate: range.end },
+		{ enabled: Boolean(apiKey), retry: false, staleTime: 5 * 60 * 1000 },
+	);
+	const me = electronTrpc.aivis.usage.me.useQuery(undefined, {
+		enabled: Boolean(apiKey),
+		retry: false,
+		staleTime: 5 * 60 * 1000,
+	});
+
+	const filled = useMemoFilled(usage.data?.days ?? [], range.start, range.end);
+	const total = usage.data?.total ?? {
+		requestCount: 0,
+		characterCount: 0,
+		creditConsumed: 0,
+	};
+	const maxValue = Math.max(
+		1,
+		...filled.map((d) =>
+			metric === "credits"
+				? d.creditConsumed
+				: metric === "requests"
+					? d.requestCount
+					: d.characterCount,
+		),
+	);
+
+	const apiKeyBreakdown = useMemo(() => {
+		const agg = new Map<
+			string,
+			{
+				name: string;
+				requestCount: number;
+				characterCount: number;
+				creditConsumed: number;
+			}
+		>();
+		for (const d of usage.data?.days ?? []) {
+			for (const [id, b] of Object.entries(d.byApiKey)) {
+				const prev = agg.get(id) ?? {
+					name: b.name,
+					requestCount: 0,
+					characterCount: 0,
+					creditConsumed: 0,
+				};
+				prev.requestCount += b.requestCount;
+				prev.characterCount += b.characterCount;
+				prev.creditConsumed += b.creditConsumed;
+				agg.set(id, prev);
+			}
+		}
+		return [...agg.entries()].sort(
+			(a, b) => b[1].creditConsumed - a[1].creditConsumed,
+		);
+	}, [usage.data]);
+
+	if (!visible) return null;
+
+	return (
+		<div className="pt-6 border-t space-y-6">
+			<div className="flex items-start justify-between gap-4">
+				<div>
+					<h3 className="text-base font-semibold">使用量 (日別)</h3>
+					<p className="text-sm text-muted-foreground mt-1">
+						Aivis API
+						のリクエスト数・文字数・クレジット消費を日別に集計します。5
+						分キャッシュ。
+					</p>
+				</div>
+				<div className="shrink-0 inline-flex rounded-md border bg-muted p-0.5 text-xs">
+					<PeriodBtn active={period === "7"} onClick={() => setPeriod("7")}>
+						7日
+					</PeriodBtn>
+					<PeriodBtn active={period === "30"} onClick={() => setPeriod("30")}>
+						30日
+					</PeriodBtn>
+				</div>
+			</div>
+
+			{!apiKey && (
+				<div className="rounded-md border border-dashed px-4 py-6 text-center text-sm text-muted-foreground">
+					Aivis API キーを設定すると使用量を表示できます。
+				</div>
+			)}
+
+			{apiKey && usage.error && (
+				<div className="text-sm text-destructive">
+					使用量の取得に失敗しました: {usage.error.message}
+				</div>
+			)}
+
+			{apiKey && (
+				<>
+					<div className="grid grid-cols-3 gap-3">
+						<StatCard
+							label="Requests"
+							value={total.requestCount.toLocaleString()}
+							sub={
+								total.requestCount > 0
+									? `平均 ${(total.characterCount / total.requestCount).toFixed(1)} 文字/回`
+									: "—"
+							}
+						/>
+						<StatCard
+							label="Characters"
+							value={total.characterCount.toLocaleString()}
+							sub={`${range.days}日間合計`}
+						/>
+						<StatCard
+							label="Credits consumed"
+							value={total.creditConsumed.toFixed(2)}
+							sub={
+								me.data?.creditBalance !== null &&
+								me.data?.creditBalance !== undefined
+									? `残高 ${me.data.creditBalance.toLocaleString()}`
+									: "—"
+							}
+						/>
+					</div>
+
+					<div className="rounded-lg border bg-card p-4">
+						<div className="flex items-center justify-between mb-3">
+							<div className="text-xs font-medium">
+								日別 {metricLabel(metric)}
+							</div>
+							<div className="inline-flex rounded border bg-muted p-0.5 text-[11px]">
+								<MetricBtn
+									active={metric === "credits"}
+									onClick={() => setMetric("credits")}
+								>
+									Credits
+								</MetricBtn>
+								<MetricBtn
+									active={metric === "requests"}
+									onClick={() => setMetric("requests")}
+								>
+									Requests
+								</MetricBtn>
+								<MetricBtn
+									active={metric === "chars"}
+									onClick={() => setMetric("chars")}
+								>
+									Chars
+								</MetricBtn>
+							</div>
+						</div>
+						<div className="flex items-end gap-[2px] h-36">
+							{filled.map((d) => {
+								const val =
+									metric === "credits"
+										? d.creditConsumed
+										: metric === "requests"
+											? d.requestCount
+											: d.characterCount;
+								const h = (val / maxValue) * 100;
+								return (
+									<div
+										key={d.date}
+										className="flex-1 bg-gradient-to-t from-emerald-500 to-emerald-400 rounded-t-sm relative group min-h-[2px]"
+										style={{ height: `${Math.max(2, h)}%` }}
+									>
+										<div className="opacity-0 group-hover:opacity-100 transition-opacity absolute bottom-full left-1/2 -translate-x-1/2 mb-1 px-2 py-1 rounded bg-popover border text-[10px] whitespace-nowrap z-10">
+											{d.date.slice(5)} · {formatMetric(metric, val)}
+										</div>
+									</div>
+								);
+							})}
+						</div>
+						<div className="flex justify-between text-[10px] text-muted-foreground mt-2 tabular-nums">
+							<span>{range.start.slice(5)}</span>
+							<span>{range.end.slice(5)}</span>
+						</div>
+					</div>
+
+					<div className="rounded-lg border overflow-hidden">
+						<table className="w-full text-xs">
+							<thead className="bg-muted text-muted-foreground">
+								<tr>
+									<th className="text-left font-medium px-3 py-2">日付</th>
+									<th className="text-right font-medium px-3 py-2">Requests</th>
+									<th className="text-right font-medium px-3 py-2">Chars</th>
+									<th className="text-right font-medium px-3 py-2">Credits</th>
+								</tr>
+							</thead>
+							<tbody className="divide-y">
+								{filled
+									.slice()
+									.reverse()
+									.slice(0, 10)
+									.map((d) => (
+										<tr key={d.date} className="hover:bg-muted/30">
+											<td className="px-3 py-1.5 tabular-nums">{d.date}</td>
+											<td className="px-3 py-1.5 text-right tabular-nums">
+												{d.requestCount.toLocaleString()}
+											</td>
+											<td className="px-3 py-1.5 text-right tabular-nums">
+												{d.characterCount.toLocaleString()}
+											</td>
+											<td className="px-3 py-1.5 text-right tabular-nums text-emerald-500">
+												{d.creditConsumed.toFixed(2)}
+											</td>
+										</tr>
+									))}
+								{filled.length > 10 && (
+									<tr className="text-muted-foreground italic">
+										<td className="px-3 py-1.5" colSpan={4}>
+											…残り {filled.length - 10} 日
+										</td>
+									</tr>
+								)}
+							</tbody>
+						</table>
+					</div>
+
+					{apiKeyBreakdown.length > 1 && (
+						<div className="rounded-lg border">
+							<div className="px-4 py-2 text-xs font-medium text-muted-foreground">
+								API キー別 ({apiKeyBreakdown.length} keys)
+							</div>
+							<div className="border-t divide-y">
+								{apiKeyBreakdown.map(([id, b]) => (
+									<div
+										key={id}
+										className="px-4 py-2.5 flex items-center justify-between"
+									>
+										<div className="text-sm font-mono truncate">{b.name}</div>
+										<div className="text-right text-xs tabular-nums text-muted-foreground">
+											{b.requestCount.toLocaleString()} req ·{" "}
+											<span className="text-emerald-500">
+												{b.creditConsumed.toFixed(2)}
+											</span>{" "}
+											credits
+										</div>
+									</div>
+								))}
+							</div>
+						</div>
+					)}
+				</>
+			)}
+		</div>
+	);
+}
+
+function useMemoFilled(
+	days: Array<{
+		date: string;
+		requestCount: number;
+		characterCount: number;
+		creditConsumed: number;
+	}>,
+	start: string,
+	end: string,
+) {
+	return useMemo(() => fillMissingDates(days, start, end), [days, start, end]);
+}
+
+function StatCard({
+	label,
+	value,
+	sub,
+}: {
+	label: string;
+	value: string;
+	sub?: string;
+}) {
+	return (
+		<div className="rounded-lg border bg-card p-4">
+			<div className="text-[11px] uppercase tracking-wider text-muted-foreground">
+				{label}
+			</div>
+			<div className="mt-1 text-2xl font-semibold tabular-nums">{value}</div>
+			{sub && (
+				<div className="text-[11px] text-muted-foreground mt-1">{sub}</div>
+			)}
+		</div>
+	);
+}
+
+function PeriodBtn({
+	active,
+	children,
+	onClick,
+}: {
+	active: boolean;
+	children: React.ReactNode;
+	onClick: () => void;
+}) {
+	return (
+		<button
+			type="button"
+			onClick={onClick}
+			className={`px-3 py-1 rounded ${
+				active ? "bg-background shadow-sm" : "text-muted-foreground"
+			}`}
+		>
+			{children}
+		</button>
+	);
+}
+
+function MetricBtn({
+	active,
+	children,
+	onClick,
+}: {
+	active: boolean;
+	children: React.ReactNode;
+	onClick: () => void;
+}) {
+	return (
+		<button
+			type="button"
+			onClick={onClick}
+			className={`px-2 py-0.5 rounded ${
+				active ? "bg-background" : "text-muted-foreground"
+			}`}
+		>
+			{children}
+		</button>
+	);
+}
+
+function metricLabel(m: Metric): string {
+	if (m === "credits") return "クレジット消費";
+	if (m === "requests") return "リクエスト数";
+	return "文字数";
+}
+
+function formatMetric(m: Metric, v: number): string {
+	if (m === "credits") return `${v.toFixed(2)} credits`;
+	if (m === "requests") return `${v.toLocaleString()} req`;
+	return `${v.toLocaleString()} chars`;
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/ringtones/components/AivisUsage/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/ringtones/components/AivisUsage/index.ts
@@ -1,0 +1,1 @@
+export { AivisUsage } from "./AivisUsage";

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/ringtones/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/ringtones/page.tsx
@@ -2,7 +2,9 @@ import { createFileRoute } from "@tanstack/react-router";
 import { useMemo } from "react";
 import { useSettingsSearchQuery } from "renderer/stores/settings-state";
 import { getMatchingItemsForSection } from "../utils/settings-search";
+import { AivisDictionary } from "./components/AivisDictionary";
 import { AivisSettings } from "./components/AivisSettings";
+import { AivisUsage } from "./components/AivisUsage";
 import { RingtonesSettings } from "./components/RingtonesSettings";
 
 export const Route = createFileRoute("/_authenticated/settings/ringtones/")({
@@ -22,7 +24,11 @@ function RingtonesSettingsPage() {
 	return (
 		<>
 			<RingtonesSettings visibleItems={visibleItems} />
-			<AivisSettings visibleItems={visibleItems} />
+			<div className="p-6 max-w-4xl w-full pt-0">
+				<AivisSettings visibleItems={visibleItems} />
+				<AivisDictionary visibleItems={visibleItems} />
+				<AivisUsage visibleItems={visibleItems} />
+			</div>
 		</>
 	);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/utils/settings-search/settings-search.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/utils/settings-search/settings-search.ts
@@ -22,6 +22,8 @@ export const SETTING_ITEM_ID = {
 
 	RINGTONES_NOTIFICATION: "ringtones-notification",
 	RINGTONES_AIVIS: "ringtones-aivis",
+	RINGTONES_AIVIS_DICTIONARY: "ringtones-aivis-dictionary",
+	RINGTONES_AIVIS_USAGE: "ringtones-aivis-usage",
 
 	KEYBOARD_SHORTCUTS: "keyboard-shortcuts",
 	BEHAVIOR_CONFIRM_QUIT: "behavior-confirm-quit",
@@ -387,6 +389,36 @@ export const SETTINGS_ITEMS: SettingsItem[] = [
 			"読み上げ",
 			"音声合成",
 			"アイビス",
+		],
+	},
+	{
+		id: SETTING_ITEM_ID.RINGTONES_AIVIS_DICTIONARY,
+		section: "ringtones",
+		title: "Aivis User Dictionary",
+		description:
+			"Register custom pronunciations for branch names, acronyms, and proper nouns",
+		keywords: [
+			"aivis",
+			"dictionary",
+			"pronunciation",
+			"辞書",
+			"読み方",
+			"カスタム読み",
+			"固有名詞",
+		],
+	},
+	{
+		id: SETTING_ITEM_ID.RINGTONES_AIVIS_USAGE,
+		section: "ringtones",
+		title: "Aivis Usage",
+		description: "Daily Aivis API request count, characters and credits",
+		keywords: [
+			"aivis",
+			"usage",
+			"credits",
+			"使用量",
+			"クレジット",
+			"リクエスト",
 		],
 	},
 	{

--- a/packages/local-db/drizzle/0061_add_aivis_user_dictionary.sql
+++ b/packages/local-db/drizzle/0061_add_aivis_user_dictionary.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `settings` ADD `aivis_user_dictionary_uuid` text;

--- a/packages/local-db/drizzle/meta/0061_snapshot.json
+++ b/packages/local-db/drizzle/meta/0061_snapshot.json
@@ -1,0 +1,2251 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "be595bf6-d957-44f9-8b74-8a28eb82cbe9",
+  "prevId": "1af42155-a814-4b9e-8237-a8832214f287",
+  "tables": {
+    "browser_history": {
+      "name": "browser_history",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "favicon_url": {
+          "name": "favicon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_visited_at": {
+          "name": "last_visited_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "visit_count": {
+          "name": "visit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "browser_history_url_unique": {
+          "name": "browser_history_url_unique",
+          "columns": [
+            "url"
+          ],
+          "isUnique": true
+        },
+        "browser_history_url_idx": {
+          "name": "browser_history_url_idx",
+          "columns": [
+            "url"
+          ],
+          "isUnique": false
+        },
+        "browser_history_last_visited_at_idx": {
+          "name": "browser_history_last_visited_at_idx",
+          "columns": [
+            "last_visited_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "browser_site_permissions": {
+      "name": "browser_site_permissions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "origin": {
+          "name": "origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'ask'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "browser_site_permissions_origin_idx": {
+          "name": "browser_site_permissions_origin_idx",
+          "columns": [
+            "origin"
+          ],
+          "isUnique": false
+        },
+        "browser_site_permissions_origin_kind_unique": {
+          "name": "browser_site_permissions_origin_kind_unique",
+          "columns": [
+            "origin",
+            "kind"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organization_members": {
+      "name": "organization_members",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organization_members_organization_id_idx": {
+          "name": "organization_members_organization_id_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "organization_members_user_id_idx": {
+          "name": "organization_members_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "organization_members_organization_id_organizations_id_fk": {
+          "name": "organization_members_organization_id_organizations_id_fk",
+          "tableFrom": "organization_members",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_members_user_id_users_id_fk": {
+          "name": "organization_members_user_id_users_id_fk",
+          "tableFrom": "organization_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organizations": {
+      "name": "organizations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "clerk_org_id": {
+          "name": "clerk_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "github_org": {
+          "name": "github_org",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organizations_clerk_org_id_unique": {
+          "name": "organizations_clerk_org_id_unique",
+          "columns": [
+            "clerk_org_id"
+          ],
+          "isUnique": true
+        },
+        "organizations_slug_unique": {
+          "name": "organizations_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        },
+        "organizations_slug_idx": {
+          "name": "organizations_slug_idx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": false
+        },
+        "organizations_clerk_org_id_idx": {
+          "name": "organizations_clerk_org_id_idx",
+          "columns": [
+            "clerk_org_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "main_repo_path": {
+          "name": "main_repo_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tab_order": {
+          "name": "tab_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_opened_at": {
+          "name": "last_opened_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config_toast_dismissed": {
+          "name": "config_toast_dismissed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_branch": {
+          "name": "default_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "workspace_base_branch": {
+          "name": "workspace_base_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "github_owner": {
+          "name": "github_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch_prefix_mode": {
+          "name": "branch_prefix_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch_prefix_custom": {
+          "name": "branch_prefix_custom",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "worktree_base_dir": {
+          "name": "worktree_base_dir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "hide_image": {
+          "name": "hide_image",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "icon_url": {
+          "name": "icon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "neon_project_id": {
+          "name": "neon_project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_app": {
+          "name": "default_app",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "projects_main_repo_path_idx": {
+          "name": "projects_main_repo_path_idx",
+          "columns": [
+            "main_repo_path"
+          ],
+          "isUnique": false
+        },
+        "projects_last_opened_at_idx": {
+          "name": "projects_last_opened_at_idx",
+          "columns": [
+            "last_opened_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "settings": {
+      "name": "settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "last_active_workspace_id": {
+          "name": "last_active_workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "terminal_presets": {
+          "name": "terminal_presets",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "terminal_presets_initialized": {
+          "name": "terminal_presets_initialized",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "agent_preset_overrides": {
+          "name": "agent_preset_overrides",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "agent_custom_definitions": {
+          "name": "agent_custom_definitions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "selected_ringtone_id": {
+          "name": "selected_ringtone_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "confirm_on_quit": {
+          "name": "confirm_on_quit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "terminal_link_behavior": {
+          "name": "terminal_link_behavior",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "persist_terminal": {
+          "name": "persist_terminal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "auto_apply_default_preset": {
+          "name": "auto_apply_default_preset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch_prefix_mode": {
+          "name": "branch_prefix_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch_prefix_custom": {
+          "name": "branch_prefix_custom",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notification_sounds_muted": {
+          "name": "notification_sounds_muted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notification_volume": {
+          "name": "notification_volume",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "aivis_enabled": {
+          "name": "aivis_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "aivis_api_key": {
+          "name": "aivis_api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "aivis_model_uuid": {
+          "name": "aivis_model_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "aivis_format": {
+          "name": "aivis_format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "aivis_format_permission": {
+          "name": "aivis_format_permission",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "aivis_user_dictionary_uuid": {
+          "name": "aivis_user_dictionary_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prevent_agent_sleep": {
+          "name": "prevent_agent_sleep",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "delete_local_branch": {
+          "name": "delete_local_branch",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "file_open_mode": {
+          "name": "file_open_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "right_sidebar_open_view_width": {
+          "name": "right_sidebar_open_view_width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "show_presets_bar": {
+          "name": "show_presets_bar",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "use_compact_terminal_add_button": {
+          "name": "use_compact_terminal_add_button",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "terminal_font_family": {
+          "name": "terminal_font_family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "terminal_font_size": {
+          "name": "terminal_font_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "editor_font_family": {
+          "name": "editor_font_family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "editor_font_size": {
+          "name": "editor_font_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "show_resource_monitor": {
+          "name": "show_resource_monitor",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "worktree_base_dir": {
+          "name": "worktree_base_dir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "open_links_in_app": {
+          "name": "open_links_in_app",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_editor": {
+          "name": "default_editor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "indent_rainbow_enabled": {
+          "name": "indent_rainbow_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "indent_rainbow_colors": {
+          "name": "indent_rainbow_colors",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trailing_spaces_enabled": {
+          "name": "trailing_spaces_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trailing_spaces_color": {
+          "name": "trailing_spaces_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reference_graph_enabled": {
+          "name": "reference_graph_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expose_host_service_via_relay": {
+          "name": "expose_host_service_via_relay",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enable_smart_commit": {
+          "name": "enable_smart_commit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "smart_commit_changes": {
+          "name": "smart_commit_changes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "auto_stash": {
+          "name": "auto_stash",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch_sort_order": {
+          "name": "branch_sort_order",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pin_default_branch": {
+          "name": "pin_default_branch",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "post_commit_command": {
+          "name": "post_commit_command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tasks": {
+      "name": "tasks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status_color": {
+          "name": "status_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status_type": {
+          "name": "status_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status_position": {
+          "name": "status_position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "assignee_id": {
+          "name": "assignee_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "estimate": {
+          "name": "estimate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "labels": {
+          "name": "labels",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pr_url": {
+          "name": "pr_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_provider": {
+          "name": "external_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_key": {
+          "name": "external_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_url": {
+          "name": "external_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sync_error": {
+          "name": "sync_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tasks_slug_unique": {
+          "name": "tasks_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        },
+        "tasks_slug_idx": {
+          "name": "tasks_slug_idx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": false
+        },
+        "tasks_organization_id_idx": {
+          "name": "tasks_organization_id_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "tasks_assignee_id_idx": {
+          "name": "tasks_assignee_id_idx",
+          "columns": [
+            "assignee_id"
+          ],
+          "isUnique": false
+        },
+        "tasks_status_idx": {
+          "name": "tasks_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "tasks_created_at_idx": {
+          "name": "tasks_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "tasks_organization_id_organizations_id_fk": {
+          "name": "tasks_organization_id_organizations_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tasks_assignee_id_users_id_fk": {
+          "name": "tasks_assignee_id_users_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "assignee_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "tasks_creator_id_users_id_fk": {
+          "name": "tasks_creator_id_users_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "clerk_id": {
+          "name": "clerk_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_clerk_id_unique": {
+          "name": "users_clerk_id_unique",
+          "columns": [
+            "clerk_id"
+          ],
+          "isUnique": true
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        },
+        "users_email_idx": {
+          "name": "users_email_idx",
+          "columns": [
+            "email"
+          ],
+          "isUnique": false
+        },
+        "users_clerk_id_idx": {
+          "name": "users_clerk_id_idx",
+          "columns": [
+            "clerk_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "workspace_sections": {
+      "name": "workspace_sections",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tab_order": {
+          "name": "tab_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_collapsed": {
+          "name": "is_collapsed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "workspace_sections_project_id_idx": {
+          "name": "workspace_sections_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "workspace_sections_project_id_projects_id_fk": {
+          "name": "workspace_sections_project_id_projects_id_fk",
+          "tableFrom": "workspace_sections",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "workspaces": {
+      "name": "workspaces",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "worktree_id": {
+          "name": "worktree_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tab_order": {
+          "name": "tab_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_opened_at": {
+          "name": "last_opened_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_unread": {
+          "name": "is_unread",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_unnamed": {
+          "name": "is_unnamed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "deleting_at": {
+          "name": "deleting_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "port_base": {
+          "name": "port_base",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "section_id": {
+          "name": "section_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "workspaces_project_id_idx": {
+          "name": "workspaces_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "workspaces_worktree_id_idx": {
+          "name": "workspaces_worktree_id_idx",
+          "columns": [
+            "worktree_id"
+          ],
+          "isUnique": false
+        },
+        "workspaces_last_opened_at_idx": {
+          "name": "workspaces_last_opened_at_idx",
+          "columns": [
+            "last_opened_at"
+          ],
+          "isUnique": false
+        },
+        "workspaces_section_id_idx": {
+          "name": "workspaces_section_id_idx",
+          "columns": [
+            "section_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "workspaces_project_id_projects_id_fk": {
+          "name": "workspaces_project_id_projects_id_fk",
+          "tableFrom": "workspaces",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workspaces_worktree_id_worktrees_id_fk": {
+          "name": "workspaces_worktree_id_worktrees_id_fk",
+          "tableFrom": "workspaces",
+          "tableTo": "worktrees",
+          "columnsFrom": [
+            "worktree_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workspaces_section_id_workspace_sections_id_fk": {
+          "name": "workspaces_section_id_workspace_sections_id_fk",
+          "tableFrom": "workspaces",
+          "tableTo": "workspace_sections",
+          "columnsFrom": [
+            "section_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "worktrees": {
+      "name": "worktrees",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "base_branch": {
+          "name": "base_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "git_status": {
+          "name": "git_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "github_status": {
+          "name": "github_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_superset": {
+          "name": "created_by_superset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        }
+      },
+      "indexes": {
+        "worktrees_project_id_idx": {
+          "name": "worktrees_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "worktrees_branch_idx": {
+          "name": "worktrees_branch_idx",
+          "columns": [
+            "branch"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "worktrees_project_id_projects_id_fk": {
+          "name": "worktrees_project_id_projects_id_fk",
+          "tableFrom": "worktrees",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "todo_prompt_presets": {
+      "name": "todo_prompt_presets",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'system'"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "todo_prompt_presets_name_idx": {
+          "name": "todo_prompt_presets_name_idx",
+          "columns": [
+            "name"
+          ],
+          "isUnique": false
+        },
+        "todo_prompt_presets_updated_at_idx": {
+          "name": "todo_prompt_presets_updated_at_idx",
+          "columns": [
+            "updated_at"
+          ],
+          "isUnique": false
+        },
+        "todo_prompt_presets_kind_idx": {
+          "name": "todo_prompt_presets_kind_idx",
+          "columns": [
+            "kind"
+          ],
+          "isUnique": false
+        },
+        "todo_prompt_presets_workspace_idx": {
+          "name": "todo_prompt_presets_workspace_idx",
+          "columns": [
+            "workspace_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "todo_schedules": {
+      "name": "todo_schedules",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "frequency": {
+          "name": "frequency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "minute": {
+          "name": "minute",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "hour": {
+          "name": "hour",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "weekday": {
+          "name": "weekday",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "monthday": {
+          "name": "monthday",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cron_expr": {
+          "name": "cron_expr",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "goal": {
+          "name": "goal",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "verify_command": {
+          "name": "verify_command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_iterations": {
+          "name": "max_iterations",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10
+        },
+        "max_wall_clock_sec": {
+          "name": "max_wall_clock_sec",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1800
+        },
+        "custom_system_prompt": {
+          "name": "custom_system_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "claude_model": {
+          "name": "claude_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "claude_effort": {
+          "name": "claude_effort",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "overlap_mode": {
+          "name": "overlap_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'skip'"
+        },
+        "auto_sync_before_fire": {
+          "name": "auto_sync_before_fire",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_run_session_id": {
+          "name": "last_run_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "todo_schedules_project_idx": {
+          "name": "todo_schedules_project_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "todo_schedules_workspace_idx": {
+          "name": "todo_schedules_workspace_idx",
+          "columns": [
+            "workspace_id"
+          ],
+          "isUnique": false
+        },
+        "todo_schedules_enabled_next_run_idx": {
+          "name": "todo_schedules_enabled_next_run_idx",
+          "columns": [
+            "enabled",
+            "next_run_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "todo_schedules_project_id_projects_id_fk": {
+          "name": "todo_schedules_project_id_projects_id_fk",
+          "tableFrom": "todo_schedules",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "todo_schedules_workspace_id_workspaces_id_fk": {
+          "name": "todo_schedules_workspace_id_workspaces_id_fk",
+          "tableFrom": "todo_schedules",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "todo_sessions": {
+      "name": "todo_sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "goal": {
+          "name": "goal",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "verify_command": {
+          "name": "verify_command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_iterations": {
+          "name": "max_iterations",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10
+        },
+        "max_wall_clock_sec": {
+          "name": "max_wall_clock_sec",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1800
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'queued'"
+        },
+        "phase": {
+          "name": "phase",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "iteration": {
+          "name": "iteration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "attached_pane_id": {
+          "name": "attached_pane_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attached_tab_id": {
+          "name": "attached_tab_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "claude_session_id": {
+          "name": "claude_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "final_assistant_text": {
+          "name": "final_assistant_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_cost_usd": {
+          "name": "total_cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_num_turns": {
+          "name": "total_num_turns",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pending_intervention": {
+          "name": "pending_intervention",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start_head_sha": {
+          "name": "start_head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "custom_system_prompt": {
+          "name": "custom_system_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "claude_model": {
+          "name": "claude_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "claude_effort": {
+          "name": "claude_effort",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "verdict_passed": {
+          "name": "verdict_passed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "verdict_reason": {
+          "name": "verdict_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "verdict_failing_test": {
+          "name": "verdict_failing_test",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "artifact_path": {
+          "name": "artifact_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "remote_control_enabled": {
+          "name": "remote_control_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "waiting_until": {
+          "name": "waiting_until",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "waiting_reason": {
+          "name": "waiting_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "todo_sessions_workspace_idx": {
+          "name": "todo_sessions_workspace_idx",
+          "columns": [
+            "workspace_id"
+          ],
+          "isUnique": false
+        },
+        "todo_sessions_status_idx": {
+          "name": "todo_sessions_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "todo_sessions_created_at_idx": {
+          "name": "todo_sessions_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "todo_sessions_project_id_projects_id_fk": {
+          "name": "todo_sessions_project_id_projects_id_fk",
+          "tableFrom": "todo_sessions",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "todo_sessions_workspace_id_workspaces_id_fk": {
+          "name": "todo_sessions_workspace_id_workspaces_id_fk",
+          "tableFrom": "todo_sessions",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/local-db/drizzle/meta/_journal.json
+++ b/packages/local-db/drizzle/meta/_journal.json
@@ -428,6 +428,13 @@
       "when": 1776440966039,
       "tag": "0060_add_aivis_settings",
       "breakpoints": true
+    },
+    {
+      "idx": 61,
+      "version": "6",
+      "when": 1776441435095,
+      "tag": "0061_add_aivis_user_dictionary",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/local-db/src/schema/schema.ts
+++ b/packages/local-db/src/schema/schema.ts
@@ -224,6 +224,7 @@ export const settings = sqliteTable("settings", {
 	aivisModelUuid: text("aivis_model_uuid"),
 	aivisFormat: text("aivis_format"),
 	aivisFormatPermission: text("aivis_format_permission"),
+	aivisUserDictionaryUuid: text("aivis_user_dictionary_uuid"),
 	preventAgentSleep: integer("prevent_agent_sleep", { mode: "boolean" }),
 	deleteLocalBranch: integer("delete_local_branch", { mode: "boolean" }),
 	fileOpenMode: text("file_open_mode").$type<FileOpenMode>(),


### PR DESCRIPTION
関連: #286 (#287 でマージ済みの Aivis 音声通知の続編)

## 概要
Settings > Notifications > Aivis セクションに、ユーザー辞書の管理と日別使用量ダッシュボードを追加。

## ユーザー辞書
- **DB**: `settings.aivis_user_dictionary_uuid` を追加 (migration 0061)
- **Main**: `main/lib/aivis/client.ts` — Bearer 認証 + エラー型 (`AivisApiKeyMissingError` / `AivisApiError`) 付きの共通 fetch ラッパー
- **TRPC aivis ルーター**: `dictionary.list/get/create/update/delete/import/export` + `usage.daily/me` + `validateKey`
- **合成**: `user_dictionary_uuid` を TTS リクエストに付与 (辞書選択中のみ)
- **UI (AivisDictionary)**:
  - 辞書一覧カード (ACTIVE マーカー、説明、単語数、更新日)
  - インライン編集ダイアログ: `surface / 読み (カタカナ検証) / アクセント型 / 優先度 0-10 / 品詞`
  - 新規作成ダイアログ、削除確認、適用切替
  - AivisSpeech 互換 JSON の import / export (ファイル選択 → blob ダウンロード)
- **UI (AivisSettings)**: Model UUID 直下に辞書セレクタを追加

## 日別使用量ダッシュボード
- **TRPC**: `aivis.usage.daily(startDate, endDate)` — Aivis `/v1/payment/usage-summaries` (時間単位) をクライアント側で日別集計 + API キー別内訳を添付
- **UI (AivisUsage)**:
  - 7 日 / 30 日の期間タブ
  - 統計カード: Requests / Characters / Credits (残高併記)
  - 日別バーグラフ (Credits / Requests / Chars トグル、ホバーツールチップ)
  - 日別テーブル (直近 10 日)
  - API キー別内訳 (複数キー保有時のみ)
  - 5 分キャッシュ

## 動作確認
- [ ] 辞書の作成 / 編集 / 削除 / import / export が動作
- [ ] 辞書選択中は TTS に読み方が反映される
- [ ] 使用量ダッシュボードが期間切替で更新される
- [ ] API キー未設定時は適切なエンプティ状態が出る
- [ ] 401 等のエラー時に UI が壊れず表示される

## スキップ
- カスタム期間ピッカー (モック上はあるが未実装。必要なら別 PR)
- アクセントビジュアルエディタ (現状は数値入力のみ)