### PR TITLE
fix(desktop): Aivis通知の{{branch}}展開バグ修正と{{project}}プレースホルダー追加

### DIFF
--- a/apps/desktop/src/main/lib/notifications/aivis-tts.ts
+++ b/apps/desktop/src/main/lib/notifications/aivis-tts.ts
@@ -12,6 +12,7 @@ export interface AivisPlaceholders {
 	branch?: string;
 	workspace?: string;
 	worktree?: string;
+	project?: string;
 	tab?: string;
 	pane?: string;
 	event?: string;
@@ -23,6 +24,7 @@ export const AIVIS_PLACEHOLDER_KEYS = [
 	"branch",
 	"workspace",
 	"worktree",
+	"project",
 	"tab",
 	"pane",
 	"event",

--- a/apps/desktop/src/main/windows/main.ts
+++ b/apps/desktop/src/main/windows/main.ts
@@ -1,6 +1,6 @@
 import { join } from "node:path";
 import * as Sentry from "@sentry/electron/main";
-import { workspaces, worktrees } from "@superset/local-db";
+import { projects, workspaces, worktrees } from "@superset/local-db";
 import { eq } from "drizzle-orm";
 import type { BrowserWindow } from "electron";
 import { app, Notification, nativeTheme, webContents } from "electron";
@@ -48,7 +48,8 @@ import { getWorkspaceRuntimeRegistry } from "../lib/workspace-runtime";
 let ipcHandler: ReturnType<typeof createIPCHandler> | null = null;
 
 function getWorkspaceRecords(workspaceId: string | undefined) {
-	if (!workspaceId) return { workspace: null, worktree: null };
+	if (!workspaceId)
+		return { workspace: null, worktree: null, project: null };
 	try {
 		const workspace =
 			localDb
@@ -63,10 +64,17 @@ function getWorkspaceRecords(workspaceId: string | undefined) {
 					.where(eq(worktrees.id, workspace.worktreeId))
 					.get() ?? null)
 			: null;
-		return { workspace, worktree };
+		const project = workspace?.projectId
+			? (localDb
+					.select()
+					.from(projects)
+					.where(eq(projects.id, workspace.projectId))
+					.get() ?? null)
+			: null;
+		return { workspace, worktree, project };
 	} catch (error) {
 		console.error("[notifications] Failed to read workspace records:", error);
-		return { workspace: null, worktree: null };
+		return { workspace: null, worktree: null, project: null };
 	}
 }
 
@@ -76,17 +84,20 @@ function getWorkspaceNameFromDb(workspaceId: string | undefined): string {
 }
 
 function buildAivisVars(event: AgentLifecycleEvent) {
-	const { workspace, worktree } = getWorkspaceRecords(event.workspaceId);
+	const { workspace, worktree, project } = getWorkspaceRecords(
+		event.workspaceId,
+	);
 	const tabs = appState.data?.tabsState?.tabs;
 	const panes = appState.data?.tabsState?.panes;
 	const tab = event.tabId ? tabs?.find((t) => t.id === event.tabId) : undefined;
 	const pane = event.paneId ? panes?.[event.paneId] : undefined;
-	const branch = worktree?.branch ?? "";
-	const worktreeName = branch || "";
+	const branch = workspace?.branch ?? worktree?.branch ?? "";
+	const worktreeName = worktree?.branch ?? "";
 	return {
 		branch,
 		workspace: workspace?.name || branch || "",
 		worktree: worktreeName,
+		project: project?.name ?? "",
 		tab: (tab?.userTitle?.trim() || tab?.name) ?? "",
 		pane: pane?.name ?? "",
 		event: event.eventType,

--- a/apps/desktop/src/main/windows/main.ts
+++ b/apps/desktop/src/main/windows/main.ts
@@ -48,8 +48,7 @@ import { getWorkspaceRuntimeRegistry } from "../lib/workspace-runtime";
 let ipcHandler: ReturnType<typeof createIPCHandler> | null = null;
 
 function getWorkspaceRecords(workspaceId: string | undefined) {
-	if (!workspaceId)
-		return { workspace: null, worktree: null, project: null };
+	if (!workspaceId) return { workspace: null, worktree: null, project: null };
 	try {
 		const workspace =
 			localDb

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/ringtones/components/AivisSettings/AivisSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/ringtones/components/AivisSettings/AivisSettings.tsx
@@ -23,6 +23,7 @@ const PLACEHOLDERS = [
 	{ key: "branch", label: "ブランチ" },
 	{ key: "workspace", label: "ワークスペース" },
 	{ key: "worktree", label: "ワークツリー" },
+	{ key: "project", label: "プロジェクト" },
 	{ key: "tab", label: "タブ" },
 	{ key: "pane", label: "ペーン" },
 	{ key: "event", label: "イベント" },
@@ -106,6 +107,7 @@ export function AivisSettings({ visibleItems }: AivisSettingsProps) {
 			.replace(/\{\{\s*branch\s*\}\}/g, "サンプルブランチ")
 			.replace(/\{\{\s*workspace\s*\}\}/g, "サンプルワークスペース")
 			.replace(/\{\{\s*worktree\s*\}\}/g, "サンプルワークツリー")
+			.replace(/\{\{\s*project\s*\}\}/g, "サンプルプロジェクト")
 			.replace(/\{\{\s*tab\s*\}\}/g, "ターミナル")
 			.replace(/\{\{\s*pane\s*\}\}/g, "ペーン1")
 			.replace(


### PR DESCRIPTION
close MocA-Love/superset#291

## Description

Aivis音声通知テンプレートの不具合修正と機能追加。

1. branch型ワークスペース（worktree を持たないもの）で `{{branch}}` プレースホルダーが空文字に展開されてしまうバグを修正
2. プレースホルダーに `{{project}}`（プロジェクト名）を追加

## Related Issues

close MocA-Love/superset#291

## Type of Change

- [x] Bug fix
- [x] New feature

## 変更内容

- `buildAivisVars` のbranch解決順を `workspace.branch ?? worktree?.branch` に修正（従来は `worktree?.branch` のみ参照していたため、branch型ワークスペースで空文字になっていた）
- `getWorkspaceRecords` で `project` も取得できるよう拡張（`workspace.projectId` から lookup）
- `AivisPlaceholders` 型と `AIVIS_PLACEHOLDER_KEYS` に `project` を追加
- 設定UIのプレースホルダーボタンとテスト再生プレビューに `{{project}}` を追加

## 動作比較

| シナリオ | 修正前 | 修正後 |
|---|---|---|
| branch型WSで `{{branch}}で完了` | `で完了`（branch空） | `<ブランチ名>で完了` |
| worktree型WSで `{{branch}}で完了` | `<ブランチ名>で完了` | `<ブランチ名>で完了`（変化なし） |
| `{{project}}の{{branch}}` | `{{project}}` は空文字に | `<プロジェクト名>の<ブランチ名>` |

## Testing

1. branch型ワークスペースで通知テンプレートに `{{branch}}` を使って通知を発火させ、ブランチ名が読み上げられることを確認
2. 設定画面 > 通知音 > Aivis で `{{project}}` ボタンを挿入し、テスト再生で「サンプルプロジェクト」と読み上げられることを確認
3. worktree型ワークスペースでも従来通り動作することを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * AI音声通知テンプレートで `{{project}}` プレースホルダーが使用できるようになりました。これにより、通知テンプレートでプロジェクト名を動的に挿入することが可能です。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->