### PR TITLE
feat(desktop): Files で音声/動画ファイルのプレビュー再生に対応 (#314)

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -45,6 +45,7 @@ import { ensureProjectIconsDir, getProjectIconPath } from "./lib/project-icons";
 import { initSentry } from "./lib/sentry";
 import { setupServiceStatusPolling } from "./lib/service-status";
 import { createTempAudioProtocolHandler } from "./lib/temp-audio-protocol";
+import { createWorkspaceMediaProtocolHandler } from "./lib/workspace-media-protocol";
 import {
 	prewarmTerminalRuntime,
 	reconcileDaemonSessions,
@@ -554,6 +555,16 @@ protocol.registerSchemesAsPrivileged([
 		},
 	},
 	{
+		scheme: "superset-workspace-media",
+		privileges: {
+			standard: true,
+			secure: true,
+			bypassCSP: true,
+			supportFetchAPI: true,
+			stream: true,
+		},
+	},
+	{
 		scheme: "vscode-webview-resource",
 		privileges: {
 			standard: true,
@@ -722,6 +733,13 @@ if (!gotTheLock) {
 		session
 			.fromPartition("persist:superset")
 			.protocol.handle("superset-temp-audio", tempAudioHandler);
+
+		// Serve workspace audio/video files for the file viewer
+		const workspaceMediaHandler = createWorkspaceMediaProtocolHandler();
+		protocol.handle("superset-workspace-media", workspaceMediaHandler);
+		session
+			.fromPartition("persist:superset")
+			.protocol.handle("superset-workspace-media", workspaceMediaHandler);
 
 		ensureProjectIconsDir();
 		setWorkspaceDockIcon();

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -45,13 +45,13 @@ import { ensureProjectIconsDir, getProjectIconPath } from "./lib/project-icons";
 import { initSentry } from "./lib/sentry";
 import { setupServiceStatusPolling } from "./lib/service-status";
 import { createTempAudioProtocolHandler } from "./lib/temp-audio-protocol";
-import { createWorkspaceMediaProtocolHandler } from "./lib/workspace-media-protocol";
 import {
 	prewarmTerminalRuntime,
 	reconcileDaemonSessions,
 } from "./lib/terminal";
 import { disposeTray, initTray } from "./lib/tray";
 import { windowManager } from "./lib/window-manager";
+import { createWorkspaceMediaProtocolHandler } from "./lib/workspace-media-protocol";
 
 // Lazy import to avoid module resolution issues during Vite build
 const loadVscodeShim = () =>

--- a/apps/desktop/src/main/lib/workspace-media-protocol.ts
+++ b/apps/desktop/src/main/lib/workspace-media-protocol.ts
@@ -1,0 +1,128 @@
+import { createReadStream } from "node:fs";
+import { stat } from "node:fs/promises";
+import { extname } from "node:path";
+import { Readable } from "node:stream";
+
+const AUDIO_MIME: Record<string, string> = {
+	".mp3": "audio/mpeg",
+	".wav": "audio/wav",
+	".ogg": "audio/ogg",
+	".oga": "audio/ogg",
+	".m4a": "audio/mp4",
+	".aac": "audio/aac",
+	".flac": "audio/flac",
+	".opus": "audio/ogg",
+	".weba": "audio/webm",
+};
+
+const VIDEO_MIME: Record<string, string> = {
+	".mp4": "video/mp4",
+	".webm": "video/webm",
+	".mov": "video/quicktime",
+	".m4v": "video/mp4",
+	".ogv": "video/ogg",
+};
+
+function mimeForExt(ext: string): string {
+	const lower = ext.toLowerCase();
+	return AUDIO_MIME[lower] ?? VIDEO_MIME[lower] ?? "application/octet-stream";
+}
+
+function decodePathFromUrl(url: URL): string | null {
+	// URL format: superset-workspace-media:///<url-encoded-absolute-path>
+	const raw = url.pathname.replace(/^\/+/, "");
+	if (!raw) return null;
+	try {
+		const decoded = decodeURIComponent(raw);
+		// Require absolute paths (POSIX "/" or Windows drive letter)
+		if (decoded.startsWith("/") || /^[a-zA-Z]:[\\/]/.test(decoded)) {
+			return decoded;
+		}
+		return null;
+	} catch {
+		return null;
+	}
+}
+
+export function encodeWorkspaceMediaUrl(absolutePath: string): string {
+	return `superset-workspace-media:///${encodeURIComponent(absolutePath)}`;
+}
+
+export function createWorkspaceMediaProtocolHandler() {
+	return async (request: Request): Promise<Response> => {
+		const url = new URL(request.url);
+		const filePath = decodePathFromUrl(url);
+		if (!filePath) {
+			return new Response("Bad request", { status: 400 });
+		}
+
+		let fileSize: number;
+		try {
+			const stats = await stat(filePath);
+			if (!stats.isFile()) {
+				return new Response("Not a file", { status: 404 });
+			}
+			fileSize = stats.size;
+		} catch {
+			return new Response("Not found", { status: 404 });
+		}
+
+		const mime = mimeForExt(extname(filePath));
+		const rangeHeader = request.headers.get("range");
+
+		if (rangeHeader) {
+			const match = /^bytes=(\d*)-(\d*)$/.exec(rangeHeader.trim());
+			if (match) {
+				const startStr = match[1];
+				const endStr = match[2];
+				let start: number;
+				let end: number;
+				if (startStr === "" && endStr !== "") {
+					const suffix = Number.parseInt(endStr, 10);
+					start = Math.max(0, fileSize - suffix);
+					end = fileSize - 1;
+				} else {
+					start = Number.parseInt(startStr, 10);
+					end = endStr ? Number.parseInt(endStr, 10) : fileSize - 1;
+				}
+				if (
+					!Number.isFinite(start) ||
+					!Number.isFinite(end) ||
+					start > end ||
+					start >= fileSize
+				) {
+					return new Response("Range not satisfiable", {
+						status: 416,
+						headers: { "Content-Range": `bytes */${fileSize}` },
+					});
+				}
+				end = Math.min(end, fileSize - 1);
+				const stream = Readable.toWeb(
+					createReadStream(filePath, { start, end }),
+				) as unknown as ReadableStream;
+				return new Response(stream, {
+					status: 206,
+					headers: {
+						"Content-Type": mime,
+						"Content-Length": String(end - start + 1),
+						"Content-Range": `bytes ${start}-${end}/${fileSize}`,
+						"Accept-Ranges": "bytes",
+						"Cache-Control": "no-store",
+					},
+				});
+			}
+		}
+
+		const stream = Readable.toWeb(
+			createReadStream(filePath),
+		) as unknown as ReadableStream;
+		return new Response(stream, {
+			headers: {
+				"Content-Type": mime,
+				"Content-Length": String(fileSize),
+				"Accept-Ranges": "bytes",
+				"Cache-Control": "no-store",
+			},
+		});
+	};
+}

--- a/apps/desktop/src/main/lib/workspace-media-protocol.ts
+++ b/apps/desktop/src/main/lib/workspace-media-protocol.ts
@@ -1,7 +1,9 @@
 import { createReadStream } from "node:fs";
-import { stat } from "node:fs/promises";
-import { extname } from "node:path";
+import { realpath, stat } from "node:fs/promises";
+import { extname, resolve, sep } from "node:path";
 import { Readable } from "node:stream";
+import { projects, worktrees } from "@superset/local-db";
+import { localDb } from "./local-db";
 
 const AUDIO_MIME: Record<string, string> = {
 	".mp3": "audio/mpeg",
@@ -23,6 +25,11 @@ const VIDEO_MIME: Record<string, string> = {
 	".ogv": "video/ogg",
 };
 
+const ALLOWED_EXTS = new Set<string>([
+	...Object.keys(AUDIO_MIME),
+	...Object.keys(VIDEO_MIME),
+]);
+
 function mimeForExt(ext: string): string {
 	const lower = ext.toLowerCase();
 	return AUDIO_MIME[lower] ?? VIDEO_MIME[lower] ?? "application/octet-stream";
@@ -34,7 +41,6 @@ function decodePathFromUrl(url: URL): string | null {
 	if (!raw) return null;
 	try {
 		const decoded = decodeURIComponent(raw);
-		// Require absolute paths (POSIX "/" or Windows drive letter)
 		if (decoded.startsWith("/") || /^[a-zA-Z]:[\\/]/.test(decoded)) {
 			return decoded;
 		}
@@ -48,17 +54,70 @@ export function encodeWorkspaceMediaUrl(absolutePath: string): string {
 	return `superset-workspace-media:///${encodeURIComponent(absolutePath)}`;
 }
 
+/**
+ * Return the set of allowed workspace root paths (project main repos + worktrees),
+ * each fully resolved. Paths are resolved fresh per-request so new workspaces
+ * become available without an app restart.
+ */
+async function loadAllowedRoots(): Promise<string[]> {
+	const rawRoots = [
+		...localDb.select({ path: projects.mainRepoPath }).from(projects).all(),
+		...localDb.select({ path: worktrees.path }).from(worktrees).all(),
+	]
+		.map((row) => row.path)
+		.filter(
+			(path): path is string => typeof path === "string" && path.length > 0,
+		);
+
+	const resolved = await Promise.all(
+		rawRoots.map(async (p) => {
+			try {
+				return await realpath(p);
+			} catch {
+				return resolve(p);
+			}
+		}),
+	);
+	return Array.from(new Set(resolved));
+}
+
+function isWithinRoot(resolvedPath: string, root: string): boolean {
+	if (resolvedPath === root) return true;
+	const rootWithSep = root.endsWith(sep) ? root : root + sep;
+	return resolvedPath.startsWith(rootWithSep);
+}
+
 export function createWorkspaceMediaProtocolHandler() {
 	return async (request: Request): Promise<Response> => {
 		const url = new URL(request.url);
-		const filePath = decodePathFromUrl(url);
-		if (!filePath) {
+		const requestedPath = decodePathFromUrl(url);
+		if (!requestedPath) {
 			return new Response("Bad request", { status: 400 });
+		}
+
+		const ext = extname(requestedPath).toLowerCase();
+		if (!ALLOWED_EXTS.has(ext)) {
+			return new Response("Forbidden", { status: 403 });
+		}
+
+		let resolvedPath: string;
+		try {
+			resolvedPath = await realpath(requestedPath);
+		} catch {
+			return new Response("Not found", { status: 404 });
+		}
+
+		const roots = await loadAllowedRoots();
+		const withinWorkspace = roots.some((root) =>
+			isWithinRoot(resolvedPath, root),
+		);
+		if (!withinWorkspace) {
+			return new Response("Forbidden", { status: 403 });
 		}
 
 		let fileSize: number;
 		try {
-			const stats = await stat(filePath);
+			const stats = await stat(resolvedPath);
 			if (!stats.isFile()) {
 				return new Response("Not a file", { status: 404 });
 			}
@@ -67,7 +126,7 @@ export function createWorkspaceMediaProtocolHandler() {
 			return new Response("Not found", { status: 404 });
 		}
 
-		const mime = mimeForExt(extname(filePath));
+		const mime = mimeForExt(ext);
 		const rangeHeader = request.headers.get("range");
 
 		if (rangeHeader) {
@@ -98,7 +157,7 @@ export function createWorkspaceMediaProtocolHandler() {
 				}
 				end = Math.min(end, fileSize - 1);
 				const stream = Readable.toWeb(
-					createReadStream(filePath, { start, end }),
+					createReadStream(resolvedPath, { start, end }),
 				) as unknown as ReadableStream;
 				return new Response(stream, {
 					status: 206,
@@ -114,7 +173,7 @@ export function createWorkspaceMediaProtocolHandler() {
 		}
 
 		const stream = Readable.toWeb(
-			createReadStream(filePath),
+			createReadStream(resolvedPath),
 		) as unknown as ReadableStream;
 		return new Response(stream, {
 			headers: {

--- a/apps/desktop/src/renderer/index.html
+++ b/apps/desktop/src/renderer/index.html
@@ -17,7 +17,7 @@
       - frame-src https: http: data: blob:: Allow webview browser pane to load any URL
       - child-src 'self' blob:: Allow workers from same origin + blob workers
     -->
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'wasm-unsafe-eval' https://*.posthog.com; style-src 'self' 'unsafe-inline'; connect-src 'self' data: blob: ws: wss: http://127.0.0.1:* %RELAY_URL% %NEXT_PUBLIC_API_URL% %NEXT_PUBLIC_ELECTRIC_URL% https://*.posthog.com https://*.sentry.io sentry-ipc:; img-src 'self' data: blob: https: http:; font-src 'self'; frame-src https: http: data: blob:; child-src 'self' blob:;" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'wasm-unsafe-eval' https://*.posthog.com; style-src 'self' 'unsafe-inline'; connect-src 'self' data: blob: ws: wss: http://127.0.0.1:* %RELAY_URL% %NEXT_PUBLIC_API_URL% %NEXT_PUBLIC_ELECTRIC_URL% https://*.posthog.com https://*.sentry.io sentry-ipc:; img-src 'self' data: blob: https: http:; media-src 'self' blob: superset-workspace-media: superset-temp-audio:; font-src 'self'; frame-src https: http: data: blob:; child-src 'self' blob:;" />
   </head>
 
   <body>

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/components/FileViewerContent/FileViewerContent.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/components/FileViewerContent/FileViewerContent.tsx
@@ -30,7 +30,15 @@ import type { Tab } from "renderer/stores/tabs/types";
 import { pathsMatch, toAbsoluteWorkspacePath } from "shared/absolute-paths";
 import { type DiffViewMode, isDiffEditable } from "shared/changes-types";
 import { detectLanguage } from "shared/detect-language";
-import { isHtmlFile, isImageFile, isSpreadsheetFile } from "shared/file-types";
+import {
+	getAudioMimeType,
+	getVideoMimeType,
+	isAudioFile,
+	isHtmlFile,
+	isImageFile,
+	isSpreadsheetFile,
+	isVideoFile,
+} from "shared/file-types";
 import type { FileViewerMode } from "shared/tabs-types";
 import { useNextEditCompletion } from "../../hooks/useNextEditCompletion";
 import { useScrollToFirstDiffChange } from "../../hooks/useScrollToFirstDiffChange";
@@ -307,6 +315,8 @@ export function FileViewerContent({
 }: FileViewerContentProps) {
 	const isImage = isImageFile(filePath);
 	const isHtml = isHtmlFile(filePath);
+	const isAudio = isAudioFile(filePath);
+	const isVideo = isVideoFile(filePath);
 	const {
 		isAvailable: isNextEditAvailable,
 		requestInlineCompletion,
@@ -860,6 +870,46 @@ export function FileViewerContent({
 					className="max-h-full max-w-full object-contain"
 					style={{ imageRendering: "auto" }}
 				/>
+			</div>
+		);
+	}
+
+	if (viewMode === "rendered" && (isAudio || isVideo) && absoluteFilePath) {
+		const mediaUrl = `superset-workspace-media:///${encodeURIComponent(
+			absoluteFilePath,
+		)}`;
+		const mimeType = isAudio
+			? getAudioMimeType(filePath)
+			: getVideoMimeType(filePath);
+
+		if (isAudio) {
+			return (
+				<div className="flex h-full flex-col items-center justify-center gap-4 bg-background-solid p-6">
+					<div className="max-w-md truncate text-sm text-muted-foreground">
+						{filePath.split("/").pop()}
+					</div>
+					<audio
+						key={absoluteFilePath}
+						controls
+						preload="metadata"
+						className="w-full max-w-xl"
+					>
+						<source src={mediaUrl} type={mimeType ?? undefined} />
+					</audio>
+				</div>
+			);
+		}
+
+		return (
+			<div className="flex h-full items-center justify-center bg-black">
+				<video
+					key={absoluteFilePath}
+					controls
+					preload="metadata"
+					className="max-h-full max-w-full"
+				>
+					<source src={mediaUrl} type={mimeType ?? undefined} />
+				</video>
 			</div>
 		);
 	}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/components/FileViewerContent/FileViewerContent.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/components/FileViewerContent/FileViewerContent.tsx
@@ -888,6 +888,7 @@ export function FileViewerContent({
 					<div className="max-w-md truncate text-sm text-muted-foreground">
 						{filePath.split("/").pop()}
 					</div>
+					{/* biome-ignore lint/a11y/useMediaCaption: user-opened media files have no caption tracks */}
 					<audio
 						key={absoluteFilePath}
 						controls
@@ -902,6 +903,7 @@ export function FileViewerContent({
 
 		return (
 			<div className="flex h-full items-center justify-center bg-black">
+				{/* biome-ignore lint/a11y/useMediaCaption: user-opened media files have no caption tracks */}
 				<video
 					key={absoluteFilePath}
 					controls

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/hooks/useFileContent/useFileContent.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/hooks/useFileContent/useFileContent.ts
@@ -2,7 +2,12 @@ import { useMemo } from "react";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import type { ChangeCategory } from "shared/changes-types";
 import { detectLanguage } from "shared/detect-language";
-import { getImageMimeType, isImageFile } from "shared/file-types";
+import {
+	getImageMimeType,
+	isAudioFile,
+	isImageFile,
+	isVideoFile,
+} from "shared/file-types";
 
 const BRANCH_QUERY_STALE_TIME_MS = 10_000;
 
@@ -55,9 +60,15 @@ export function useFileContent({
 		branchData?.worktreeBaseBranch ?? branchData?.defaultBranch ?? "main";
 
 	const isImage = isImageFile(filePath);
+	const isMedia = isAudioFile(filePath) || isVideoFile(filePath);
 
 	const rawReadEnabled =
-		!isRemote && viewMode !== "diff" && !isImage && !!filePath && !!workspaceId;
+		!isRemote &&
+		viewMode !== "diff" &&
+		!isImage &&
+		!isMedia &&
+		!!filePath &&
+		!!workspaceId;
 	const rawQuery = electronTrpc.filesystem.readFile.useQuery(
 		{
 			workspaceId: workspaceId ?? "",

--- a/apps/desktop/src/shared/file-types.ts
+++ b/apps/desktop/src/shared/file-types.ts
@@ -30,6 +30,42 @@ const IMAGE_MIME_TYPES: Record<string, string> = {
 /** Spreadsheet extensions */
 const SPREADSHEET_EXTENSIONS = new Set(["xlsx", "xls", "xlsm", "xlsb", "ods"]);
 
+/** Audio extensions playable in Chromium */
+const AUDIO_EXTENSIONS = new Set([
+	"mp3",
+	"wav",
+	"ogg",
+	"oga",
+	"m4a",
+	"aac",
+	"flac",
+	"opus",
+	"weba",
+]);
+
+const AUDIO_MIME_TYPES: Record<string, string> = {
+	mp3: "audio/mpeg",
+	wav: "audio/wav",
+	ogg: "audio/ogg",
+	oga: "audio/ogg",
+	m4a: "audio/mp4",
+	aac: "audio/aac",
+	flac: "audio/flac",
+	opus: "audio/ogg",
+	weba: "audio/webm",
+};
+
+/** Video extensions playable in Chromium */
+const VIDEO_EXTENSIONS = new Set(["mp4", "webm", "mov", "m4v", "ogv"]);
+
+const VIDEO_MIME_TYPES: Record<string, string> = {
+	mp4: "video/mp4",
+	webm: "video/webm",
+	mov: "video/quicktime",
+	m4v: "video/mp4",
+	ogv: "video/ogg",
+};
+
 /** Extensions for supported image MIME types */
 const IMAGE_MIME_TYPE_EXTENSIONS: Record<string, string> = {
 	"image/png": "png",
@@ -126,10 +162,42 @@ export function isSpreadsheetFile(filePath: string): boolean {
 }
 
 /**
- * Checks if a file supports rendered preview (markdown, image, or HTML)
+ * Checks if a file is an audio file based on extension
+ */
+export function isAudioFile(filePath: string): boolean {
+	return AUDIO_EXTENSIONS.has(getExtension(filePath));
+}
+
+/**
+ * Checks if a file is a video file based on extension
+ */
+export function isVideoFile(filePath: string): boolean {
+	return VIDEO_EXTENSIONS.has(getExtension(filePath));
+}
+
+/**
+ * Gets the MIME type for an audio file. Returns null if unsupported.
+ */
+export function getAudioMimeType(filePath: string): string | null {
+	return AUDIO_MIME_TYPES[getExtension(filePath)] ?? null;
+}
+
+/**
+ * Gets the MIME type for a video file. Returns null if unsupported.
+ */
+export function getVideoMimeType(filePath: string): string | null {
+	return VIDEO_MIME_TYPES[getExtension(filePath)] ?? null;
+}
+
+/**
+ * Checks if a file supports rendered preview (markdown, image, HTML, audio, or video)
  */
 export function hasRenderedPreview(filePath: string): boolean {
 	return (
-		isMarkdownFile(filePath) || isImageFile(filePath) || isHtmlFile(filePath)
+		isMarkdownFile(filePath) ||
+		isImageFile(filePath) ||
+		isHtmlFile(filePath) ||
+		isAudioFile(filePath) ||
+		isVideoFile(filePath)
 	);
 }


### PR DESCRIPTION
Closes #314

## 概要
Files サイドバーから音声/動画ファイルを開いたとき、これまで `Binary file preview not supported` と表示されていたのを HTML5 の `<audio>` / `<video>` プレーヤーで再生できるようにした。

## 対応フォーマット
- **音声**: `mp3`, `wav`, `ogg`, `oga`, `m4a`, `aac`, `flac`, `opus`, `weba`
- **動画**: `mp4`, `webm`, `mov`, `m4v`, `ogv`

Chromium 標準で再生可能なコーデック/コンテナに限定。`.wma` / `.mkv` / `.avi` / `.wmv` / `.flv` 等は除外。

## 実装
- `shared/file-types.ts`: `isAudioFile` / `isVideoFile` + MIME 取得関数を追加し、`hasRenderedPreview` に組み込み（rendered モードがデフォルトで開くようになる）
- `main/lib/workspace-media-protocol.ts` (新規): `superset-workspace-media://` カスタムプロトコル。**Range リクエスト対応**なので動画のシークや途中からの再生ができる
- `main/index.ts`: privileged スキーム登録 + default/persist セッション両方に handler 登録
- `renderer/index.html`: CSP に `media-src 'self' blob: superset-workspace-media: superset-temp-audio:` を追加
- `useFileContent`: 音声/動画ではテキスト読み込みを行わない
- `FileViewerContent`: rendered モードで音声はコントロール付き中央配置、動画は黒背景のビデオプレーヤーを表示

## Test plan
- [ ] `.mp3` ファイルを Files から開いて再生できる
- [ ] `.mp4` ファイルを Files から開いて再生・シークできる
- [ ] `.wav`, `.ogg`, `.webm` など他フォーマットも再生できる
- [ ] 大きめ（100MB+）の動画でもシークバー操作で途中に飛べる（Range 対応の確認）
- [ ] 非対応拡張子（例: `.wma`, `.mkv`）は従来通り binary preview 扱いになる