### PR TITLE
fix(desktop): 透過設定スライダーのコミット挙動を安定化

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/settings/appearance/components/AppearanceSettings/components/VibrancySection/VibrancySection.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/appearance/components/AppearanceSettings/components/VibrancySection/VibrancySection.tsx
@@ -64,6 +64,29 @@ export function VibrancySection() {
 	const displayBlurLevelValue =
 		draftBlurLevelValue ?? blurLevelToSliderValue(blurLevel);
 
+	const commitOpacity = (value: number) => {
+		void setState({ opacity: value }).finally(() => {
+			setDraftOpacity((current) => (current === value ? null : current));
+		});
+	};
+
+	const commitBlurRadius = (value: number) => {
+		void setState({ blurRadius: value }).finally(() => {
+			setDraftBlurRadius((current) => (current === value ? null : current));
+		});
+	};
+
+	const commitBlurLevelValue = (value: number) => {
+		const nextLevel = sliderValueToBlurLevel(value);
+		if (nextLevel === blurLevel) {
+			setDraftBlurLevelValue((current) => (current === value ? null : current));
+			return;
+		}
+		void setState({ blurLevel: nextLevel }).finally(() => {
+			setDraftBlurLevelValue((current) => (current === value ? null : current));
+		});
+	};
+
 	useEffect(() => {
 		// index.tsx already kicks off hydrate at startup; this is a safety net
 		// for cold settings-only flows. The store itself dedupes concurrent
@@ -140,8 +163,7 @@ export function VibrancySection() {
 					onValueCommit={(values) => {
 						const value = values[0];
 						if (typeof value !== "number") return;
-						setDraftOpacity(null);
-						void setState({ opacity: value });
+						commitOpacity(value);
 					}}
 				/>
 				<p className="text-xs text-muted-foreground">
@@ -174,8 +196,7 @@ export function VibrancySection() {
 						onValueCommit={(values) => {
 							const value = values[0];
 							if (typeof value !== "number") return;
-							setDraftBlurRadius(null);
-							void setState({ blurRadius: value });
+							commitBlurRadius(value);
 						}}
 					/>
 					<p className="text-xs text-muted-foreground">
@@ -210,11 +231,7 @@ export function VibrancySection() {
 						onValueCommit={(values) => {
 							const value = values[0];
 							if (typeof value !== "number") return;
-							setDraftBlurLevelValue(null);
-							const nextLevel = sliderValueToBlurLevel(value);
-							if (nextLevel !== blurLevel) {
-								void setState({ blurLevel: nextLevel });
-							}
+							commitBlurLevelValue(value);
 						}}
 					/>
 					<p className="text-xs text-muted-foreground">

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/appearance/components/AppearanceSettings/components/VibrancySection/VibrancySection.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/appearance/components/AppearanceSettings/components/VibrancySection/VibrancySection.tsx
@@ -1,7 +1,7 @@
 import { Label } from "@superset/ui/label";
 import { Slider } from "@superset/ui/slider";
 import { Switch } from "@superset/ui/switch";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useVibrancyStore } from "renderer/stores/vibrancy";
 import {
 	VIBRANCY_BLUR_RADIUS_MAX,
@@ -63,27 +63,37 @@ export function VibrancySection() {
 	);
 	const displayBlurLevelValue =
 		draftBlurLevelValue ?? blurLevelToSliderValue(blurLevel);
+	const opacityDraftRevisionRef = useRef(0);
+	const blurRadiusDraftRevisionRef = useRef(0);
+	const blurLevelDraftRevisionRef = useRef(0);
 
 	const commitOpacity = (value: number) => {
+		const revision = opacityDraftRevisionRef.current;
 		void setState({ opacity: value }).finally(() => {
-			setDraftOpacity((current) => (current === value ? null : current));
+			if (opacityDraftRevisionRef.current !== revision) return;
+			setDraftOpacity(null);
 		});
 	};
 
 	const commitBlurRadius = (value: number) => {
+		const revision = blurRadiusDraftRevisionRef.current;
 		void setState({ blurRadius: value }).finally(() => {
-			setDraftBlurRadius((current) => (current === value ? null : current));
+			if (blurRadiusDraftRevisionRef.current !== revision) return;
+			setDraftBlurRadius(null);
 		});
 	};
 
 	const commitBlurLevelValue = (value: number) => {
+		const revision = blurLevelDraftRevisionRef.current;
 		const nextLevel = sliderValueToBlurLevel(value);
 		if (nextLevel === blurLevel) {
-			setDraftBlurLevelValue((current) => (current === value ? null : current));
+			if (blurLevelDraftRevisionRef.current !== revision) return;
+			setDraftBlurLevelValue(null);
 			return;
 		}
 		void setState({ blurLevel: nextLevel }).finally(() => {
-			setDraftBlurLevelValue((current) => (current === value ? null : current));
+			if (blurLevelDraftRevisionRef.current !== revision) return;
+			setDraftBlurLevelValue(null);
 		});
 	};
 
@@ -155,6 +165,7 @@ export function VibrancySection() {
 					onValueChange={(values) => {
 						const value = values[0];
 						if (typeof value !== "number") return;
+						opacityDraftRevisionRef.current += 1;
 						setDraftOpacity(value);
 						// Live-preview via the store so all CSS variable
 						// overlays are recomputed — no disk write, no IPC.
@@ -191,6 +202,7 @@ export function VibrancySection() {
 						onValueChange={(values) => {
 							const value = values[0];
 							if (typeof value !== "number") return;
+							blurRadiusDraftRevisionRef.current += 1;
 							setDraftBlurRadius(value);
 						}}
 						onValueCommit={(values) => {
@@ -226,6 +238,7 @@ export function VibrancySection() {
 						onValueChange={(values) => {
 							const value = values[0];
 							if (typeof value !== "number") return;
+							blurLevelDraftRevisionRef.current += 1;
 							setDraftBlurLevelValue(value);
 						}}
 						onValueCommit={(values) => {


### PR DESCRIPTION
## 概要
- 透過設定のスライダーで、非同期保存が完了するまで draft 値を保持するように変更
- 古い commit の完了で新しい draft が消えないようにガードを追加
- 変更範囲を Appearance Settings の VibrancySection のみに限定

## テスト
- 未実施（依頼なし）