### PR TITLE
upstream取り込み: Cmd+O 二重発火修正 (#3511)

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/workspace/$workspaceId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/workspace/$workspaceId/page.tsx
@@ -9,6 +9,7 @@ import {
 import { useCallback, useEffect, useMemo } from "react";
 import { useCopyToClipboard } from "renderer/hooks/useCopyToClipboard";
 import { useFileOpenMode } from "renderer/hooks/useFileOpenMode";
+import { isTearoffWindow } from "renderer/hooks/useTearoffInit";
 import { useRightSidebarOpenViewWidth } from "renderer/hooks/useRightSidebarOpenViewWidth";
 import { useHotkey } from "renderer/hotkeys";
 import {
@@ -540,6 +541,13 @@ export function WorkspacePage({
 			});
 		}
 	}, [workspace?.worktreePath, resolvedDefaultApp, mutateOpenInApp, projectId]);
+	// FORK NOTE: upstream #3511 removed this page-level hotkey to avoid double
+	// firing with OpenInMenuButton. Fork tearoff windows do not render TopBar
+	// (layout.tsx gates it on !isTearoff), so OpenInMenuButton is absent there
+	// — keep the page-level registration alive only in tearoff windows.
+	useHotkey("OPEN_IN_APP", handleOpenInApp, {
+		enabled: isActive && isTearoffWindow(),
+	});
 
 	// Copy path shortcut
 	const { copyToClipboard } = useCopyToClipboard();

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/workspace/$workspaceId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/workspace/$workspaceId/page.tsx
@@ -9,8 +9,8 @@ import {
 import { useCallback, useEffect, useMemo } from "react";
 import { useCopyToClipboard } from "renderer/hooks/useCopyToClipboard";
 import { useFileOpenMode } from "renderer/hooks/useFileOpenMode";
-import { isTearoffWindow } from "renderer/hooks/useTearoffInit";
 import { useRightSidebarOpenViewWidth } from "renderer/hooks/useRightSidebarOpenViewWidth";
+import { isTearoffWindow } from "renderer/hooks/useTearoffInit";
 import { useHotkey } from "renderer/hotkeys";
 import {
 	addBrowserShortcutListener,

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/workspace/$workspaceId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/workspace/$workspaceId/page.tsx
@@ -540,7 +540,6 @@ export function WorkspacePage({
 			});
 		}
 	}, [workspace?.worktreePath, resolvedDefaultApp, mutateOpenInApp, projectId]);
-	useHotkey("OPEN_IN_APP", handleOpenInApp, { enabled: isActive });
 
 	// Copy path shortcut
 	const { copyToClipboard } = useCopyToClipboard();


### PR DESCRIPTION
## 概要

upstream `superset-sh/superset` から Cmd+O 二重発火 fix (#3511) を取り込む PR です。behind 4 → 3。

## 取り込み commit

| SHA | タイトル | 分類 |
|---|---|---|
| `07c1ee0eb` | fix(desktop): Cmd+O firing open-in twice on v1 workspace route (#3511) | 確実に安全 |

## 背景

upstream は v1 workspace page.tsx から `useHotkey("OPEN_IN_APP", handleOpenInApp)` を削除し、OpenInMenuButton 側の登録に一本化することで二重発火を解消しました。

## fork 適応修正

fork では tearoff window で `TopBar` 自体が描画されないため、page 側 registration を丸ごと削除すると tearoff 内で Cmd+O が死にます（Codex pre-review High 指摘）。

対応: `useHotkey("OPEN_IN_APP", handler, { enabled: isActive && isTearoffWindow() })` として tearoff 限定で page 側登録を残しました。

- main window: OpenInMenuButton のみ発火（upstream の意図通り二重発火解消）
- tearoff window: page.tsx のみ発火（TopBar 不在を補う）
- FORK NOTE コメント追加

## Codex pre-review

- 初回: No（tearoff で Cmd+O 死ぬ High 指摘）
- 再レビュー: **Yes**（fork adaptation で解消確認）

## テストチェックリスト

- [ ] main window で v1 workspace を開き Cmd+O が 1 回だけ発火するか（openInApp mutation ログ）
- [ ] tearoff window で v1 workspace を開き Cmd+O が 1 回発火するか
- [ ] 通常クリック（OpenInMenuButton）動作は従来通り

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## バグ修正
* **ホットキー動作の改善** - 「アプリで開く」ホットキーがティアオフウィンドウ使用時のみ有効になるよう調整されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->