### PR TITLE
fix(git): preserve env-backed simple-git behavior

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/projects/projects.ts
+++ b/apps/desktop/src/lib/trpc/routers/projects/projects.ts
@@ -25,7 +25,7 @@ import {
 } from "main/lib/project-icons";
 import { getWorkspaceRuntimeRegistry } from "main/lib/workspace-runtime";
 import { PROJECT_COLOR_VALUES } from "shared/constants/project-colors";
-import simpleGit, { type SimpleGitProgressEvent } from "simple-git";
+import type { SimpleGitProgressEvent } from "simple-git";
 import { z } from "zod";
 import { publicProcedure, router } from "../..";
 import { resolveDefaultEditor } from "../external";
@@ -45,11 +45,11 @@ import {
 	refreshDefaultBranch,
 	sanitizeAuthorPrefix,
 } from "../workspaces/utils/git";
-import { getSimpleGitWithShellPath } from "../workspaces/utils/git-client";
 import {
-	execWithShellEnv,
-	getProcessEnvWithShellPath,
-} from "../workspaces/utils/shell-env";
+	createSimpleGitWithShellPath,
+	getSimpleGitWithShellPath,
+} from "../workspaces/utils/git-client";
+import { execWithShellEnv } from "../workspaces/utils/shell-env";
 import { getDefaultProjectColor } from "./utils/colors";
 import { discoverAndSaveProjectIcon } from "./utils/favicon-discovery";
 import { fetchGitHubOwner, getGitHubAvatarUrl } from "./utils/github";
@@ -1493,7 +1493,7 @@ export const createProjectsRouter = (getWindow: () => BrowserWindow | null) => {
 							`Preparing clone into ${basename(clonePath)}`,
 						);
 						try {
-							const gitWithProgress = simpleGit({
+							const gitWithProgress = await createSimpleGitWithShellPath({
 								abort: abortController.signal,
 								progress: (event: SimpleGitProgressEvent) => {
 									emitCloneEvent({
@@ -1507,7 +1507,6 @@ export const createProjectsRouter = (getWindow: () => BrowserWindow | null) => {
 									});
 								},
 							});
-							gitWithProgress.env(await getProcessEnvWithShellPath());
 							emitCloneLog(
 								cloneId,
 								`Cloning ${redactGitCredentials(input.url)}`,

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/git-client.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/git-client.ts
@@ -3,18 +3,64 @@ import {
 	type ExecFileOptionsWithStringEncoding,
 	execFile,
 } from "node:child_process";
-import simpleGit, { type SimpleGit } from "simple-git";
 import {
-	getProcessEnvWithShellPath,
-	stripSimpleGitUnsafeEnv,
-} from "./shell-env";
+	buildSimpleGitUnsafeOptions,
+	type SimpleGitUnsafeOptions,
+} from "@superset/shared/simple-git-unsafe";
+import simpleGit, { type SimpleGit, type SimpleGitProgressEvent } from "simple-git";
+import { getProcessEnvWithShellPath } from "./shell-env";
+
+interface CreateSimpleGitWithShellPathOptions {
+	abort?: AbortSignal;
+	baseEnv?: NodeJS.ProcessEnv;
+	progress?: (event: SimpleGitProgressEvent) => void;
+	repoPath?: string;
+}
+
+function createSimpleGitWithEnv(
+	env: Record<string, string>,
+	options: Omit<CreateSimpleGitWithShellPathOptions, "baseEnv"> = {},
+): SimpleGit {
+	const unsafe = buildSimpleGitUnsafeOptions(env);
+	const gitOptions: {
+		abort?: AbortSignal;
+		baseDir?: string;
+		progress?: (event: SimpleGitProgressEvent) => void;
+		unsafe?: SimpleGitUnsafeOptions;
+	} = {};
+
+	if (options.abort) {
+		gitOptions.abort = options.abort;
+	}
+	if (options.progress) {
+		gitOptions.progress = options.progress;
+	}
+	if (options.repoPath) {
+		gitOptions.baseDir = options.repoPath;
+	}
+	if (unsafe) {
+		gitOptions.unsafe = unsafe;
+	}
+
+	const git =
+		Object.keys(gitOptions).length > 0
+			? simpleGit(gitOptions as never)
+			: simpleGit();
+	git.env(env);
+	return git;
+}
+
+export async function createSimpleGitWithShellPath(
+	options: CreateSimpleGitWithShellPathOptions = {},
+): Promise<SimpleGit> {
+	const env = await getProcessEnvWithShellPath(options.baseEnv ?? process.env);
+	return createSimpleGitWithEnv(env, options);
+}
 
 export async function getSimpleGitWithShellPath(
 	repoPath?: string,
 ): Promise<SimpleGit> {
-	const git = repoPath ? simpleGit(repoPath) : simpleGit();
-	git.env(stripSimpleGitUnsafeEnv(await getProcessEnvWithShellPath()));
-	return git;
+	return createSimpleGitWithShellPath({ repoPath });
 }
 
 export async function execGitWithShellPath(
@@ -48,10 +94,8 @@ async function execGitWithShellPathWithEncoding<
 	stdout: TEncoding extends "buffer" ? Buffer : string;
 	stderr: TEncoding extends "buffer" ? Buffer : string;
 }> {
-	const env = stripSimpleGitUnsafeEnv(
-		await getProcessEnvWithShellPath(
-			options?.env ? { ...process.env, ...options.env } : process.env,
-		),
+	const env = await getProcessEnvWithShellPath(
+		options?.env ? { ...process.env, ...options.env } : process.env,
 	);
 
 	return new Promise((resolve, reject) => {

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/git-client.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/git-client.ts
@@ -4,13 +4,16 @@ import {
 	execFile,
 } from "node:child_process";
 import simpleGit, { type SimpleGit } from "simple-git";
-import { getProcessEnvWithShellPath } from "./shell-env";
+import {
+	getProcessEnvWithShellPath,
+	stripSimpleGitUnsafeEnv,
+} from "./shell-env";
 
 export async function getSimpleGitWithShellPath(
 	repoPath?: string,
 ): Promise<SimpleGit> {
 	const git = repoPath ? simpleGit(repoPath) : simpleGit();
-	git.env(await getProcessEnvWithShellPath());
+	git.env(stripSimpleGitUnsafeEnv(await getProcessEnvWithShellPath()));
 	return git;
 }
 
@@ -45,8 +48,10 @@ async function execGitWithShellPathWithEncoding<
 	stdout: TEncoding extends "buffer" ? Buffer : string;
 	stderr: TEncoding extends "buffer" ? Buffer : string;
 }> {
-	const env = await getProcessEnvWithShellPath(
-		options?.env ? { ...process.env, ...options.env } : process.env,
+	const env = stripSimpleGitUnsafeEnv(
+		await getProcessEnvWithShellPath(
+			options?.env ? { ...process.env, ...options.env } : process.env,
+		),
 	);
 
 	return new Promise((resolve, reject) => {

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/shell-env.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/shell-env.ts
@@ -149,49 +149,6 @@ function copyStringEnv(
 }
 
 /**
- * Env var names flagged as "unsafe" by simple-git's block-unsafe-operations
- * plugin (v3.36+). If present in the env handed to simple-git, it throws
- * `Use of "X" is not permitted without enabling allowUnsafeY` — e.g. a user
- * shell with `PAGER=less` blocks every simple-git call.
- *
- * None of these are required for the git operations this app performs, so we
- * strip them rather than toggling allowUnsafe flags.
- */
-const SIMPLE_GIT_UNSAFE_ENV_KEYS = new Set([
-	"EDITOR",
-	"PAGER",
-	"PREFIX",
-	"SSH_ASKPASS",
-	"GIT_ASKPASS",
-	"GIT_CONFIG",
-	"GIT_CONFIG_COUNT",
-	"GIT_CONFIG_GLOBAL",
-	"GIT_CONFIG_SYSTEM",
-	"GIT_EDITOR",
-	"GIT_EXEC_PATH",
-	"GIT_EXTERNAL_DIFF",
-	"GIT_PAGER",
-	"GIT_PROXY_COMMAND",
-	"GIT_SEQUENCE_EDITOR",
-	"GIT_SSH",
-	"GIT_SSH_COMMAND",
-	"GIT_TEMPLATE_DIR",
-]);
-
-export function stripSimpleGitUnsafeEnv(
-	env: Record<string, string>,
-): Record<string, string> {
-	const result: Record<string, string> = {};
-	for (const [key, value] of Object.entries(env)) {
-		const upper = key.toUpperCase();
-		if (SIMPLE_GIT_UNSAFE_ENV_KEYS.has(upper)) continue;
-		if (/^GIT_CONFIG_(KEY|VALUE)_\d+$/.test(upper)) continue;
-		result[key] = value;
-	}
-	return result;
-}
-
-/**
  * Returns process env merged with missing variables from the user's shell.
  * Existing values always win so Electron/app-managed vars remain intact.
  */

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/shell-env.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/shell-env.ts
@@ -149,6 +149,49 @@ function copyStringEnv(
 }
 
 /**
+ * Env var names flagged as "unsafe" by simple-git's block-unsafe-operations
+ * plugin (v3.36+). If present in the env handed to simple-git, it throws
+ * `Use of "X" is not permitted without enabling allowUnsafeY` — e.g. a user
+ * shell with `PAGER=less` blocks every simple-git call.
+ *
+ * None of these are required for the git operations this app performs, so we
+ * strip them rather than toggling allowUnsafe flags.
+ */
+const SIMPLE_GIT_UNSAFE_ENV_KEYS = new Set([
+	"EDITOR",
+	"PAGER",
+	"PREFIX",
+	"SSH_ASKPASS",
+	"GIT_ASKPASS",
+	"GIT_CONFIG",
+	"GIT_CONFIG_COUNT",
+	"GIT_CONFIG_GLOBAL",
+	"GIT_CONFIG_SYSTEM",
+	"GIT_EDITOR",
+	"GIT_EXEC_PATH",
+	"GIT_EXTERNAL_DIFF",
+	"GIT_PAGER",
+	"GIT_PROXY_COMMAND",
+	"GIT_SEQUENCE_EDITOR",
+	"GIT_SSH",
+	"GIT_SSH_COMMAND",
+	"GIT_TEMPLATE_DIR",
+]);
+
+export function stripSimpleGitUnsafeEnv(
+	env: Record<string, string>,
+): Record<string, string> {
+	const result: Record<string, string> = {};
+	for (const [key, value] of Object.entries(env)) {
+		const upper = key.toUpperCase();
+		if (SIMPLE_GIT_UNSAFE_ENV_KEYS.has(upper)) continue;
+		if (/^GIT_CONFIG_(KEY|VALUE)_\d+$/.test(upper)) continue;
+		result[key] = value;
+	}
+	return result;
+}
+
+/**
  * Returns process env merged with missing variables from the user's shell.
  * Existing values always win so Electron/app-managed vars remain intact.
  */

--- a/packages/host-service/src/runtime/git/git.ts
+++ b/packages/host-service/src/runtime/git/git.ts
@@ -1,19 +1,25 @@
-import simpleGit from "simple-git";
-
 import type { GitCredentialProvider, GitFactory } from "./types";
+import { createSimpleGitWithEnv } from "./simple-git";
 import { getRemoteUrl } from "./utils";
 
 export function createGitFactory(provider: GitCredentialProvider): GitFactory {
 	return async (repoPath: string) => {
 		const initialCredentials = await provider.getCredentials(null);
-		const git = simpleGit(repoPath).env(initialCredentials.env);
+		const git = createSimpleGitWithEnv({
+			baseDir: repoPath,
+			env: initialCredentials.env,
+		});
 		const remoteUrl = await getRemoteUrl(git);
 		const credentials = await provider.getCredentials(remoteUrl);
-
-		return git.env({
+		const env = {
 			...initialCredentials.env,
 			...credentials.env,
 			GIT_OPTIONAL_LOCKS: "0",
+		};
+
+		return createSimpleGitWithEnv({
+			baseDir: repoPath,
+			env,
 		});
 	};
 }

--- a/packages/host-service/src/runtime/git/simple-git.ts
+++ b/packages/host-service/src/runtime/git/simple-git.ts
@@ -1,0 +1,48 @@
+import {
+	buildSimpleGitUnsafeOptions,
+	type SimpleGitUnsafeOptions,
+} from "@superset/shared/simple-git-unsafe";
+import simpleGit, { type SimpleGit } from "simple-git";
+
+interface CreateSimpleGitWithEnvOptions {
+	baseDir?: string;
+	env?: NodeJS.ProcessEnv | Record<string, string>;
+}
+
+function copyStringEnv(
+	baseEnv: NodeJS.ProcessEnv | Record<string, string> = process.env,
+): Record<string, string> {
+	const env: Record<string, string> = {};
+
+	for (const [key, value] of Object.entries(baseEnv)) {
+		if (typeof value === "string") {
+			env[key] = value;
+		}
+	}
+
+	return env;
+}
+
+export function createSimpleGitWithEnv(
+	options: CreateSimpleGitWithEnvOptions = {},
+): SimpleGit {
+	const env = copyStringEnv(options.env ?? process.env);
+	const unsafe = buildSimpleGitUnsafeOptions(env);
+	const gitOptions: {
+		baseDir?: string;
+		unsafe?: SimpleGitUnsafeOptions;
+	} = {};
+
+	if (options.baseDir) {
+		gitOptions.baseDir = options.baseDir;
+	}
+	if (unsafe) {
+		gitOptions.unsafe = unsafe;
+	}
+
+	const git =
+		Object.keys(gitOptions).length > 0
+			? simpleGit(gitOptions as never)
+			: simpleGit();
+	return git.env(env);
+}

--- a/packages/host-service/src/trpc/router/project/project.ts
+++ b/packages/host-service/src/trpc/router/project/project.ts
@@ -2,8 +2,8 @@ import { existsSync, rmSync, statSync } from "node:fs";
 import { basename, join, resolve } from "node:path";
 import { TRPCError } from "@trpc/server";
 import { eq } from "drizzle-orm";
-import simpleGit from "simple-git";
 import { z } from "zod";
+import { createSimpleGitWithEnv } from "../../../runtime/git/simple-git";
 import { projects, workspaces } from "../../../db/schema";
 import { parseGitHubRemote } from "../../../runtime/pull-requests/utils/parse-github-remote";
 import { protectedProcedure, router } from "../../index";
@@ -162,7 +162,7 @@ async function importExistingRepo(
 		});
 	}
 
-	const git = simpleGit(localPath);
+	const git = createSimpleGitWithEnv({ baseDir: localPath });
 
 	let gitRoot: string;
 	try {
@@ -174,7 +174,9 @@ async function importExistingRepo(
 		});
 	}
 
-	const remotes = await getGitHubRemotes(simpleGit(gitRoot));
+	const remotes = await getGitHubRemotes(
+		createSimpleGitWithEnv({ baseDir: gitRoot }),
+	);
 	const matchingRemote = findMatchingRemote(remotes, expectedSlug);
 
 	if (!matchingRemote) {
@@ -230,7 +232,7 @@ async function cloneRepo(
 	}
 
 	try {
-		await simpleGit().clone(repoCloneUrl, targetPath);
+		await createSimpleGitWithEnv().clone(repoCloneUrl, targetPath);
 	} catch (err) {
 		if (existsSync(targetPath)) {
 			rmSync(targetPath, { recursive: true, force: true });
@@ -241,7 +243,9 @@ async function cloneRepo(
 		});
 	}
 
-	const remotes = await getGitHubRemotes(simpleGit(targetPath));
+	const remotes = await getGitHubRemotes(
+		createSimpleGitWithEnv({ baseDir: targetPath }),
+	);
 	const matchingRemote = findMatchingRemote(remotes, expectedSlug);
 
 	if (!matchingRemote) {

--- a/packages/host-service/src/trpc/router/workspace-creation/workspace-creation.ts
+++ b/packages/host-service/src/trpc/router/workspace-creation/workspace-creation.ts
@@ -3,9 +3,9 @@ import { dirname, join, resolve, sep } from "node:path";
 import { getDeviceName, getHashedDeviceId } from "@superset/shared/device-info";
 import { TRPCError } from "@trpc/server";
 import { and, eq } from "drizzle-orm";
-import simpleGit from "simple-git";
 import { z } from "zod";
 import { projects, workspaces } from "../../../db/schema";
+import { createSimpleGitWithEnv } from "../../../runtime/git/simple-git";
 import {
 	asLocalRef,
 	asRemoteRef,
@@ -732,7 +732,10 @@ export const workspaceCreationRouter = router({
 
 				if (!existsSync(repoPath)) {
 					mkdirSync(dirname(repoPath), { recursive: true });
-					await simpleGit().clone(cloudProject.repoCloneUrl, repoPath);
+					await createSimpleGitWithEnv().clone(
+						cloudProject.repoCloneUrl,
+						repoPath,
+					);
 				}
 
 				localProject = ctx.db
@@ -1073,7 +1076,10 @@ export const workspaceCreationRouter = router({
 				const repoPath = join(homeDir, ".superset", "repos", input.projectId);
 				if (!existsSync(repoPath)) {
 					mkdirSync(dirname(repoPath), { recursive: true });
-					await simpleGit().clone(cloudProject.repoCloneUrl, repoPath);
+					await createSimpleGitWithEnv().clone(
+						cloudProject.repoCloneUrl,
+						repoPath,
+					);
 				}
 				localProject = ctx.db
 					.insert(projects)

--- a/packages/host-service/src/trpc/router/workspace/workspace.ts
+++ b/packages/host-service/src/trpc/router/workspace/workspace.ts
@@ -3,9 +3,9 @@ import { dirname, join } from "node:path";
 import { getDeviceName, getHashedDeviceId } from "@superset/shared/device-info";
 import { TRPCError } from "@trpc/server";
 import { eq } from "drizzle-orm";
-import simpleGit from "simple-git";
 import { z } from "zod";
 import { projects, workspaces } from "../../../db/schema";
+import { createSimpleGitWithEnv } from "../../../runtime/git/simple-git";
 import { protectedProcedure, router } from "../../index";
 
 export const workspaceRouter = router({
@@ -64,7 +64,7 @@ export const workspaceRouter = router({
 
 				if (!existsSync(repoPath)) {
 					mkdirSync(dirname(repoPath), { recursive: true });
-					await simpleGit().clone(cloudProject.repoCloneUrl, repoPath);
+					await createSimpleGitWithEnv().clone(cloudProject.repoCloneUrl, repoPath);
 				}
 
 				const inserted = ctx.db

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -67,6 +67,10 @@
 		"./shell-ready-scanner": {
 			"types": "./src/shell-ready-scanner.ts",
 			"default": "./src/shell-ready-scanner.ts"
+		},
+		"./simple-git-unsafe": {
+			"types": "./src/simple-git-unsafe.ts",
+			"default": "./src/simple-git-unsafe.ts"
 		}
 	},
 	"scripts": {

--- a/packages/shared/src/simple-git-unsafe.ts
+++ b/packages/shared/src/simple-git-unsafe.ts
@@ -1,0 +1,198 @@
+export interface SimpleGitUnsafeOptions {
+	allowUnsafeAlias?: true;
+	allowUnsafeAskPass?: true;
+	allowUnsafeConfigEnvCount?: true;
+	allowUnsafeConfigPaths?: true;
+	allowUnsafeCredentialHelper?: true;
+	allowUnsafeDiffExternal?: true;
+	allowUnsafeDiffTextConv?: true;
+	allowUnsafeEditor?: true;
+	allowUnsafeFilter?: true;
+	allowUnsafeFsMonitor?: true;
+	allowUnsafeGitProxy?: true;
+	allowUnsafeGpgProgram?: true;
+	allowUnsafeHooksPath?: true;
+	allowUnsafeMergeDriver?: true;
+	allowUnsafePack?: true;
+	allowUnsafePager?: true;
+	allowUnsafeProtocolOverride?: true;
+	allowUnsafeSshCommand?: true;
+	allowUnsafeTemplateDir?: true;
+}
+
+const SIMPLE_GIT_UNSAFE_ENV_TO_OPTION = {
+	EDITOR: "allowUnsafeEditor",
+	GIT_ASKPASS: "allowUnsafeAskPass",
+	GIT_CONFIG: "allowUnsafeConfigPaths",
+	GIT_CONFIG_COUNT: "allowUnsafeConfigEnvCount",
+	GIT_CONFIG_GLOBAL: "allowUnsafeConfigPaths",
+	GIT_CONFIG_SYSTEM: "allowUnsafeConfigPaths",
+	GIT_EDITOR: "allowUnsafeEditor",
+	GIT_EXEC_PATH: "allowUnsafeConfigPaths",
+	GIT_EXTERNAL_DIFF: "allowUnsafeDiffExternal",
+	GIT_PAGER: "allowUnsafePager",
+	GIT_PROXY_COMMAND: "allowUnsafeGitProxy",
+	GIT_SEQUENCE_EDITOR: "allowUnsafeEditor",
+	GIT_SSH: "allowUnsafeSshCommand",
+	GIT_SSH_COMMAND: "allowUnsafeSshCommand",
+	GIT_TEMPLATE_DIR: "allowUnsafeTemplateDir",
+	PAGER: "allowUnsafePager",
+	PREFIX: "allowUnsafeConfigPaths",
+	SSH_ASKPASS: "allowUnsafeAskPass",
+} as const satisfies Record<string, keyof SimpleGitUnsafeOptions>;
+
+function escapeRegex(value: string): string {
+	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function createUnsafeConfigPattern(value: string): RegExp {
+	return new RegExp(`^\\s*${escapeRegex(value.toLowerCase())}`);
+}
+
+function createExpandedUnsafeConfigPattern(value: string): RegExp {
+	const escaped = escapeRegex(value.toLowerCase()).replace(
+		/\\\./g,
+		"(?:\\\\..+)?\\\\.",
+	);
+	return new RegExp(`^\\s*${escaped}`);
+}
+
+const SIMPLE_GIT_UNSAFE_CONFIG_PATTERNS = [
+	{
+		pattern: createUnsafeConfigPattern("alias"),
+		option: "allowUnsafeAlias",
+	},
+	{
+		pattern: createUnsafeConfigPattern("core.askPass"),
+		option: "allowUnsafeAskPass",
+	},
+	{
+		pattern: createUnsafeConfigPattern("core.editor"),
+		option: "allowUnsafeEditor",
+	},
+	{
+		pattern: createUnsafeConfigPattern("core.fsmonitor"),
+		option: "allowUnsafeFsMonitor",
+	},
+	{
+		pattern: createUnsafeConfigPattern("core.gitProxy"),
+		option: "allowUnsafeGitProxy",
+	},
+	{
+		pattern: createUnsafeConfigPattern("core.hooksPath"),
+		option: "allowUnsafeHooksPath",
+	},
+	{
+		pattern: createUnsafeConfigPattern("core.pager"),
+		option: "allowUnsafePager",
+	},
+	{
+		pattern: createUnsafeConfigPattern("core.sshCommand"),
+		option: "allowUnsafeSshCommand",
+	},
+	{
+		pattern: createExpandedUnsafeConfigPattern("credential.helper"),
+		option: "allowUnsafeCredentialHelper",
+	},
+	{
+		pattern: createExpandedUnsafeConfigPattern("diff.command"),
+		option: "allowUnsafeDiffExternal",
+	},
+	{
+		pattern: createUnsafeConfigPattern("diff.external"),
+		option: "allowUnsafeDiffExternal",
+	},
+	{
+		pattern: createExpandedUnsafeConfigPattern("diff.textconv"),
+		option: "allowUnsafeDiffTextConv",
+	},
+	{
+		pattern: createExpandedUnsafeConfigPattern("filter.clean"),
+		option: "allowUnsafeFilter",
+	},
+	{
+		pattern: createExpandedUnsafeConfigPattern("filter.smudge"),
+		option: "allowUnsafeFilter",
+	},
+	{
+		pattern: createExpandedUnsafeConfigPattern("gpg.program"),
+		option: "allowUnsafeGpgProgram",
+	},
+	{
+		pattern: createUnsafeConfigPattern("init.templateDir"),
+		option: "allowUnsafeTemplateDir",
+	},
+	{
+		pattern: createExpandedUnsafeConfigPattern("merge.driver"),
+		option: "allowUnsafeMergeDriver",
+	},
+	{
+		pattern: createExpandedUnsafeConfigPattern("mergetool.path"),
+		option: "allowUnsafeMergeDriver",
+	},
+	{
+		pattern: createExpandedUnsafeConfigPattern("mergetool.cmd"),
+		option: "allowUnsafeMergeDriver",
+	},
+	{
+		pattern: createExpandedUnsafeConfigPattern("protocol.allow"),
+		option: "allowUnsafeProtocolOverride",
+	},
+	{
+		pattern: createExpandedUnsafeConfigPattern("remote.receivepack"),
+		option: "allowUnsafePack",
+	},
+	{
+		pattern: createExpandedUnsafeConfigPattern("remote.uploadpack"),
+		option: "allowUnsafePack",
+	},
+	{
+		pattern: createUnsafeConfigPattern("sequence.editor"),
+		option: "allowUnsafeEditor",
+	},
+] as const satisfies ReadonlyArray<{
+	pattern: RegExp;
+	option: keyof SimpleGitUnsafeOptions;
+}>;
+
+function markUnsafeOption(
+	options: SimpleGitUnsafeOptions,
+	option: keyof SimpleGitUnsafeOptions,
+): void {
+	options[option] = true;
+}
+
+export function buildSimpleGitUnsafeOptions(
+	env: Record<string, string>,
+): SimpleGitUnsafeOptions | undefined {
+	const unsafe: SimpleGitUnsafeOptions = {};
+	const upperEnv = Object.fromEntries(
+		Object.entries(env).map(([key, value]) => [key.toUpperCase(), value]),
+	);
+
+	for (const key of Object.keys(upperEnv)) {
+		const option = SIMPLE_GIT_UNSAFE_ENV_TO_OPTION[key];
+		if (option) {
+			markUnsafeOption(unsafe, option);
+		}
+	}
+
+	const count = Number.parseInt(upperEnv.GIT_CONFIG_COUNT ?? "", 10);
+	if (Number.isFinite(count) && count > 0) {
+		for (let index = 0; index < count; index += 1) {
+			const configKey = upperEnv[`GIT_CONFIG_KEY_${index}`];
+			if (!configKey) {
+				continue;
+			}
+
+			const normalizedConfigKey = configKey.trim().toLowerCase();
+			for (const { pattern, option } of SIMPLE_GIT_UNSAFE_CONFIG_PATTERNS) {
+				if (pattern.test(normalizedConfigKey)) {
+					markUnsafeOption(unsafe, option);
+				}
+			}
+		}
+	}
+
+	return Object.keys(unsafe).length > 0 ? unsafe : undefined;
+}


### PR DESCRIPTION
## 概要

Desktop 1.5.5 相当で入った `simple-git 3.36+` の block-unsafe-operations により、ユーザーの shell / credential provider から渡される通常の env が原因で Git 操作が失敗する。

代表例:

```text
Use of "PAGER" is not permitted without enabling allowUnsafePager
```

当初は unsafe な env を strip する案だったが、その方式だと `GIT_SSH_COMMAND` / `GIT_ASKPASS` / `GIT_CONFIG_*` 依存の clone / fetch / push / auth フローを壊す。

この PR では、既存の env ベース挙動を維持したまま、`simple-git` 側に必要な `allowUnsafe*` だけを与える形に修正した。

## 原因

- `simple-git 3.36+` は `PAGER`, `EDITOR`, `GIT_ASKPASS`, `GIT_SSH_COMMAND`, `GIT_CONFIG_*` などを "unsafe" として検出する
- desktop 側は `getProcessEnvWithShellPath()` で shell env を継承して `simple-git` に渡している
- host-service 側も credential provider 経由で `GIT_ASKPASS` や local env を `simple-git` に渡している
- そのため、Git タブだけでなく clone / import / fetch / push / author 取得 / workspace 作成系まで同じ種類の failure が起こりうる

## 対応

- `@superset/shared/simple-git-unsafe` に `buildSimpleGitUnsafeOptions()` を追加
- 継承した env と `GIT_CONFIG_COUNT` / `GIT_CONFIG_KEY_n` を解析して、必要な `allowUnsafe*` だけを導出
- desktop:
  - `getSimpleGitWithShellPath()` を新 helper ベースに置き換え
  - progress clone の `simpleGit()` 直呼びも同じ helper に統一
  - raw `git` 実行 (`execGitWithShellPath*`) からは env strip を除去
- host-service:
  - credential factory を helper ベースに置き換え
  - project/workspace/workspace-creation 内の `simpleGit()` 直呼び clone/import 経路も同じ helper に統一

## 期待する効果

- `PAGER` / `GIT_PAGER` / `EDITOR` が設定された shell 環境でも desktop の Git タブや worktree 操作が壊れない
- `GIT_SSH_COMMAND` / `GIT_ASKPASS` / `GIT_CONFIG_*` を使うユーザーの remote/auth フローを壊さない
- 既存の env ベース挙動を保ったまま `simple-git 3.36+` に追従できる

## テスト観点

- [ ] `PAGER` / `GIT_PAGER` / `EDITOR` を設定した shell で desktop の Git タブ / worktree 作成 / 削除が通る
- [ ] `GIT_SSH_COMMAND` を使う remote で fetch / push / clone が通る
- [ ] `GIT_ASKPASS` / `SSH_ASKPASS` を使う認証フローが通る
- [ ] `GIT_CONFIG_GLOBAL` / `GIT_CONFIG_COUNT` を使う環境で author / clone / fetch 挙動が変わらない
- [ ] host-service の clone / import / workspace creation が通る
