### PR TITLE
upstream取り込み: Create Section Below を top-level に昇格 (#3537)

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceContextMenu/DashboardSidebarWorkspaceContextMenu.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceContextMenu/DashboardSidebarWorkspaceContextMenu.tsx
@@ -97,33 +97,35 @@ export function DashboardSidebarWorkspaceContextMenu({
 				</>
 			)}
 			<ContextMenuSeparator />
-			<ContextMenuSub>
-				<ContextMenuSubTrigger>
-					<LuArrowRightLeft className="size-4 mr-2" />
-					Move to Section
-				</ContextMenuSubTrigger>
-				<ContextMenuSubContent>
-					<ContextMenuItem onSelect={onCreateSection}>
-						<LuFolderPlus className="size-4 mr-2" />
-						New Section
-					</ContextMenuItem>
-					{sections.length > 0 && <ContextMenuSeparator />}
-					{sections.map((section) => (
-						<ContextMenuItem
-							key={section.id}
-							onSelect={() => onMoveToSection(section.id)}
-						>
-							{section.color && (
-								<span
-									className="size-2 shrink-0 rounded-full mr-2"
-									style={{ backgroundColor: section.color }}
-								/>
-							)}
-							{section.name}
-						</ContextMenuItem>
-					))}
-				</ContextMenuSubContent>
-			</ContextMenuSub>
+			<ContextMenuItem onSelect={onCreateSection}>
+				<LuFolderPlus className="size-4 mr-2" />
+				Create Section Below
+			</ContextMenuItem>
+			{(sections.length > 0 || isInSection) && <ContextMenuSeparator />}
+			{sections.length > 0 && (
+				<ContextMenuSub>
+					<ContextMenuSubTrigger>
+						<LuArrowRightLeft className="size-4 mr-2" />
+						Move to Section
+					</ContextMenuSubTrigger>
+					<ContextMenuSubContent>
+						{sections.map((section) => (
+							<ContextMenuItem
+								key={section.id}
+								onSelect={() => onMoveToSection(section.id)}
+							>
+								{section.color && (
+									<span
+										className="size-2 shrink-0 rounded-full mr-2"
+										style={{ backgroundColor: section.color }}
+									/>
+								)}
+								{section.name}
+							</ContextMenuItem>
+						))}
+					</ContextMenuSubContent>
+				</ContextMenuSub>
+			)}
 			{isInSection && (
 				<ContextMenuItem onSelect={() => onMoveToSection(null)}>
 					<LuArrowUp className="size-4 mr-2" />

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/hooks/useDashboardSidebarWorkspaceItemActions/useDashboardSidebarWorkspaceItemActions.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/hooks/useDashboardSidebarWorkspaceItemActions/useDashboardSidebarWorkspaceItemActions.ts
@@ -99,8 +99,9 @@ export function useDashboardSidebarWorkspaceItemActions({
 	};
 
 	const handleCreateSection = () => {
-		const newSectionId = createSection(projectId);
-		moveWorkspaceToSection(workspaceId, projectId, newSectionId);
+		createSection(projectId, {
+			insertAfterWorkspaceId: workspaceId,
+		});
 	};
 
 	const resolveWorktreePath = async (): Promise<string | null> => {

--- a/apps/desktop/src/renderer/routes/_authenticated/hooks/useDashboardSidebarState/useDashboardSidebarState.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/hooks/useDashboardSidebarState/useDashboardSidebarState.ts
@@ -182,25 +182,71 @@ export function useDashboardSidebarState() {
 	);
 
 	const createSection = useCallback(
-		(projectId: string, name = "New Section") => {
+		(
+			projectId: string,
+			options: { name?: string; insertAfterWorkspaceId?: string } = {},
+		) => {
+			const { name = "New Section", insertAfterWorkspaceId } = options;
 			ensureSidebarProjectRecord(collections, projectId);
 
 			const sectionId = crypto.randomUUID();
-			const sectionOrders = Array.from(
-				collections.v2SidebarSections.state.values(),
-			).filter((item) => item.projectId === projectId);
-
 			const randomColor =
 				PROJECT_CUSTOM_COLORS[
 					Math.floor(Math.random() * PROJECT_CUSTOM_COLORS.length)
 				].value;
+
+			let tabOrder: number;
+			if (insertAfterWorkspaceId) {
+				const anchorWorkspace = collections.v2WorkspaceLocalState.get(
+					insertAfterWorkspaceId,
+				);
+				const anchorTabOrder = anchorWorkspace?.sidebarState.sectionId
+					? (collections.v2SidebarSections.get(
+							anchorWorkspace.sidebarState.sectionId,
+						)?.tabOrder ?? 0)
+					: (anchorWorkspace?.sidebarState.tabOrder ?? 0);
+
+				for (const workspace of collections.v2WorkspaceLocalState.state.values()) {
+					if (
+						workspace.sidebarState.projectId === projectId &&
+						workspace.sidebarState.sectionId === null &&
+						workspace.sidebarState.tabOrder > anchorTabOrder
+					) {
+						const nextOrder = workspace.sidebarState.tabOrder + 1;
+						collections.v2WorkspaceLocalState.update(
+							workspace.workspaceId,
+							(draft) => {
+								draft.sidebarState.tabOrder = nextOrder;
+							},
+						);
+					}
+				}
+				for (const section of collections.v2SidebarSections.state.values()) {
+					if (
+						section.projectId === projectId &&
+						section.tabOrder > anchorTabOrder
+					) {
+						const nextOrder = section.tabOrder + 1;
+						collections.v2SidebarSections.update(section.sectionId, (draft) => {
+							draft.tabOrder = nextOrder;
+						});
+					}
+				}
+
+				tabOrder = anchorTabOrder + 1;
+			} else {
+				const sectionOrders = Array.from(
+					collections.v2SidebarSections.state.values(),
+				).filter((item) => item.projectId === projectId);
+				tabOrder = getNextTabOrder(sectionOrders);
+			}
 
 			collections.v2SidebarSections.insert({
 				sectionId,
 				projectId,
 				name,
 				createdAt: new Date(),
-				tabOrder: getNextTabOrder(sectionOrders),
+				tabOrder,
 				isCollapsed: false,
 				color: randomColor,
 			});


### PR DESCRIPTION
## 概要

upstream から sidebar context menu 改善 (#3537) を取り込む PR です。behind 5 → 4。

## 取り込み commit

| SHA | タイトル | 分類 |
|---|---|---|
| `78b7dc839` | feat(desktop): promote 'Create Section Below' to top-level on workspace menu (#3537) | 確実に安全（独立） |

## fork 適応修正

なし（clean cherry-pick）。3 files, +84/-35。

## 依存関係

- 親は `a3df48954` (PR #304 で取り込み済)
- `c504a5036` とは独立（変更ファイル交差 0）

## Codex pre-review

- 初回: No（section 内 workspace 上での挙動を fork 独自と誤認）
- 再レビュー: **Yes**（section/grouping は upstream 機能で fork 独自なし、現挙動は upstream 共通仕様で本 PR 起因の回帰なし）

## テストチェックリスト

- [ ] dashboard sidebar の workspace context menu に "Create Section Below" が top-level で表示されるか
- [ ] section 内 workspace / section 外 workspace 双方で動作確認