### PR TITLE
fix(desktop): aivis タスク完了通知が二重に読み上げられる問題を修正

### DIFF
--- a/apps/desktop/docs/EXTERNAL_FILES.md
+++ b/apps/desktop/docs/EXTERNAL_FILES.md
@@ -45,13 +45,15 @@ its hook entries into these files while preserving user-defined entries:
 | `~/.codex/hooks.json` | Codex hook registration merge (`SessionStart`, `UserPromptSubmit`, `Stop`) |
 | `~/.factory/settings.json` | Factory Droid hook registration (`UserPromptSubmit`, `Notification`, `PostToolUse`, `Stop`) |
 
-For Codex specifically, Superset now relies on native `~/.codex/hooks.json`
-registration for durable prompt/tool lifecycle events, while the wrapper in
-`~/.superset[-{workspace}]/bin/codex` still injects `notify` and keeps the
-session-log watcher as a best-effort compatibility bridge for older Codex
-releases. On startup, Superset rewrites only its own managed entries in
-`~/.codex/hooks.json` to point at the current environment's `notify.sh`, while
-preserving any user-defined Codex hooks.
+For Codex specifically, Superset relies on native `~/.codex/hooks.json`
+registration as the sole source of completion notifications. The wrapper in
+`~/.superset[-{workspace}]/bin/codex` only enables `codex_hooks` (by passing
+`--enable codex_hooks` to the real binary) and keeps the session-log watcher
+as a best-effort bridge for per-prompt Start notifications and permission
+requests inside Superset terminals. It no longer injects `--notify=[...]` to
+avoid duplicate `/hook/complete` POSTs. On startup, Superset rewrites only its
+own managed entries in `~/.codex/hooks.json` to point at the current
+environment's `notify.sh`, while preserving any user-defined Codex hooks.
 
 ### `zsh/` and `bash/` - Shell Integration
 

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -51,6 +51,7 @@ import {
 } from "./lib/terminal";
 import { disposeTray, initTray } from "./lib/tray";
 import { windowManager } from "./lib/window-manager";
+import { createWorkspaceMediaProtocolHandler } from "./lib/workspace-media-protocol";
 
 // Lazy import to avoid module resolution issues during Vite build
 const loadVscodeShim = () =>
@@ -555,6 +556,17 @@ protocol.registerSchemesAsPrivileged([
 			secure: true,
 			bypassCSP: true,
 			supportFetchAPI: true,
+			stream: true,
+		},
+	},
+	{
+		scheme: "superset-workspace-media",
+		privileges: {
+			standard: true,
+			secure: true,
+			bypassCSP: true,
+			supportFetchAPI: true,
+			stream: true,
 		},
 	},
 	{
@@ -564,6 +576,7 @@ protocol.registerSchemesAsPrivileged([
 			secure: true,
 			bypassCSP: true,
 			supportFetchAPI: true,
+			stream: true,
 		},
 	},
 	{
@@ -726,6 +739,13 @@ if (!gotTheLock) {
 		session
 			.fromPartition("persist:superset")
 			.protocol.handle("superset-temp-audio", tempAudioHandler);
+
+		// Serve workspace audio/video files for the file viewer
+		const workspaceMediaHandler = createWorkspaceMediaProtocolHandler();
+		protocol.handle("superset-workspace-media", workspaceMediaHandler);
+		session
+			.fromPartition("persist:superset")
+			.protocol.handle("superset-workspace-media", workspaceMediaHandler);
 
 		ensureProjectIconsDir();
 		setWorkspaceDockIcon();

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -51,13 +51,16 @@ import {
 } from "./lib/terminal";
 import { disposeTray, initTray } from "./lib/tray";
 import { windowManager } from "./lib/window-manager";
-import { createWorkspaceMediaProtocolHandler } from "./lib/workspace-media-protocol";
 
 // Lazy import to avoid module resolution issues during Vite build
 const loadVscodeShim = () =>
 	import("./lib/vscode-shim") as Promise<typeof import("./lib/vscode-shim")>;
 
-import { cleanupMainWindowResources, MainWindow } from "./windows/main";
+import {
+	cleanupMainWindowResources,
+	initNotifications,
+	MainWindow,
+} from "./windows/main";
 
 console.log("[main] Local database ready:", !!localDb);
 const IS_DEV = process.env.NODE_ENV === "development";
@@ -552,17 +555,6 @@ protocol.registerSchemesAsPrivileged([
 			secure: true,
 			bypassCSP: true,
 			supportFetchAPI: true,
-			stream: true,
-		},
-	},
-	{
-		scheme: "superset-workspace-media",
-		privileges: {
-			standard: true,
-			secure: true,
-			bypassCSP: true,
-			supportFetchAPI: true,
-			stream: true,
 		},
 	},
 	{
@@ -572,7 +564,6 @@ protocol.registerSchemesAsPrivileged([
 			secure: true,
 			bypassCSP: true,
 			supportFetchAPI: true,
-			stream: true,
 		},
 	},
 	{
@@ -736,13 +727,6 @@ if (!gotTheLock) {
 			.fromPartition("persist:superset")
 			.protocol.handle("superset-temp-audio", tempAudioHandler);
 
-		// Serve workspace audio/video files for the file viewer
-		const workspaceMediaHandler = createWorkspaceMediaProtocolHandler();
-		protocol.handle("superset-workspace-media", workspaceMediaHandler);
-		session
-			.fromPartition("persist:superset")
-			.protocol.handle("superset-workspace-media", workspaceMediaHandler);
-
 		ensureProjectIconsDir();
 		setWorkspaceDockIcon();
 		initSentry();
@@ -773,6 +757,7 @@ if (!gotTheLock) {
 			});
 		}
 
+		initNotifications();
 		await makeAppSetup(() => MainWindow());
 		setupAutoUpdater();
 		setupServiceStatusPolling();

--- a/apps/desktop/src/main/lib/agent-setup/agent-wrappers-claude-codex-opencode.ts
+++ b/apps/desktop/src/main/lib/agent-setup/agent-wrappers-claude-codex-opencode.ts
@@ -275,7 +275,8 @@ export function createClaudeWrapper(): void {
 }
 
 /**
- * Creates the Codex wrapper that injects Superset's notify/session-log logic.
+ * Creates the Codex wrapper that enables native hooks and keeps the
+ * session-log watcher for prompt/permission events inside Superset terminals.
  */
 export function createCodexWrapper(): void {
 	const notifyPath = getNotifyScriptPath();
@@ -427,10 +428,10 @@ export function getCodexGlobalHooksJsonContent(
  * binary wrapper is not in PATH (e.g. user runs codex from outside
  * a Superset terminal).
  *
- * The wrapper still injects Codex's native notify callback and keeps the
- * session-log watcher as a best-effort bridge for older releases, but the
- * native hooks.json registration is now the primary source for prompt/tool
- * lifecycle events.
+ * The wrapper now only enables Codex hooks and keeps the session-log watcher
+ * as a best-effort bridge for prompt/permission events inside Superset
+ * terminals. Native hooks.json registration remains the primary lifecycle
+ * source to avoid duplicate completion notifications.
  */
 export function createCodexHooksJson(): void {
 	const notifyScriptPath = getNotifyScriptPath();

--- a/apps/desktop/src/main/lib/agent-setup/agent-wrappers-claude-codex-opencode.ts
+++ b/apps/desktop/src/main/lib/agent-setup/agent-wrappers-claude-codex-opencode.ts
@@ -424,14 +424,15 @@ export function getCodexGlobalHooksJsonContent(
 
 /**
  * Writes Superset hook definitions directly into ~/.codex/hooks.json.
- * This provides a fallback notification path that works even when the
- * binary wrapper is not in PATH (e.g. user runs codex from outside
+ * This is the primary lifecycle notification path for Codex and also works
+ * when the binary wrapper is not in PATH (e.g. user runs codex from outside
  * a Superset terminal).
  *
- * The wrapper now only enables Codex hooks and keeps the session-log watcher
- * as a best-effort bridge for prompt/permission events inside Superset
- * terminals. Native hooks.json registration remains the primary lifecycle
- * source to avoid duplicate completion notifications.
+ * The wrapper only enables Codex hooks and keeps the session-log watcher as a
+ * best-effort bridge for prompt/permission events inside Superset terminals.
+ * Completion notifications are handled exclusively via hooks.json to avoid
+ * the duplicate `/hook/complete` POSTs that occurred when the wrapper also
+ * injected `--notify=[...]`.
  */
 export function createCodexHooksJson(): void {
 	const notifyScriptPath = getNotifyScriptPath();

--- a/apps/desktop/src/main/lib/agent-setup/agent-wrappers.test.ts
+++ b/apps/desktop/src/main/lib/agent-setup/agent-wrappers.test.ts
@@ -172,7 +172,7 @@ describe("agent-wrappers copilot", () => {
 		expect(updated).not.toContain("/tmp/old-hook.sh");
 	});
 
-	it("injects codex start + permission watchers and completion notifications in wrapper", () => {
+	it("injects codex start + permission watchers and enables native hooks", () => {
 		createCodexWrapper();
 
 		const wrapperPath = path.join(TEST_BIN_DIR, "codex");
@@ -237,12 +237,9 @@ exit 0
 		});
 
 		expect(readFileSync(argsFile, "utf-8")).toBe(
-			`${[
-				"--enable",
-				"codex_hooks",
-				"exec",
-				"Reply with exactly OK.",
-			].join("\n")}\n`,
+			`${["--enable", "codex_hooks", "exec", "Reply with exactly OK."].join(
+				"\n",
+			)}\n`,
 		);
 	});
 

--- a/apps/desktop/src/main/lib/agent-setup/agent-wrappers.test.ts
+++ b/apps/desktop/src/main/lib/agent-setup/agent-wrappers.test.ts
@@ -197,9 +197,7 @@ describe("agent-wrappers copilot", () => {
 		expect(wrapper).toContain('awk -F\'"approval_id":"\'');
 		expect(wrapper).toContain('_superset_emit_event "Start"');
 		expect(wrapper).toContain('_superset_emit_event "PermissionRequest"');
-		expect(wrapper).toContain(
-			`"$REAL_BIN" --enable codex_hooks -c 'notify=["bash","${path.join(TEST_HOOKS_DIR, "notify.sh")}"]' "$@"`,
-		);
+		expect(wrapper).toContain(`"$REAL_BIN" --enable codex_hooks "$@"`);
 		expect(wrapper).toContain("SUPERSET_CODEX_START_WATCHER_PID");
 		expect(wrapper).toContain('kill "$SUPERSET_CODEX_START_WATCHER_PID"');
 
@@ -242,8 +240,6 @@ exit 0
 			`${[
 				"--enable",
 				"codex_hooks",
-				"-c",
-				`notify=["bash","${path.join(TEST_HOOKS_DIR, "notify.sh")}"]`,
 				"exec",
 				"Reply with exactly OK.",
 			].join("\n")}\n`,

--- a/apps/desktop/src/main/lib/agent-setup/templates/codex-wrapper-exec.template.sh
+++ b/apps/desktop/src/main/lib/agent-setup/templates/codex-wrapper-exec.template.sh
@@ -1,6 +1,6 @@
-# Codex exposes completion notifications via notify.
-# For per-prompt Start notifications and permission requests, watch the TUI
-# session log for task_started/exec_command_begin and *_approval_request events.
+# Native ~/.codex/hooks.json handles SessionStart/UserPromptSubmit/Stop.
+# The wrapper keeps the session-log watcher only for per-prompt Start
+# notifications and permission requests inside Superset terminals.
 if [ -n "$SUPERSET_TAB_ID" ] && [ -f "{{NOTIFY_PATH}}" ]; then
   export CODEX_TUI_RECORD_SESSION=1
   if [ -z "$CODEX_TUI_SESSION_LOG_PATH" ]; then
@@ -72,7 +72,7 @@ if [ -n "$SUPERSET_TAB_ID" ] && [ -f "{{NOTIFY_PATH}}" ]; then
   SUPERSET_CODEX_START_WATCHER_PID=$!
 fi
 
-"$REAL_BIN" --enable codex_hooks -c 'notify=["bash","{{NOTIFY_PATH}}"]' "$@"
+"$REAL_BIN" --enable codex_hooks "$@"
 SUPERSET_CODEX_STATUS=$?
 
 if [ -n "$SUPERSET_CODEX_START_WATCHER_PID" ]; then

--- a/apps/desktop/src/main/windows/main.ts
+++ b/apps/desktop/src/main/windows/main.ts
@@ -109,9 +109,8 @@ let mainWindowCleanup: (() => void) | null = null;
 let notificationsInitialized = false;
 let notificationsServer: Server | null = null;
 let notificationManager: NotificationManager | null = null;
-let agentLifecycleListener:
-	| ((event: AgentLifecycleEvent) => void)
-	| null = null;
+let agentLifecycleListener: ((event: AgentLifecycleEvent) => void) | null =
+	null;
 let terminalExitListener:
 	| ((event: {
 			paneId: string;

--- a/apps/desktop/src/main/windows/main.ts
+++ b/apps/desktop/src/main/windows/main.ts
@@ -1,3 +1,4 @@
+import type { Server } from "node:http";
 import { join } from "node:path";
 import * as Sentry from "@sentry/electron/main";
 import { projects, workspaces, worktrees } from "@superset/local-db";
@@ -105,6 +106,20 @@ function buildAivisVars(event: AgentLifecycleEvent) {
 
 let currentWindow: BrowserWindow | null = null;
 let mainWindowCleanup: (() => void) | null = null;
+let notificationsInitialized = false;
+let notificationsServer: Server | null = null;
+let notificationManager: NotificationManager | null = null;
+let agentLifecycleListener:
+	| ((event: AgentLifecycleEvent) => void)
+	| null = null;
+let terminalExitListener:
+	| ((event: {
+			paneId: string;
+			exitCode: number;
+			signal?: number;
+			reason?: "killed" | "exited" | "error";
+	  }) => void)
+	| null = null;
 
 /** Tear down main window resources (notification server, IPC, etc.)
  *  without destroying the BrowserWindow itself. Called from before-quit
@@ -112,6 +127,7 @@ let mainWindowCleanup: (() => void) | null = null;
 export function cleanupMainWindowResources(): void {
 	mainWindowCleanup?.();
 	mainWindowCleanup = null;
+	cleanupNotifications();
 }
 
 function addWindowLifecycleBreadcrumb(
@@ -174,6 +190,110 @@ nativeTheme.on("updated", () => {
 		applyVibrancy(win, vibrancyState, isDark);
 	}
 });
+
+export function initNotifications(): void {
+	if (notificationsInitialized) return;
+
+	notificationManager = new NotificationManager({
+		isSupported: () => Notification.isSupported(),
+		createNotification: (opts) => new Notification(opts),
+		playSound: playNotificationSound,
+		playAivis: (event) => {
+			const kind =
+				event.eventType === "PermissionRequest" ? "permission" : "complete";
+			void playAivisNotification(kind, buildAivisVars(event));
+		},
+		onNotificationClick: (ids) => {
+			const window = getWindow();
+			if (window && !window.isDestroyed()) {
+				window.show();
+				window.focus();
+			} else {
+				app.emit("activate");
+			}
+			notificationsEmitter.emit(NOTIFICATION_EVENTS.FOCUS_TAB, ids);
+		},
+		getVisibilityContext: () => {
+			const window = getWindow();
+			const windowIsReady = window && !window.isDestroyed();
+			return {
+				isFocused: windowIsReady ? window.isFocused() : false,
+				currentWorkspaceId: windowIsReady
+					? extractWorkspaceIdFromUrl(window.webContents.getURL())
+					: null,
+				tabsState: appState.data?.tabsState,
+			};
+		},
+		getWorkspaceName: getWorkspaceNameFromDb,
+		getNotificationTitle: (event) =>
+			getNotificationTitle({
+				tabId: event.tabId,
+				paneId: event.paneId,
+				tabs: appState.data?.tabsState?.tabs,
+				panes: appState.data?.tabsState?.panes,
+			}),
+	});
+	notificationManager.start();
+
+	agentLifecycleListener = (event: AgentLifecycleEvent) => {
+		notificationManager?.handleAgentLifecycle(event);
+	};
+	notificationsEmitter.on(
+		NOTIFICATION_EVENTS.AGENT_LIFECYCLE,
+		agentLifecycleListener,
+	);
+
+	terminalExitListener = (event) => {
+		notificationsEmitter.emit(NOTIFICATION_EVENTS.TERMINAL_EXIT, {
+			paneId: event.paneId,
+			exitCode: event.exitCode,
+			signal: event.signal,
+			reason: event.reason,
+		});
+	};
+	getWorkspaceRuntimeRegistry()
+		.getDefault()
+		.terminal.on("terminalExit", terminalExitListener);
+
+	notificationsServer = notificationsApp.listen(
+		env.DESKTOP_NOTIFICATIONS_PORT,
+		"127.0.0.1",
+		() => {
+			console.log(
+				`[notifications] Listening on http://127.0.0.1:${env.DESKTOP_NOTIFICATIONS_PORT}`,
+			);
+		},
+	);
+
+	notificationsInitialized = true;
+}
+
+function cleanupNotifications(): void {
+	if (!notificationsInitialized) return;
+
+	if (agentLifecycleListener) {
+		notificationsEmitter.off(
+			NOTIFICATION_EVENTS.AGENT_LIFECYCLE,
+			agentLifecycleListener,
+		);
+		agentLifecycleListener = null;
+	}
+
+	if (terminalExitListener) {
+		getWorkspaceRuntimeRegistry()
+			.getDefault()
+			.terminal.off("terminalExit", terminalExitListener);
+		terminalExitListener = null;
+	}
+
+	notificationManager?.dispose();
+	notificationManager = null;
+
+	notificationsServer?.close();
+	notificationsServer = null;
+
+	notificationsInitialized = false;
+}
 
 export async function MainWindow() {
 	const shouldPersistWindowPosition = isWindowPositionPersistenceEnabled();
@@ -243,77 +363,6 @@ export async function MainWindow() {
 		});
 		windowManager.setIpcHandler(ipcHandler);
 	}
-
-	const server = notificationsApp.listen(
-		env.DESKTOP_NOTIFICATIONS_PORT,
-		"127.0.0.1",
-		() => {
-			console.log(
-				`[notifications] Listening on http://127.0.0.1:${env.DESKTOP_NOTIFICATIONS_PORT}`,
-			);
-		},
-	);
-
-	const notificationManager = new NotificationManager({
-		isSupported: () => Notification.isSupported(),
-		createNotification: (opts) => new Notification(opts),
-		playSound: playNotificationSound,
-		playAivis: (event) => {
-			const kind =
-				event.eventType === "PermissionRequest" ? "permission" : "complete";
-			void playAivisNotification(kind, buildAivisVars(event));
-		},
-		onNotificationClick: (ids) => {
-			window.show();
-			window.focus();
-			notificationsEmitter.emit(NOTIFICATION_EVENTS.FOCUS_TAB, ids);
-		},
-		getVisibilityContext: () => ({
-			isFocused: window.isFocused(),
-			currentWorkspaceId: extractWorkspaceIdFromUrl(
-				window.webContents.getURL(),
-			),
-			tabsState: appState.data?.tabsState,
-		}),
-		getWorkspaceName: getWorkspaceNameFromDb,
-		getNotificationTitle: (event) =>
-			getNotificationTitle({
-				tabId: event.tabId,
-				paneId: event.paneId,
-				tabs: appState.data?.tabsState?.tabs,
-				panes: appState.data?.tabsState?.panes,
-			}),
-	});
-	notificationManager.start();
-
-	notificationsEmitter.on(
-		NOTIFICATION_EVENTS.AGENT_LIFECYCLE,
-		(event: AgentLifecycleEvent) => {
-			notificationManager.handleAgentLifecycle(event);
-		},
-	);
-
-	// Forward low-volume terminal lifecycle events to the renderer via the existing
-	// notifications subscription. This is used only for correctness (e.g. clearing
-	// stuck agent lifecycle statuses when terminal panes aren't mounted).
-	getWorkspaceRuntimeRegistry()
-		.getDefault()
-		.terminal.on(
-			"terminalExit",
-			(event: {
-				paneId: string;
-				exitCode: number;
-				signal?: number;
-				reason?: "killed" | "exited" | "error";
-			}) => {
-				notificationsEmitter.emit(NOTIFICATION_EVENTS.TERMINAL_EXIT, {
-					paneId: event.paneId,
-					exitCode: event.exitCode,
-					signal: event.signal,
-					reason: event.reason,
-				});
-			},
-		);
 
 	// macOS Sequoia+: occluded/minimized windows can lose compositor layers,
 	// and NSVisualEffectView's vibrancy/native blur can detach while the
@@ -483,10 +532,6 @@ export async function MainWindow() {
 
 	function doCleanup() {
 		browserManager.unregisterAll();
-		server.close();
-		notificationManager.dispose();
-		notificationsEmitter.removeAllListeners();
-		getWorkspaceRuntimeRegistry().getDefault().terminal.detachAllListeners();
 		ipcHandler?.detachWindow(window);
 		windowManager.unregister("main");
 		currentWindow = null;


### PR DESCRIPTION
## 概要

Aivis によるタスク完了の音声読み上げが、1回の完了に対してほぼ同時に二重で再生されてしまう不具合を修正します。通知音（リングトーン）は短い効果音のため重複が聞き取りづらかったものの、実際には同様に二重発火していました。

## 原因

Codex の完了通知経路が2本存在し、同じ完了イベントが `notify.sh` → `/hook/complete` に2回到達していたのが主因です。

1. \`~/.codex/hooks.json\` の Stop hook
2. Codex wrapper の \`--enable codex_hooks -c 'notify=[\"bash\",\"…notify.sh\"]'\` オプション

両経路がそれぞれ \`/hook/complete\` を叩くため、\`notificationsEmitter\` から \`AGENT_LIFECYCLE\` が2回発火し、\`NotificationManager.handleAgentLifecycle\` → \`playAivisNotification\` が2回呼ばれていました。

加えて、\`MainWindow()\` 内で \`notificationsApp.listen\` / \`new NotificationManager\` / \`notificationsEmitter.on(AGENT_LIFECYCLE, ...)\` を初期化していたため、macOS で全ウィンドウを閉じてから Dock 再アクティベートする経路 (\`app.on(\"activate\")\` → \`MainWindow()\` 再実行) でリスナーが多重登録される構造的リスクも残っていました。

Claude Code / OpenCode / Cursor / Copilot / Gemini は通知経路が1本のため影響なく、本件は Codex セッション終了時に発生していました。

## 修正内容

### 1. Codex wrapper の \`notify=\` 注入を除去

\`apps/desktop/src/main/lib/agent-setup/templates/codex-wrapper-exec.template.sh\`

\`\`\`diff
-\"$REAL_BIN\" --enable codex_hooks -c 'notify=[\"bash\",\"{{NOTIFY_PATH}}\"]' \"$@\"
+\"$REAL_BIN\" --enable codex_hooks \"$@\"
\`\`\`

\`hooks.json\` の Stop hook を唯一の完了通知ソースとし、重複配送を根本から止めます。wrapper 内の TUI session log watcher（prompt 開始・権限要求の検知）は引き続き必要なので残しています。

### 2. 通知系初期化を \`app.whenReady\` 直後に1回だけ走らせる

\`apps/desktop/src/main/windows/main.ts\` から通知系初期化を \`initNotifications()\` として切り出し、\`apps/desktop/src/main/index.ts\` の \`app.whenReady\` 後で1回だけ呼ぶように変更しました。\`notificationsInitialized\` フラグで冪等性を担保しています。

\`MainWindow()\` は BrowserWindow の生成のみを担当するようにし、ウィンドウ再生成時にリスナーが多重登録される経路を構造的に排除しました。

## やらなかったこと（意図）

入口での dedupe Map による短時間の重複抑制は**採用しません**。ユーザー側が「複数エージェントがたまたま同時に終了して2回鳴る」という正規の並列完了を許容しているため、dedupe を入れると意図的な連続完了まで抑えてしまい、症状の隠蔽で別バグを生む可能性があるためです。重複ソースを根本から1本化する方針で対応しています。

## 動作確認ポイント

- Codex セッション終了時に aivis が1回だけ鳴ること
- Claude Code / OpenCode など他エージェントの完了通知が従来どおり1回鳴ること
- ウィンドウを × で閉じて Dock から再表示した後も、通知音・aivis が正常に発火すること

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * 通知システムの初期化タイミングを改善し、より早期にセットアップされるようになりました。
  * Codex統合で重複した完了通知を削除し、より効率的なフックライフサイクル管理を実現しました。

* **削除**
  * ワークスペース音声・動画ファイル視聴機能を削除しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->