### PR TITLE
Add v1 split previews for sidebar file drags

### DIFF
--- a/apps/desktop/src/renderer/hooks/useFileDragBehavior/index.ts
+++ b/apps/desktop/src/renderer/hooks/useFileDragBehavior/index.ts
@@ -1,0 +1,4 @@
+export {
+	getFileDragBehavior,
+	useFileDragBehavior,
+} from "./useFileDragBehavior";

--- a/apps/desktop/src/renderer/hooks/useFileDragBehavior/useFileDragBehavior.ts
+++ b/apps/desktop/src/renderer/hooks/useFileDragBehavior/useFileDragBehavior.ts
@@ -1,0 +1,17 @@
+import type { FileDragBehavior } from "@superset/local-db";
+import { electronTrpc } from "renderer/lib/electron-trpc";
+import { DEFAULT_FILE_DRAG_BEHAVIOR } from "shared/constants";
+
+let cachedFileDragBehavior: FileDragBehavior = DEFAULT_FILE_DRAG_BEHAVIOR;
+
+/** Non-React getter, kept in sync by useFileDragBehavior(). */
+export function getFileDragBehavior(): FileDragBehavior {
+	return cachedFileDragBehavior;
+}
+
+export function useFileDragBehavior(): FileDragBehavior {
+	const { data } = electronTrpc.settings.getFileDragBehavior.useQuery();
+	const behavior = data ?? DEFAULT_FILE_DRAG_BEHAVIOR;
+	cachedFileDragBehavior = behavior;
+	return behavior;
+}

--- a/apps/desktop/src/renderer/lib/file-drag.ts
+++ b/apps/desktop/src/renderer/lib/file-drag.ts
@@ -1,9 +1,15 @@
 export const INTERNAL_FILE_PATH_MIME = "application/x-superset-file-path";
 
+export function hasInternalDraggedFilePath(
+	dataTransfer: DataTransfer,
+): boolean {
+	return Array.from(dataTransfer.types).includes(INTERNAL_FILE_PATH_MIME);
+}
+
 export function getInternalDraggedFilePath(
 	dataTransfer: DataTransfer,
 ): string | null {
-	if (!Array.from(dataTransfer.types).includes(INTERNAL_FILE_PATH_MIME)) {
+	if (!hasInternalDraggedFilePath(dataTransfer)) {
 		return null;
 	}
 

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/components/BasePaneWindow/BasePaneWindow.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/components/BasePaneWindow/BasePaneWindow.tsx
@@ -268,17 +268,16 @@ export function BasePaneWindow({
 				return;
 			}
 
+			event.preventDefault();
+			event.stopPropagation();
+
 			const filePath = getInternalDraggedFilePath(event.dataTransfer);
 			if (!filePath) {
 				resetInternalFileDragState();
 				return;
 			}
 
-			event.preventDefault();
-			event.stopPropagation();
-			const dropPosition =
-				internalFileDropPositionRef.current ??
-				updateInternalFileDropPosition(event);
+			const dropPosition = updateInternalFileDropPosition(event);
 
 			addFileViewerPane(workspaceId, {
 				filePath,

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/components/BasePaneWindow/BasePaneWindow.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/components/BasePaneWindow/BasePaneWindow.tsx
@@ -1,11 +1,18 @@
 import { cn } from "@superset/ui/utils";
-import { useContext, useRef } from "react";
+import { useCallback, useContext, useEffect, useRef, useState } from "react";
 import type { MosaicBranch } from "react-mosaic-component";
 import { MosaicWindow, MosaicWindowContext } from "react-mosaic-component";
+import { useFileDragBehavior } from "renderer/hooks/useFileDragBehavior";
+import {
+	getInternalDraggedFilePath,
+	hasInternalDraggedFilePath,
+} from "renderer/lib/file-drag";
 import { useDragPaneStore } from "renderer/stores/drag-pane-store";
 import { useTabsStore } from "renderer/stores/tabs/store";
+import type { MosaicDropPosition } from "renderer/stores/tabs/types";
 import type { SplitOrientation } from "../../hooks";
 import { useSplitOrientation } from "../../hooks";
+import { InternalFileDropOverlay } from "./components/InternalFileDropOverlay";
 
 export interface PaneHandlers {
 	onFocus: () => void;
@@ -14,6 +21,23 @@ export interface PaneHandlers {
 	onSplitPaneOpposite?: (e: React.MouseEvent) => void;
 	onPopOut?: (e: React.MouseEvent) => void;
 	splitOrientation: SplitOrientation;
+}
+
+function getInternalFileDropPosition(
+	clientX: number,
+	clientY: number,
+	rect: DOMRect,
+): MosaicDropPosition {
+	const cx = rect.left + rect.width / 2;
+	const cy = rect.top + rect.height / 2;
+	const dx = clientX - cx;
+	const dy = clientY - cy;
+
+	if (Math.abs(dx) > Math.abs(dy)) {
+		return dx > 0 ? "right" : "left";
+	}
+
+	return dy > 0 ? "bottom" : "top";
 }
 
 /**
@@ -76,9 +100,13 @@ export function BasePaneWindow({
 	hideToolbar = false,
 }: BasePaneWindowProps) {
 	const isActive = useTabsStore((s) => s.focusedPaneIds[tabId] === paneId);
+	const workspaceId = useTabsStore(
+		(s) => s.tabs.find((tab) => tab.id === tabId)?.workspaceId ?? null,
+	);
 	const workspaceRunState = useTabsStore(
 		(s) => s.panes[paneId]?.workspaceRun?.state,
 	);
+	const addFileViewerPane = useTabsStore((s) => s.addFileViewerPane);
 	const containerRef = useRef<HTMLDivElement>(null);
 	const splitOrientation = useSplitOrientation(containerRef);
 	const isDragging = useDragPaneStore((s) => s.draggingPaneId !== null);
@@ -86,6 +114,11 @@ export function BasePaneWindow({
 	const isResizing = useDragPaneStore((s) => s.isResizing);
 	const setDragging = useDragPaneStore((s) => s.setDragging);
 	const clearDragging = useDragPaneStore((s) => s.clearDragging);
+	const fileDragBehavior = useFileDragBehavior();
+	const internalFileDragDepthRef = useRef(0);
+	const internalFileDropPositionRef = useRef<MosaicDropPosition | null>(null);
+	const [internalFileDropPosition, setInternalFileDropPosition] =
+		useState<MosaicDropPosition | null>(null);
 
 	const handleFocus = () => {
 		setFocusedPane(tabId, paneId);
@@ -135,6 +168,141 @@ export function BasePaneWindow({
 
 	const isRoot = path.length === 0;
 
+	const resetInternalFileDragState = useCallback(() => {
+		internalFileDragDepthRef.current = 0;
+		internalFileDropPositionRef.current = null;
+		setInternalFileDropPosition(null);
+	}, []);
+
+	const isInternalFileViewerDropEnabled =
+		fileDragBehavior === "open-file-viewer" && workspaceId !== null;
+
+	const updateInternalFileDropPosition = useCallback(
+		(event: React.DragEvent<HTMLDivElement>): MosaicDropPosition => {
+			const nextPosition = getInternalFileDropPosition(
+				event.clientX,
+				event.clientY,
+				event.currentTarget.getBoundingClientRect(),
+			);
+
+			if (nextPosition !== internalFileDropPositionRef.current) {
+				internalFileDropPositionRef.current = nextPosition;
+				setInternalFileDropPosition(nextPosition);
+			}
+
+			return nextPosition;
+		},
+		[],
+	);
+
+	useEffect(() => {
+		if (!isInternalFileViewerDropEnabled) {
+			resetInternalFileDragState();
+		}
+	}, [isInternalFileViewerDropEnabled, resetInternalFileDragState]);
+
+	const handleInternalFileDragEnterCapture = useCallback(
+		(event: React.DragEvent<HTMLDivElement>) => {
+			if (
+				!isInternalFileViewerDropEnabled ||
+				!hasInternalDraggedFilePath(event.dataTransfer)
+			) {
+				return;
+			}
+
+			internalFileDragDepthRef.current += 1;
+			event.preventDefault();
+			event.stopPropagation();
+			event.dataTransfer.dropEffect = "copy";
+			updateInternalFileDropPosition(event);
+		},
+		[isInternalFileViewerDropEnabled, updateInternalFileDropPosition],
+	);
+
+	const handleInternalFileDragOverCapture = useCallback(
+		(event: React.DragEvent<HTMLDivElement>) => {
+			if (
+				!isInternalFileViewerDropEnabled ||
+				!hasInternalDraggedFilePath(event.dataTransfer)
+			) {
+				return;
+			}
+
+			event.preventDefault();
+			event.stopPropagation();
+			event.dataTransfer.dropEffect = "copy";
+			updateInternalFileDropPosition(event);
+		},
+		[isInternalFileViewerDropEnabled, updateInternalFileDropPosition],
+	);
+
+	const handleInternalFileDragLeaveCapture = useCallback(
+		(event: React.DragEvent<HTMLDivElement>) => {
+			if (
+				!isInternalFileViewerDropEnabled ||
+				!hasInternalDraggedFilePath(event.dataTransfer)
+			) {
+				return;
+			}
+
+			event.stopPropagation();
+			internalFileDragDepthRef.current = Math.max(
+				0,
+				internalFileDragDepthRef.current - 1,
+			);
+
+			if (internalFileDragDepthRef.current === 0) {
+				resetInternalFileDragState();
+			}
+		},
+		[isInternalFileViewerDropEnabled, resetInternalFileDragState],
+	);
+
+	const handleInternalFileDropCapture = useCallback(
+		(event: React.DragEvent<HTMLDivElement>) => {
+			if (
+				!isInternalFileViewerDropEnabled ||
+				!workspaceId ||
+				!hasInternalDraggedFilePath(event.dataTransfer)
+			) {
+				return;
+			}
+
+			const filePath = getInternalDraggedFilePath(event.dataTransfer);
+			if (!filePath) {
+				resetInternalFileDragState();
+				return;
+			}
+
+			event.preventDefault();
+			event.stopPropagation();
+			const dropPosition =
+				internalFileDropPositionRef.current ??
+				updateInternalFileDropPosition(event);
+
+			addFileViewerPane(workspaceId, {
+				filePath,
+				isPinned: true,
+				openInNewTab: false,
+				reuseExisting: "none",
+				relativeToPaneId: paneId,
+				relativeToTabId: tabId,
+				relativeSplitPosition: dropPosition,
+				useRightSidebarOpenViewWidth: true,
+			});
+			resetInternalFileDragState();
+		},
+		[
+			addFileViewerPane,
+			isInternalFileViewerDropEnabled,
+			paneId,
+			resetInternalFileDragState,
+			tabId,
+			updateInternalFileDropPosition,
+			workspaceId,
+		],
+	);
+
 	return (
 		<MosaicWindow<string>
 			path={path}
@@ -157,14 +325,19 @@ export function BasePaneWindow({
 			{/* biome-ignore lint/a11y/useKeyWithClickEvents lint/a11y/noStaticElementInteractions: Focus handler for pane */}
 			<div
 				ref={containerRef}
-				className={contentClassName}
+				className={cn("relative", contentClassName)}
 				style={
 					isDragging || isTabDragging || isResizing
 						? { pointerEvents: "none" }
 						: undefined
 				}
+				onDragEnterCapture={handleInternalFileDragEnterCapture}
+				onDragOverCapture={handleInternalFileDragOverCapture}
+				onDragLeaveCapture={handleInternalFileDragLeaveCapture}
+				onDropCapture={handleInternalFileDropCapture}
 				onClick={handleFocus}
 			>
+				<InternalFileDropOverlay position={internalFileDropPosition} />
 				{children}
 			</div>
 		</MosaicWindow>

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/components/BasePaneWindow/components/InternalFileDropOverlay/InternalFileDropOverlay.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/components/BasePaneWindow/components/InternalFileDropOverlay/InternalFileDropOverlay.tsx
@@ -1,0 +1,31 @@
+import type { CSSProperties } from "react";
+import type { MosaicDropPosition } from "renderer/stores/tabs/types";
+
+interface InternalFileDropOverlayProps {
+	position: MosaicDropPosition | null;
+}
+
+const ZONE_STYLES: Record<MosaicDropPosition, CSSProperties> = {
+	top: { top: 0, left: 0, width: "100%", height: "50%" },
+	bottom: { top: "50%", left: 0, width: "100%", height: "50%" },
+	left: { top: 0, left: 0, width: "50%", height: "100%" },
+	right: { top: 0, left: "50%", width: "50%", height: "100%" },
+};
+
+export function InternalFileDropOverlay({
+	position,
+}: InternalFileDropOverlayProps) {
+	if (!position) return null;
+
+	return (
+		<div className="pointer-events-none absolute inset-0 z-10">
+			<div
+				className="absolute rounded-sm border-2 border-primary/70 bg-primary/10"
+				style={{
+					...ZONE_STYLES[position],
+					transition: "all 150ms ease",
+				}}
+			/>
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/components/BasePaneWindow/components/InternalFileDropOverlay/index.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/components/BasePaneWindow/components/InternalFileDropOverlay/index.ts
@@ -1,0 +1,1 @@
+export { InternalFileDropOverlay } from "./InternalFileDropOverlay";

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/Terminal.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/Terminal.tsx
@@ -4,12 +4,10 @@ import type { Terminal as XTerm } from "@xterm/xterm";
 import "@xterm/xterm/css/xterm.css";
 import { memo, useCallback, useEffect, useRef, useState } from "react";
 import { electronTrpc } from "renderer/lib/electron-trpc";
-import { getInternalDraggedFilePath } from "renderer/lib/file-drag";
 import { buildTerminalCommand } from "renderer/lib/terminal/launch-command";
 import { useTabsStore } from "renderer/stores/tabs/store";
 import { useTerminalSuggestionsStore } from "renderer/stores/terminal-suggestions";
 import { useEffectiveTerminalTheme } from "renderer/stores/vibrancy";
-import { DEFAULT_FILE_DRAG_BEHAVIOR } from "shared/constants";
 import { sanitizeForTitle } from "./commandBuffer";
 import { SessionKilledOverlay } from "./components";
 import {
@@ -56,9 +54,6 @@ export const Terminal = memo(function Terminal({
 	const isWorkspaceRunPane = Boolean(pane?.workspaceRun?.workspaceId);
 	const paneInitialCwd = pane?.initialCwd;
 	const clearPaneInitialData = useTabsStore((s) => s.clearPaneInitialData);
-	const addFileViewerPane = useTabsStore((s) => s.addFileViewerPane);
-	const { data: fileDragBehavior } =
-		electronTrpc.settings.getFileDragBehavior.useQuery();
 
 	const { data: workspaceData } = electronTrpc.workspaces.get.useQuery(
 		{ id: workspaceId },
@@ -567,19 +562,6 @@ export const Terminal = memo(function Terminal({
 	const handleDrop = (event: React.DragEvent) => {
 		event.preventDefault();
 		const files = Array.from(event.dataTransfer.files);
-		const internalFilePath = getInternalDraggedFilePath(event.dataTransfer);
-		if (
-			files.length === 0 &&
-			internalFilePath &&
-			(fileDragBehavior ?? DEFAULT_FILE_DRAG_BEHAVIOR) === "open-file-viewer"
-		) {
-			addFileViewerPane(workspaceId, {
-				filePath: internalFilePath,
-				useRightSidebarOpenViewWidth: true,
-			});
-			return;
-		}
-
 		let text: string;
 		if (files.length > 0) {
 			// Native file drop (from Finder, etc.)

--- a/apps/desktop/src/renderer/stores/tabs/store.ts
+++ b/apps/desktop/src/renderer/stores/tabs/store.ts
@@ -1126,9 +1126,7 @@ export const useTabsStore = create<TabsStore>()(
 						options.useRightSidebarOpenViewWidth,
 					);
 					const splitTargetTab =
-						options.relativeToTabId &&
-						!options.openInNewTab &&
-						options.relativeToPaneId
+						options.relativeToTabId && options.relativeToPaneId
 							? (state.tabs.find((tab) => tab.id === options.relativeToTabId) ??
 								null)
 							: null;
@@ -1142,13 +1140,19 @@ export const useTabsStore = create<TabsStore>()(
 						splitTargetPane.tabId === splitTargetTab.id
 							? findPanePathInLayout(splitTargetTab.layout, splitTargetPane.id)
 							: null;
+					const resolvedRelativeTarget =
+						splitTargetTab && splitTargetPane && splitTargetPath !== null
+							? {
+									tab: splitTargetTab,
+									pane: splitTargetPane,
+									path: splitTargetPath,
+								}
+							: null;
 
-					const targetTab = splitTargetTab ?? activeTab;
+					const targetTab = resolvedRelativeTarget?.tab ?? activeTab;
 					const newPaneForTarget = createFileViewerPane(targetTab.id, options);
 					const targetLayoutNode =
-						splitTargetTab && splitTargetPane && splitTargetPath !== null
-							? splitTargetPane.id
-							: targetTab.layout;
+						resolvedRelativeTarget?.pane.id ?? targetTab.layout;
 					const splitDirection =
 						relativeSplitPosition === "top" ||
 						relativeSplitPosition === "bottom"
@@ -1162,22 +1166,16 @@ export const useTabsStore = create<TabsStore>()(
 						second: insertBeforeTarget ? targetLayoutNode : newPaneForTarget.id,
 						splitPercentage,
 					};
-					const newLayout: MosaicNode<string> =
-						splitTargetTab && splitTargetPane && splitTargetPath !== null
-							? splitTargetPath.length > 0
-								? updateTree(targetTab.layout, [
-										{
-											path: splitTargetPath,
-											spec: { $set: splitNode },
-										},
-									])
-								: splitNode
-							: {
-									direction: "row",
-									first: targetTab.layout,
-									second: newPaneForTarget.id,
-									splitPercentage,
-								};
+					const newLayout: MosaicNode<string> = resolvedRelativeTarget
+						? resolvedRelativeTarget.path.length > 0
+							? updateTree(targetTab.layout, [
+									{
+										path: resolvedRelativeTarget.path,
+										spec: { $set: splitNode },
+									},
+								])
+							: splitNode
+						: splitNode;
 
 					const newPanes = {
 						...state.panes,

--- a/apps/desktop/src/renderer/stores/tabs/store.ts
+++ b/apps/desktop/src/renderer/stores/tabs/store.ts
@@ -49,6 +49,7 @@ import {
 	createVscodeExtensionTabWithPane,
 	equalizeSplitPercentages,
 	extractPaneIdsFromLayout,
+	findPanePathInLayout,
 	findReusableFileViewerPane,
 	generateId,
 	generateTabName,
@@ -63,6 +64,22 @@ import {
 import { killTerminalForPane } from "./utils/terminal-cleanup";
 
 const DEFAULT_FILE_VIEWER_SPLIT_PERCENTAGE = 50;
+
+const getRelativeFileViewerSplitPercentage = (
+	position: "top" | "bottom" | "left" | "right",
+	useRightSidebarOpenViewWidth?: boolean,
+): number => {
+	if (
+		!useRightSidebarOpenViewWidth ||
+		position === "top" ||
+		position === "bottom"
+	) {
+		return DEFAULT_FILE_VIEWER_SPLIT_PERCENTAGE;
+	}
+
+	const sidebarWidth = getRightSidebarOpenViewWidth();
+	return position === "left" ? sidebarWidth : 100 - sidebarWidth;
+};
 
 /**
  * Finds the next best tab to activate when closing a tab.
@@ -1102,41 +1119,92 @@ export const useTabsStore = create<TabsStore>()(
 						return newPane.id;
 					}
 
-					const newPane = createFileViewerPane(activeTab.id, options);
-					const splitPercentage = options.useRightSidebarOpenViewWidth
-						? 100 - getRightSidebarOpenViewWidth()
-						: DEFAULT_FILE_VIEWER_SPLIT_PERCENTAGE;
+					const relativeSplitPosition =
+						options.relativeSplitPosition ?? "right";
+					const splitPercentage = getRelativeFileViewerSplitPercentage(
+						relativeSplitPosition,
+						options.useRightSidebarOpenViewWidth,
+					);
+					const splitTargetTab =
+						options.relativeToTabId &&
+						!options.openInNewTab &&
+						options.relativeToPaneId
+							? (state.tabs.find((tab) => tab.id === options.relativeToTabId) ??
+								null)
+							: null;
+					const splitTargetPane =
+						splitTargetTab && options.relativeToPaneId
+							? state.panes[options.relativeToPaneId]
+							: null;
+					const splitTargetPath =
+						splitTargetTab &&
+						splitTargetPane &&
+						splitTargetPane.tabId === splitTargetTab.id
+							? findPanePathInLayout(splitTargetTab.layout, splitTargetPane.id)
+							: null;
 
-					const newLayout: MosaicNode<string> = {
-						direction: "row",
-						first: activeTab.layout,
-						second: newPane.id,
+					const targetTab = splitTargetTab ?? activeTab;
+					const newPaneForTarget = createFileViewerPane(targetTab.id, options);
+					const targetLayoutNode =
+						splitTargetTab && splitTargetPane && splitTargetPath !== null
+							? splitTargetPane.id
+							: targetTab.layout;
+					const splitDirection =
+						relativeSplitPosition === "top" ||
+						relativeSplitPosition === "bottom"
+							? "column"
+							: "row";
+					const insertBeforeTarget =
+						relativeSplitPosition === "left" || relativeSplitPosition === "top";
+					const splitNode: MosaicNode<string> = {
+						direction: splitDirection,
+						first: insertBeforeTarget ? newPaneForTarget.id : targetLayoutNode,
+						second: insertBeforeTarget ? targetLayoutNode : newPaneForTarget.id,
 						splitPercentage,
 					};
+					const newLayout: MosaicNode<string> =
+						splitTargetTab && splitTargetPane && splitTargetPath !== null
+							? splitTargetPath.length > 0
+								? updateTree(targetTab.layout, [
+										{
+											path: splitTargetPath,
+											spec: { $set: splitNode },
+										},
+									])
+								: splitNode
+							: {
+									direction: "row",
+									first: targetTab.layout,
+									second: newPaneForTarget.id,
+									splitPercentage,
+								};
 
-					const newPanes = { ...state.panes, [newPane.id]: newPane };
-					const tabName = deriveTabName(newPanes, activeTab.id);
+					const newPanes = {
+						...state.panes,
+						[newPaneForTarget.id]: newPaneForTarget,
+					};
+					const tabName = deriveTabName(newPanes, targetTab.id);
 
 					set({
 						tabs: state.tabs.map((t) =>
-							t.id === activeTab.id
+							t.id === targetTab.id
 								? { ...t, layout: newLayout, name: tabName }
 								: t,
 						),
 						panes: newPanes,
 						focusedPaneIds: {
 							...state.focusedPaneIds,
-							[activeTab.id]: newPane.id,
+							[targetTab.id]: newPaneForTarget.id,
 						},
 					});
 
 					posthog.capture("panel_opened", {
 						panel_type: "file_viewer",
-						workspace_id: activeTab.workspaceId,
-						pane_id: newPane.id,
+						workspace_id: targetTab.workspaceId,
+						pane_id: newPaneForTarget.id,
 					});
 
-					return newPane.id;
+					return newPaneForTarget.id;
 				},
 
 				removePane: (paneId) => {

--- a/apps/desktop/src/renderer/stores/tabs/types.ts
+++ b/apps/desktop/src/renderer/stores/tabs/types.ts
@@ -94,6 +94,12 @@ export interface AddFileViewerPaneOptions {
 	reuseExisting?: FileViewerReuseScope;
 	/** If true, use the right sidebar initial split width setting for new split panes */
 	useRightSidebarOpenViewWidth?: boolean;
+	/** When provided, split relative to this existing pane instead of the root layout */
+	relativeToPaneId?: string;
+	/** Tab containing `relativeToPaneId`; ignored when the pane is missing or invalid */
+	relativeToTabId?: string;
+	/** Split direction to use when opening relative to an existing pane */
+	relativeSplitPosition?: MosaicDropPosition;
 }
 
 /**

--- a/apps/desktop/src/renderer/stores/tabs/utils.ts
+++ b/apps/desktop/src/renderer/stores/tabs/utils.ts
@@ -162,27 +162,6 @@ export const extractPaneIdsFromLayout = (
 /** Alias for extractPaneIdsFromLayout emphasizing the visual ordering contract */
 export const getPaneIdsInVisualOrder = extractPaneIdsFromLayout;
 
-export const findPanePathInLayout = (
-	layout: MosaicNode<string>,
-	paneId: string,
-	currentPath: MosaicBranch[] = [],
-): MosaicBranch[] | null => {
-	if (typeof layout === "string") {
-		return layout === paneId ? currentPath : null;
-	}
-
-	const firstPath = findPanePathInLayout(layout.first, paneId, [
-		...currentPath,
-		"first",
-	]);
-	if (firstPath) return firstPath;
-
-	return findPanePathInLayout(layout.second, paneId, [
-		...currentPath,
-		"second",
-	]);
-};
-
 /**
  * Options for creating a pane with preset configuration
  */
@@ -696,6 +675,8 @@ export const findPanePath = (
 
 	return null;
 };
+
+export const findPanePathInLayout = findPanePath;
 
 export type FocusDirection = "left" | "right" | "up" | "down";
 

--- a/apps/desktop/src/renderer/stores/tabs/utils.ts
+++ b/apps/desktop/src/renderer/stores/tabs/utils.ts
@@ -162,6 +162,27 @@ export const extractPaneIdsFromLayout = (
 /** Alias for extractPaneIdsFromLayout emphasizing the visual ordering contract */
 export const getPaneIdsInVisualOrder = extractPaneIdsFromLayout;
 
+export const findPanePathInLayout = (
+	layout: MosaicNode<string>,
+	paneId: string,
+	currentPath: MosaicBranch[] = [],
+): MosaicBranch[] | null => {
+	if (typeof layout === "string") {
+		return layout === paneId ? currentPath : null;
+	}
+
+	const firstPath = findPanePathInLayout(layout.first, paneId, [
+		...currentPath,
+		"first",
+	]);
+	if (firstPath) return firstPath;
+
+	return findPanePathInLayout(layout.second, paneId, [
+		...currentPath,
+		"second",
+	]);
+};
+
 /**
  * Options for creating a pane with preset configuration
  */


### PR DESCRIPTION
## 概要
- v1 の各 pane で内部ファイルドラッグを受けられる drop target を追加
- ドロップ位置に応じて青い split preview を表示し、left/right/top/bottom の4方向に file viewer を開けるように対応
- 既存のクリック挙動、外部ファイル drop 時のパス貼り付け、file drag behavior 設定はそのまま維持

## 補足
- 右サイドバーからの内部 file drag を file viewer で開くようにした #334 の follow-up
- `bun run lint` と `bun run typecheck` はローカルで通過済み

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ペイン上のファイルドラッグ&ドロップサポートを追加しました。内部ファイルをペインにドラッグして、新しいペインでファイルビューアーを開くことができます。
  * ドラッグ時に相対的な分割位置を指定できるようになり、ファイルを左右または上下に配置できます。
  * ドラッグ中のファイルドロップ位置を視覚的にプレビューするオーバーレイを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->