### PR TITLE
feat(desktop): ターミナルタブの一括操作モード (#346)

### DIFF
--- a/apps/desktop/src/lib/trpc/index.ts
+++ b/apps/desktop/src/lib/trpc/index.ts
@@ -63,7 +63,9 @@ const sentryMiddleware = t.middleware(async ({ next, path, type }) => {
 				"! [rejected]",
 				"failed to push some refs",
 			];
-			if (USER_ENV_NOISE_PATTERNS.some((pattern) => message.includes(pattern))) {
+			if (
+				USER_ENV_NOISE_PATTERNS.some((pattern) => message.includes(pattern))
+			) {
 				return result;
 			}
 

--- a/apps/desktop/src/main/lib/todo-daemon/client.ts
+++ b/apps/desktop/src/main/lib/todo-daemon/client.ts
@@ -230,7 +230,10 @@ export class TodoDaemonClient extends EventEmitter {
 					},
 					{
 						captureMessage: true,
-						fingerprint: ["todo.agent.main", "todo-daemon-client-authenticated"],
+						fingerprint: [
+							"todo.agent.main",
+							"todo-daemon-client-authenticated",
+						],
 					},
 				);
 				return;
@@ -733,7 +736,10 @@ export class TodoDaemonClient extends EventEmitter {
 				},
 				{
 					captureMessage: true,
-					fingerprint: ["todo.agent.main", "todo-daemon-client-rehydrate-success"],
+					fingerprint: [
+						"todo.agent.main",
+						"todo-daemon-client-rehydrate-success",
+					],
 				},
 			);
 			return response;
@@ -743,7 +749,10 @@ export class TodoDaemonClient extends EventEmitter {
 				"todo-daemon-client-rehydrate-failed",
 				undefined,
 				{
-					fingerprint: ["todo.agent.main", "todo-daemon-client-rehydrate-failed"],
+					fingerprint: [
+						"todo.agent.main",
+						"todo-daemon-client-rehydrate-failed",
+					],
 				},
 			);
 			throw error;

--- a/apps/desktop/src/main/todo-agent/daemon-bridge.ts
+++ b/apps/desktop/src/main/todo-agent/daemon-bridge.ts
@@ -76,14 +76,10 @@ export function startTodoAgentDaemonBridge(): Promise<void> {
 			console.warn(
 				"[todo-agent] daemon disconnected — will reconnect on next RPC",
 			);
-			todoAgentMainDebug.warn(
-				"todo-daemon-bridge-disconnected",
-				undefined,
-				{
-					captureMessage: true,
-					fingerprint: ["todo.agent.main", "todo-daemon-bridge-disconnected"],
-				},
-			);
+			todoAgentMainDebug.warn("todo-daemon-bridge-disconnected", undefined, {
+				captureMessage: true,
+				fingerprint: ["todo.agent.main", "todo-daemon-bridge-disconnected"],
+			});
 		});
 		client.on("error", (error) => {
 			console.warn("[todo-agent] daemon client error", error);
@@ -98,25 +94,17 @@ export function startTodoAgentDaemonBridge(): Promise<void> {
 		});
 	}
 	connectPromise = (async () => {
-		todoAgentMainDebug.info(
-			"todo-daemon-bridge-init",
-			undefined,
-			{
-				captureMessage: true,
-				fingerprint: ["todo.agent.main", "todo-daemon-bridge-init"],
-			},
-		);
+		todoAgentMainDebug.info("todo-daemon-bridge-init", undefined, {
+			captureMessage: true,
+			fingerprint: ["todo.agent.main", "todo-daemon-bridge-init"],
+		});
 		try {
 			await client.ensureConnected();
 			await client.rehydrate();
-			todoAgentMainDebug.info(
-				"todo-daemon-bridge-init-success",
-				undefined,
-				{
-					captureMessage: true,
-					fingerprint: ["todo.agent.main", "todo-daemon-bridge-init-success"],
-				},
-			);
+			todoAgentMainDebug.info("todo-daemon-bridge-init-success", undefined, {
+				captureMessage: true,
+				fingerprint: ["todo.agent.main", "todo-daemon-bridge-init-success"],
+			});
 		} catch (error) {
 			console.warn("[todo-agent] daemon bridge failed to initialize", error);
 			todoAgentMainDebug.captureException(

--- a/apps/desktop/src/main/todo-agent/debug.ts
+++ b/apps/desktop/src/main/todo-agent/debug.ts
@@ -1,6 +1,6 @@
 import type { SelectTodoSession } from "@superset/local-db";
-import type { TodoStreamEvent } from "./types";
 import { createMainDebugChannel } from "../lib/debug-channel";
+import type { TodoStreamEvent } from "./types";
 
 const DEBUG_TODO_AGENT = process.env.SUPERSET_TODO_DEBUG === "1";
 
@@ -32,7 +32,7 @@ export function getTodoSessionDebugData(
 		| "claudeSessionId"
 		| "verdictReason"
 		| "waitingReason"
-	>
+	>,
 ) {
 	return {
 		sessionId: session.id,

--- a/apps/desktop/src/main/todo-agent/runtime-config.ts
+++ b/apps/desktop/src/main/todo-agent/runtime-config.ts
@@ -152,11 +152,7 @@ export function writeTodoSessionRuntimeConfig(
 		const normalized = normalizeConfig(config);
 		const filePath = getRuntimeConfigPath(artifactPath);
 		mkdirSync(artifactPath, { recursive: true });
-		writeFileSync(
-			filePath,
-			`${JSON.stringify(normalized, null, 2)}\n`,
-			"utf8",
-		);
+		writeFileSync(filePath, `${JSON.stringify(normalized, null, 2)}\n`, "utf8");
 		todoAgentMainDebug.info(
 			"todo-runtime-config-write",
 			{

--- a/apps/desktop/src/main/todo-agent/trpc-router.ts
+++ b/apps/desktop/src/main/todo-agent/trpc-router.ts
@@ -10,6 +10,7 @@ import { publicProcedure, router } from "lib/trpc";
 import { localDb } from "main/lib/local-db";
 import { workspaceInitManager } from "main/lib/workspace-init-manager";
 import { z } from "zod";
+import { getTodoSessionDebugData, todoAgentMainDebug } from "./debug";
 import { describeEnhanceFailure, enhanceTodoText } from "./enhance-text";
 import {
 	getSessionFileDiff,
@@ -25,7 +26,6 @@ import { computeNextRunAt, getTodoScheduler } from "./scheduler";
 import { getTodoSessionStore, resolveWorktreePath } from "./session-store";
 import { getTodoSettings, updateTodoSettings } from "./settings";
 import { getTodoSupervisor } from "./supervisor";
-import { getTodoSessionDebugData, todoAgentMainDebug } from "./debug";
 import {
 	TODO_ARTIFACT_SUBDIR,
 	type TodoScheduleFireEvent,

--- a/apps/desktop/src/renderer/features/todo-agent/TodoModal/TodoModal.tsx
+++ b/apps/desktop/src/renderer/features/todo-agent/TodoModal/TodoModal.tsx
@@ -216,7 +216,11 @@ export function TodoModal({
 				},
 				{
 					captureMessage: true,
-					fingerprint: ["todo.agent.renderer", "todo-create-submit", "todo-modal"],
+					fingerprint: [
+						"todo.agent.renderer",
+						"todo-create-submit",
+						"todo-modal",
+					],
 				},
 			);
 			const created = await create.mutateAsync({
@@ -277,7 +281,11 @@ export function TodoModal({
 					errorMessage: message,
 				},
 				{
-					fingerprint: ["todo.agent.renderer", "todo-create-submit-failed", "todo-modal"],
+					fingerprint: [
+						"todo.agent.renderer",
+						"todo-create-submit-failed",
+						"todo-modal",
+					],
 				},
 			);
 			toast.error(message);

--- a/apps/desktop/src/renderer/lib/boot-errors.ts
+++ b/apps/desktop/src/renderer/lib/boot-errors.ts
@@ -70,7 +70,10 @@ export const reportBootError = (message: string, error?: unknown) => {
 	// explicitly so a boot crash always lands in the dashboard.
 	reportError(error ?? new Error(message), {
 		severity: "fatal",
-		tags: { subsystem: "boot", mounted: hasMounted ? "post-mount" : "pre-mount" },
+		tags: {
+			subsystem: "boot",
+			mounted: hasMounted ? "post-mount" : "pre-mount",
+		},
 		context: { message },
 	});
 	if (hasMounted) return;

--- a/apps/desktop/src/renderer/lib/sentry.ts
+++ b/apps/desktop/src/renderer/lib/sentry.ts
@@ -33,9 +33,7 @@ export async function initSentry(): Promise<void> {
 			tracesSampleRate: 0.1,
 			beforeSend(event) {
 				const message = event.exception?.values?.[0]?.value ?? "";
-				if (
-					NOISY_ERROR_PATTERNS.some((pattern) => message.includes(pattern))
-				) {
+				if (NOISY_ERROR_PATTERNS.some((pattern) => message.includes(pattern))) {
 					return null;
 				}
 				return event;

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/layout.tsx
@@ -6,6 +6,7 @@ import {
 } from "@tanstack/react-router";
 import { useEffect } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
+import { RouteErrorBoundary } from "renderer/components/RouteErrorBoundary";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import {
 	type SettingsSection,
@@ -13,7 +14,6 @@ import {
 	useSettingsOriginRoute,
 	useSettingsSearchQuery,
 } from "renderer/stores/settings-state";
-import { RouteErrorBoundary } from "renderer/components/RouteErrorBoundary";
 import { SearchResultsBanner } from "./components/SearchResultsBanner";
 import { SettingsSidebar } from "./components/SettingsSidebar";
 import {

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/GroupStrip/GroupItem.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/GroupStrip/GroupItem.tsx
@@ -14,14 +14,15 @@ import { cn } from "@superset/ui/utils";
 import { useEffect, useState } from "react";
 import { useDrag, useDrop } from "react-dnd";
 import { getEmptyImage } from "react-dnd-html5-backend";
-import { HiMiniXMark } from "react-icons/hi2";
-import { LuEyeOff, LuPalette, LuPencil } from "react-icons/lu";
+import { HiMiniCheck, HiMiniXMark } from "react-icons/hi2";
+import { LuEyeOff, LuListChecks, LuPalette, LuPencil } from "react-icons/lu";
 import type { MosaicBranch } from "react-mosaic-component";
 import { MosaicDragType } from "react-mosaic-component";
 import { ColorSelector } from "renderer/components/ColorSelector/ColorSelector";
 import { StatusIndicator } from "renderer/screens/main/components/StatusIndicator";
 import { RenameInput } from "renderer/screens/main/components/WorkspaceSidebar/RenameInput";
 import { useDragPaneStore } from "renderer/stores/drag-pane-store";
+import { useTabBulkSelectionStore } from "renderer/stores/tab-bulk-selection-store";
 import { useTabsStore } from "renderer/stores/tabs/store";
 import type {
 	MosaicDropPosition,
@@ -57,6 +58,7 @@ interface GroupItemProps {
 	onMarkAsUnread: () => void;
 	onPaneDrop?: (paneId: string) => void;
 	onReorder?: (fromIndex: number, toIndex: number) => void;
+	onEnterBulkMode?: () => void;
 }
 
 export function GroupItem({
@@ -71,8 +73,15 @@ export function GroupItem({
 	onMarkAsUnread,
 	onPaneDrop,
 	onReorder,
+	onEnterBulkMode,
 }: GroupItemProps) {
 	const displayName = getTabDisplayName(tab);
+	const bulkWorkspaceId = useTabBulkSelectionStore((s) => s.workspaceId);
+	const isBulkMode = bulkWorkspaceId === tab.workspaceId;
+	const isBulkSelected = useTabBulkSelectionStore((s) =>
+		s.selectedTabIds.has(tab.id),
+	);
+	const toggleBulkSelect = useTabBulkSelectionStore((s) => s.toggleSelect);
 	const [isEditing, setIsEditing] = useState(false);
 	const [editValue, setEditValue] = useState("");
 	const activeTabId = useTabsStore((s) =>
@@ -203,7 +212,8 @@ export function GroupItem({
 	const hasTabColor = tab.color && tab.color !== PROJECT_COLOR_DEFAULT;
 
 	const tabStyles = cn(
-		"flex items-center gap-2 transition-all w-full shrink-0 pl-3 pr-8 h-full",
+		"flex items-center gap-2 transition-all w-full shrink-0 pl-3 h-full",
+		isBulkMode ? "pr-3" : "pr-8",
 		hasTabColor
 			? "text-foreground"
 			: isActive
@@ -235,6 +245,9 @@ export function GroupItem({
 						"group relative flex items-center shrink-0 h-full border-r border-border",
 						isOver && canDrop && "bg-primary/5",
 						isDragging && "opacity-50 text-muted-foreground/50",
+						isBulkMode &&
+							isBulkSelected &&
+							"bg-primary/10 ring-1 ring-inset ring-primary/60",
 					)}
 					style={{
 						cursor: isDragging ? "grabbing" : undefined,
@@ -260,16 +273,37 @@ export function GroupItem({
 						<>
 							<button
 								type="button"
-								onClick={onSelect}
-								onDoubleClick={startEditing}
+								onClick={() => {
+									if (isBulkMode) {
+										toggleBulkSelect(tab.id);
+										return;
+									}
+									onSelect();
+								}}
+								onDoubleClick={isBulkMode ? undefined : startEditing}
 								onAuxClick={(e) => {
+									if (isBulkMode) return;
 									if (e.button === 1) {
 										e.preventDefault();
 										onClose();
 									}
 								}}
 								className={tabStyles}
+								aria-pressed={isBulkMode ? isBulkSelected : undefined}
 							>
+								{isBulkMode && (
+									<span
+										className={cn(
+											"flex size-4 shrink-0 items-center justify-center rounded-sm border",
+											isBulkSelected
+												? "border-primary bg-primary text-primary-foreground"
+												: "border-muted-foreground/40 bg-background",
+										)}
+										aria-hidden
+									>
+										{isBulkSelected && <HiMiniCheck className="size-3" />}
+									</span>
+								)}
 								<span className="text-sm truncate flex-1 text-left">
 									{displayName}
 								</span>
@@ -277,28 +311,30 @@ export function GroupItem({
 									<StatusIndicator status={status} />
 								)}
 							</button>
-							<div className="absolute right-1 top-1/2 -translate-y-1/2 hidden items-center gap-0.5 group-hover:flex">
-								<Tooltip delayDuration={500}>
-									<TooltipTrigger asChild>
-										<Button
-											type="button"
-											variant="ghost"
-											size="icon"
-											onClick={(e) => {
-												e.stopPropagation();
-												onClose();
-											}}
-											className="cursor-pointer size-6 hover:bg-muted"
-											aria-label="Close pane"
-										>
-											<HiMiniXMark className="size-4" />
-										</Button>
-									</TooltipTrigger>
-									<TooltipContent side="top" showArrow={false}>
-										Close pane
-									</TooltipContent>
-								</Tooltip>
-							</div>
+							{!isBulkMode && (
+								<div className="absolute right-1 top-1/2 -translate-y-1/2 hidden items-center gap-0.5 group-hover:flex">
+									<Tooltip delayDuration={500}>
+										<TooltipTrigger asChild>
+											<Button
+												type="button"
+												variant="ghost"
+												size="icon"
+												onClick={(e) => {
+													e.stopPropagation();
+													onClose();
+												}}
+												className="cursor-pointer size-6 hover:bg-muted"
+												aria-label="Close pane"
+											>
+												<HiMiniXMark className="size-4" />
+											</Button>
+										</TooltipTrigger>
+										<TooltipContent side="top" showArrow={false}>
+											Close pane
+										</TooltipContent>
+									</Tooltip>
+								</div>
+							)}
 						</>
 					)}
 				</div>
@@ -328,6 +364,15 @@ export function GroupItem({
 					<LuEyeOff className="size-4 mr-2" />
 					Mark as Unread
 				</ContextMenuItem>
+				{onEnterBulkMode && (
+					<>
+						<ContextMenuSeparator />
+						<ContextMenuItem onSelect={onEnterBulkMode}>
+							<LuListChecks className="size-4 mr-2" />
+							Select Multiple Tabs…
+						</ContextMenuItem>
+					</>
+				)}
 				<ContextMenuSeparator />
 				<ContextMenuItem onSelect={onClose}>
 					<HiMiniXMark className="size-4 mr-2" />

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/GroupStrip/GroupStrip.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/GroupStrip/GroupStrip.tsx
@@ -54,9 +54,6 @@ export function GroupStrip() {
 	const setPaneStatus = useTabsStore((s) => s.setPaneStatus);
 	const enterBulkMode = useTabBulkSelectionStore((s) => s.enterBulkMode);
 	const exitBulkMode = useTabBulkSelectionStore((s) => s.exitBulkMode);
-	const removeFromBulkSelection = useTabBulkSelectionStore(
-		(s) => s.removeFromSelection,
-	);
 	const pruneBulkSelection = useTabBulkSelectionStore((s) => s.pruneSelection);
 	const bulkSelectionWorkspaceId = useTabBulkSelectionStore(
 		(s) => s.workspaceId,
@@ -285,7 +282,10 @@ export function GroupStrip() {
 	};
 
 	const handleCloseGroup = (tabId: string) => {
-		removeFromBulkSelection(tabId);
+		// 選択からの除外は close が確定したタイミング (= tabs 配列から消える)
+		// で pruneSelection effect が自動的に行うため、ここでは事前削除しない。
+		// dirty タブで pending-close フローがキャンセルされてもタブは残るので、
+		// 選択状態だけ外れる不整合を防ぐ。
 		requestTabClose(tabId);
 	};
 

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/GroupStrip/GroupStrip.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/GroupStrip/GroupStrip.tsx
@@ -57,6 +57,7 @@ export function GroupStrip() {
 	const removeFromBulkSelection = useTabBulkSelectionStore(
 		(s) => s.removeFromSelection,
 	);
+	const pruneBulkSelection = useTabBulkSelectionStore((s) => s.pruneSelection);
 	const bulkSelectionWorkspaceId = useTabBulkSelectionStore(
 		(s) => s.workspaceId,
 	);
@@ -367,6 +368,13 @@ export function GroupStrip() {
 			exitBulkMode();
 		}
 	}, [activeWorkspaceId, bulkSelectionWorkspaceId, exitBulkMode, tabs.length]);
+
+	// 選択中のタブが editorCoordinator 経由など外部で消えた場合に
+	// phantom selection が残らないよう、現在のタブ集合で選択を pruning する
+	useEffect(() => {
+		if (bulkSelectionWorkspaceId !== activeWorkspaceId) return;
+		pruneBulkSelection(tabs.map((t) => t.id));
+	}, [activeWorkspaceId, bulkSelectionWorkspaceId, pruneBulkSelection, tabs]);
 
 	const useCompactAddButton =
 		useCompactTerminalAddButton ?? DEFAULT_USE_COMPACT_TERMINAL_ADD_BUTTON;

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/GroupStrip/GroupStrip.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/GroupStrip/GroupStrip.tsx
@@ -18,6 +18,7 @@ import { usePresets } from "renderer/react-query/presets";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 import { useWorkspaceId } from "renderer/screens/main/components/WorkspaceView/WorkspaceIdContext";
 import { requestTabClose } from "renderer/stores/editor-state/editorCoordinator";
+import { useTabBulkSelectionStore } from "renderer/stores/tab-bulk-selection-store";
 import { useTabsStore } from "renderer/stores/tabs/store";
 import { useTabsWithPresets } from "renderer/stores/tabs/useTabsWithPresets";
 import {
@@ -51,6 +52,14 @@ export function GroupStrip() {
 	const movePaneToNewTab = useTabsStore((s) => s.movePaneToNewTab);
 	const reorderTabs = useTabsStore((s) => s.reorderTabs);
 	const setPaneStatus = useTabsStore((s) => s.setPaneStatus);
+	const enterBulkMode = useTabBulkSelectionStore((s) => s.enterBulkMode);
+	const exitBulkMode = useTabBulkSelectionStore((s) => s.exitBulkMode);
+	const removeFromBulkSelection = useTabBulkSelectionStore(
+		(s) => s.removeFromSelection,
+	);
+	const bulkSelectionWorkspaceId = useTabBulkSelectionStore(
+		(s) => s.workspaceId,
+	);
 
 	const setTabAutoTitle = useTabsStore((s) => s.setTabAutoTitle);
 	const setPaneAutoTitle = useTabsStore((s) => s.setPaneAutoTitle);
@@ -275,8 +284,17 @@ export function GroupStrip() {
 	};
 
 	const handleCloseGroup = (tabId: string) => {
+		removeFromBulkSelection(tabId);
 		requestTabClose(tabId);
 	};
+
+	const handleEnterBulkMode = useCallback(
+		(tabId: string) => {
+			if (!activeWorkspaceId) return;
+			enterBulkMode(activeWorkspaceId, tabId);
+		},
+		[activeWorkspaceId, enterBulkMode],
+	);
 
 	const handleRenameGroup = (tabId: string, newName: string) => {
 		renameTab(tabId, newName);
@@ -335,6 +353,21 @@ export function GroupStrip() {
 		requestAnimationFrame(updateOverflow);
 	}, [updateOverflow]);
 
+	useEffect(() => {
+		if (
+			bulkSelectionWorkspaceId &&
+			bulkSelectionWorkspaceId !== activeWorkspaceId
+		) {
+			exitBulkMode();
+		}
+	}, [activeWorkspaceId, bulkSelectionWorkspaceId, exitBulkMode]);
+
+	useEffect(() => {
+		if (bulkSelectionWorkspaceId === activeWorkspaceId && tabs.length === 0) {
+			exitBulkMode();
+		}
+	}, [activeWorkspaceId, bulkSelectionWorkspaceId, exitBulkMode, tabs.length]);
+
 	const useCompactAddButton =
 		useCompactTerminalAddButton ?? DEFAULT_USE_COMPACT_TERMINAL_ADD_BUTTON;
 
@@ -389,6 +422,7 @@ export function GroupStrip() {
 											onMarkAsUnread={() => handleMarkTabAsUnread(tab.id)}
 											onPaneDrop={(paneId) => movePaneToTab(paneId, tab.id)}
 											onReorder={handleReorderTabs}
+											onEnterBulkMode={() => handleEnterBulkMode(tab.id)}
 										/>
 									</div>
 								);

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/GroupStrip/components/BulkActionBar/BulkActionBar.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/GroupStrip/components/BulkActionBar/BulkActionBar.tsx
@@ -1,0 +1,142 @@
+import { Button } from "@superset/ui/button";
+import { Popover, PopoverContent, PopoverTrigger } from "@superset/ui/popover";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
+import { useMemo, useState } from "react";
+import { HiMiniXMark } from "react-icons/hi2";
+import { LuListChecks, LuListMinus, LuPalette, LuTrash2 } from "react-icons/lu";
+import { ColorSelector } from "renderer/components/ColorSelector/ColorSelector";
+import { requestTabClose } from "renderer/stores/editor-state/editorCoordinator";
+import { useTabBulkSelectionStore } from "renderer/stores/tab-bulk-selection-store";
+import { useTabsStore } from "renderer/stores/tabs/store";
+import { PROJECT_COLOR_DEFAULT } from "shared/constants/project-colors";
+
+interface BulkActionBarProps {
+	workspaceId: string;
+}
+
+export function BulkActionBar({ workspaceId }: BulkActionBarProps) {
+	const bulkWorkspaceId = useTabBulkSelectionStore((s) => s.workspaceId);
+	const selectedTabIds = useTabBulkSelectionStore((s) => s.selectedTabIds);
+	const exitBulkMode = useTabBulkSelectionStore((s) => s.exitBulkMode);
+	const setSelection = useTabBulkSelectionStore((s) => s.setSelection);
+	const allTabs = useTabsStore((s) => s.tabs);
+	const setTabColor = useTabsStore((s) => s.setTabColor);
+	const [colorOpen, setColorOpen] = useState(false);
+
+	const workspaceTabIds = useMemo(
+		() =>
+			allTabs
+				.filter((tab) => tab.workspaceId === workspaceId)
+				.map((tab) => tab.id),
+		[allTabs, workspaceId],
+	);
+
+	if (bulkWorkspaceId !== workspaceId) {
+		return null;
+	}
+
+	const selectedCount = selectedTabIds.size;
+	const allSelected =
+		workspaceTabIds.length > 0 && selectedCount === workspaceTabIds.length;
+
+	const handleSelectAll = () => {
+		setSelection(workspaceTabIds);
+	};
+
+	const handleInvert = () => {
+		const inverted = workspaceTabIds.filter((id) => !selectedTabIds.has(id));
+		setSelection(inverted);
+	};
+
+	const handleApplyColor = (color: string) => {
+		const resolvedColor = color === PROJECT_COLOR_DEFAULT ? null : color;
+		for (const tabId of selectedTabIds) {
+			setTabColor(tabId, resolvedColor);
+		}
+		setColorOpen(false);
+	};
+
+	const handleBulkClose = () => {
+		const ids = Array.from(selectedTabIds);
+		for (const tabId of ids) {
+			requestTabClose(tabId);
+		}
+		exitBulkMode();
+	};
+
+	return (
+		<div className="flex h-9 items-center gap-2 border-b border-border bg-muted/30 px-3">
+			<Tooltip delayDuration={400}>
+				<TooltipTrigger asChild>
+					<Button
+						variant="ghost"
+						size="icon"
+						className="size-7"
+						aria-label="Exit selection mode"
+						onClick={exitBulkMode}
+					>
+						<HiMiniXMark className="size-4" />
+					</Button>
+				</TooltipTrigger>
+				<TooltipContent side="bottom">Exit selection mode</TooltipContent>
+			</Tooltip>
+			<span className="text-xs text-muted-foreground">
+				{selectedCount} selected
+			</span>
+			<div className="ml-2 flex items-center gap-1">
+				<Button
+					variant="ghost"
+					size="sm"
+					className="h-7 px-2 text-xs"
+					onClick={handleSelectAll}
+					disabled={allSelected}
+				>
+					<LuListChecks className="size-3.5 mr-1.5" />
+					Select all
+				</Button>
+				<Button
+					variant="ghost"
+					size="sm"
+					className="h-7 px-2 text-xs"
+					onClick={handleInvert}
+					disabled={workspaceTabIds.length === 0}
+				>
+					<LuListMinus className="size-3.5 mr-1.5" />
+					Invert
+				</Button>
+			</div>
+			<div className="ml-auto flex items-center gap-2">
+				<Popover open={colorOpen} onOpenChange={setColorOpen}>
+					<PopoverTrigger asChild>
+						<Button
+							variant="outline"
+							size="sm"
+							className="h-7 px-2 text-xs"
+							disabled={selectedCount === 0}
+						>
+							<LuPalette className="size-3.5 mr-1.5" />
+							Set color
+						</Button>
+					</PopoverTrigger>
+					<PopoverContent className="w-auto p-3" align="end">
+						<div className="mb-2 text-xs text-muted-foreground">
+							Apply color to {selectedCount} tab
+							{selectedCount === 1 ? "" : "s"}
+						</div>
+						<ColorSelector variant="inline" onSelectColor={handleApplyColor} />
+					</PopoverContent>
+				</Popover>
+				<Button
+					variant="destructive"
+					size="sm"
+					className="h-7 px-2 text-xs"
+					onClick={handleBulkClose}
+					disabled={selectedCount === 0}
+				>
+					<LuTrash2 className="size-3.5 mr-1.5" />
+					Close selected
+				</Button>
+			</div>
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/GroupStrip/components/BulkActionBar/BulkActionBar.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/GroupStrip/components/BulkActionBar/BulkActionBar.tsx
@@ -58,10 +58,23 @@ export function BulkActionBar({ workspaceId }: BulkActionBarProps) {
 
 	const handleBulkClose = () => {
 		const ids = Array.from(selectedTabIds);
-		for (const tabId of ids) {
-			requestTabClose(tabId);
+		const remaining: string[] = [];
+		for (let i = 0; i < ids.length; i++) {
+			const tabId = ids[i];
+			if (!tabId) continue;
+			const closed = requestTabClose(tabId);
+			if (!closed) {
+				// requestTabClose は dirty タブ確認を 1 件しか保持できないため、
+				// ここで停止して残りは選択に残し、ユーザーに順次対応してもらう
+				remaining.push(...ids.slice(i));
+				break;
+			}
 		}
-		exitBulkMode();
+		if (remaining.length === 0) {
+			exitBulkMode();
+		} else {
+			setSelection(remaining);
+		}
 	};
 
 	return (

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/GroupStrip/components/BulkActionBar/index.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/GroupStrip/components/BulkActionBar/index.ts
@@ -1,0 +1,1 @@
+export { BulkActionBar } from "./BulkActionBar";

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/index.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/index.tsx
@@ -9,6 +9,7 @@ import { ContentHeader } from "./ContentHeader";
 import { PresetsBar } from "./components/PresetsBar";
 import { TabsContent } from "./TabsContent";
 import { GroupStrip } from "./TabsContent/GroupStrip";
+import { BulkActionBar } from "./TabsContent/GroupStrip/components/BulkActionBar";
 
 interface ContentViewProps {
 	workspaceId: string;
@@ -46,6 +47,7 @@ export function ContentView({
 					<GroupStrip />
 				</ContentHeader>
 			)}
+			{!isBrowserFullscreen && <BulkActionBar workspaceId={workspaceId} />}
 			{showPresetsBar && !isBrowserFullscreen && <PresetsBar />}
 			<TabsContent
 				workspaceId={workspaceId}

--- a/apps/desktop/src/renderer/stores/tab-bulk-selection-store.ts
+++ b/apps/desktop/src/renderer/stores/tab-bulk-selection-store.ts
@@ -11,6 +11,7 @@ interface TabBulkSelectionActions {
 	toggleSelect: (tabId: string) => void;
 	setSelection: (tabIds: string[]) => void;
 	removeFromSelection: (tabId: string) => void;
+	pruneSelection: (validTabIds: string[]) => void;
 }
 
 export const useTabBulkSelectionStore = create<
@@ -39,6 +40,19 @@ export const useTabBulkSelectionStore = create<
 			if (!state.selectedTabIds.has(tabId)) return state;
 			const next = new Set(state.selectedTabIds);
 			next.delete(tabId);
+			return { selectedTabIds: next };
+		}),
+	pruneSelection: (validTabIds) =>
+		set((state) => {
+			if (state.selectedTabIds.size === 0) return state;
+			const valid = new Set(validTabIds);
+			let changed = false;
+			const next = new Set<string>();
+			for (const id of state.selectedTabIds) {
+				if (valid.has(id)) next.add(id);
+				else changed = true;
+			}
+			if (!changed) return state;
 			return { selectedTabIds: next };
 		}),
 }));

--- a/apps/desktop/src/renderer/stores/tab-bulk-selection-store.ts
+++ b/apps/desktop/src/renderer/stores/tab-bulk-selection-store.ts
@@ -1,0 +1,44 @@
+import { create } from "zustand";
+
+interface TabBulkSelectionState {
+	workspaceId: string | null;
+	selectedTabIds: Set<string>;
+}
+
+interface TabBulkSelectionActions {
+	enterBulkMode: (workspaceId: string, initialTabId?: string) => void;
+	exitBulkMode: () => void;
+	toggleSelect: (tabId: string) => void;
+	setSelection: (tabIds: string[]) => void;
+	removeFromSelection: (tabId: string) => void;
+}
+
+export const useTabBulkSelectionStore = create<
+	TabBulkSelectionState & TabBulkSelectionActions
+>((set) => ({
+	workspaceId: null,
+	selectedTabIds: new Set<string>(),
+	enterBulkMode: (workspaceId, initialTabId) =>
+		set(() => {
+			const next = new Set<string>();
+			if (initialTabId) next.add(initialTabId);
+			return { workspaceId, selectedTabIds: next };
+		}),
+	exitBulkMode: () =>
+		set({ workspaceId: null, selectedTabIds: new Set<string>() }),
+	toggleSelect: (tabId) =>
+		set((state) => {
+			const next = new Set(state.selectedTabIds);
+			if (next.has(tabId)) next.delete(tabId);
+			else next.add(tabId);
+			return { selectedTabIds: next };
+		}),
+	setSelection: (tabIds) => set({ selectedTabIds: new Set(tabIds) }),
+	removeFromSelection: (tabId) =>
+		set((state) => {
+			if (!state.selectedTabIds.has(tabId)) return state;
+			const next = new Set(state.selectedTabIds);
+			next.delete(tabId);
+			return { selectedTabIds: next };
+		}),
+}));

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -11,7 +11,8 @@
 			"!**/drizzle",
 			"!**/*.template.js",
 			"!**/*.template.sh",
-			"!apps/mobile/uniwind-types.d.ts"
+			"!apps/mobile/uniwind-types.d.ts",
+			"!mock.html"
 		]
 	},
 	"formatter": {

--- a/mock.html
+++ b/mock.html
@@ -1,0 +1,826 @@
+<!doctype html>
+<html lang="ja">
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<title>Mock — Terminal Tab Bulk Actions (Issue #346)</title>
+		<script src="https://cdn.tailwindcss.com"></script>
+		<style>
+			:root {
+				--background: #0b0b0c;
+				--foreground: #ededed;
+				--muted: #1a1a1c;
+				--muted-foreground: #9ca3af;
+				--border: #2a2a2d;
+				--tertiary: #3a3a3d;
+				--primary: #3b82f6;
+				--ring: #3b82f6;
+			}
+			html,
+			body {
+				background: var(--background);
+				color: var(--foreground);
+				font-family:
+					ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto,
+					"Helvetica Neue", Arial;
+			}
+			.bg-background {
+				background: var(--background);
+			}
+			.bg-muted {
+				background: var(--muted);
+			}
+			.bg-border {
+				background: var(--border);
+			}
+			.bg-tertiary {
+				background: var(--tertiary);
+			}
+			.text-foreground {
+				color: var(--foreground);
+			}
+			.text-muted-foreground {
+				color: var(--muted-foreground);
+			}
+			.border-border {
+				border-color: var(--border);
+			}
+			.ring-ring {
+				--tw-ring-color: var(--ring);
+			}
+
+			/* xterm-ish terminal background */
+			.terminal-area {
+				background: #050506;
+				font-family:
+					"JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Consolas,
+					monospace;
+				color: #d4d4d4;
+			}
+			.cursor-blink {
+				animation: blink 1s step-end infinite;
+			}
+			@keyframes blink {
+				50% {
+					opacity: 0;
+				}
+			}
+
+			.context-menu {
+				min-width: 220px;
+				background: #161618;
+				border: 1px solid var(--border);
+				border-radius: 8px;
+				padding: 4px;
+				box-shadow:
+					0 10px 30px rgba(0, 0, 0, 0.5),
+					0 0 0 1px rgba(255, 255, 255, 0.02);
+			}
+			.context-menu .item {
+				display: flex;
+				align-items: center;
+				gap: 8px;
+				padding: 6px 8px;
+				font-size: 13px;
+				border-radius: 4px;
+				cursor: default;
+				color: var(--foreground);
+			}
+			.context-menu .item:hover {
+				background: rgba(255, 255, 255, 0.06);
+			}
+			.context-menu .item.danger:hover {
+				background: rgba(239, 68, 68, 0.15);
+				color: #fca5a5;
+			}
+			.context-menu .sep {
+				height: 1px;
+				background: var(--border);
+				margin: 4px 0;
+			}
+			.context-menu .label {
+				padding: 4px 8px 6px;
+				font-size: 11px;
+				color: var(--muted-foreground);
+				text-transform: uppercase;
+				letter-spacing: 0.06em;
+			}
+			.context-menu .item .right {
+				margin-left: auto;
+				color: var(--muted-foreground);
+				font-size: 11px;
+			}
+
+			.color-swatch {
+				width: 18px;
+				height: 18px;
+				border-radius: 4px;
+				border: 1px solid rgba(255, 255, 255, 0.1);
+				cursor: pointer;
+			}
+			.color-swatch.selected {
+				outline: 2px solid var(--ring);
+				outline-offset: 1px;
+			}
+
+			.checkbox {
+				appearance: none;
+				width: 16px;
+				height: 16px;
+				border-radius: 3px;
+				border: 1px solid #4b5563;
+				background: transparent;
+				position: relative;
+				cursor: pointer;
+				flex-shrink: 0;
+			}
+			.checkbox:checked {
+				background: var(--primary);
+				border-color: var(--primary);
+			}
+			.checkbox:checked::after {
+				content: "";
+				position: absolute;
+				left: 4px;
+				top: 1px;
+				width: 5px;
+				height: 9px;
+				border: solid white;
+				border-width: 0 2px 2px 0;
+				transform: rotate(45deg);
+			}
+
+			.tab {
+				position: relative;
+				display: flex;
+				align-items: center;
+				gap: 8px;
+				padding: 0 32px 0 12px;
+				height: 100%;
+				border-right: 1px solid var(--border);
+				font-size: 13px;
+				color: rgba(156, 163, 175, 0.7);
+				cursor: pointer;
+				flex-shrink: 0;
+				transition: background 0.12s;
+			}
+			.tab:hover {
+				color: var(--muted-foreground);
+				background: rgba(58, 58, 61, 0.2);
+			}
+			.tab.active {
+				color: var(--foreground);
+				background: rgba(42, 42, 45, 0.3);
+			}
+			.tab .x-btn {
+				position: absolute;
+				right: 4px;
+				top: 50%;
+				transform: translateY(-50%);
+				width: 22px;
+				height: 22px;
+				border-radius: 4px;
+				display: none;
+				align-items: center;
+				justify-content: center;
+				color: var(--muted-foreground);
+			}
+			.tab:hover .x-btn {
+				display: inline-flex;
+			}
+			.tab .x-btn:hover {
+				background: rgba(255, 255, 255, 0.08);
+				color: var(--foreground);
+			}
+			.tab .selection-check {
+				display: none;
+			}
+			body.bulk-mode .tab .selection-check {
+				display: inline-flex;
+			}
+			body.bulk-mode .tab .x-btn {
+				display: none;
+			}
+			.tab.bulk-selected {
+				outline: 1.5px solid var(--primary);
+				outline-offset: -2px;
+				background: rgba(59, 130, 246, 0.1);
+			}
+
+			.dot {
+				width: 8px;
+				height: 8px;
+				border-radius: 50%;
+				background: #6b7280;
+			}
+			.dot.running {
+				background: #22c55e;
+			}
+			.dot.warn {
+				background: #eab308;
+			}
+
+			.dialog-backdrop {
+				position: fixed;
+				inset: 0;
+				background: rgba(0, 0, 0, 0.6);
+				display: flex;
+				align-items: center;
+				justify-content: center;
+				z-index: 50;
+			}
+			.dialog {
+				width: 460px;
+				background: #141416;
+				border: 1px solid var(--border);
+				border-radius: 12px;
+				box-shadow: 0 20px 60px rgba(0, 0, 0, 0.6);
+			}
+			.btn {
+				display: inline-flex;
+				align-items: center;
+				gap: 6px;
+				padding: 6px 12px;
+				border-radius: 6px;
+				font-size: 13px;
+				border: 1px solid var(--border);
+				background: transparent;
+				color: var(--foreground);
+				cursor: pointer;
+			}
+			.btn:hover {
+				background: rgba(255, 255, 255, 0.04);
+			}
+			.btn.primary {
+				background: var(--primary);
+				border-color: var(--primary);
+				color: white;
+			}
+			.btn.primary:hover {
+				background: #2563eb;
+			}
+			.btn.danger {
+				background: #dc2626;
+				border-color: #dc2626;
+				color: white;
+			}
+			.btn.danger:hover {
+				background: #b91c1c;
+			}
+
+			.toolbar {
+				display: flex;
+				align-items: center;
+				gap: 8px;
+				padding: 6px 10px;
+				background: #131315;
+				border-bottom: 1px solid var(--border);
+				border-top: 1px solid var(--border);
+			}
+			.toolbar .count {
+				font-size: 12px;
+				color: var(--muted-foreground);
+			}
+		</style>
+	</head>
+	<body class="min-h-screen">
+		<!-- ========================== Layout ========================== -->
+		<div class="flex h-screen">
+			<!-- Sidebar -->
+			<aside
+				class="w-56 shrink-0 bg-[#0e0e10] border-r border-border flex flex-col"
+			>
+				<div
+					class="px-3 py-3 text-xs uppercase tracking-wider text-muted-foreground"
+				>
+					Workspace
+				</div>
+				<div class="px-2 space-y-0.5 text-sm">
+					<div
+						class="px-2 py-1.5 rounded bg-[#1a1a1c] text-foreground flex items-center gap-2"
+					>
+						<span
+							class="w-2 h-2 rounded-full"
+							style="background: #3b82f6"
+						></span>
+						superset
+					</div>
+					<div
+						class="px-2 py-1.5 rounded text-muted-foreground hover:bg-[#161618] flex items-center gap-2"
+					>
+						<span
+							class="w-2 h-2 rounded-full"
+							style="background: #22c55e"
+						></span>
+						web
+					</div>
+					<div
+						class="px-2 py-1.5 rounded text-muted-foreground hover:bg-[#161618] flex items-center gap-2"
+					>
+						<span
+							class="w-2 h-2 rounded-full"
+							style="background: #f97316"
+						></span>
+						mobile
+					</div>
+				</div>
+				<div class="mt-auto p-3 text-[11px] text-muted-foreground">
+					mock.html — Issue #346
+				</div>
+			</aside>
+
+			<!-- Main -->
+			<main class="flex-1 flex flex-col min-w-0">
+				<!-- Tab strip -->
+				<div
+					class="h-9 flex items-center bg-[#0e0e10] border-b border-border overflow-x-auto"
+					id="tab-strip"
+				>
+					<!-- tabs injected -->
+				</div>
+
+				<!-- Bulk-action toolbar (shown only in bulk mode) -->
+				<div id="bulk-toolbar" class="toolbar hidden">
+					<button class="btn" onclick="exitBulkMode()">
+						<svg
+							width="14"
+							height="14"
+							viewBox="0 0 24 24"
+							fill="none"
+							stroke="currentColor"
+							stroke-width="2"
+						>
+							<path d="M18 6 6 18M6 6l12 12" />
+						</svg>
+						キャンセル
+					</button>
+					<span class="count" id="selection-count">0 件選択中</span>
+					<div class="ml-auto flex items-center gap-2">
+						<button class="btn" onclick="selectAll()">すべて選択</button>
+						<button class="btn" onclick="invertSelection()">選択反転</button>
+						<button class="btn" onclick="openBulkColor()">
+							<svg
+								width="14"
+								height="14"
+								viewBox="0 0 24 24"
+								fill="none"
+								stroke="currentColor"
+								stroke-width="2"
+							>
+								<circle cx="13.5" cy="6.5" r=".5" fill="currentColor" />
+								<circle cx="17.5" cy="10.5" r=".5" fill="currentColor" />
+								<circle cx="8.5" cy="7.5" r=".5" fill="currentColor" />
+								<circle cx="6.5" cy="12.5" r=".5" fill="currentColor" />
+								<path
+									d="M12 2C6.5 2 2 6.5 2 12s4.5 10 10 10c.926 0 1.648-.746 1.648-1.688 0-.437-.18-.835-.437-1.125-.29-.289-.438-.652-.438-1.125a1.64 1.64 0 0 1 1.668-1.668h1.996c3.051 0 5.555-2.503 5.555-5.554C21.965 6.012 17.461 2 12 2z"
+								/>
+							</svg>
+							一括で色を設定
+						</button>
+						<button class="btn danger" onclick="openBulkClose()">
+							<svg
+								width="14"
+								height="14"
+								viewBox="0 0 24 24"
+								fill="none"
+								stroke="currentColor"
+								stroke-width="2"
+							>
+								<path d="M3 6h18M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
+								<path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6" />
+							</svg>
+							一括クローズ
+						</button>
+					</div>
+				</div>
+
+				<!-- Terminal area -->
+				<div class="flex-1 terminal-area p-4 text-sm overflow-auto">
+					<div id="active-terminal-name" class="text-muted-foreground mb-2">
+						—
+					</div>
+					<pre class="whitespace-pre leading-5">
+$ bun dev
+$ DESKTOP_VITE_PORT=5222 bun run dev
+
+  vite v6.3.1  dev server running at:
+  > Local: http://localhost:5222
+
+[electron] Main process started
+[electron] Preload loaded
+[electron] Renderer ready (1234ms)
+$ <span class="cursor-blink">▍</span></pre
+					>
+				</div>
+			</main>
+		</div>
+
+		<!-- ========================== Context Menu (existing single-tab) ========================== -->
+		<div
+			id="ctx-single"
+			class="context-menu hidden absolute"
+			style="position: absolute"
+		>
+			<div class="item" onclick="action('rename')">
+				<svg
+					width="14"
+					height="14"
+					viewBox="0 0 24 24"
+					fill="none"
+					stroke="currentColor"
+					stroke-width="2"
+				>
+					<path
+						d="M17 3a2.85 2.83 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5Z"
+					/></svg
+				>Rename
+			</div>
+			<div class="item" onclick="openColorSubmenu(event)">
+				<svg
+					width="14"
+					height="14"
+					viewBox="0 0 24 24"
+					fill="none"
+					stroke="currentColor"
+					stroke-width="2"
+				>
+					<circle cx="13.5" cy="6.5" r=".5" fill="currentColor" />
+					<circle cx="17.5" cy="10.5" r=".5" fill="currentColor" />
+					<circle cx="8.5" cy="7.5" r=".5" fill="currentColor" />
+					<circle cx="6.5" cy="12.5" r=".5" fill="currentColor" />
+					<path
+						d="M12 2C6.5 2 2 6.5 2 12s4.5 10 10 10c.926 0 1.648-.746 1.648-1.688 0-.437-.18-.835-.437-1.125-.29-.289-.438-.652-.438-1.125a1.64 1.64 0 0 1 1.668-1.668h1.996c3.051 0 5.555-2.503 5.555-5.554C21.965 6.012 17.461 2 12 2z"
+					/></svg
+				>Set Color
+				<span class="right">▸</span>
+			</div>
+			<div class="sep"></div>
+			<div class="item" onclick="action('mark-unread')">
+				<svg
+					width="14"
+					height="14"
+					viewBox="0 0 24 24"
+					fill="none"
+					stroke="currentColor"
+					stroke-width="2"
+				>
+					<path
+						d="M9.88 9.88a3 3 0 1 0 4.24 4.24M10.73 5.08A10.43 10.43 0 0 1 12 5c7 0 10 7 10 7a13.16 13.16 0 0 1-1.67 2.68"
+					/>
+					<path d="M6.61 6.61A13.526 13.526 0 0 0 2 12s3 7 10 7a9.74 9.74 0 0 0 5.39-1.61" />
+					<line x1="2" y1="2" x2="22" y2="22" /></svg
+				>Mark as Unread
+			</div>
+			<div class="sep"></div>
+			<!-- NEW: bulk-mode trigger -->
+			<div class="label">複数選択</div>
+			<div class="item" onclick="enterBulkMode()">
+				<svg
+					width="14"
+					height="14"
+					viewBox="0 0 24 24"
+					fill="none"
+					stroke="currentColor"
+					stroke-width="2"
+				>
+					<path
+						d="M9 11l3 3L22 4M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"
+					/></svg
+				>選択モードに入る…
+			</div>
+			<div class="sep"></div>
+			<div class="item danger" onclick="action('close')">
+				<svg
+					width="14"
+					height="14"
+					viewBox="0 0 24 24"
+					fill="none"
+					stroke="currentColor"
+					stroke-width="2"
+				>
+					<path d="M18 6 6 18M6 6l12 12" /></svg
+				>Close
+			</div>
+		</div>
+
+		<!-- Color submenu (existing single-tab) -->
+		<div id="ctx-color" class="context-menu hidden">
+			<div class="grid grid-cols-6 gap-1.5 p-1.5" id="color-grid"></div>
+		</div>
+
+		<!-- ========================== Bulk: Set Color dialog ========================== -->
+		<div id="bulk-color-dialog" class="dialog-backdrop hidden">
+			<div class="dialog">
+				<div class="px-5 py-4 border-b border-border">
+					<div class="text-base font-medium">一括で色を設定</div>
+					<div class="text-xs text-muted-foreground mt-1">
+						<span id="bulk-color-count">0</span> 件のターミナルに色を適用します
+					</div>
+				</div>
+				<div class="px-5 py-5">
+					<div class="grid grid-cols-6 gap-2" id="bulk-color-grid"></div>
+					<div class="flex items-center gap-2 mt-4 text-xs text-muted-foreground">
+						<button
+							class="btn"
+							onclick="setBulkColor(null)"
+							style="padding: 4px 10px"
+						>
+							色をリセット
+						</button>
+					</div>
+				</div>
+				<div
+					class="px-5 py-3 border-t border-border flex items-center justify-end gap-2"
+				>
+					<button class="btn" onclick="closeBulkColor()">キャンセル</button>
+					<button class="btn primary" onclick="applyBulkColor()">適用</button>
+				</div>
+			</div>
+		</div>
+
+		<!-- ========================== Bulk: Close confirm dialog ========================== -->
+		<div id="bulk-close-dialog" class="dialog-backdrop hidden">
+			<div class="dialog">
+				<div class="px-5 py-4 border-b border-border">
+					<div class="text-base font-medium">一括クローズ</div>
+					<div class="text-xs text-muted-foreground mt-1">
+						選択した <span id="bulk-close-count">0</span> 件のターミナルを閉じます
+					</div>
+				</div>
+				<div class="px-5 py-4">
+					<div
+						id="bulk-close-list"
+						class="text-sm space-y-1 max-h-48 overflow-y-auto"
+					></div>
+					<label
+						class="flex items-center gap-2 text-xs text-muted-foreground mt-4"
+					>
+						<input type="checkbox" class="checkbox" id="bulk-close-skip" />
+						実行中のプロセスがあっても確認せず閉じる
+					</label>
+				</div>
+				<div
+					class="px-5 py-3 border-t border-border flex items-center justify-end gap-2"
+				>
+					<button class="btn" onclick="closeBulkClose()">キャンセル</button>
+					<button class="btn danger" onclick="applyBulkClose()">
+						選択を閉じる
+					</button>
+				</div>
+			</div>
+		</div>
+
+		<script>
+			const PROJECT_COLORS = [
+				{ name: "Red", value: "#ef4444" },
+				{ name: "Orange", value: "#f97316" },
+				{ name: "Yellow", value: "#eab308" },
+				{ name: "Lime", value: "#84cc16" },
+				{ name: "Green", value: "#22c55e" },
+				{ name: "Teal", value: "#14b8a6" },
+				{ name: "Cyan", value: "#06b6d4" },
+				{ name: "Blue", value: "#3b82f6" },
+				{ name: "Indigo", value: "#6366f1" },
+				{ name: "Purple", value: "#a855f7" },
+				{ name: "Pink", value: "#ec4899" },
+				{ name: "Slate", value: "#64748b" },
+			];
+
+			const tabs = [
+				{ id: "t1", name: "bun dev", color: "#3b82f6", status: "running" },
+				{ id: "t2", name: "vite", color: null, status: "running" },
+				{ id: "t3", name: "test:watch", color: "#22c55e", status: "warn" },
+				{ id: "t4", name: "drizzle", color: null, status: null },
+				{ id: "t5", name: "logs", color: "#a855f7", status: null },
+				{ id: "t6", name: "shell", color: null, status: null },
+			];
+			let activeId = "t1";
+			const selected = new Set();
+			let pendingBulkColor = null;
+			let ctxTabId = null;
+
+			function renderTabs() {
+				const strip = document.getElementById("tab-strip");
+				strip.innerHTML = "";
+				for (const t of tabs) {
+					const el = document.createElement("div");
+					el.className = "tab" + (t.id === activeId ? " active" : "");
+					if (selected.has(t.id)) el.classList.add("bulk-selected");
+					if (t.color) {
+						el.style.backgroundColor =
+							t.color + (t.id === activeId ? "30" : "18");
+						el.style.color = "var(--foreground)";
+					}
+					el.innerHTML = `
+            <input type="checkbox" class="checkbox selection-check" ${selected.has(t.id) ? "checked" : ""} data-id="${t.id}">
+            <span class="truncate">${t.name}</span>
+            ${
+						t.status
+							? `<span class="dot ${t.status}" title="${t.status}"></span>`
+							: ""
+					}
+            <span class="x-btn" data-close="${t.id}">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 6 6 18M6 6l12 12"/></svg>
+            </span>
+          `;
+					el.addEventListener("click", (e) => {
+						if (e.target.closest("[data-close]")) {
+							removeTab(t.id);
+							return;
+						}
+						if (document.body.classList.contains("bulk-mode")) {
+							toggleSelect(t.id);
+							return;
+						}
+						activeId = t.id;
+						renderTabs();
+						document.getElementById("active-terminal-name").textContent =
+							"● " + t.name;
+					});
+					el.addEventListener("contextmenu", (e) => {
+						e.preventDefault();
+						ctxTabId = t.id;
+						if (!document.body.classList.contains("bulk-mode")) {
+							activeId = t.id;
+							renderTabs();
+						}
+						openContextMenu(e.clientX, e.clientY);
+					});
+					strip.appendChild(el);
+				}
+				document
+					.querySelectorAll(".selection-check")
+					.forEach((cb) =>
+						cb.addEventListener("change", (e) =>
+							toggleSelect(e.target.dataset.id),
+						),
+					);
+				updateSelectionCount();
+			}
+
+			function removeTab(id) {
+				const i = tabs.findIndex((t) => t.id === id);
+				if (i >= 0) tabs.splice(i, 1);
+				selected.delete(id);
+				if (activeId === id && tabs[0]) activeId = tabs[0].id;
+				renderTabs();
+			}
+
+			// ----- context menu -----
+			function openContextMenu(x, y) {
+				const menu = document.getElementById("ctx-single");
+				menu.style.left = x + "px";
+				menu.style.top = y + "px";
+				menu.classList.remove("hidden");
+				document.getElementById("ctx-color").classList.add("hidden");
+			}
+			function closeContextMenu() {
+				document.getElementById("ctx-single").classList.add("hidden");
+				document.getElementById("ctx-color").classList.add("hidden");
+			}
+			document.addEventListener("click", (e) => {
+				if (!e.target.closest(".context-menu")) closeContextMenu();
+			});
+
+			function action(kind) {
+				if (kind === "close") removeTab(ctxTabId);
+				if (kind === "rename") {
+					const t = tabs.find((x) => x.id === ctxTabId);
+					const v = prompt("新しい名前", t?.name);
+					if (v && t) {
+						t.name = v;
+						renderTabs();
+					}
+				}
+				closeContextMenu();
+			}
+
+			function openColorSubmenu(e) {
+				const sub = document.getElementById("ctx-color");
+				const src = document.getElementById("ctx-single");
+				const r = src.getBoundingClientRect();
+				sub.style.position = "absolute";
+				sub.style.left = r.right + 4 + "px";
+				sub.style.top = r.top + "px";
+				sub.classList.remove("hidden");
+				renderColorGrid("color-grid", (c) => {
+					const t = tabs.find((x) => x.id === ctxTabId);
+					if (t) t.color = c;
+					renderTabs();
+					closeContextMenu();
+				});
+				e.stopPropagation();
+			}
+
+			function renderColorGrid(targetId, onPick) {
+				const g = document.getElementById(targetId);
+				g.innerHTML = "";
+				for (const c of PROJECT_COLORS) {
+					const s = document.createElement("div");
+					s.className = "color-swatch";
+					s.style.background = c.value;
+					s.title = c.name;
+					if (pendingBulkColor === c.value) s.classList.add("selected");
+					s.addEventListener("click", () => onPick(c.value));
+					g.appendChild(s);
+				}
+			}
+
+			// ----- bulk mode -----
+			function enterBulkMode() {
+				document.body.classList.add("bulk-mode");
+				document.getElementById("bulk-toolbar").classList.remove("hidden");
+				if (ctxTabId) selected.add(ctxTabId);
+				renderTabs();
+				closeContextMenu();
+			}
+			function exitBulkMode() {
+				document.body.classList.remove("bulk-mode");
+				document.getElementById("bulk-toolbar").classList.add("hidden");
+				selected.clear();
+				renderTabs();
+			}
+			function toggleSelect(id) {
+				if (selected.has(id)) selected.delete(id);
+				else selected.add(id);
+				renderTabs();
+			}
+			function selectAll() {
+				tabs.forEach((t) => selected.add(t.id));
+				renderTabs();
+			}
+			function invertSelection() {
+				tabs.forEach((t) =>
+					selected.has(t.id) ? selected.delete(t.id) : selected.add(t.id),
+				);
+				renderTabs();
+			}
+			function updateSelectionCount() {
+				document.getElementById("selection-count").textContent =
+					selected.size + " 件選択中";
+			}
+
+			// ----- bulk: set color -----
+			function openBulkColor() {
+				if (selected.size === 0) return;
+				pendingBulkColor = null;
+				document.getElementById("bulk-color-count").textContent = selected.size;
+				renderColorGrid("bulk-color-grid", (c) => {
+					pendingBulkColor = c;
+					renderColorGrid("bulk-color-grid", arguments.callee);
+				});
+				document.getElementById("bulk-color-dialog").classList.remove("hidden");
+			}
+			function closeBulkColor() {
+				document.getElementById("bulk-color-dialog").classList.add("hidden");
+			}
+			function setBulkColor(c) {
+				pendingBulkColor = c;
+				applyBulkColor();
+			}
+			function applyBulkColor() {
+				for (const id of selected) {
+					const t = tabs.find((x) => x.id === id);
+					if (t) t.color = pendingBulkColor;
+				}
+				closeBulkColor();
+				renderTabs();
+			}
+
+			// ----- bulk: close -----
+			function openBulkClose() {
+				if (selected.size === 0) return;
+				document.getElementById("bulk-close-count").textContent = selected.size;
+				const list = document.getElementById("bulk-close-list");
+				list.innerHTML = "";
+				for (const id of selected) {
+					const t = tabs.find((x) => x.id === id);
+					if (!t) continue;
+					const row = document.createElement("div");
+					row.className =
+						"flex items-center gap-2 px-2 py-1 rounded bg-[#0e0e10] border border-border";
+					row.innerHTML = `
+            <span class="w-2 h-2 rounded-full" style="background:${t.color || "#6b7280"}"></span>
+            <span>${t.name}</span>
+            ${t.status === "running" ? `<span class="ml-auto text-[11px] text-yellow-400">実行中</span>` : ""}
+          `;
+					list.appendChild(row);
+				}
+				document.getElementById("bulk-close-dialog").classList.remove("hidden");
+			}
+			function closeBulkClose() {
+				document.getElementById("bulk-close-dialog").classList.add("hidden");
+			}
+			function applyBulkClose() {
+				const ids = Array.from(selected);
+				for (const id of ids) removeTab(id);
+				closeBulkClose();
+				exitBulkMode();
+			}
+
+			renderTabs();
+			document.getElementById("active-terminal-name").textContent =
+				"● bun dev";
+		</script>
+	</body>
+</html>


### PR DESCRIPTION
## Summary

Issue #346 対応。ワークスペース内のターミナルタブをまとめて選択し、一括で色設定 / クローズできる「選択モード」を追加した。

- タブ右クリックメニューに **Select Multiple Tabs…** を追加
- 選択モード時は ContentView 上部に **BulkActionBar** を表示
  - Select all / Invert
  - **Set color** (Popover + 既存 `ColorSelector`)
  - **Close selected** (`requestTabClose` を選択分繰り返す)
- 選択状態は新しい zustand ストア `useTabBulkSelectionStore` で管理し、ワークスペースに紐づけて保持。アクティブワークスペースが切り替わったり、全タブが消えた場合は自動で選択モードを抜ける
- 既存タブ UI: 選択モード中はチェックマーク表示 + クリックで選択トグル / × ボタンは非表示

UI 検討用の `./mock.html` も同梱（Biome 対象外）。

## 動作確認

- [x] `bun run typecheck` ✅
- [x] `bun run lint` ✅ (mock.html は除外設定済み)
- [ ] 実機で確認:
  - [ ] タブ右クリック → Select Multiple Tabs… で選択モード入り、対象タブが初期選択される
  - [ ] 他タブをクリックして選択追加 / 解除
  - [ ] Select all / Invert / Set color (色適用 & リセット) / Close selected
  - [ ] 別ワークスペースに切替で自動 exit
  - [ ] 全タブクローズで自動 exit

Closes #346