### PR TITLE
feat(desktop): PRへの新規コメント投稿機能を追加

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/ReviewPanel/ReviewPanel.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/ReviewPanel/ReviewPanel.tsx
@@ -1387,7 +1387,8 @@ export function ReviewPanel({
 							<TooltipTrigger asChild>
 								<button
 									type="button"
-									className="shrink-0 flex items-center gap-1 rounded-sm px-1.5 py-0.5 text-[10px] text-muted-foreground transition-colors hover:bg-accent/30 hover:text-foreground"
+									aria-label="New comment"
+									className="mr-1.5 shrink-0 flex items-center gap-1 rounded-sm px-1.5 py-0.5 text-[10px] text-muted-foreground transition-colors hover:bg-accent/30 hover:text-foreground"
 									onClick={() => setIsNewCommentDialogOpen(true)}
 								>
 									<LuMessageSquarePlus className="size-3" />

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/ReviewPanel/ReviewPanel.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/ReviewPanel/ReviewPanel.tsx
@@ -28,6 +28,7 @@ import {
 	LuCopy,
 	LuExternalLink,
 	LuLoaderCircle,
+	LuMessageSquarePlus,
 	LuRefreshCw,
 	LuReply,
 	LuX,
@@ -135,6 +136,8 @@ export function ReviewPanel({
 	const [replyTargetComment, setReplyTargetComment] =
 		useState<PullRequestComment | null>(null);
 	const [isReplySubmitting, setIsReplySubmitting] = useState(false);
+	const [isNewCommentDialogOpen, setIsNewCommentDialogOpen] = useState(false);
+	const [isNewCommentSubmitting, setIsNewCommentSubmitting] = useState(false);
 	const [identityPopoverOpen, setIdentityPopoverOpen] = useState<
 		"reviewers" | "assignees" | null
 	>(null);
@@ -282,6 +285,30 @@ export function ReviewPanel({
 			toast.error(`Failed to post reply: ${message}`);
 		} finally {
 			setIsReplySubmitting(false);
+		}
+	};
+
+	const handleSubmitNewComment = async (body: string) => {
+		if (!resolvedWorkspaceId) {
+			return;
+		}
+
+		setIsNewCommentSubmitting(true);
+		try {
+			await replyToPullRequestCommentMutation.mutateAsync({
+				workspaceId: resolvedWorkspaceId,
+				body,
+				pullRequestNumber: pr?.number,
+				pullRequestUrl: pr?.url,
+			});
+			toast.success("Comment posted");
+			setIsNewCommentDialogOpen(false);
+			void refreshReview("full");
+		} catch (error) {
+			const message = error instanceof Error ? error.message : "Unknown error";
+			toast.error(`Failed to post comment: ${message}`);
+		} finally {
+			setIsNewCommentSubmitting(false);
 		}
 	};
 
@@ -1355,6 +1382,20 @@ export function ReviewPanel({
 							{commentsCountLabel}
 						</span>
 					</CollapsibleTrigger>
+					{pr && canEditPullRequest && (
+						<Tooltip>
+							<TooltipTrigger asChild>
+								<button
+									type="button"
+									className="shrink-0 flex items-center gap-1 rounded-sm px-1.5 py-0.5 text-[10px] text-muted-foreground transition-colors hover:bg-accent/30 hover:text-foreground"
+									onClick={() => setIsNewCommentDialogOpen(true)}
+								>
+									<LuMessageSquarePlus className="size-3" />
+								</button>
+							</TooltipTrigger>
+							<TooltipContent side="bottom">New comment</TooltipContent>
+						</Tooltip>
+					)}
 					{activeComments.length > 0 && (
 						<button
 							type="button"
@@ -1423,6 +1464,18 @@ export function ReviewPanel({
 				onSubmit={handleSubmitReply}
 				isSubmitting={isReplySubmitting}
 				onOpenUrl={handleOpenUrl}
+			/>
+			<ReplyDialog
+				comment={null}
+				open={isNewCommentDialogOpen}
+				onOpenChange={(open) => {
+					if (!isNewCommentSubmitting) {
+						setIsNewCommentDialogOpen(open);
+					}
+				}}
+				onSubmit={handleSubmitNewComment}
+				isSubmitting={isNewCommentSubmitting}
+				isNewComment
 			/>
 		</div>
 	);

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/ReviewPanel/components/ReplyDialog/ReplyDialog.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/ReviewPanel/components/ReplyDialog/ReplyDialog.tsx
@@ -22,6 +22,8 @@ interface ReplyDialogProps {
 	onSubmit: (body: string) => Promise<void> | void;
 	isSubmitting: boolean;
 	onOpenUrl?: (url: string, e: React.MouseEvent) => void;
+	/** When true, shows a "New comment" dialog instead of a reply dialog */
+	isNewComment?: boolean;
 }
 
 export function ReplyDialog({
@@ -31,6 +33,7 @@ export function ReplyDialog({
 	onSubmit,
 	isSubmitting,
 	onOpenUrl,
+	isNewComment = false,
 }: ReplyDialogProps) {
 	const [body, setBody] = useState("");
 	const inFlightRef = useRef(false);
@@ -42,11 +45,11 @@ export function ReplyDialog({
 		}
 	}, [open]);
 
-	if (!comment) {
+	if (!isNewComment && !comment) {
 		return null;
 	}
 
-	const isReviewThreadReply = Boolean(comment.threadId);
+	const isReviewThreadReply = Boolean(comment?.threadId);
 	const trimmed = body.trim();
 	const canSubmit = trimmed.length > 0 && !isSubmitting;
 
@@ -74,56 +77,64 @@ export function ReplyDialog({
 		}
 	};
 
+	const dialogTitle = isNewComment
+		? "New comment"
+		: isReviewThreadReply
+			? "Reply to review thread"
+			: "Reply to comment";
+
+	const dialogDescription = isNewComment
+		? "Your comment will be posted on this pull request."
+		: isReviewThreadReply
+			? "Your reply will be posted to this review thread on GitHub."
+			: "Your reply will be posted as a new comment on this pull request.";
+
 	return (
 		<Dialog open={open} onOpenChange={onOpenChange}>
 			<DialogContent className="max-w-lg">
 				<DialogHeader>
-					<DialogTitle>
-						{isReviewThreadReply
-							? "Reply to review thread"
-							: "Reply to comment"}
-					</DialogTitle>
-					<DialogDescription>
-						{isReviewThreadReply
-							? "Your reply will be posted to this review thread on GitHub."
-							: "Your reply will be posted as a new comment on this pull request."}
-					</DialogDescription>
+					<DialogTitle>{dialogTitle}</DialogTitle>
+					<DialogDescription>{dialogDescription}</DialogDescription>
 				</DialogHeader>
 
-				<div className="max-h-48 overflow-y-auto rounded-md border border-border/60 bg-muted/30 p-2 text-xs">
-					<div className="mb-1 flex items-center gap-1.5">
-						<Avatar className="size-4">
-							{comment.avatarUrl ? (
-								<AvatarImage
-									src={comment.avatarUrl}
-									alt={comment.authorLogin}
-								/>
-							) : null}
-							<AvatarFallback className="text-[10px] font-medium">
-								{getCommentAvatarFallback(comment.authorLogin)}
-							</AvatarFallback>
-						</Avatar>
-						<span className="font-medium text-foreground">
-							{comment.authorLogin}
-						</span>
-						{comment.path ? (
-							<span className="truncate text-muted-foreground">
-								{comment.path}
-								{comment.line ? `:${comment.line}` : ""}
+				{comment ? (
+					<div className="max-h-48 overflow-y-auto rounded-md border border-border/60 bg-muted/30 p-2 text-xs">
+						<div className="mb-1 flex items-center gap-1.5">
+							<Avatar className="size-4">
+								{comment.avatarUrl ? (
+									<AvatarImage
+										src={comment.avatarUrl}
+										alt={comment.authorLogin}
+									/>
+								) : null}
+								<AvatarFallback className="text-[10px] font-medium">
+									{getCommentAvatarFallback(comment.authorLogin)}
+								</AvatarFallback>
+							</Avatar>
+							<span className="font-medium text-foreground">
+								{comment.authorLogin}
 							</span>
-						) : null}
+							{comment.path ? (
+								<span className="truncate text-muted-foreground">
+									{comment.path}
+									{comment.line ? `:${comment.line}` : ""}
+								</span>
+							) : null}
+						</div>
+						<div className="review-comment-body break-words text-xs leading-5 text-muted-foreground">
+							<CommentBody body={comment.body} onOpenUrl={onOpenUrl} />
+						</div>
 					</div>
-					<div className="review-comment-body break-words text-xs leading-5 text-muted-foreground">
-						<CommentBody body={comment.body} onOpenUrl={onOpenUrl} />
-					</div>
-				</div>
+				) : null}
 
 				<form className="space-y-3" onSubmit={handleSubmit}>
 					<Textarea
 						value={body}
 						onChange={(event) => setBody(event.target.value)}
 						onKeyDown={handleKeyDown}
-						placeholder="Write a reply..."
+						placeholder={
+							isNewComment ? "Write a comment..." : "Write a reply..."
+						}
 						className="min-h-[120px] resize-none text-sm"
 						disabled={isSubmitting}
 						autoFocus
@@ -141,7 +152,7 @@ export function ReplyDialog({
 							{isSubmitting ? (
 								<LuLoaderCircle className="mr-1 size-3.5 animate-spin" />
 							) : null}
-							Reply
+							{isNewComment ? "Comment" : "Reply"}
 						</Button>
 					</DialogFooter>
 				</form>


### PR DESCRIPTION
## 概要

Issue #339 の対応。GitタブのCommentsセクションに、新規でPRコメントを投稿できるボタンを追加。

## 変更内容

- **CommentsヘッダーのCopy allボタン左に新規コメントボタンを配置**
  - `LuMessageSquarePlus` アイコンを使用
  - ホバー時にTooltipで "New comment" を表示
  - PRがopen/draft状態のときのみ表示
- **`ReplyDialog` を `isNewComment` モードに対応**
  - `isNewComment=true` のとき `comment=null` でも動作
  - タイトル・説明・プレースホルダー・送信ボタンラベルを新規コメント用に変更
  - コメントプレビューは返信時のみ表示
- **バックエンドは既存の `replyToPullRequestComment` を再利用**
  - `threadId` を省略して呼ぶと `addPullRequestConversationComment` が使われる仕組みを活用

## テスト方法

1. PRが存在するブランチのWorktreeを開く
2. 右サイドバーのGitタブ → Reviewタブ → Commentsセクションを確認
3. Commentsヘッダーの右側にメッセージプラスアイコンが表示されることを確認
4. ボタンをクリックしてダイアログが開くことを確認
5. コメントを入力して "Comment" ボタンで投稿できることを確認

Closes #339

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新機能
  * プルリクエストのコメント機能を改善しました。コメントセクションから新規トップレベルコメントをより簡単に作成できるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->