### PR TITLE
fix(desktop): ヘッダーの Claude/Codex ステータス checkedAt が古いまま固定される問題を修正

### DIFF
--- a/apps/desktop/src/main/lib/service-status/index.ts
+++ b/apps/desktop/src/main/lib/service-status/index.ts
@@ -162,20 +162,14 @@ class ServiceStatusService extends EventEmitter {
 	}
 
 	private updateSnapshot(next: ServiceStatusSnapshot): void {
-		const prev = this.snapshots.get(next.id);
 		this.snapshots.set(next.id, next);
-		// Only emit when user-visible state actually changes. checkedAt isn't
-		// directly rendered — the tooltip uses a relative formatter on
-		// Date.now() so it auto-refreshes whenever the Tooltip remounts.
-		if (
-			!prev ||
-			prev.level !== next.level ||
-			prev.indicator !== next.indicator ||
-			prev.description !== next.description ||
-			Boolean(prev.fetchError) !== Boolean(next.fetchError)
-		) {
-			this.emit("change", next);
-		}
+		// Always emit so renderers receive the latest checkedAt. The tooltip
+		// renders "N分前に確認" from snapshot.checkedAt against Date.now(); if
+		// we skip emit when level/description are unchanged, the renderer's
+		// checkedAt stays pinned to the first snapshot it received and the
+		// label drifts (e.g. "45分前") while polling keeps running every 5
+		// minutes.
+		this.emit("change", next);
 	}
 
 	// Use Electron's net module so fetch uses Chromium's network stack and


### PR DESCRIPTION
## 概要

Fixes #294

ヘッダーに表示される Claude/Codex のステータスインジケータが、ずっとオンラインなのに「45分前に確認」のような古い時刻を表示し続ける問題を修正します。

## 原因

`apps/desktop/src/main/lib/service-status/index.ts` の \`updateSnapshot\` が、\`level\` / \`indicator\` / \`description\` / \`fetchError\` のいずれかに変化がある時しか \`change\` イベントを emit していませんでした。

- 5分毎にポーリングは走り \`checkedAt\` は更新される
- しかし Claude/Codex が operational のまま推移すると emit されない
- レンダラ（\`ServiceStatusIndicators.tsx\`）は \`onChange\` 購読でしか snapshot を受け取らないため、\`snapshot.checkedAt\` が最初に届いた値のまま固定される
- \`formatCheckedAt(snapshot.checkedAt)\` は固定値と \`Date.now()\` の差分を出すので、時間経過とともに「N分前に確認」が伸び続ける

修正前のコードコメントには「tooltip は Tooltip 再マウント時に自動更新される」と記述がありましたが、\`snapshot.checkedAt\` 自体がレンダラ側で更新されないため誤りでした。

## 修正内容

\`updateSnapshot\` を常に emit するように変更。ポーリング毎（5分間隔）に最新の \`checkedAt\` がレンダラへ伝搬されるようになります。emit 頻度は 5分1回なので負荷は無視できる範囲。

## 動作確認

- [ ] デスクトップアプリを起動し、ヘッダーの Claude/Codex アイコンにカーソルを合わせる
- [ ] 5分以上経過後もポップオーバーの「N分前に確認」が 5分以内を示すことを確認