### PR TITLE
fix(desktop): AgentManager の TODO/スケジュールタブにステータスフィルタを追加 (#298)

### DIFF
--- a/apps/desktop/src/renderer/features/todo-agent/TodoManager/SchedulesSection/SchedulesSection.tsx
+++ b/apps/desktop/src/renderer/features/todo-agent/TodoManager/SchedulesSection/SchedulesSection.tsx
@@ -5,8 +5,19 @@ import { ScrollArea } from "@superset/ui/scroll-area";
 import { useMemo, useState } from "react";
 import { HiMiniPlus } from "react-icons/hi2";
 import { electronTrpc } from "renderer/lib/electron-trpc";
+import {
+	type StatusFilterOption,
+	StatusFilterPopover,
+} from "../components/StatusFilterPopover";
 import { ScheduleEditorDialog } from "./components/ScheduleEditorDialog";
 import { ScheduleListRow } from "./components/ScheduleListRow";
+
+type ScheduleStatus = "enabled" | "disabled";
+
+const SCHEDULE_STATUS_OPTIONS: readonly StatusFilterOption<ScheduleStatus>[] = [
+	{ value: "enabled", label: "有効" },
+	{ value: "disabled", label: "無効" },
+];
 
 /**
  * Tab shown inside TodoManager's left sidebar when the user flips to
@@ -17,6 +28,9 @@ export function SchedulesSection() {
 	const [editorOpen, setEditorOpen] = useState(false);
 	const [editing, setEditing] = useState<SelectTodoSchedule | null>(null);
 	const [filter, setFilter] = useState("");
+	const [statusFilter, setStatusFilter] = useState<Set<ScheduleStatus>>(
+		() => new Set(),
+	);
 
 	const { data: schedules } = electronTrpc.todoAgent.schedule.listAll.useQuery(
 		undefined,
@@ -42,8 +56,14 @@ export function SchedulesSection() {
 	const filteredSchedules = useMemo(() => {
 		const list = schedules ?? [];
 		const needle = filter.trim().toLowerCase();
-		if (!needle) return list;
+		const hasStatus = statusFilter.size > 0;
+		if (!needle && !hasStatus) return list;
 		return list.filter((s) => {
+			if (hasStatus) {
+				const statusKey: ScheduleStatus = s.enabled ? "enabled" : "disabled";
+				if (!statusFilter.has(statusKey)) return false;
+			}
+			if (!needle) return true;
 			const wsName = s.workspaceId
 				? (workspaceNameById.get(s.workspaceId) ?? "")
 				: "";
@@ -56,7 +76,7 @@ export function SchedulesSection() {
 				projName.toLowerCase().includes(needle)
 			);
 		});
-	}, [schedules, filter, workspaceNameById, projectNameById]);
+	}, [schedules, filter, statusFilter, workspaceNameById, projectNameById]);
 
 	const openNew = () => {
 		setEditing(null);
@@ -86,12 +106,17 @@ export function SchedulesSection() {
 					新規
 				</Button>
 			</div>
-			<div className="p-2 border-b shrink-0">
+			<div className="p-2 border-b shrink-0 flex items-center gap-2">
 				<Input
 					value={filter}
 					onChange={(e) => setFilter(e.target.value)}
 					placeholder="絞り込み（名前 / タイトル / プロジェクト）"
-					className="h-8 text-xs rounded-md"
+					className="h-8 text-xs rounded-md flex-1 min-w-0"
+				/>
+				<StatusFilterPopover
+					options={SCHEDULE_STATUS_OPTIONS}
+					selected={statusFilter}
+					onChange={setStatusFilter}
 				/>
 			</div>
 			<ScrollArea className="flex-1 min-h-0">

--- a/apps/desktop/src/renderer/features/todo-agent/TodoManager/TodoManager.tsx
+++ b/apps/desktop/src/renderer/features/todo-agent/TodoManager/TodoManager.tsx
@@ -1,3 +1,7 @@
+import {
+	type TodoSessionStatus,
+	todoSessionStatusValues,
+} from "@superset/local-db";
 import { Button } from "@superset/ui/button";
 import { Checkbox } from "@superset/ui/checkbox";
 import { Dialog, DialogContent, DialogTitle } from "@superset/ui/dialog";
@@ -83,6 +87,10 @@ import {
 import { ChangesSidebar } from "./ChangesSidebar";
 import { AttachmentChips } from "./components/AttachmentChips";
 import { AttachmentPreviewDialog } from "./components/AttachmentPreviewDialog";
+import {
+	type StatusFilterOption,
+	StatusFilterPopover,
+} from "./components/StatusFilterPopover";
 import { PresetsDialog } from "./PresetsDialog";
 import { SchedulesSection } from "./SchedulesSection";
 import {
@@ -90,6 +98,25 @@ import {
 	extractAttachmentRefs,
 	stripAttachmentRefs,
 } from "./utils/attachmentRefs";
+
+const TODO_STATUS_LABELS: Record<TodoSessionStatus, string> = {
+	queued: "待機列",
+	preparing: "準備中",
+	running: "実行中",
+	verifying: "検証中",
+	done: "完了",
+	failed: "失敗",
+	escalated: "要確認",
+	aborted: "中止",
+	paused: "一時停止",
+	waiting: "再開待ち",
+};
+
+const TODO_STATUS_FILTER_OPTIONS: readonly StatusFilterOption<TodoSessionStatus>[] =
+	todoSessionStatusValues.map((v) => ({
+		value: v,
+		label: TODO_STATUS_LABELS[v],
+	}));
 
 async function copyToClipboard(text: string, label = "コピーしました") {
 	try {
@@ -372,6 +399,9 @@ export function TodoManager({
 }: TodoManagerProps) {
 	const [selectedId, setSelectedId] = useState<string | null>(null);
 	const [filter, setFilter] = useState("");
+	const [statusFilter, setStatusFilter] = useState<Set<TodoSessionStatus>>(
+		() => new Set(),
+	);
 	const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(
 		new Set(),
 	);
@@ -389,16 +419,23 @@ export function TodoManager({
 	);
 
 	const filtered = useMemo(() => {
-		if (!filter.trim()) return sessions ?? [];
+		const base = sessions ?? [];
 		const needle = filter.trim().toLowerCase();
-		return (sessions ?? []).filter(
-			(s) =>
+		const hasStatus = statusFilter.size > 0;
+		if (!needle && !hasStatus) return base;
+		return base.filter((s) => {
+			if (hasStatus && !statusFilter.has(s.status as TodoSessionStatus)) {
+				return false;
+			}
+			if (!needle) return true;
+			return (
 				s.title.toLowerCase().includes(needle) ||
 				s.description.toLowerCase().includes(needle) ||
 				(s.workspaceName ?? "").toLowerCase().includes(needle) ||
-				(s.projectName ?? "").toLowerCase().includes(needle),
-		);
-	}, [sessions, filter]);
+				(s.projectName ?? "").toLowerCase().includes(needle)
+			);
+		});
+	}, [sessions, filter, statusFilter]);
 
 	const grouped = useMemo(() => groupByWorkspace(filtered), [filtered]);
 
@@ -545,12 +582,17 @@ export function TodoManager({
 										新規
 									</Button>
 								</div>
-								<div className="p-2 border-b shrink-0">
+								<div className="p-2 border-b shrink-0 flex items-center gap-2">
 									<Input
 										value={filter}
 										onChange={(e) => setFilter(e.target.value)}
 										placeholder="絞り込み（タイトル / ワークスペース）"
-										className="h-8 text-xs rounded-md"
+										className="h-8 text-xs rounded-md flex-1 min-w-0"
+									/>
+									<StatusFilterPopover
+										options={TODO_STATUS_FILTER_OPTIONS}
+										selected={statusFilter}
+										onChange={setStatusFilter}
 									/>
 								</div>
 								<ScrollArea className="flex-1 min-h-0">

--- a/apps/desktop/src/renderer/features/todo-agent/TodoManager/components/StatusFilterPopover/StatusFilterPopover.tsx
+++ b/apps/desktop/src/renderer/features/todo-agent/TodoManager/components/StatusFilterPopover/StatusFilterPopover.tsx
@@ -1,0 +1,95 @@
+import { Button } from "@superset/ui/button";
+import {
+	DropdownMenu,
+	DropdownMenuCheckboxItem,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuLabel,
+	DropdownMenuSeparator,
+	DropdownMenuTrigger,
+} from "@superset/ui/dropdown-menu";
+import { cn } from "@superset/ui/utils";
+import { LuFilter } from "react-icons/lu";
+
+export type StatusFilterOption<T extends string> = {
+	value: T;
+	label: string;
+};
+
+type Props<T extends string> = {
+	options: readonly StatusFilterOption<T>[];
+	selected: ReadonlySet<T>;
+	onChange: (next: Set<T>) => void;
+	title?: string;
+};
+
+export function StatusFilterPopover<T extends string>({
+	options,
+	selected,
+	onChange,
+	title = "ステータスで絞り込み",
+}: Props<T>) {
+	const count = selected.size;
+
+	const toggle = (value: T) => {
+		const next = new Set(selected);
+		if (next.has(value)) next.delete(value);
+		else next.add(value);
+		onChange(next);
+	};
+
+	const clear = () => onChange(new Set<T>());
+
+	return (
+		<DropdownMenu>
+			<DropdownMenuTrigger asChild>
+				<Button
+					type="button"
+					size="sm"
+					variant="outline"
+					className={cn(
+						"h-8 gap-1 px-2 text-xs rounded-md shrink-0",
+						count > 0 && "border-primary/60 text-primary",
+					)}
+					title={title}
+				>
+					<LuFilter className="size-3.5" />
+					{count > 0 && (
+						<span className="tabular-nums text-[10px]">{count}</span>
+					)}
+				</Button>
+			</DropdownMenuTrigger>
+			<DropdownMenuContent align="end" className="w-56">
+				<DropdownMenuLabel className="text-xs">{title}</DropdownMenuLabel>
+				<DropdownMenuSeparator />
+				{options.map((opt) => (
+					<DropdownMenuCheckboxItem
+						key={opt.value}
+						checked={selected.has(opt.value)}
+						onSelect={(e) => {
+							e.preventDefault();
+							toggle(opt.value);
+						}}
+						className="text-xs"
+					>
+						{opt.label}
+					</DropdownMenuCheckboxItem>
+				))}
+				{count > 0 && (
+					<>
+						<DropdownMenuSeparator />
+						<DropdownMenuItem
+							onSelect={(e) => {
+								e.preventDefault();
+								clear();
+							}}
+							className="text-xs text-muted-foreground"
+						>
+							クリア
+						</DropdownMenuItem>
+					</>
+				)}
+			</DropdownMenuContent>
+		</DropdownMenu>
+	);
+}

--- a/apps/desktop/src/renderer/features/todo-agent/TodoManager/components/StatusFilterPopover/index.ts
+++ b/apps/desktop/src/renderer/features/todo-agent/TodoManager/components/StatusFilterPopover/index.ts
@@ -1,0 +1,4 @@
+export {
+	type StatusFilterOption,
+	StatusFilterPopover,
+} from "./StatusFilterPopover";


### PR DESCRIPTION
## Summary
- TODOタブとスケジュールタブの検索窓の右にフィルタアイコン（`LuFilter`）を配置
- ステータス複数選択による絞り込みを実装（`DropdownMenuCheckboxItem`）
- TODO: 10種のステータス（queued/preparing/running/verifying/done/failed/escalated/aborted/paused/waiting）を日本語ラベルで表示
- スケジュール: enabled/disabled の2値で絞り込み
- 選択中のステータス数をフィルタボタンにバッジ表示、「クリア」メニューで一括解除

Closes #298

## Test plan
- [ ] TODOタブ: フィルタを開き、複数ステータスを選択するとリストが絞り込まれる
- [ ] スケジュールタブ: 有効/無効フィルタが機能する
- [ ] 検索テキストとステータスフィルタの AND 条件が効く
- [ ] 「クリア」で選択が解除される
- [ ] 選択数バッジが正しく表示される