### PR TITLE
fix: v1のセットアップ書き込みを確認付きにする

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/terminal/terminal.ts
+++ b/apps/desktop/src/lib/trpc/routers/terminal/terminal.ts
@@ -219,7 +219,11 @@ export const createTerminalRouter = () => {
 			.mutation(async ({ input }) => {
 				const shouldThrow = input.throwOnError ?? false;
 				try {
-					terminal.write(input);
+					await terminal.write({
+						paneId: input.paneId,
+						data: input.data,
+						requireAck: shouldThrow,
+					});
 				} catch (error) {
 					const message =
 						error instanceof Error ? error.message : "Write failed";

--- a/apps/desktop/src/main/lib/terminal/daemon/daemon-manager.ts
+++ b/apps/desktop/src/main/lib/terminal/daemon/daemon-manager.ts
@@ -682,12 +682,22 @@ export class DaemonTerminalManager extends EventEmitter {
 		}
 	}
 
-	write(params: { paneId: string; data: string }): void {
-		const { paneId, data } = params;
+	write(params: {
+		paneId: string;
+		data: string;
+		requireAck?: boolean;
+	}): Promise<void> | void {
+		const { paneId, data, requireAck = false } = params;
 
 		const session = this.sessions.get(paneId);
 		if (!session || !session.isAlive) {
 			throw new Error(`Terminal session ${paneId} not found or not alive`);
+		}
+
+		// Critical one-shot commands like workspace setup should fail loudly if
+		// the daemon didn't actually accept the write.
+		if (requireAck) {
+			return this.client.write({ sessionId: paneId, data }).then(() => {});
 		}
 
 		this.client.writeNoAck({ sessionId: paneId, data });

--- a/apps/desktop/src/main/lib/workspace-runtime/types.ts
+++ b/apps/desktop/src/main/lib/workspace-runtime/types.ts
@@ -9,8 +9,9 @@
  * 1. Stream subscriptions MUST NOT complete on session exit (exit is a state transition)
  * 2. Capability presence (e.g., management !== null) indicates feature availability,
  *    not "health right now"; mid-session failures should propagate as errors
- * 3. Operations use sync signatures where latency-critical (write, resize, signal, detach);
- *    async signatures for lifecycle ops (createOrAttach, kill, cleanup)
+ * 3. Operations stay sync where latency-critical by default (resize, signal, detach).
+ *    `write` can opt into an ack-backed async path for critical one-shot commands;
+ *    lifecycle ops remain async (createOrAttach, kill, cleanup).
  *
  * Reference: apps/desktop/plans/20260109-2313-terminal-runtime-abstraction-rewrite.md
  */
@@ -79,8 +80,15 @@ export interface TerminalSessionOperations {
 	/** Cancel the current createOrAttach attempt for a pane if it matches requestId. */
 	cancelCreateOrAttach(params: { paneId: string; requestId: string }): void;
 
-	/** Write data to the terminal */
-	write(params: { paneId: string; data: string; requireAck?: boolean }): void;
+	/**
+	 * Write data to the terminal.
+	 * `requireAck` opts into a confirmed async write for critical one-shot commands.
+	 */
+	write(params: {
+		paneId: string;
+		data: string;
+		requireAck?: boolean;
+	}): void | Promise<void>;
 
 	/** Resize the terminal */
 	resize(params: { paneId: string; cols: number; rows: number }): void;

--- a/apps/desktop/src/main/lib/workspace-runtime/types.ts
+++ b/apps/desktop/src/main/lib/workspace-runtime/types.ts
@@ -80,7 +80,7 @@ export interface TerminalSessionOperations {
 	cancelCreateOrAttach(params: { paneId: string; requestId: string }): void;
 
 	/** Write data to the terminal */
-	write(params: { paneId: string; data: string }): void;
+	write(params: { paneId: string; data: string; requireAck?: boolean }): void;
 
 	/** Resize the terminal */
 	resize(params: { paneId: string; cols: number; rows: number }): void;


### PR DESCRIPTION
## 概要

v1 の workspace setup 書き込みが `throwOnError: true` でも no-ack 送信になっており、setup コマンドが silent drop しても表面化しない経路になっていました。
今回の変更で、重要な one-shot write だけ ack 付き送信に切り替えて、setup 失敗をきちんと検知できるようにしています。

## 変更内容

- `terminal.write` の `throwOnError` を runtime 側の `requireAck` に変換
- daemon manager で `requireAck` 時のみ `client.write` を使うように変更
- terminal runtime の write パラメータ型に `requireAck` を追加

## 確認内容

- `bun install`
- `bun run typecheck`
- `bun run lint` は既存の unrelated エラー 4 件で失敗
- `bunx @biomejs/biome check apps/desktop/src/lib/trpc/routers/terminal/terminal.ts apps/desktop/src/main/lib/terminal/daemon/daemon-manager.ts apps/desktop/src/main/lib/workspace-runtime/types.ts`

## 補足

- `bun run lint` の失敗は今回の変更箇所ではなく、ringtones settings 配下の `useExhaustiveDependencies` 既存エラーです。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ターミナル書き込み操作に確認応答メカニズムを追加しました。重要な操作はエラーハンドリングが強化され、より信頼性の高い通信が可能になりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->