### PR TITLE
fix(desktop): Settings の Metrics と Security を両立

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/settings/components/SettingsSidebar/GeneralSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/components/SettingsSidebar/GeneralSettings.tsx
@@ -3,6 +3,7 @@ import { Link, useMatchRoute } from "@tanstack/react-router";
 import {
 	HiOutlineBell,
 	HiOutlineBuildingOffice2,
+	HiOutlineChartBar,
 	HiOutlineCommandLine,
 	HiOutlineCpuChip,
 	HiOutlineCreditCard,
@@ -173,6 +174,12 @@ const SECTION_GROUPS: SectionGroup[] = [
 	{
 		label: "System",
 		items: [
+			{
+				id: "/settings/metrics",
+				section: "metrics",
+				label: "Metrics",
+				icon: <HiOutlineChartBar className="h-4 w-4" />,
+			},
 			{
 				id: "/settings/security",
 				section: "security",

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/layout.tsx
@@ -41,6 +41,7 @@ const SECTION_ORDER: SettingsSection[] = [
 	"billing",
 	"apikeys",
 	"metrics",
+	"security",
 	"permissions",
 ];
 
@@ -59,6 +60,7 @@ function getSectionFromPath(pathname: string): SettingsSection | null {
 	if (pathname.includes("/settings/vscode-extensions"))
 		return "vscodeExtensions";
 	if (pathname.includes("/settings/extensions")) return "extensions";
+	if (pathname.includes("/settings/security")) return "security";
 	if (pathname.includes("/settings/permissions")) return "permissions";
 	if (pathname.includes("/settings/metrics")) return "metrics";
 	if (pathname.includes("/settings/project")) return "project";
@@ -93,6 +95,8 @@ function getPathFromSection(section: SettingsSection): string {
 			return "/settings/extensions";
 		case "vscodeExtensions":
 			return "/settings/vscode-extensions";
+		case "security":
+			return "/settings/security";
 		case "permissions":
 			return "/settings/permissions";
 		case "metrics":


### PR DESCRIPTION
## 概要
Settings の System セクションで Metrics が Security に上書きされて見えなくなっていたため、両方の項目が共存するように修正しました。

## 変更内容
- Settings サイドバーの System セクションに Metrics を復帰
- Security は残したまま、Metrics / Security / Permissions が並ぶように調整
- settings layout 側でも security section を正式に扱い、検索時の section 解決と遷移先を整合

## 背景
Security 設定追加時の差分で、既存の Metrics 項目に security のキーが追記され、結果として Metrics がサイドバーから消えていました。

## テスト
- 未実施
