### PR TITLE
upstream取り込み: v2 sidebar section count fix (#3544)

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/useDashboardSidebarData.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/useDashboardSidebarData.ts
@@ -324,9 +324,31 @@ export function useDashboardSidebarData() {
 				sectionMap: _sectionMap,
 				...sidebarProject
 			} = resolvedProject;
-			sidebarProject.children = childEntries
+
+			const sortedChildren = childEntries
 				.sort((left, right) => left.tabOrder - right.tabOrder)
 				.map(({ child }) => child);
+
+			// Ungrouped workspaces rendered after a section header are visually
+			// grouped with that section (shared accent, collapse-together) and will
+			// be committed into it on next DnD. Reparent them here so section counts
+			// match what the user sees.
+			const children: DashboardSidebarProjectChild[] = [];
+			let currentSection: DashboardSidebarSection | null = null;
+			for (const child of sortedChildren) {
+				if (child.type === "section") {
+					currentSection = child.section;
+					children.push(child);
+				} else if (currentSection) {
+					currentSection.workspaces.push({
+						...child.workspace,
+						accentColor: currentSection.color,
+					});
+				} else {
+					children.push(child);
+				}
+			}
+			sidebarProject.children = children;
 			return [sidebarProject];
 		});
 	}, [


### PR DESCRIPTION
## 概要

upstream から v2 sidebar の section count 表示 fix を取り込む PR。behind 2 → 1（残り 867ef8746 は別 PR で手動移植）。

## 取り込み commit

| SHA | 内容 | 分類 |
|---|---|---|
| `1979f4cae` | fix(desktop): v2 sidebar section count reflects visually grouped workspaces (#3544) — 1 file, +23/-1 | 確実に安全（clean cherry-pick） |

## fork 適応修正

なし。`useDashboardSidebarData.ts` への clean apply。

## 検証

- typecheck: 全 26 タスク pass
- lint: 3件 baseline（regression なし）

## Codex pre-review

**Yes**（fork衝突低、git apply --check clean）。

## テストチェックリスト

- [ ] v2 sidebar で section にグループ化された workspace が section count に正しく反映されるか

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **リファクタリング**
  * ダッシュボードサイドバーの項目の整理構造を改善しました。セクション配下のワークスペースのグループ化と配色処理を最適化しています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->