### PR TITLE
fix(desktop): TODO の PTY モードをセッション単位で切り替え可能にする

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/index.ts
@@ -1,7 +1,7 @@
 import type { BrowserWindow } from "electron";
 import type { WindowManager } from "main/lib/window-manager";
 // Fork-local: TODO autonomous agent feature.
-import { createTodoAgentRouter } from "main/todo-agent";
+import { createTodoAgentRouter } from "main/todo-agent/trpc-router";
 import { router } from "..";
 import { createAivisRouter } from "./aivis";
 import { createAnalyticsRouter } from "./analytics";

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -597,7 +597,9 @@ if (!gotTheLock) {
 		// One-shot sweep of 30-day-old pasted attachments so userData
 		// doesn't grow forever from screenshots dropped into TODOs.
 		try {
-			const { cleanupOldAttachments } = await import("./todo-agent");
+			const { cleanupOldAttachments } = await import(
+				"./todo-agent/attachments-cleanup"
+			);
 			cleanupOldAttachments();
 		} catch (error) {
 			console.warn("[main] todo-agent attachment cleanup skipped", error);
@@ -608,7 +610,9 @@ if (!gotTheLock) {
 		// sweep so deleted sessions' images also drop out of the
 		// attachment reference set on the next run.
 		try {
-			const { cleanupOldSessions } = await import("./todo-agent");
+			const { cleanupOldSessions } = await import(
+				"./todo-agent/sessions-cleanup"
+			);
 			cleanupOldSessions();
 		} catch (error) {
 			console.warn("[main] todo-agent session cleanup skipped", error);

--- a/apps/desktop/src/main/lib/local-db/index.ts
+++ b/apps/desktop/src/main/lib/local-db/index.ts
@@ -6,7 +6,6 @@ import * as schema from "@superset/local-db";
 import Database from "better-sqlite3";
 import { drizzle } from "drizzle-orm/better-sqlite3";
 import { migrate } from "drizzle-orm/better-sqlite3/migrator";
-import { app } from "electron";
 import { validate as uuidValidate, version as uuidVersion } from "uuid";
 import { env } from "../../env.main";
 import {
@@ -19,6 +18,20 @@ const DB_PATH = join(SUPERSET_HOME_DIR, "local.db");
 
 ensureSupersetHomeDirExists();
 
+type ElectronAppLike = Pick<
+	typeof import("electron").app,
+	"getAppPath" | "isPackaged"
+>;
+
+function getElectronApp(): ElectronAppLike | null {
+	try {
+		const electron = require("electron") as typeof import("electron");
+		return electron.app;
+	} catch {
+		return null;
+	}
+}
+
 /**
  * Gets the migrations directory path.
  *
@@ -29,12 +42,19 @@ ensureSupersetHomeDirExists();
  * - Test environment: Use monorepo path relative to __dirname
  */
 function getMigrationsDirectory(): string {
+	const electronApp = getElectronApp();
+	const packagedResourcesPath = process.resourcesPath
+		? join(process.resourcesPath, "resources/migrations")
+		: null;
+	if (packagedResourcesPath && existsSync(packagedResourcesPath)) {
+		return packagedResourcesPath;
+	}
 	// Check if running in Electron (app.getAppPath exists)
 	const isElectron =
-		typeof app?.getAppPath === "function" &&
-		typeof app?.isPackaged === "boolean";
+		typeof electronApp?.getAppPath === "function" &&
+		typeof electronApp?.isPackaged === "boolean";
 
-	if (isElectron && app.isPackaged) {
+	if (isElectron && electronApp.isPackaged) {
 		return join(process.resourcesPath, "resources/migrations");
 	}
 
@@ -42,7 +62,7 @@ function getMigrationsDirectory(): string {
 
 	if (isElectron && isDev) {
 		// Development: source files in monorepo
-		return join(app.getAppPath(), "../../packages/local-db/drizzle");
+		return join(electronApp.getAppPath(), "../../packages/local-db/drizzle");
 	}
 
 	// Preview mode or test: __dirname is dist/main, so go up one level to dist/resources/migrations
@@ -63,7 +83,10 @@ function getMigrationsDirectory(): string {
 
 	// Try Electron app path if available
 	if (isElectron) {
-		const srcPath = join(app.getAppPath(), "../../packages/local-db/drizzle");
+		const srcPath = join(
+			electronApp.getAppPath(),
+			"../../packages/local-db/drizzle",
+		);
 		if (existsSync(srcPath)) {
 			return srcPath;
 		}

--- a/apps/desktop/src/main/todo-agent/runtime-config.ts
+++ b/apps/desktop/src/main/todo-agent/runtime-config.ts
@@ -1,0 +1,76 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+const TODO_RUNTIME_CONFIG_FILE = "runtime-config.json";
+
+export interface TodoSessionRuntimeConfig {
+	ptyEnabled: boolean;
+	remoteControlEnabled: boolean;
+}
+
+function getRuntimeConfigPath(artifactPath: string): string {
+	return path.join(artifactPath, TODO_RUNTIME_CONFIG_FILE);
+}
+
+function normalizeConfig(
+	config: TodoSessionRuntimeConfig,
+): TodoSessionRuntimeConfig {
+	const ptyEnabled = config.ptyEnabled === true;
+	return {
+		ptyEnabled,
+		remoteControlEnabled: ptyEnabled && config.remoteControlEnabled === true,
+	};
+}
+
+export function readTodoSessionRuntimeConfig(params: {
+	artifactPath: string;
+	fallbackRemoteControlEnabled?: boolean | null;
+}): TodoSessionRuntimeConfig {
+	const legacyRemoteControlEnabled =
+		params.fallbackRemoteControlEnabled === true;
+	const legacyFallback = {
+		ptyEnabled: legacyRemoteControlEnabled,
+		remoteControlEnabled: legacyRemoteControlEnabled,
+	};
+	if (!params.artifactPath.startsWith("/")) {
+		return legacyFallback;
+	}
+
+	const filePath = getRuntimeConfigPath(params.artifactPath);
+	if (!existsSync(filePath)) {
+		return legacyFallback;
+	}
+
+	try {
+		const parsed = JSON.parse(
+			readFileSync(filePath, "utf8"),
+		) as Partial<TodoSessionRuntimeConfig> | null;
+		if (!parsed || typeof parsed !== "object") {
+			return legacyFallback;
+		}
+		return normalizeConfig({
+			ptyEnabled: parsed.ptyEnabled === true,
+			remoteControlEnabled: parsed.remoteControlEnabled === true,
+		});
+	} catch (error) {
+		console.warn("[todo-agent] failed to read runtime config", error);
+		return legacyFallback;
+	}
+}
+
+export function writeTodoSessionRuntimeConfig(
+	artifactPath: string,
+	config: TodoSessionRuntimeConfig,
+): void {
+	if (!artifactPath.startsWith("/")) return;
+	try {
+		mkdirSync(artifactPath, { recursive: true });
+		writeFileSync(
+			getRuntimeConfigPath(artifactPath),
+			`${JSON.stringify(normalizeConfig(config), null, 2)}\n`,
+			"utf8",
+		);
+	} catch (error) {
+		console.warn("[todo-agent] failed to write runtime config", error);
+	}
+}

--- a/apps/desktop/src/main/todo-agent/runtime-config.ts
+++ b/apps/desktop/src/main/todo-agent/runtime-config.ts
@@ -32,7 +32,7 @@ export function readTodoSessionRuntimeConfig(params: {
 		ptyEnabled: legacyRemoteControlEnabled,
 		remoteControlEnabled: legacyRemoteControlEnabled,
 	};
-	if (!params.artifactPath.startsWith("/")) {
+	if (!path.isAbsolute(params.artifactPath)) {
 		return legacyFallback;
 	}
 
@@ -62,7 +62,7 @@ export function writeTodoSessionRuntimeConfig(
 	artifactPath: string,
 	config: TodoSessionRuntimeConfig,
 ): void {
-	if (!artifactPath.startsWith("/")) return;
+	if (!path.isAbsolute(artifactPath)) return;
 	try {
 		mkdirSync(artifactPath, { recursive: true });
 		writeFileSync(

--- a/apps/desktop/src/main/todo-agent/trpc-router.ts
+++ b/apps/desktop/src/main/todo-agent/trpc-router.ts
@@ -16,6 +16,10 @@ import {
 	getSessionGitSnapshot,
 	type SessionDiffScope,
 } from "./git-status";
+import {
+	readTodoSessionRuntimeConfig,
+	writeTodoSessionRuntimeConfig,
+} from "./runtime-config";
 import { getTodoScheduleStore } from "./schedule-store";
 import { computeNextRunAt, getTodoScheduler } from "./scheduler";
 import { getTodoSessionStore, resolveWorktreePath } from "./session-store";
@@ -138,6 +142,10 @@ export const createTodoAgentRouter = () => {
 				// the row exists the user can delete the broken session
 				// from the Manager — same as any other filesystem error.
 				supervisor.prepareArtifacts(session);
+				writeTodoSessionRuntimeConfig(session.artifactPath, {
+					ptyEnabled: input.ptyEnabled,
+					remoteControlEnabled: input.remoteControlEnabled,
+				});
 
 				return { sessionId: session.id };
 			}),
@@ -427,6 +435,11 @@ export const createTodoAgentRouter = () => {
 				});
 
 				supervisor.prepareArtifacts(next);
+				const runtimeConfig = readTodoSessionRuntimeConfig({
+					artifactPath: source.artifactPath,
+					fallbackRemoteControlEnabled: source.remoteControlEnabled ?? false,
+				});
+				writeTodoSessionRuntimeConfig(next.artifactPath, runtimeConfig);
 
 				return { sessionId: next.id };
 			}),

--- a/apps/desktop/src/main/todo-agent/types.ts
+++ b/apps/desktop/src/main/todo-agent/types.ts
@@ -105,12 +105,13 @@ export const todoCreateInputSchema = z.object({
 	// means "use the user's configured default" (see todoSettingsSchema).
 	claudeModel: todoClaudeModelSchema.nullish(),
 	claudeEffort: todoClaudeEffortSchema.nullish(),
-	// When true, the daemon starts the session under the PTY engine
-	// and sends `/remote-control` after spawn so it is reachable from
-	// claude.ai/code and the Claude mobile app. Requires the daemon to
-	// be running in PTY mode (`TODO_ENGINE=pty`) and a claude.ai
-	// subscription (Pro/Max). See
-	// apps/desktop/plans/20260417-todo-agent-remote-control.md.
+	// Beta escape hatch: opt a single TODO into the interactive PTY
+	// engine without flipping the whole app over from headless `-p`.
+	// Persisted in the artifact runtime config, not the DB row.
+	ptyEnabled: z.boolean().optional().default(false),
+	// When true, the PTY runner sends `/remote-control` after spawn so
+	// the session becomes reachable from claude.ai/code / Claude mobile.
+	// Requires `ptyEnabled=true`; the UI prevents invalid combinations.
 	remoteControlEnabled: z.boolean().optional().default(false),
 });
 

--- a/apps/desktop/src/main/todo-daemon/supervisor-engine.ts
+++ b/apps/desktop/src/main/todo-daemon/supervisor-engine.ts
@@ -2,6 +2,7 @@ import { type ChildProcess, spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import type { SelectTodoSession } from "@superset/local-db";
 import { getCurrentHeadSha } from "main/todo-agent/git-status";
+import { readTodoSessionRuntimeConfig } from "main/todo-agent/runtime-config";
 import {
 	getTodoSessionStore,
 	resolveWorktreePath,
@@ -266,8 +267,13 @@ export class TodoSupervisorEngine {
 					parts.push(`effort: ${session0.claudeEffort}`);
 				appendSetupEvent(sessionId, "Claude 設定", parts.join(" / "));
 			}
-			const willUsePty =
-				PTY_ENGINE_ENABLED || Boolean(session0.remoteControlEnabled);
+			const runtimeConfig = readTodoSessionRuntimeConfig({
+				artifactPath: session0.artifactPath,
+				fallbackRemoteControlEnabled: session0.remoteControlEnabled ?? false,
+			});
+			const willUsePty = PTY_ENGINE_ENABLED || runtimeConfig.ptyEnabled;
+			const remoteControlEnabled =
+				willUsePty && runtimeConfig.remoteControlEnabled;
 			appendSetupEvent(
 				sessionId,
 				"Claude",
@@ -275,7 +281,7 @@ export class TodoSupervisorEngine {
 					? "claude を PTY (interactive) モードで起動します"
 					: "claude -p --output-format stream-json を起動します",
 			);
-			if (session0.remoteControlEnabled) {
+			if (remoteControlEnabled) {
 				appendSetupEvent(
 					sessionId,
 					"Remote Control",
@@ -418,7 +424,8 @@ export class TodoSupervisorEngine {
 					claudeModel: currentSession.claudeModel ?? null,
 					claudeEffort: currentSession.claudeEffort ?? null,
 					signal: ac.signal,
-					remoteControlEnabled: Boolean(currentSession.remoteControlEnabled),
+					usePty: willUsePty,
+					remoteControlEnabled,
 					onChild: (child) => {
 						run.currentChild = child;
 					},
@@ -618,6 +625,7 @@ export class TodoSupervisorEngine {
 		claudeModel: string | null;
 		claudeEffort: string | null;
 		signal: AbortSignal;
+		usePty: boolean;
 		onChild: (child: ChildProcess) => void;
 		remoteControlEnabled: boolean;
 	}): Promise<{
@@ -629,12 +637,7 @@ export class TodoSupervisorEngine {
 		interrupted: boolean;
 		scheduledWakeup: { delayMs: number; reason: string | null } | null;
 	}> {
-		// The PTY engine is the only path that can drive `/remote-control`.
-		// We therefore dispatch to it whenever the daemon is running in
-		// PTY mode OR the session asked for Remote Control — the latter
-		// is a defensive fallback for when a user checks the box before
-		// the env flag is set, so the feature does not silently no-op.
-		if (PTY_ENGINE_ENABLED || params.remoteControlEnabled) {
+		if (params.usePty) {
 			return runClaudeTurnPty({
 				sessionId: params.sessionId,
 				iteration: params.iteration,

--- a/apps/desktop/src/renderer/features/todo-agent/TodoModal/TodoModal.tsx
+++ b/apps/desktop/src/renderer/features/todo-agent/TodoModal/TodoModal.tsx
@@ -46,6 +46,7 @@ const DEFAULT_VERIFY_COMMAND = "";
 const DEFAULT_MAX_ITERATIONS = 10;
 const DEFAULT_MAX_MINUTES = 30;
 const DEFAULT_CREATE_WORKTREE = false;
+const DEFAULT_PTY = false;
 const DEFAULT_REMOTE_CONTROL = false;
 
 /**
@@ -73,6 +74,7 @@ export function TodoModal({
 	const [maxMinutes, setMaxMinutes] = useState(DEFAULT_MAX_MINUTES);
 	const [submitting, setSubmitting] = useState(false);
 	const [createWorktree, setCreateWorktree] = useState(DEFAULT_CREATE_WORKTREE);
+	const [ptyEnabled, setPtyEnabled] = useState(DEFAULT_PTY);
 	const [remoteControlEnabled, setRemoteControlEnabled] = useState(
 		DEFAULT_REMOTE_CONTROL,
 	);
@@ -133,6 +135,7 @@ export function TodoModal({
 		);
 		setMaxMinutes(todoSettings?.defaultMaxWallClockMin ?? DEFAULT_MAX_MINUTES);
 		setCreateWorktree(DEFAULT_CREATE_WORKTREE);
+		setPtyEnabled(DEFAULT_PTY);
 		setRemoteControlEnabled(DEFAULT_REMOTE_CONTROL);
 		setSelectedPresetId(null);
 		setClaudeModel(
@@ -162,6 +165,12 @@ export function TodoModal({
 
 	const hasVerify = verifyCommand.trim().length > 0;
 	const hasGoal = goal.trim().length > 0;
+
+	useEffect(() => {
+		if (!ptyEnabled && remoteControlEnabled) {
+			setRemoteControlEnabled(false);
+		}
+	}, [ptyEnabled, remoteControlEnabled]);
 
 	const handleSubmit = useCallback(async () => {
 		if (!canSubmit) return;
@@ -202,6 +211,7 @@ export function TodoModal({
 				customSystemPrompt: selectedPreset?.content ?? undefined,
 				claudeModel: toPersistedModel(claudeModel),
 				claudeEffort: toPersistedEffort(claudeEffort),
+				ptyEnabled,
 				remoteControlEnabled,
 			});
 			if (createWorktree) {
@@ -234,6 +244,7 @@ export function TodoModal({
 		maxIterations,
 		maxMinutes,
 		projectId,
+		ptyEnabled,
 		remoteControlEnabled,
 		selectedPreset,
 		title,
@@ -284,18 +295,47 @@ export function TodoModal({
 					</label>
 
 					<label
+						htmlFor="todo-pty-mode"
+						className={cn(
+							"flex items-center gap-2 rounded-lg border px-3 py-2 cursor-pointer transition",
+							ptyEnabled
+								? "border-emerald-400/50 bg-emerald-500/5"
+								: "border-border/40 hover:bg-muted/40",
+						)}
+						title="beta 機能です。Claude を interactive PTY で起動し、headless より実環境に近い経路で実行します。"
+					>
+						<Checkbox
+							id="todo-pty-mode"
+							checked={ptyEnabled}
+							onCheckedChange={(checked) => setPtyEnabled(checked === true)}
+						/>
+						<div className="flex-1 flex flex-col gap-0.5">
+							<span className="text-xs font-medium">PTY モードで実行</span>
+							<span className="text-[10px] text-muted-foreground">
+								beta: interactive Claude を使う
+							</span>
+						</div>
+					</label>
+
+					<label
 						htmlFor="todo-remote-control"
 						className={cn(
 							"flex items-center gap-2 rounded-lg border px-3 py-2 cursor-pointer transition",
 							remoteControlEnabled
 								? "border-indigo-400/50 bg-indigo-500/5"
 								: "border-border/40 hover:bg-muted/40",
+							!ptyEnabled && "opacity-60 cursor-not-allowed",
 						)}
-						title="claude.ai/code や Claude モバイルアプリからこのセッションを閲覧・操作できるようにします。Pro/Max プランと claude.ai ログイン済みの CLI が必要です。"
+						title={
+							ptyEnabled
+								? "claude.ai/code や Claude モバイルアプリからこのセッションを閲覧・操作できるようにします。Pro/Max プランと claude.ai ログイン済みの CLI が必要です。"
+								: "Remote Control は PTY モード時のみ有効です。"
+						}
 					>
 						<Checkbox
 							id="todo-remote-control"
 							checked={remoteControlEnabled}
+							disabled={!ptyEnabled}
 							onCheckedChange={(checked) =>
 								setRemoteControlEnabled(checked === true)
 							}
@@ -305,7 +345,7 @@ export function TodoModal({
 								Remote Control を有効化
 							</span>
 							<span className="text-[10px] text-muted-foreground">
-								claude.ai / Claude アプリから接続できる (Pro/Max プラン必須)
+								PTY 時のみ。claude.ai / Claude アプリから接続できる
 							</span>
 						</div>
 					</label>


### PR DESCRIPTION
## 概要
- TODO 作成時に `PTY モードで実行` を選べるようにし、`Remote Control` は PTY 有効時のみ選択できるように変更
- PTY / Remote Control の実行設定を TODO artifact 配下に保存し、beta 機能をセッション単位で opt-in できるように変更
- `ELECTRON_RUN_AS_NODE=1` での daemon 起動時に `electron` 依存に巻き込まれて落ちる経路を回避

## 確認結果
- `bun run lint`
  - 今回の変更ファイル自体は通過
  - ただし、既存の別件チェックで失敗
    - `apps/desktop/src/lib/trpc/routers/projects/projects.ts` の `simple-git` 直接利用
    - `apps/desktop/src/main/todo-agent/schedule-sync.ts` の `startsWith("origin/")`
- `bun run typecheck`
  - 今回の変更とは別の既存エラーで失敗
    - `cron-parser`
    - `cronstrue`
    - `dexie`
