### PR TITLE
fix(desktop): YouTube Import の 3 不具合を修正 (#290)

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/ringtone/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/ringtone/index.ts
@@ -1,5 +1,6 @@
 import type { ChildProcess } from "node:child_process";
 import { TRPCError } from "@trpc/server";
+import { observable } from "@trpc/server/observable";
 import type { BrowserWindow, OpenDialogOptions } from "electron";
 import { dialog } from "electron";
 import {
@@ -16,8 +17,11 @@ import {
 	checkMissingBinaries,
 	cleanupTempAudio,
 	downloadFullYouTubeAudio,
+	getBufferedInstallEvents,
+	type InstallProgressEvent,
 	importRingtoneFromYouTube,
 	installMissingBinaries,
+	subscribeInstallEvents,
 	YouTubeRingtoneError,
 } from "main/lib/youtube-ringtone";
 import {
@@ -229,21 +233,48 @@ export const createRingtoneRouter = (getWindow: () => BrowserWindow | null) => {
 
 		/**
 		 * Install yt-dlp and ffmpeg via Homebrew (macOS only).
+		 * Log events are streamed via `installProgress` subscription keyed on installId.
 		 */
-		installBinaries: publicProcedure.mutation(async () => {
-			try {
-				await installMissingBinaries();
-				return { success: true as const };
-			} catch (error) {
-				throw new TRPCError({
-					code: "INTERNAL_SERVER_ERROR",
-					message:
-						error instanceof Error
-							? error.message
-							: "Failed to install dependencies",
+		installBinaries: publicProcedure
+			.input(z.object({ installId: z.string().min(1) }))
+			.mutation(async ({ input }) => {
+				try {
+					await installMissingBinaries(input.installId);
+					return { success: true as const };
+				} catch (error) {
+					throw new TRPCError({
+						code: "INTERNAL_SERVER_ERROR",
+						message:
+							error instanceof Error
+								? error.message
+								: "Failed to install dependencies",
+					});
+				}
+			}),
+
+		/**
+		 * Subscribe to install progress events for a given installId.
+		 * Emits buffered events on connect (replay) plus live events.
+		 */
+		installProgress: publicProcedure
+			.input(z.object({ installId: z.string().min(1) }))
+			.subscription(({ input }) => {
+				return observable<InstallProgressEvent>((emit) => {
+					let lastSeq = 0;
+					const deliver = (event: InstallProgressEvent) => {
+						if (event.seq <= lastSeq) return;
+						lastSeq = event.seq;
+						emit.next(event);
+					};
+					const unsubscribe = subscribeInstallEvents(input.installId, deliver);
+					for (const event of getBufferedInstallEvents(input.installId)) {
+						deliver(event);
+					}
+					return () => {
+						unsubscribe();
+					};
 				});
-			}
-		}),
+			}),
 
 		/**
 		 * Download the full audio from a YouTube URL to a temp file.

--- a/apps/desktop/src/main/lib/youtube-ringtone.ts
+++ b/apps/desktop/src/main/lib/youtube-ringtone.ts
@@ -1,5 +1,6 @@
 import { spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
+import { EventEmitter } from "node:events";
 import {
 	existsSync,
 	constants as fsConstants,
@@ -158,54 +159,200 @@ export async function checkMissingBinaries(): Promise<string[]> {
 	return entries.filter(([, p]) => !p).map(([name]) => name);
 }
 
-export async function installMissingBinaries(): Promise<void> {
+interface InstallEventBase {
+	installId: string;
+	seq: number;
+	time: number;
+}
+
+export type InstallProgressEvent =
+	| (InstallEventBase & {
+			type: "log";
+			message: string;
+			level: "info" | "warn" | "error";
+			stream: "stdout" | "stderr" | "system";
+	  })
+	| (InstallEventBase & { type: "done" })
+	| (InstallEventBase & { type: "error"; message: string });
+
+const installEventBus = new EventEmitter();
+installEventBus.setMaxListeners(0);
+
+const installEventBuffers = new Map<string, InstallProgressEvent[]>();
+const installBufferEvictTimers = new Map<string, NodeJS.Timeout>();
+const installSeqCounters = new Map<string, number>();
+const INSTALL_MAX_BUFFERED_EVENTS = 1000;
+const INSTALL_TERMINAL_EVICT_MS = 30_000;
+
+function isTerminalInstallEvent(event: InstallProgressEvent): boolean {
+	return event.type === "done" || event.type === "error";
+}
+
+function nextInstallSeq(installId: string): number {
+	const next = (installSeqCounters.get(installId) ?? 0) + 1;
+	installSeqCounters.set(installId, next);
+	return next;
+}
+
+type DistributiveOmit<
+	T,
+	K extends keyof InstallProgressEvent,
+> = T extends unknown ? Omit<T, K> : never;
+type InstallEventInput = DistributiveOmit<InstallProgressEvent, "seq">;
+
+function emitInstallEvent(input: InstallEventInput): void {
+	const event = {
+		...input,
+		seq: nextInstallSeq(input.installId),
+	} as InstallProgressEvent;
+	let buffer = installEventBuffers.get(event.installId);
+	if (!buffer) {
+		buffer = [];
+		installEventBuffers.set(event.installId, buffer);
+	}
+	buffer.push(event);
+	if (buffer.length > INSTALL_MAX_BUFFERED_EVENTS) {
+		buffer.splice(0, buffer.length - INSTALL_MAX_BUFFERED_EVENTS);
+	}
+	installEventBus.emit(event.installId, event);
+
+	if (isTerminalInstallEvent(event)) {
+		const existing = installBufferEvictTimers.get(event.installId);
+		if (existing) clearTimeout(existing);
+		const timer = setTimeout(() => {
+			installEventBuffers.delete(event.installId);
+			installBufferEvictTimers.delete(event.installId);
+			installSeqCounters.delete(event.installId);
+		}, INSTALL_TERMINAL_EVICT_MS);
+		installBufferEvictTimers.set(event.installId, timer);
+	}
+}
+
+function emitInstallLog(
+	installId: string,
+	message: string,
+	level: "info" | "warn" | "error",
+	stream: "stdout" | "stderr" | "system",
+): void {
+	for (const line of message.split(/\r?\n/)) {
+		const trimmed = line.trimEnd();
+		if (!trimmed) continue;
+		emitInstallEvent({
+			type: "log",
+			installId,
+			time: Date.now(),
+			message: trimmed,
+			level,
+			stream,
+		});
+	}
+}
+
+export function subscribeInstallEvents(
+	installId: string,
+	listener: (event: InstallProgressEvent) => void,
+): () => void {
+	installEventBus.on(installId, listener);
+	return () => installEventBus.off(installId, listener);
+}
+
+export function getBufferedInstallEvents(
+	installId: string,
+): InstallProgressEvent[] {
+	return installEventBuffers.get(installId)?.slice() ?? [];
+}
+
+export async function installMissingBinaries(installId: string): Promise<void> {
 	if (process.platform !== "darwin") {
-		throw new Error(
-			"Auto-install is only supported on macOS. Please install yt-dlp and ffmpeg manually.",
-		);
+		const msg =
+			"Auto-install is only supported on macOS. Please install yt-dlp and ffmpeg manually.";
+		emitInstallLog(installId, msg, "error", "system");
+		emitInstallEvent({
+			type: "error",
+			installId,
+			time: Date.now(),
+			message: msg,
+		});
+		throw new Error(msg);
 	}
 
+	emitInstallLog(installId, "Resolving Homebrew path…", "info", "system");
 	const shellEnv = await getProcessEnvWithShellPath();
 	const brewPath = await resolveBinaryPath("brew", shellEnv);
 	if (!brewPath) {
-		throw new Error(
-			"Homebrew is not installed. Please install it from https://brew.sh and then install yt-dlp and ffmpeg.",
-		);
+		const msg =
+			"Homebrew is not installed. Please install it from https://brew.sh and then install yt-dlp and ffmpeg.";
+		emitInstallLog(installId, msg, "error", "system");
+		emitInstallEvent({
+			type: "error",
+			installId,
+			time: Date.now(),
+			message: msg,
+		});
+		throw new Error(msg);
 	}
 
-	await new Promise<void>((resolve, reject) => {
-		const proc = spawn(brewPath, ["install", "yt-dlp", "ffmpeg"], {
-			env: shellEnv,
-			stdio: ["ignore", "pipe", "pipe"],
+	emitInstallLog(
+		installId,
+		`$ ${brewPath} install yt-dlp ffmpeg`,
+		"info",
+		"system",
+	);
+
+	try {
+		await new Promise<void>((resolve, reject) => {
+			const proc = spawn(brewPath, ["install", "yt-dlp", "ffmpeg"], {
+				env: shellEnv,
+				stdio: ["ignore", "pipe", "pipe"],
+			});
+
+			const timer = setTimeout(() => {
+				proc.kill("SIGKILL");
+				reject(new Error("Installation timed out after 10 minutes."));
+			}, 600_000);
+
+			let stderrTail = "";
+			proc.stdout?.on("data", (chunk: Buffer) => {
+				emitInstallLog(installId, chunk.toString(), "info", "stdout");
+			});
+			proc.stderr?.on("data", (chunk: Buffer) => {
+				const text = chunk.toString();
+				stderrTail = (stderrTail + text).split("\n").slice(-20).join("\n");
+				// brew writes progress banners to stderr; show as info by default
+				emitInstallLog(installId, text, "info", "stderr");
+			});
+
+			proc.on("error", (err) => {
+				clearTimeout(timer);
+				reject(new Error(`Failed to run brew: ${err.message}`));
+			});
+
+			proc.on("exit", (code) => {
+				clearTimeout(timer);
+				if (code === 0) {
+					resolve();
+				} else {
+					const msg = stderrTail.trim().split("\n").slice(-3).join("\n");
+					reject(
+						new Error(msg || `brew install exited with code ${code ?? "?"}`),
+					);
+				}
+			});
 		});
 
-		const timer = setTimeout(() => {
-			proc.kill("SIGKILL");
-			reject(new Error("Installation timed out after 10 minutes."));
-		}, 600_000);
-
-		let stderr = "";
-		proc.stderr?.on("data", (chunk: Buffer) => {
-			stderr += chunk.toString();
+		emitInstallLog(installId, "Installation complete.", "info", "system");
+		emitInstallEvent({ type: "done", installId, time: Date.now() });
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		emitInstallLog(installId, message, "error", "system");
+		emitInstallEvent({
+			type: "error",
+			installId,
+			time: Date.now(),
+			message,
 		});
-
-		proc.on("error", (err) => {
-			clearTimeout(timer);
-			reject(new Error(`Failed to run brew: ${err.message}`));
-		});
-
-		proc.on("exit", (code) => {
-			clearTimeout(timer);
-			if (code === 0) {
-				resolve();
-			} else {
-				const msg = stderr.trim().split("\n").slice(-3).join("\n");
-				reject(
-					new Error(msg || `brew install exited with code ${code ?? "?"}`),
-				);
-			}
-		});
-	});
+		throw err;
+	}
 }
 
 function runProcess(

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/ringtones/components/RingtonesSettings/RingtonesSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/ringtones/components/RingtonesSettings/RingtonesSettings.tsx
@@ -256,6 +256,16 @@ export function RingtonesSettings({ visibleItems }: RingtonesSettingsProps) {
 	const [youtubeDialogOpen, setYoutubeDialogOpen] = useState(false);
 
 	const handleYouTubeImportSuccess = useCallback(async () => {
+		if (previewTimerRef.current) {
+			clearTimeout(previewTimerRef.current);
+			previewTimerRef.current = null;
+		}
+		try {
+			await electronTrpcClient.ringtone.stop.mutate();
+		} catch (error) {
+			console.error("Failed to stop ringtone before import:", error);
+		}
+		setPlayingId(null);
 		await utils.ringtone.getCustom.invalidate();
 		setRingtone(CUSTOM_RINGTONE_ID);
 	}, [utils, setRingtone]);

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/ringtones/components/RingtonesSettings/components/YouTubeImportDialog/YouTubeImportDialog.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/ringtones/components/RingtonesSettings/components/YouTubeImportDialog/YouTubeImportDialog.tsx
@@ -9,7 +9,14 @@ import {
 } from "@superset/ui/dialog";
 import { Input } from "@superset/ui/input";
 import { Label } from "@superset/ui/label";
-import { useCallback, useEffect, useId, useMemo, useState } from "react";
+import {
+	useCallback,
+	useEffect,
+	useId,
+	useMemo,
+	useRef,
+	useState,
+} from "react";
 import { LuLoaderCircle } from "react-icons/lu";
 import { SiYoutube } from "react-icons/si";
 import { electronTrpc } from "renderer/lib/electron-trpc";
@@ -19,6 +26,21 @@ const YOUTUBE_URL_HINT =
 	/^https?:\/\/(?:www\.|m\.|music\.)?(?:youtube\.com|youtu\.be)\//i;
 
 type Step = "url" | "installing" | "downloading" | "editor";
+
+interface InstallLogLine {
+	id: number;
+	time: string;
+	message: string;
+	level: "info" | "warn" | "error";
+}
+
+function formatInstallTime(ts: number): string {
+	const d = new Date(ts);
+	const hh = String(d.getHours()).padStart(2, "0");
+	const mm = String(d.getMinutes()).padStart(2, "0");
+	const ss = String(d.getSeconds()).padStart(2, "0");
+	return `${hh}:${mm}:${ss}`;
+}
 
 interface DownloadedAudioState {
 	tempId: string;
@@ -33,7 +55,7 @@ interface DownloadedAudioState {
 interface YouTubeImportDialogProps {
 	open: boolean;
 	onOpenChange: (open: boolean) => void;
-	onImportSuccess: () => void;
+	onImportSuccess: () => void | Promise<void>;
 }
 
 export function YouTubeImportDialog({
@@ -51,6 +73,11 @@ export function YouTubeImportDialog({
 	);
 	const [displayName, setDisplayName] = useState("");
 
+	const [installId, setInstallId] = useState<string | null>(null);
+	const [installLogs, setInstallLogs] = useState<InstallLogLine[]>([]);
+	const installLogIdRef = useRef(0);
+	const installLogContainerRef = useRef<HTMLDivElement | null>(null);
+
 	// Binary check
 	const { data: binariesData, refetch: refetchBinaries } =
 		electronTrpc.ringtone.checkBinaries.useQuery(undefined, {
@@ -65,12 +92,60 @@ export function YouTubeImportDialog({
 			await refetchBinaries();
 			setStep("url");
 			setErrorMessage(null);
+			setInstallId(null);
 		},
 		onError: (err) => {
 			setErrorMessage(err.message);
-			setStep("url");
 		},
 	});
+
+	electronTrpc.ringtone.installProgress.useSubscription(
+		{ installId: installId ?? "" },
+		{
+			enabled: installId !== null,
+			onData: (event) => {
+				if (event.type === "log") {
+					setInstallLogs((prev) => {
+						installLogIdRef.current += 1;
+						return [
+							...prev,
+							{
+								id: installLogIdRef.current,
+								time: formatInstallTime(event.time),
+								message: event.message,
+								level: event.level,
+							},
+						];
+					});
+				} else if (event.type === "error") {
+					setInstallLogs((prev) => {
+						installLogIdRef.current += 1;
+						return [
+							...prev,
+							{
+								id: installLogIdRef.current,
+								time: formatInstallTime(event.time),
+								message: event.message,
+								level: "error",
+							},
+						];
+					});
+				}
+			},
+			onError: (err) => {
+				// Subscription transport errors shouldn't block the install mutation result.
+				console.error("install progress subscription error:", err);
+			},
+		},
+	);
+
+	// biome-ignore lint/correctness/useExhaustiveDependencies: auto-scroll on new log lines
+	useEffect(() => {
+		const el = installLogContainerRef.current;
+		if (el) {
+			el.scrollTop = el.scrollHeight;
+		}
+	}, [installLogs]);
 
 	const downloadAudio = electronTrpc.ringtone.downloadYouTubeAudio.useMutation({
 		onSuccess: (result) => {
@@ -98,7 +173,7 @@ export function YouTubeImportDialog({
 					cleanupTempAudio.mutate({ tempId: downloaded.tempId });
 				}
 				setErrorMessage(null);
-				onImportSuccess();
+				await onImportSuccess();
 				onOpenChange(false);
 			},
 			onError: (err) => {
@@ -127,9 +202,13 @@ export function YouTubeImportDialog({
 	const urlLooksValid = useMemo(() => YOUTUBE_URL_HINT.test(url.trim()), [url]);
 
 	const handleInstall = () => {
+		const newInstallId = crypto.randomUUID();
 		setStep("installing");
 		setErrorMessage(null);
-		installBinaries.mutate();
+		setInstallLogs([]);
+		installLogIdRef.current = 0;
+		setInstallId(newInstallId);
+		installBinaries.mutate({ installId: newInstallId });
 	};
 
 	const handleLoad = () => {
@@ -187,7 +266,7 @@ export function YouTubeImportDialog({
 				if (!isLoading && !importFromYouTube.isPending) onOpenChange(o);
 			}}
 		>
-			<DialogContent className="!max-w-lg sm:!max-w-2xl">
+			<DialogContent className="!max-w-lg sm:!max-w-4xl">
 				<DialogHeader>
 					<DialogTitle className="flex items-center gap-2">
 						<SiYoutube className="h-4 w-4 text-red-500" />
@@ -198,21 +277,75 @@ export function YouTubeImportDialog({
 
 				{/* Step: installing */}
 				{step === "installing" && (
-					<div className="flex flex-col items-center gap-4 py-6">
-						<LuLoaderCircle className="h-8 w-8 animate-spin text-muted-foreground" />
-						<p className="text-sm text-center text-muted-foreground">
-							Running{" "}
-							<code className="rounded bg-muted px-1">
-								brew install yt-dlp ffmpeg
-							</code>
-							<br />
-							This may take a few minutes…
-						</p>
+					<div className="space-y-3 py-2">
+						<div className="flex items-center gap-3">
+							{installBinaries.isPending ? (
+								<LuLoaderCircle className="h-4 w-4 animate-spin text-muted-foreground" />
+							) : errorMessage ? (
+								<span className="h-2 w-2 rounded-full bg-destructive" />
+							) : (
+								<span className="h-2 w-2 rounded-full bg-emerald-500" />
+							)}
+							<p className="text-sm text-muted-foreground">
+								{installBinaries.isPending
+									? "Running brew install yt-dlp ffmpeg…"
+									: errorMessage
+										? "Installation failed."
+										: "Installation complete."}
+							</p>
+						</div>
+
+						<div className="rounded-md border border-border bg-muted/20 overflow-hidden">
+							<div
+								ref={installLogContainerRef}
+								className="max-h-56 overflow-y-auto px-3 py-2 font-mono text-[11px] leading-[1.55]"
+							>
+								{installLogs.length === 0 ? (
+									<div className="text-muted-foreground/60">
+										Waiting for output…
+									</div>
+								) : (
+									installLogs.map((line) => (
+										<div
+											key={line.id}
+											className={
+												line.level === "error"
+													? "text-red-400"
+													: line.level === "warn"
+														? "text-amber-400"
+														: "text-muted-foreground"
+											}
+										>
+											<span className="text-muted-foreground/60">
+												{line.time}
+											</span>{" "}
+											{line.message}
+										</div>
+									))
+								)}
+							</div>
+						</div>
+
 						{errorMessage && (
-							<p className="text-sm text-destructive break-words text-center">
+							<p className="text-sm text-destructive break-words">
 								{errorMessage}
 							</p>
 						)}
+
+						<DialogFooter>
+							{!installBinaries.isPending && (
+								<Button
+									type="button"
+									variant="ghost"
+									onClick={() => {
+										setStep("url");
+										setErrorMessage(null);
+									}}
+								>
+									Back
+								</Button>
+							)}
+						</DialogFooter>
 					</div>
 				)}
 


### PR DESCRIPTION
## Summary

Issue #290 で報告された YouTube Import 関連の 3 つの不具合を修正。

- **波形編集ダイアログの幅**: `sm:!max-w-2xl` → `sm:!max-w-4xl` に拡大し、波形トリミング操作を快適にした。
- **Import 後に再生ボタンが反応しない**: `handleYouTubeImportSuccess` で再生中のリングトーンを `ringtone.stop` で停止し、`previewTimerRef` をクリアし `playingId` を `null` にリセットするよう変更。さらに `onImportSuccess` の型を `() => void | Promise<void>` に広げ、`importFromYouTube.onSuccess` で `await onImportSuccess()` してから Dialog を閉じるようにした（invalidate 完了前に close されて state 競合していた）。
- **brew install のログが出ずフリーズに見える**: `cloneProgress` の実装を参考に、`installMissingBinaries(installId)` を EventEmitter + replay バッファ化し、tRPC `installProgress` observable subscription を追加。Dialog の installing ステップを CloneRepoTab 風のログ UI に差し替え、stdout/stderr を行単位でストリーミング表示する。

## 対象ファイル

- `apps/desktop/src/main/lib/youtube-ringtone.ts`
- `apps/desktop/src/lib/trpc/routers/ringtone/index.ts`
- `apps/desktop/src/renderer/routes/_authenticated/settings/ringtones/components/RingtonesSettings/RingtonesSettings.tsx`
- `apps/desktop/src/renderer/routes/_authenticated/settings/ringtones/components/RingtonesSettings/components/YouTubeImportDialog/YouTubeImportDialog.tsx`

## Test plan

- [ ] Settings → Ringtones → Import from YouTube を開き、ダイアログが 4xl 幅で表示されることを確認
- [ ] ビルトインおよび既存 custom ringtone を再生中に YouTube Import を実施し、Import 後に新しい custom の再生ボタンがすぐ反応することを確認
- [ ] yt-dlp / ffmpeg 未インストール状態で "Install with Homebrew" を押し、`brew install` の stdout / stderr がリアルタイムでダイアログ内に流れることを確認
- [ ] インストール失敗時（例: 権限エラーを再現）、エラー行が赤字で表示され Back ボタンで URL ステップに戻れること
- [ ] `bun run typecheck` と `bun run lint` が通ること

Closes #290