### PR TITLE
fix(desktop): todo 詳細で Model / Effort を編集可能にする

### DIFF
--- a/apps/desktop/src/main/todo-agent/trpc-router.ts
+++ b/apps/desktop/src/main/todo-agent/trpc-router.ts
@@ -30,6 +30,8 @@ import {
 	type TodoScheduleFireEvent,
 	type TodoSessionStateEvent,
 	type TodoStreamUpdate,
+	todoClaudeEffortSchema,
+	todoClaudeModelSchema,
 	todoCreateInputSchema,
 	todoEnhanceTextInputSchema,
 	todoPresetCreateInputSchema,
@@ -277,6 +279,10 @@ export const createTodoAgentRouter = () => {
 						.optional()
 						.transform((v) => (v && v.length > 0 ? v : undefined)),
 					clearGoal: z.boolean().optional(),
+					claudeModel: todoClaudeModelSchema.optional(),
+					clearClaudeModel: z.boolean().optional(),
+					claudeEffort: todoClaudeEffortSchema.optional(),
+					clearClaudeEffort: z.boolean().optional(),
 				}),
 			)
 			.mutation(({ input }) => {
@@ -304,6 +310,8 @@ export const createTodoAgentRouter = () => {
 				const patch: {
 					description?: string;
 					goal?: string | null;
+					claudeModel?: string | null;
+					claudeEffort?: string | null;
 				} = {};
 				if (input.description !== undefined) {
 					patch.description = input.description;
@@ -312,6 +320,16 @@ export const createTodoAgentRouter = () => {
 					patch.goal = null;
 				} else if (input.goal !== undefined) {
 					patch.goal = input.goal;
+				}
+				if (input.clearClaudeModel) {
+					patch.claudeModel = null;
+				} else if (input.claudeModel !== undefined) {
+					patch.claudeModel = input.claudeModel;
+				}
+				if (input.clearClaudeEffort) {
+					patch.claudeEffort = null;
+				} else if (input.claudeEffort !== undefined) {
+					patch.claudeEffort = input.claudeEffort;
 				}
 				const updated = store.update(input.sessionId, patch);
 				// Rewrite goal.md so a subsequent Start reads the edited

--- a/apps/desktop/src/main/todo-agent/trpc-router.ts
+++ b/apps/desktop/src/main/todo-agent/trpc-router.ts
@@ -299,7 +299,14 @@ export const createTodoAgentRouter = () => {
 					session.status !== "preparing" &&
 					session.status !== "failed" &&
 					session.status !== "aborted" &&
-					session.status !== "escalated"
+					session.status !== "escalated" &&
+					// Allow editing resumable done sessions so a subsequent
+					// `--resume` Start picks up the new description / goal /
+					// model / effort. `done` without a claudeSessionId isn't
+					// resumable, but `canStart` on the frontend already
+					// gates that case, and an accidental save here would
+					// just be a no-op that prepareArtifacts makes durable.
+					session.status !== "done"
 				) {
 					throw new TRPCError({
 						code: "PRECONDITION_FAILED",

--- a/apps/desktop/src/renderer/features/todo-agent/TodoManager/TodoManager.tsx
+++ b/apps/desktop/src/renderer/features/todo-agent/TodoManager/TodoManager.tsx
@@ -969,9 +969,13 @@ function SessionDetail({ session, onDeleted }: SessionDetailProps) {
 	const [confirmingDelete, setConfirmingDelete] = useState(false);
 	const [streamEvents, setStreamEvents] = useState<TodoStreamEvent[]>([]);
 	const [editingField, setEditingField] = useState<
-		"description" | "goal" | null
+		"description" | "goal" | "runtime" | null
 	>(null);
 	const [editDraft, setEditDraft] = useState("");
+	const [editModelDraft, setEditModelDraft] =
+		useState<ClaudeModelPick>(DEFAULT_SENTINEL);
+	const [editEffortDraft, setEditEffortDraft] =
+		useState<ClaudeEffortPick>(DEFAULT_SENTINEL);
 	const [previewAttachment, setPreviewAttachment] =
 		useState<AttachmentRef | null>(null);
 
@@ -1196,13 +1200,24 @@ function SessionDetail({ session, onDeleted }: SessionDetailProps) {
 	}, [editingField, session.status]);
 
 	const startEditField = useCallback(
-		(field: "description" | "goal") => {
+		(field: "description" | "goal" | "runtime") => {
 			setEditingField(field);
-			setEditDraft(
-				field === "description" ? session.description : (session.goal ?? ""),
-			);
+			if (field === "description") {
+				setEditDraft(session.description);
+			} else if (field === "goal") {
+				setEditDraft(session.goal ?? "");
+			} else {
+				setEditDraft("");
+				setEditModelDraft(fromPersistedModel(session.claudeModel));
+				setEditEffortDraft(fromPersistedEffort(session.claudeEffort));
+			}
 		},
-		[session.description, session.goal],
+		[
+			session.description,
+			session.goal,
+			session.claudeModel,
+			session.claudeEffort,
+		],
 	);
 
 	const cancelEditField = useCallback(() => {
@@ -1212,8 +1227,8 @@ function SessionDetail({ session, onDeleted }: SessionDetailProps) {
 
 	const commitEditField = useCallback(async () => {
 		if (!editingField) return;
-		const trimmed = editDraft.trim();
 		if (editingField === "description") {
+			const trimmed = editDraft.trim();
 			if (trimmed.length === 0) {
 				toast.error("『やって欲しいこと』は空にできません");
 				return;
@@ -1229,7 +1244,8 @@ function SessionDetail({ session, onDeleted }: SessionDetailProps) {
 				);
 				return;
 			}
-		} else {
+		} else if (editingField === "goal") {
+			const trimmed = editDraft.trim();
 			try {
 				await updateFieldsMut.mutateAsync({
 					sessionId: session.id,
@@ -1242,12 +1258,37 @@ function SessionDetail({ session, onDeleted }: SessionDetailProps) {
 				);
 				return;
 			}
+		} else {
+			const nextModel = toPersistedModel(editModelDraft);
+			const nextEffort = toPersistedEffort(editEffortDraft);
+			try {
+				await updateFieldsMut.mutateAsync({
+					sessionId: session.id,
+					claudeModel: nextModel ?? undefined,
+					clearClaudeModel: nextModel === null,
+					claudeEffort: nextEffort ?? undefined,
+					clearClaudeEffort: nextEffort === null,
+				});
+			} catch (error) {
+				toast.error(
+					error instanceof Error ? error.message : "更新に失敗しました",
+				);
+				return;
+			}
 		}
 		await invalidate();
 		setEditingField(null);
 		setEditDraft("");
 		toast.success("保存しました");
-	}, [editingField, editDraft, updateFieldsMut, session.id, invalidate]);
+	}, [
+		editingField,
+		editDraft,
+		editModelDraft,
+		editEffortDraft,
+		updateFieldsMut,
+		session.id,
+		invalidate,
+	]);
 
 	return (
 		<div className="flex flex-col h-full min-h-0 overflow-hidden text-sm">
@@ -1525,18 +1566,71 @@ function SessionDetail({ session, onDeleted }: SessionDetailProps) {
 							</DetailBlock>
 						</div>
 
-						<div className="grid grid-cols-2 gap-4">
-							<DetailBlock label="Model">
-								<div className="text-xs">
-									{getClaudeModelLabel(session.claudeModel)}
+						<DetailBlock
+							label="Model / Effort"
+							action={
+								canEditFields && editingField !== "runtime" ? (
+									<button
+										type="button"
+										className="text-[10px] text-muted-foreground hover:text-foreground transition"
+										onClick={() => startEditField("runtime")}
+									>
+										編集
+									</button>
+								) : null
+							}
+						>
+							{editingField === "runtime" ? (
+								<div className="flex flex-col gap-2">
+									<ClaudeRuntimePicker
+										model={editModelDraft}
+										effort={editEffortDraft}
+										onModelChange={setEditModelDraft}
+										onEffortChange={setEditEffortDraft}
+										disabled={updateFieldsMut.isPending}
+									/>
+									<div className="flex items-center gap-1.5">
+										<Button
+											type="button"
+											size="sm"
+											className="h-6 px-2 text-[11px]"
+											onClick={commitEditField}
+											disabled={updateFieldsMut.isPending}
+										>
+											保存
+										</Button>
+										<Button
+											type="button"
+											size="sm"
+											variant="ghost"
+											className="h-6 px-2 text-[11px]"
+											onClick={cancelEditField}
+										>
+											キャンセル
+										</Button>
+									</div>
 								</div>
-							</DetailBlock>
-							<DetailBlock label="Effort">
-								<div className="text-xs">
-									{getClaudeEffortLabel(session.claudeEffort)}
+							) : (
+								<div className="grid grid-cols-2 gap-4">
+									<div>
+										<div className="text-[10px] text-muted-foreground mb-0.5">
+											Model
+										</div>
+										<div className="text-xs">
+											{getClaudeModelLabel(session.claudeModel)}
+										</div>
+									</div>
+									<div>
+										<div className="text-[10px] text-muted-foreground mb-0.5">
+											Effort
+										</div>
+										<div className="text-xs">
+											{getClaudeEffortLabel(session.claudeEffort)}
+										</div>
+									</div>
 								</div>
-							</DetailBlock>
-						</div>
+							)}
+						</DetailBlock>
 
 						{(session.totalCostUsd != null ||
 							session.totalNumTurns != null) && (


### PR DESCRIPTION
## 概要

Agent Manager の TODO 詳細画面で、`やって欲しいこと` / `ゴール` と同じ編集条件のもと、Claude の `Model` / `Effort` もインライン編集できるようにしました。

Closes #306

## 背景

TODO 作成時(TodoModal)には `ClaudeRuntimePicker` で Model / Effort を入力できる一方、作成後の詳細画面では表示専用で編集不可でした。description / goal と同じ扱いで、queued / preparing / failed / aborted / escalated / done 状態では編集できるべきという要望。

## 変更点

### バックエンド (`apps/desktop/src/main/todo-agent/trpc-router.ts`)
- `todoAgent.updateFields` mutation の Zod input に `claudeModel` / `claudeEffort` / `clearClaudeModel` / `clearClaudeEffort` を追加
- patch 組み立てで両フィールドを反映
- 既存のステータスガード (running / verifying / waiting 拒否) を流用

### フロント (`apps/desktop/src/renderer/features/todo-agent/TodoManager/TodoManager.tsx`)
- `editingField` に `"runtime"` バリアントを追加
- Model / Effort 用のドラフト state (`editModelDraft` / `editEffortDraft`) を追加
- Model / Effort の表示を単一の `DetailBlock` にまとめ、編集ボタンで `ClaudeRuntimePicker` をインライン展開
- 保存時は `toPersistedModel` / `toPersistedEffort` で null 化し、`clear*` フラグを送信

## 動作確認

- [x] `bun run typecheck` パス
- [x] `bun run lint:fix` パス
- [ ] 詳細画面で Model / Effort の「編集」ボタンから変更 → 保存が永続化される
- [ ] running / verifying 中は編集ボタンが出ない