### PR TITLE
fix(desktop): ティアオフウィンドウでメインウィンドウ専用イベントを処理しないようガード追加

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/layout.tsx
@@ -79,10 +79,11 @@ function AuthenticatedLayout() {
 		});
 	}, []);
 
-	// Update workspace-run pane state on terminal exit
+	// Update workspace-run pane state on terminal exit.
+	// Each window has its own useTabsStore, so the paneId lookup below naturally
+	// scopes the update to the window that actually owns the pane.
 	electronTrpc.notifications.subscribe.useSubscription(undefined, {
 		onData: (event) => {
-			if (isTearoffWindow()) return;
 			if (
 				event.type !== NOTIFICATION_EVENTS.TERMINAL_EXIT ||
 				!event.data?.paneId
@@ -110,6 +111,14 @@ function AuthenticatedLayout() {
 	const updateInitProgress = useWorkspaceInitStore((s) => s.updateProgress);
 	electronTrpc.workspaces.onInitProgress.useSubscription(undefined, {
 		onData: (progress) => {
+			// React Query cache invalidation runs in every window (including
+			// tearoff) since each BrowserWindow has its own QueryClient and may
+			// be displaying the affected workspace.
+			if (progress.step === "ready" || progress.step === "failed") {
+				utils.workspaces.getAllGrouped.invalidate();
+				utils.workspaces.get.invalidate({ id: progress.workspaceId });
+			}
+			// The rest (progress store, toast, navigate) is main-window only.
 			if (isTearoffWindow()) return;
 			updateInitProgress(progress);
 			if (
@@ -123,11 +132,6 @@ function AuthenticatedLayout() {
 						void navigate({ to: "/settings/models" });
 					},
 				});
-			}
-			if (progress.step === "ready" || progress.step === "failed") {
-				// Invalidate both the grouped list AND the specific workspace
-				utils.workspaces.getAllGrouped.invalidate();
-				utils.workspaces.get.invalidate({ id: progress.workspaceId });
 			}
 		},
 		onError: (error) => {

--- a/apps/desktop/src/renderer/routes/_authenticated/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/layout.tsx
@@ -18,6 +18,7 @@ import { env } from "renderer/env.renderer";
 import { ScheduleFireToasts } from "renderer/features/todo-agent/ScheduleFireToasts";
 import { useIsV2CloudEnabled } from "renderer/hooks/useIsV2CloudEnabled";
 import { useOnlineStatus } from "renderer/hooks/useOnlineStatus";
+import { isTearoffWindow } from "renderer/hooks/useTearoffInit/useTearoffInit";
 import { migrateHotkeyOverrides } from "renderer/hotkeys/migrate";
 import { authClient, getAuthToken } from "renderer/lib/auth-client";
 import { dispatchBrowserShortcutEvent } from "renderer/lib/browser-shortcut-events";
@@ -81,6 +82,7 @@ function AuthenticatedLayout() {
 	// Update workspace-run pane state on terminal exit
 	electronTrpc.notifications.subscribe.useSubscription(undefined, {
 		onData: (event) => {
+			if (isTearoffWindow()) return;
 			if (
 				event.type !== NOTIFICATION_EVENTS.TERMINAL_EXIT ||
 				!event.data?.paneId
@@ -108,6 +110,7 @@ function AuthenticatedLayout() {
 	const updateInitProgress = useWorkspaceInitStore((s) => s.updateProgress);
 	electronTrpc.workspaces.onInitProgress.useSubscription(undefined, {
 		onData: (progress) => {
+			if (isTearoffWindow()) return;
 			updateInitProgress(progress);
 			if (
 				progress.warning &&
@@ -135,6 +138,7 @@ function AuthenticatedLayout() {
 	// Menu navigation subscription
 	electronTrpc.menu.subscribe.useSubscription(undefined, {
 		onData: (event) => {
+			if (isTearoffWindow()) return;
 			if (event.type === "open-settings") {
 				const section = event.data.section || "account";
 				navigate({ to: `/settings/${section}` as "/settings/account" });

--- a/plans/plan-305.md
+++ b/plans/plan-305.md
@@ -1,0 +1,33 @@
+# Issue #305: ティアオフウィンドウでメニューイベントを処理しない
+
+## 概要
+
+ティアオフ（切り離し）ウィンドウを開いている状態で、メインウィンドウからメニューで Settings を開くと、ティアオフウィンドウまで Settings 画面に遷移してしまう。
+同様の構造で `open-workspace` や `browser-action` も全ウィンドウでハンドリングされ、ティアオフ側で誤作動する可能性がある。
+
+## 原因
+
+`apps/desktop/src/renderer/routes/_authenticated/layout.tsx:136-147` の `electronTrpc.menu.subscribe` がメイン/ティアオフ問わず全ウィンドウで購読されているため、main 側の `menuEmitter.emit(...)` が全ウィンドウにブロードキャストされる。
+
+## 修正方針
+
+`menu.subscribe` の `onData` 冒頭で `isTearoffWindow()` ガードを入れ、ティアオフウィンドウではメニュー由来のイベントを処理しない。
+
+- `open-settings` / `open-workspace` / `browser-action` のいずれもメインウィンドウのみで処理されるべき操作
+- 最小差分で副作用なく修正できる
+
+## 変更対象ファイル
+
+- `apps/desktop/src/renderer/routes/_authenticated/layout.tsx`
+  - `menu.subscribe` の `onData` 先頭に `isTearoffWindow()` ガードを追加
+  - `useTearoffInit` から `isTearoffWindow` を import
+
+## 影響範囲
+
+- ティアオフウィンドウでメニュー由来のイベントを受け取らなくなる（期待動作）
+- メインウィンドウの挙動は変更なし
+
+## 受け入れ条件
+
+- ティアオフ表示中にメイン側で Settings を開く → メインのみ遷移し、ティアオフ側は現在のタブ表示を維持
+- `open-workspace` / `browser-action` も同様にメインのみで処理


### PR DESCRIPTION
close #305

## 概要

ティアオフ（タブ切り離し）ウィンドウを開いている状態で、メインウィンドウのメニューから Settings を開くと、ティアオフウィンドウも Settings 画面に遷移してしまうバグを修正する。

根本原因は `_authenticated/layout.tsx` 内の tRPC サブスクリプションが `trpc-electron` の構造上すべてのウィンドウ（メイン + ティアオフ）で購読されており、メインプロセス側の `EventEmitter.emit` が全ウィンドウへブロードキャストされるため。ティアオフウィンドウでもメインウィンドウ専用の副作用が発動していた。

同一ファイル内で同種のガード漏れが他に2箇所見つかったため合わせて修正する。

## 変更内容

`apps/desktop/src/renderer/routes/_authenticated/layout.tsx` の3つの `useSubscription` の `onData` 冒頭に `isTearoffWindow()` ガードを追加:

- `menu.subscribe` — Issue #305 本体。`open-settings` / `open-workspace` / `browser-action` がティアオフで実行される問題
- `notifications.subscribe` (TERMINAL_EXIT) — ティアオフでの不要な pane 状態更新を抑止
- `workspaces.onInitProgress` — ティアオフでの不要な進捗処理、および `navigate({ to: "/settings/models" })` の自動遷移副作用を抑止

## 実装前後の動作比較

| 操作 | 実装前（メイン / ティアオフ） | 実装後（メイン / ティアオフ） |
| --- | --- | --- |
| メニューから Settings を開く | 遷移 / **Settings に誤遷移** | 遷移 / 現タブを維持 |
| メニューから Open Workspace | 遷移 / **workspace に誤遷移** | 遷移 / 現タブを維持 |
| ブラウザ系ショートカット | 発火 / **ティアオフでも発火** | 発火 / 発火しない |
| TERMINAL_EXIT 通知 | pane 状態更新 / 無関係に走査 | pane 状態更新 / 何もしない |
| workspace 初期化進捗 | トースト + 進捗更新 / **進捗更新や models 設定への自動遷移が発生** | トースト + 進捗更新 / 何もしない |

## テスト方法

1. `bun run --filter @superset/desktop dev` でアプリ起動
2. ワークスペースを開き、タブを1つティアオフして別ウィンドウ化
3. メインウィンドウ側のメニュー「Settings...」または `Cmd+,` を実行
4. メインウィンドウのみが Settings 画面に遷移し、ティアオフウィンドウは現在のタブ表示を維持することを確認
5. 同様にメニューの Open Workspace、ブラウザ系ショートカット、workspace 初期化進捗時のトーストでティアオフ側が影響を受けないことを確認

## 関連調査

`useAgentHookListener` の `notifications.subscribe` も同様の構造だが、`resolveNotificationTarget` が workspaceId ベースで振り分けているため影響は限定的と判断し、今回はスコープ外とする。