### PR TITLE
fix(desktop): ドラッグドロップの分割幅をプレビューと一致させる (#342)

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/components/BasePaneWindow/BasePaneWindow.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/components/BasePaneWindow/BasePaneWindow.tsx
@@ -287,7 +287,6 @@ export function BasePaneWindow({
 				relativeToPaneId: paneId,
 				relativeToTabId: tabId,
 				relativeSplitPosition: dropPosition,
-				useRightSidebarOpenViewWidth: true,
 			});
 			resetInternalFileDragState();
 		},


### PR DESCRIPTION
## 概要

Files タブから pane にファイルをドラッグして開いたとき、青いプレビューは 50% ゾーンを示しているのに、実際に開かれた file viewer が Right sidebar open view width 設定 (例: 25%) の幅で開いてしまい、プレビューと食い違う問題を修正。

## 原因

#336 で追加したドロップ処理では `addFileViewerPane` に `useRightSidebarOpenViewWidth: true` を渡していた。これによりストア側が Right sidebar の幅設定を split percentage に流用するため、設定が 25% だとドロップ結果の pane も 25% になっていた。プレビュー側は常に 50% ゾーンを表示するため不一致が発生。

## 変更点

- `BasePaneWindow` のドロップハンドラから `useRightSidebarOpenViewWidth: true` を外し、ドロップ時は常に DEFAULT (50/50) で分割するように変更。
- サイドバー右側の幅設定は、クリックで開く既存動線にのみ適用される状態に戻る。

## 動作確認

- `bun run lint`、`apps/desktop` の `bun run typecheck` パス。
- ローカルで Right sidebar open view width を 25% に設定 → Files タブからペインの右半分にドラッグ → プレビュー通り 50/50 で分割されることを想定。

Closes #342

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * ファイルを内部的にドラッグ&ドロップした際の動作を調整しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->