### PR TITLE
fix(desktop): restore local media streaming

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -552,6 +552,7 @@ protocol.registerSchemesAsPrivileged([
 			secure: true,
 			bypassCSP: true,
 			supportFetchAPI: true,
+			stream: true,
 		},
 	},
 	{
@@ -571,6 +572,7 @@ protocol.registerSchemesAsPrivileged([
 			secure: true,
 			bypassCSP: true,
 			supportFetchAPI: true,
+			stream: true,
 		},
 	},
 	{

--- a/apps/desktop/src/main/lib/file-streaming.ts
+++ b/apps/desktop/src/main/lib/file-streaming.ts
@@ -1,0 +1,226 @@
+import { createReadStream } from "node:fs";
+import { stat } from "node:fs/promises";
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { extname } from "node:path";
+import { Readable } from "node:stream";
+
+export const AUDIO_MIME_TYPES: Record<string, string> = {
+	".mp3": "audio/mpeg",
+	".wav": "audio/wav",
+	".ogg": "audio/ogg",
+	".oga": "audio/ogg",
+	".m4a": "audio/mp4",
+	".aac": "audio/aac",
+	".flac": "audio/flac",
+	".opus": "audio/ogg",
+	".weba": "audio/webm",
+};
+
+export const VIDEO_MIME_TYPES: Record<string, string> = {
+	".mp4": "video/mp4",
+	".webm": "video/webm",
+	".mov": "video/quicktime",
+	".m4v": "video/mp4",
+	".ogv": "video/ogg",
+};
+
+export const MEDIA_MIME_TYPES: Record<string, string> = {
+	...AUDIO_MIME_TYPES,
+	...VIDEO_MIME_TYPES,
+};
+
+type FileResponseOptions = {
+	cacheControl?: string;
+	contentType?: string;
+};
+
+type ByteRange = {
+	start: number;
+	end: number;
+};
+
+function parseRangeHeader(
+	rangeHeader: string | null,
+	fileSize: number,
+): ByteRange | "unsatisfiable" | null {
+	if (!rangeHeader) return null;
+
+	const match = /^bytes=(\d*)-(\d*)$/.exec(rangeHeader.trim());
+	if (!match) return null;
+
+	const startStr = match[1];
+	const endStr = match[2];
+	let start: number;
+	let end: number;
+
+	if (startStr === "" && endStr !== "") {
+		const suffix = Number.parseInt(endStr, 10);
+		if (!Number.isFinite(suffix) || suffix <= 0) {
+			return "unsatisfiable";
+		}
+		start = Math.max(0, fileSize - suffix);
+		end = fileSize - 1;
+	} else {
+		start = Number.parseInt(startStr, 10);
+		end = endStr ? Number.parseInt(endStr, 10) : fileSize - 1;
+	}
+
+	if (
+		!Number.isFinite(start) ||
+		!Number.isFinite(end) ||
+		start > end ||
+		start < 0 ||
+		start >= fileSize
+	) {
+		return "unsatisfiable";
+	}
+
+	return {
+		start,
+		end: Math.min(end, fileSize - 1),
+	};
+}
+
+function createWebStream(filePath: string, range?: ByteRange): ReadableStream {
+	const nodeStream = range
+		? createReadStream(filePath, range)
+		: createReadStream(filePath);
+	return Readable.toWeb(nodeStream) as unknown as ReadableStream;
+}
+
+function createHeaders(
+	contentType: string,
+	fileSize: number,
+	cacheControl: string,
+	range?: ByteRange,
+): Record<string, string> {
+	if (range) {
+		return {
+			"Content-Type": contentType,
+			"Content-Length": String(range.end - range.start + 1),
+			"Content-Range": `bytes ${range.start}-${range.end}/${fileSize}`,
+			"Accept-Ranges": "bytes",
+			"Cache-Control": cacheControl,
+		};
+	}
+
+	return {
+		"Content-Type": contentType,
+		"Content-Length": String(fileSize),
+		"Accept-Ranges": "bytes",
+		"Cache-Control": cacheControl,
+	};
+}
+
+export function getMediaMimeType(filePath: string): string | null {
+	const key = filePath.startsWith(".")
+		? filePath.toLowerCase()
+		: extname(filePath).toLowerCase();
+	return MEDIA_MIME_TYPES[key] ?? null;
+}
+
+export function isSupportedMediaFile(filePath: string): boolean {
+	return getMediaMimeType(filePath) !== null;
+}
+
+export async function createFileProtocolResponse(
+	request: Request,
+	filePath: string,
+	options: FileResponseOptions = {},
+): Promise<Response> {
+	let fileSize: number;
+	try {
+		const fileStat = await stat(filePath);
+		if (!fileStat.isFile()) {
+			return new Response("Not found", { status: 404 });
+		}
+		fileSize = fileStat.size;
+	} catch {
+		return new Response("Not found", { status: 404 });
+	}
+
+	const contentType = options.contentType ?? "application/octet-stream";
+	const cacheControl = options.cacheControl ?? "no-store";
+	const range = parseRangeHeader(request.headers.get("range"), fileSize);
+
+	if (range === "unsatisfiable") {
+		return new Response("Range not satisfiable", {
+			status: 416,
+			headers: { "Content-Range": `bytes */${fileSize}` },
+		});
+	}
+
+	const headers = createHeaders(
+		contentType,
+		fileSize,
+		cacheControl,
+		range ?? undefined,
+	);
+	const status = range ? 206 : 200;
+	const body =
+		request.method === "HEAD"
+			? null
+			: createWebStream(filePath, range ?? undefined);
+
+	return new Response(body, { status, headers });
+}
+
+export async function writeFileHttpResponse(
+	req: IncomingMessage,
+	res: ServerResponse<IncomingMessage>,
+	filePath: string,
+	options: FileResponseOptions = {},
+): Promise<void> {
+	let fileSize: number;
+	try {
+		const fileStat = await stat(filePath);
+		if (!fileStat.isFile()) {
+			res.writeHead(404, { "Content-Type": "text/plain" });
+			res.end("Not found");
+			return;
+		}
+		fileSize = fileStat.size;
+	} catch {
+		res.writeHead(404, { "Content-Type": "text/plain" });
+		res.end("Not found");
+		return;
+	}
+
+	const contentType = options.contentType ?? "application/octet-stream";
+	const cacheControl = options.cacheControl ?? "no-store";
+	const range = parseRangeHeader(req.headers.range ?? null, fileSize);
+
+	if (range === "unsatisfiable") {
+		res.writeHead(416, {
+			"Content-Type": "text/plain",
+			"Content-Range": `bytes */${fileSize}`,
+		});
+		res.end("Range not satisfiable");
+		return;
+	}
+
+	const headers = createHeaders(
+		contentType,
+		fileSize,
+		cacheControl,
+		range ?? undefined,
+	);
+	const status = range ? 206 : 200;
+	res.writeHead(status, headers);
+
+	if (req.method === "HEAD") {
+		res.end();
+		return;
+	}
+
+	const stream = range
+		? createReadStream(filePath, range)
+		: createReadStream(filePath);
+	stream.on("error", () => {
+		if (!res.headersSent) {
+			res.writeHead(500, { "Content-Type": "text/plain" });
+		}
+		res.end("Error reading file");
+	});
+	stream.pipe(res);
+}

--- a/apps/desktop/src/main/lib/temp-audio-protocol.ts
+++ b/apps/desktop/src/main/lib/temp-audio-protocol.ts
@@ -1,5 +1,4 @@
-import { readFile } from "node:fs/promises";
-import { extname } from "node:path";
+import { createFileProtocolResponse, getMediaMimeType } from "./file-streaming";
 
 const registry = new Map<string, string>();
 
@@ -15,13 +14,6 @@ export function getTempAudioPath(id: string): string | null {
 	return registry.get(id) ?? null;
 }
 
-function mimeForExt(ext: string): string {
-	if (ext === ".mp3") return "audio/mpeg";
-	if (ext === ".wav") return "audio/wav";
-	if (ext === ".ogg") return "audio/ogg";
-	return "audio/mpeg";
-}
-
 export function createTempAudioProtocolHandler() {
 	return async (request: Request): Promise<Response> => {
 		const url = new URL(request.url);
@@ -30,19 +22,10 @@ export function createTempAudioProtocolHandler() {
 		if (!filePath) {
 			return new Response("Not found", { status: 404 });
 		}
-		try {
-			const data = await readFile(filePath);
-			const mime = mimeForExt(extname(filePath).toLowerCase());
-			return new Response(data, {
-				headers: {
-					"Content-Type": mime,
-					"Content-Length": String(data.length),
-					"Accept-Ranges": "bytes",
-					"Cache-Control": "no-store",
-				},
-			});
-		} catch {
-			return new Response("Error reading file", { status: 500 });
-		}
+
+		return createFileProtocolResponse(request, filePath, {
+			contentType: getMediaMimeType(filePath) ?? "audio/mpeg",
+			cacheControl: "no-store",
+		});
 	};
 }

--- a/apps/desktop/src/main/lib/vscode-shim/api/protocol-handler.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/api/protocol-handler.ts
@@ -9,6 +9,10 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import {
+	createFileProtocolResponse,
+	MEDIA_MIME_TYPES,
+} from "../../file-streaming";
 import { shimLog } from "./debug-log";
 
 /** Allowed base directories for serving extension resources */
@@ -39,6 +43,7 @@ const MIME_TYPES: Record<string, string> = {
 	".woff2": "font/woff2",
 	".ttf": "font/ttf",
 	".ico": "image/x-icon",
+	...MEDIA_MIME_TYPES,
 };
 
 function getMimeType(filePath: string): string {
@@ -50,7 +55,7 @@ export function registerWebviewProtocol(): void {
 	try {
 		const { protocol } = require("electron");
 
-		protocol.handle("vscode-webview-resource", (request: Request) => {
+		protocol.handle("vscode-webview-resource", async (request: Request) => {
 			const url = new URL(request.url);
 			let filePath = decodeURIComponent(url.pathname);
 
@@ -66,11 +71,11 @@ export function registerWebviewProtocol(): void {
 				return new Response("Not found", { status: 404 });
 			}
 
-			const content = fs.readFileSync(filePath);
 			const mimeType = getMimeType(filePath);
 
-			return new Response(content, {
-				headers: { "Content-Type": mimeType },
+			return createFileProtocolResponse(request, filePath, {
+				contentType: mimeType,
+				cacheControl: "public, max-age=3600",
 			});
 		});
 

--- a/apps/desktop/src/main/lib/vscode-shim/api/webview-server.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/api/webview-server.ts
@@ -10,6 +10,7 @@ import fs from "node:fs";
 import http from "node:http";
 import os from "node:os";
 import path from "node:path";
+import { MEDIA_MIME_TYPES, writeFileHttpResponse } from "../../file-streaming";
 import { shimLog, shimWarn } from "./debug-log";
 
 const MIME_TYPES: Record<string, string> = {
@@ -28,6 +29,7 @@ const MIME_TYPES: Record<string, string> = {
 	".ttf": "font/ttf",
 	".ico": "image/x-icon",
 	".wasm": "application/wasm",
+	...MEDIA_MIME_TYPES,
 };
 
 const ALLOWED_ROOTS = [
@@ -242,7 +244,7 @@ export async function startWebviewServer(): Promise<number> {
 	if (server) return serverPort;
 
 	return new Promise((resolve, reject) => {
-		server = http.createServer((req, res) => {
+		server = http.createServer(async (req, res) => {
 			const url = new URL(req.url ?? "/", `http://127.0.0.1`);
 			shimLog(`[webview-server] ${req.method} ${url.pathname}`);
 
@@ -294,6 +296,7 @@ export async function startWebviewServer(): Promise<number> {
 						`style-src 'unsafe-inline' http://127.0.0.1:${serverPort} https:`,
 						`img-src http://127.0.0.1:${serverPort} https: data: blob:`,
 						`font-src http://127.0.0.1:${serverPort} https: data:`,
+						`media-src vscode-webview-resource: http://127.0.0.1:${serverPort} https: data: blob:`,
 						"connect-src https: wss: ws: http://127.0.0.1:* http://localhost:*",
 						`frame-src http://127.0.0.1:${serverPort} https:`,
 						"worker-src blob:",
@@ -333,12 +336,10 @@ export async function startWebviewServer(): Promise<number> {
 				const ext = path.extname(filePath).toLowerCase();
 				const mimeType = MIME_TYPES[ext] ?? "application/octet-stream";
 
-				const content = fs.readFileSync(filePath);
-				res.writeHead(200, {
-					"Content-Type": mimeType,
-					"Cache-Control": "public, max-age=3600",
+				await writeFileHttpResponse(req, res, filePath, {
+					contentType: mimeType,
+					cacheControl: "public, max-age=3600",
 				});
-				res.end(content);
 				return;
 			}
 

--- a/apps/desktop/src/main/lib/workspace-media-protocol.ts
+++ b/apps/desktop/src/main/lib/workspace-media-protocol.ts
@@ -1,39 +1,12 @@
-import { createReadStream } from "node:fs";
-import { realpath, stat } from "node:fs/promises";
-import { extname, resolve, sep } from "node:path";
-import { Readable } from "node:stream";
+import { realpath } from "node:fs/promises";
+import { resolve, sep } from "node:path";
 import { projects, worktrees } from "@superset/local-db";
+import {
+	createFileProtocolResponse,
+	getMediaMimeType,
+	isSupportedMediaFile,
+} from "./file-streaming";
 import { localDb } from "./local-db";
-
-const AUDIO_MIME: Record<string, string> = {
-	".mp3": "audio/mpeg",
-	".wav": "audio/wav",
-	".ogg": "audio/ogg",
-	".oga": "audio/ogg",
-	".m4a": "audio/mp4",
-	".aac": "audio/aac",
-	".flac": "audio/flac",
-	".opus": "audio/ogg",
-	".weba": "audio/webm",
-};
-
-const VIDEO_MIME: Record<string, string> = {
-	".mp4": "video/mp4",
-	".webm": "video/webm",
-	".mov": "video/quicktime",
-	".m4v": "video/mp4",
-	".ogv": "video/ogg",
-};
-
-const ALLOWED_EXTS = new Set<string>([
-	...Object.keys(AUDIO_MIME),
-	...Object.keys(VIDEO_MIME),
-]);
-
-function mimeForExt(ext: string): string {
-	const lower = ext.toLowerCase();
-	return AUDIO_MIME[lower] ?? VIDEO_MIME[lower] ?? "application/octet-stream";
-}
 
 function decodePathFromUrl(url: URL): string | null {
 	// URL format: superset-workspace-media:///<url-encoded-absolute-path>
@@ -95,8 +68,7 @@ export function createWorkspaceMediaProtocolHandler() {
 			return new Response("Bad request", { status: 400 });
 		}
 
-		const ext = extname(requestedPath).toLowerCase();
-		if (!ALLOWED_EXTS.has(ext)) {
+		if (!isSupportedMediaFile(requestedPath)) {
 			return new Response("Forbidden", { status: 403 });
 		}
 
@@ -115,73 +87,9 @@ export function createWorkspaceMediaProtocolHandler() {
 			return new Response("Forbidden", { status: 403 });
 		}
 
-		let fileSize: number;
-		try {
-			const stats = await stat(resolvedPath);
-			if (!stats.isFile()) {
-				return new Response("Not a file", { status: 404 });
-			}
-			fileSize = stats.size;
-		} catch {
-			return new Response("Not found", { status: 404 });
-		}
-
-		const mime = mimeForExt(ext);
-		const rangeHeader = request.headers.get("range");
-
-		if (rangeHeader) {
-			const match = /^bytes=(\d*)-(\d*)$/.exec(rangeHeader.trim());
-			if (match) {
-				const startStr = match[1];
-				const endStr = match[2];
-				let start: number;
-				let end: number;
-				if (startStr === "" && endStr !== "") {
-					const suffix = Number.parseInt(endStr, 10);
-					start = Math.max(0, fileSize - suffix);
-					end = fileSize - 1;
-				} else {
-					start = Number.parseInt(startStr, 10);
-					end = endStr ? Number.parseInt(endStr, 10) : fileSize - 1;
-				}
-				if (
-					!Number.isFinite(start) ||
-					!Number.isFinite(end) ||
-					start > end ||
-					start >= fileSize
-				) {
-					return new Response("Range not satisfiable", {
-						status: 416,
-						headers: { "Content-Range": `bytes */${fileSize}` },
-					});
-				}
-				end = Math.min(end, fileSize - 1);
-				const stream = Readable.toWeb(
-					createReadStream(resolvedPath, { start, end }),
-				) as unknown as ReadableStream;
-				return new Response(stream, {
-					status: 206,
-					headers: {
-						"Content-Type": mime,
-						"Content-Length": String(end - start + 1),
-						"Content-Range": `bytes ${start}-${end}/${fileSize}`,
-						"Accept-Ranges": "bytes",
-						"Cache-Control": "no-store",
-					},
-				});
-			}
-		}
-
-		const stream = Readable.toWeb(
-			createReadStream(resolvedPath),
-		) as unknown as ReadableStream;
-		return new Response(stream, {
-			headers: {
-				"Content-Type": mime,
-				"Content-Length": String(fileSize),
-				"Accept-Ranges": "bytes",
-				"Cache-Control": "no-store",
-			},
+		return createFileProtocolResponse(request, resolvedPath, {
+			contentType: getMediaMimeType(resolvedPath) ?? "application/octet-stream",
+			cacheControl: "no-store",
 		});
 	};
 }


### PR DESCRIPTION
## Summary
- add shared local file streaming helpers with MIME detection and byte-range support for media playback
- fix `superset-temp-audio` so audio preview uses streaming responses and privileged `stream: true`
- harden VS Code shim resource serving for audio/video by adding media MIME types, range responses, and `media-src` allowances
- keep workspace file previews on the same range-aware media serving path, which also covers video formats handled by `superset-workspace-media`

## Why
Closes #319.

The issue was caused by our local media-serving paths not being consistently implemented as real media responses. Some paths returned whole buffers without proper streaming/range semantics, and the VS Code shim paths were also missing audio/video media support.

## Verification
- `bun run lint`
  - blocked by pre-existing unrelated repository checks in `apps/desktop/src/lib/trpc/routers/projects/projects.ts` and `apps/desktop/src/main/todo-agent/schedule-sync.ts`
- `bunx biome check apps/desktop/src/main/index.ts apps/desktop/src/main/lib/file-streaming.ts apps/desktop/src/main/lib/temp-audio-protocol.ts apps/desktop/src/main/lib/workspace-media-protocol.ts apps/desktop/src/main/lib/vscode-shim/api/protocol-handler.ts apps/desktop/src/main/lib/vscode-shim/api/webview-server.ts`
  - passed
- `PATH="$PWD/node_modules/.bin:$PATH" turbo typecheck`
  - blocked by pre-existing unrelated `@superset/host-service` module-resolution errors for `@superset/chat/server/shared`
- `PATH="$PWD/apps/desktop/node_modules/.bin:$PWD/node_modules/.bin:$PATH" bun run --cwd apps/desktop typecheck`
  - blocked by pre-existing unrelated desktop type errors outside this diff
- local smoke check for `createFileProtocolResponse`
  - verified `audio/ogg` and `video/webm` MIME detection
  - verified `200` full response, `206` range response, and `416` unsatisfiable range response
