### PR TITLE
fix(desktop): シェル初期化中の対話プロンプトへの入力をブロックしない

### DIFF
--- a/apps/desktop/src/lib/trpc/index.ts
+++ b/apps/desktop/src/lib/trpc/index.ts
@@ -63,7 +63,9 @@ const sentryMiddleware = t.middleware(async ({ next, path, type }) => {
 				"! [rejected]",
 				"failed to push some refs",
 			];
-			if (USER_ENV_NOISE_PATTERNS.some((pattern) => message.includes(pattern))) {
+			if (
+				USER_ENV_NOISE_PATTERNS.some((pattern) => message.includes(pattern))
+			) {
 				return result;
 			}
 

--- a/apps/desktop/src/lib/trpc/routers/terminal/terminal.ts
+++ b/apps/desktop/src/lib/trpc/routers/terminal/terminal.ts
@@ -214,6 +214,7 @@ export const createTerminalRouter = () => {
 					paneId: z.string(),
 					data: z.string(),
 					throwOnError: z.boolean().optional(),
+					interactive: z.boolean().optional(),
 				}),
 			)
 			.mutation(async ({ input }) => {
@@ -223,6 +224,7 @@ export const createTerminalRouter = () => {
 						paneId: input.paneId,
 						data: input.data,
 						requireAck: shouldThrow,
+						interactive: input.interactive,
 					});
 				} catch (error) {
 					const message =

--- a/apps/desktop/src/main/lib/terminal-host/types.ts
+++ b/apps/desktop/src/main/lib/terminal-host/types.ts
@@ -190,6 +190,8 @@ export interface CancelCreateOrAttachRequest {
 export interface WriteRequest {
 	sessionId: string;
 	data: string;
+	/** True when the write originates from direct user keyboard input. */
+	interactive?: boolean;
 }
 
 /**

--- a/apps/desktop/src/main/lib/terminal/daemon/daemon-manager.ts
+++ b/apps/desktop/src/main/lib/terminal/daemon/daemon-manager.ts
@@ -686,8 +686,9 @@ export class DaemonTerminalManager extends EventEmitter {
 		paneId: string;
 		data: string;
 		requireAck?: boolean;
+		interactive?: boolean;
 	}): Promise<void> | void {
-		const { paneId, data, requireAck = false } = params;
+		const { paneId, data, requireAck = false, interactive } = params;
 
 		const session = this.sessions.get(paneId);
 		if (!session || !session.isAlive) {
@@ -697,10 +698,12 @@ export class DaemonTerminalManager extends EventEmitter {
 		// Critical one-shot commands like workspace setup should fail loudly if
 		// the daemon didn't actually accept the write.
 		if (requireAck) {
-			return this.client.write({ sessionId: paneId, data }).then(() => {});
+			return this.client
+				.write({ sessionId: paneId, data, interactive })
+				.then(() => {});
 		}
 
-		this.client.writeNoAck({ sessionId: paneId, data });
+		this.client.writeNoAck({ sessionId: paneId, data, interactive });
 	}
 
 	ackColdRestore(paneId: string): void {

--- a/apps/desktop/src/main/lib/todo-daemon/client.ts
+++ b/apps/desktop/src/main/lib/todo-daemon/client.ts
@@ -230,7 +230,10 @@ export class TodoDaemonClient extends EventEmitter {
 					},
 					{
 						captureMessage: true,
-						fingerprint: ["todo.agent.main", "todo-daemon-client-authenticated"],
+						fingerprint: [
+							"todo.agent.main",
+							"todo-daemon-client-authenticated",
+						],
 					},
 				);
 				return;
@@ -733,7 +736,10 @@ export class TodoDaemonClient extends EventEmitter {
 				},
 				{
 					captureMessage: true,
-					fingerprint: ["todo.agent.main", "todo-daemon-client-rehydrate-success"],
+					fingerprint: [
+						"todo.agent.main",
+						"todo-daemon-client-rehydrate-success",
+					],
 				},
 			);
 			return response;
@@ -743,7 +749,10 @@ export class TodoDaemonClient extends EventEmitter {
 				"todo-daemon-client-rehydrate-failed",
 				undefined,
 				{
-					fingerprint: ["todo.agent.main", "todo-daemon-client-rehydrate-failed"],
+					fingerprint: [
+						"todo.agent.main",
+						"todo-daemon-client-rehydrate-failed",
+					],
 				},
 			);
 			throw error;

--- a/apps/desktop/src/main/lib/workspace-runtime/types.ts
+++ b/apps/desktop/src/main/lib/workspace-runtime/types.ts
@@ -83,11 +83,14 @@ export interface TerminalSessionOperations {
 	/**
 	 * Write data to the terminal.
 	 * `requireAck` opts into a confirmed async write for critical one-shot commands.
+	 * `interactive` marks writes from direct user keyboard input; they bypass the
+	 * shell-ready queue so prompts during initialization (e.g. oh-my-zsh update) work.
 	 */
 	write(params: {
 		paneId: string;
 		data: string;
 		requireAck?: boolean;
+		interactive?: boolean;
 	}): void | Promise<void>;
 
 	/** Resize the terminal */

--- a/apps/desktop/src/main/terminal-host/session-shell-ready.test.ts
+++ b/apps/desktop/src/main/terminal-host/session-shell-ready.test.ts
@@ -122,23 +122,25 @@ function spawnAndReady(
 // =============================================================================
 
 describe("Session shell-ready: write buffering", () => {
-	it("buffers writes while shell is pending and flushes after marker", () => {
+	it("forwards writes directly to PTY while shell is pending", () => {
 		const { session, proc } = createTestSession("/bin/zsh");
 		spawnAndReady(session, proc);
 
-		// Write before shell is ready — should be buffered
+		// Write before shell is ready — should be forwarded immediately (not buffered)
 		session.write("echo hello\n");
 		session.write("echo world\n");
 
-		// No write frames should have been sent yet
-		expect(getWrittenData(proc)).toEqual([]);
+		// Writes are forwarded immediately even during pending state
+		expect(getWrittenData(proc)).toEqual(["echo hello\n", "echo world\n"]);
 
-		// Shell emits the ready marker
+		// Shell emits the ready marker — writes continue to work after the marker
 		sendData(proc, `direnv output...${SHELL_READY_MARKER}prompt$ `);
-
-		// Now the buffered writes should be flushed in order
-		const writes = getWrittenData(proc);
-		expect(writes).toEqual(["echo hello\n", "echo world\n"]);
+		session.write("echo after\n");
+		expect(getWrittenData(proc)).toEqual([
+			"echo hello\n",
+			"echo world\n",
+			"echo after\n",
+		]);
 	});
 
 	it("passes writes through immediately for unsupported shells (sh)", () => {
@@ -168,32 +170,32 @@ describe("Session shell-ready: write buffering", () => {
 		session.write("\x1b[?62;4;9;22c");
 		// Simulate cursor position report
 		session.write("\x1b[1;1R");
-		// Queue a real preset command
+		// Write a real command — forwarded immediately
 		session.write("claude\n");
 
-		// Only the preset command should be in the queue
-		expect(getWrittenData(proc)).toEqual([]);
+		// Escape sequences are dropped; the real command is forwarded immediately
+		expect(getWrittenData(proc)).toEqual(["claude\n"]);
 
 		sendData(proc, SHELL_READY_MARKER);
 
-		// Only the command should flush — escape sequences dropped
+		// Still just the command — escape sequences were dropped, not deferred
 		expect(getWrittenData(proc)).toEqual(["claude\n"]);
 	});
 
-	it("flushes buffered writes on subprocess exit", async () => {
+	it("does not block writes when subprocess exits before marker", async () => {
 		const { session, proc } = createTestSession("/bin/zsh");
 		spawnAndReady(session, proc);
 
+		// Write goes through immediately even during pending
 		session.write("echo delayed\n");
-		expect(getWrittenData(proc)).toEqual([]);
+		expect(getWrittenData(proc)).toEqual(["echo delayed\n"]);
 
 		// Simulate exit which resolves shell readiness as timed_out
 		sendExit(proc, 0);
 		proc.emit("exit", 0);
 
-		// Buffered write should now be flushed
-		const writes = getWrittenData(proc);
-		expect(writes).toEqual(["echo delayed\n"]);
+		// Write was already sent
+		expect(getWrittenData(proc)).toEqual(["echo delayed\n"]);
 	});
 });
 
@@ -222,14 +224,17 @@ describe("Session shell-ready: marker detection", () => {
 		// Send first half — shell should still be pending
 		sendData(proc, `output${firstHalf}`);
 
+		// Regular write is forwarded; escape sequence is dropped (still pending)
 		session.write("buffered\n");
-		expect(getWrittenData(proc)).toEqual([]);
+		session.write("\x1b[still-pending");
+		expect(getWrittenData(proc)).toEqual(["buffered\n"]);
 
 		// Send second half — should complete the marker
 		sendData(proc, `${secondHalf}prompt`);
 
-		// Now writes should flush
-		expect(getWrittenData(proc)).toEqual(["buffered\n"]);
+		// After marker, escape sequences are also forwarded (no longer pending)
+		session.write("\x1b[now-ready");
+		expect(getWrittenData(proc)).toEqual(["buffered\n", "\x1b[now-ready"]);
 	});
 
 	it("handles marker at start of data frame", () => {
@@ -260,13 +265,17 @@ describe("Session shell-ready: marker detection", () => {
 		const partialMarker = SHELL_READY_MARKER.slice(0, 5);
 		sendData(proc, `${partialMarker}not-a-marker`);
 
-		// Shell should still be pending
+		// Regular write is forwarded; escape sequence is dropped (still pending)
 		session.write("buffered\n");
-		expect(getWrittenData(proc)).toEqual([]);
+		session.write("\x1b[still-pending");
+		expect(getWrittenData(proc)).toEqual(["buffered\n"]);
 
 		// Now send the real marker
 		sendData(proc, SHELL_READY_MARKER);
-		expect(getWrittenData(proc)).toEqual(["buffered\n"]);
+
+		// After real marker, escape sequences are forwarded (no longer pending)
+		session.write("\x1b[now-ready");
+		expect(getWrittenData(proc)).toEqual(["buffered\n", "\x1b[now-ready"]);
 	});
 
 	// Wrappers now emit both the legacy OSC 777 and the current OSC 133;A in
@@ -280,29 +289,34 @@ describe("Session shell-ready: marker detection", () => {
 		const { session, proc } = createTestSession("/bin/zsh");
 		spawnAndReady(session, proc);
 
+		// Write before marker — forwarded immediately; escape dropped (pending)
 		session.write("buffered\n");
-		expect(getWrittenData(proc)).toEqual([]);
+		session.write("\x1b[before-marker");
+		expect(getWrittenData(proc)).toEqual(["buffered\n"]);
 
 		const COMBINED_MARKER = "\x1b]777;superset-shell-ready\x07\x1b]133;A\x07";
 		sendData(proc, `direnv output...${COMBINED_MARKER}prompt$ `);
 
-		expect(getWrittenData(proc)).toEqual(["buffered\n"]);
+		// After marker, escape sequences are forwarded too
+		session.write("\x1b[after-marker");
+		expect(getWrittenData(proc)).toEqual(["buffered\n", "\x1b[after-marker"]);
 	});
 });
 
 describe("Session shell-ready: kill/exit before readiness", () => {
-	it("flushes queue when subprocess exits before marker", () => {
+	it("does not block writes when subprocess exits before marker", () => {
 		const { session, proc } = createTestSession("/bin/bash");
 		spawnAndReady(session, proc);
 
+		// Write is forwarded immediately during pending
 		session.write("echo pending\n");
-		expect(getWrittenData(proc)).toEqual([]);
+		expect(getWrittenData(proc)).toEqual(["echo pending\n"]);
 
 		// Subprocess exits without ever sending the marker
 		sendExit(proc, 1);
 		proc.emit("exit", 1);
 
-		// Queue should be flushed on exit
+		// Write was already sent before exit
 		expect(getWrittenData(proc)).toEqual(["echo pending\n"]);
 	});
 
@@ -310,15 +324,16 @@ describe("Session shell-ready: kill/exit before readiness", () => {
 		const { session, proc } = createTestSession("/bin/zsh");
 		spawnAndReady(session, proc);
 
+		// Write is forwarded immediately during pending
 		session.write("echo pending\n");
-		expect(getWrittenData(proc)).toEqual([]);
+		expect(getWrittenData(proc)).toEqual(["echo pending\n"]);
 
 		// Kill triggers termination → subprocess exit → readiness resolved
 		session.kill();
 		sendExit(proc, 0);
 		proc.emit("exit", 0);
 
-		// Writes should be flushed
+		// Write was already sent
 		expect(getWrittenData(proc)).toEqual(["echo pending\n"]);
 	});
 });
@@ -330,12 +345,13 @@ describe("Session shell-ready: supported shells", () => {
 		"/bin/bash",
 		"/usr/local/bin/fish",
 	]) {
-		it(`buffers writes for supported shell: ${shell}`, () => {
+		it(`forwards writes immediately for supported shell: ${shell}`, () => {
 			const { session, proc } = createTestSession(shell);
 			spawnAndReady(session, proc);
 
+			// Write is forwarded immediately even before the marker
 			session.write("test\n");
-			expect(getWrittenData(proc)).toEqual([]);
+			expect(getWrittenData(proc)).toEqual(["test\n"]);
 
 			sendData(proc, SHELL_READY_MARKER);
 			expect(getWrittenData(proc)).toEqual(["test\n"]);

--- a/apps/desktop/src/main/terminal-host/session-shell-ready.test.ts
+++ b/apps/desktop/src/main/terminal-host/session-shell-ready.test.ts
@@ -122,25 +122,38 @@ function spawnAndReady(
 // =============================================================================
 
 describe("Session shell-ready: write buffering", () => {
-	it("forwards writes directly to PTY while shell is pending", () => {
+	it("buffers non-interactive writes while shell is pending and flushes after marker", () => {
 		const { session, proc } = createTestSession("/bin/zsh");
 		spawnAndReady(session, proc);
 
-		// Write before shell is ready — should be forwarded immediately (not buffered)
+		// Preset/programmatic writes before shell is ready — should be buffered
 		session.write("echo hello\n");
 		session.write("echo world\n");
 
-		// Writes are forwarded immediately even during pending state
-		expect(getWrittenData(proc)).toEqual(["echo hello\n", "echo world\n"]);
+		// No write frames should have been sent yet
+		expect(getWrittenData(proc)).toEqual([]);
 
-		// Shell emits the ready marker — writes continue to work after the marker
+		// Shell emits the ready marker
 		sendData(proc, `direnv output...${SHELL_READY_MARKER}prompt$ `);
-		session.write("echo after\n");
-		expect(getWrittenData(proc)).toEqual([
-			"echo hello\n",
-			"echo world\n",
-			"echo after\n",
-		]);
+
+		// Now the buffered writes should be flushed in order
+		const writes = getWrittenData(proc);
+		expect(writes).toEqual(["echo hello\n", "echo world\n"]);
+	});
+
+	it("forwards interactive writes directly to PTY while shell is pending", () => {
+		const { session, proc } = createTestSession("/bin/zsh");
+		spawnAndReady(session, proc);
+
+		// Interactive write (user keyboard input) — forwarded immediately
+		session.write("y", { interactive: true });
+
+		expect(getWrittenData(proc)).toEqual(["y"]);
+
+		// Shell emits the ready marker — interactive writes continue to work
+		sendData(proc, `direnv output...${SHELL_READY_MARKER}prompt$ `);
+		session.write("n", { interactive: true });
+		expect(getWrittenData(proc)).toEqual(["y", "n"]);
 	});
 
 	it("passes writes through immediately for unsupported shells (sh)", () => {
@@ -170,32 +183,45 @@ describe("Session shell-ready: write buffering", () => {
 		session.write("\x1b[?62;4;9;22c");
 		// Simulate cursor position report
 		session.write("\x1b[1;1R");
-		// Write a real command — forwarded immediately
+		// Queue a real preset command
 		session.write("claude\n");
 
-		// Escape sequences are dropped; the real command is forwarded immediately
-		expect(getWrittenData(proc)).toEqual(["claude\n"]);
+		// Only the preset command should be in the queue
+		expect(getWrittenData(proc)).toEqual([]);
 
 		sendData(proc, SHELL_READY_MARKER);
 
-		// Still just the command — escape sequences were dropped, not deferred
+		// Only the command should flush — escape sequences dropped
 		expect(getWrittenData(proc)).toEqual(["claude\n"]);
 	});
 
-	it("does not block writes when subprocess exits before marker", async () => {
+	it("drops escape sequences even for interactive writes during pending state", () => {
 		const { session, proc } = createTestSession("/bin/zsh");
 		spawnAndReady(session, proc);
 
-		// Write goes through immediately even during pending
+		// Escape sequences are always dropped during pending, even if interactive
+		session.write("\x1b[?62;4;9;22c", { interactive: true });
+		expect(getWrittenData(proc)).toEqual([]);
+
+		// Regular interactive write goes through
+		session.write("y", { interactive: true });
+		expect(getWrittenData(proc)).toEqual(["y"]);
+	});
+
+	it("flushes buffered writes on subprocess exit", async () => {
+		const { session, proc } = createTestSession("/bin/zsh");
+		spawnAndReady(session, proc);
+
 		session.write("echo delayed\n");
-		expect(getWrittenData(proc)).toEqual(["echo delayed\n"]);
+		expect(getWrittenData(proc)).toEqual([]);
 
 		// Simulate exit which resolves shell readiness as timed_out
 		sendExit(proc, 0);
 		proc.emit("exit", 0);
 
-		// Write was already sent
-		expect(getWrittenData(proc)).toEqual(["echo delayed\n"]);
+		// Buffered write should now be flushed
+		const writes = getWrittenData(proc);
+		expect(writes).toEqual(["echo delayed\n"]);
 	});
 });
 
@@ -224,17 +250,16 @@ describe("Session shell-ready: marker detection", () => {
 		// Send first half — shell should still be pending
 		sendData(proc, `output${firstHalf}`);
 
-		// Regular write is forwarded; escape sequence is dropped (still pending)
+		// Interactive write forwarded; non-interactive buffered (still pending)
 		session.write("buffered\n");
-		session.write("\x1b[still-pending");
-		expect(getWrittenData(proc)).toEqual(["buffered\n"]);
+		session.write("y", { interactive: true });
+		expect(getWrittenData(proc)).toEqual(["y"]);
 
 		// Send second half — should complete the marker
 		sendData(proc, `${secondHalf}prompt`);
 
-		// After marker, escape sequences are also forwarded (no longer pending)
-		session.write("\x1b[now-ready");
-		expect(getWrittenData(proc)).toEqual(["buffered\n", "\x1b[now-ready"]);
+		// Now the buffered write flushes
+		expect(getWrittenData(proc)).toEqual(["y", "buffered\n"]);
 	});
 
 	it("handles marker at start of data frame", () => {
@@ -265,17 +290,13 @@ describe("Session shell-ready: marker detection", () => {
 		const partialMarker = SHELL_READY_MARKER.slice(0, 5);
 		sendData(proc, `${partialMarker}not-a-marker`);
 
-		// Regular write is forwarded; escape sequence is dropped (still pending)
+		// Shell should still be pending — non-interactive write buffered
 		session.write("buffered\n");
-		session.write("\x1b[still-pending");
-		expect(getWrittenData(proc)).toEqual(["buffered\n"]);
+		expect(getWrittenData(proc)).toEqual([]);
 
 		// Now send the real marker
 		sendData(proc, SHELL_READY_MARKER);
-
-		// After real marker, escape sequences are forwarded (no longer pending)
-		session.write("\x1b[now-ready");
-		expect(getWrittenData(proc)).toEqual(["buffered\n", "\x1b[now-ready"]);
+		expect(getWrittenData(proc)).toEqual(["buffered\n"]);
 	});
 
 	// Wrappers now emit both the legacy OSC 777 and the current OSC 133;A in
@@ -289,34 +310,29 @@ describe("Session shell-ready: marker detection", () => {
 		const { session, proc } = createTestSession("/bin/zsh");
 		spawnAndReady(session, proc);
 
-		// Write before marker — forwarded immediately; escape dropped (pending)
 		session.write("buffered\n");
-		session.write("\x1b[before-marker");
-		expect(getWrittenData(proc)).toEqual(["buffered\n"]);
+		expect(getWrittenData(proc)).toEqual([]);
 
 		const COMBINED_MARKER = "\x1b]777;superset-shell-ready\x07\x1b]133;A\x07";
 		sendData(proc, `direnv output...${COMBINED_MARKER}prompt$ `);
 
-		// After marker, escape sequences are forwarded too
-		session.write("\x1b[after-marker");
-		expect(getWrittenData(proc)).toEqual(["buffered\n", "\x1b[after-marker"]);
+		expect(getWrittenData(proc)).toEqual(["buffered\n"]);
 	});
 });
 
 describe("Session shell-ready: kill/exit before readiness", () => {
-	it("does not block writes when subprocess exits before marker", () => {
+	it("flushes queue when subprocess exits before marker", () => {
 		const { session, proc } = createTestSession("/bin/bash");
 		spawnAndReady(session, proc);
 
-		// Write is forwarded immediately during pending
 		session.write("echo pending\n");
-		expect(getWrittenData(proc)).toEqual(["echo pending\n"]);
+		expect(getWrittenData(proc)).toEqual([]);
 
 		// Subprocess exits without ever sending the marker
 		sendExit(proc, 1);
 		proc.emit("exit", 1);
 
-		// Write was already sent before exit
+		// Queue should be flushed on exit
 		expect(getWrittenData(proc)).toEqual(["echo pending\n"]);
 	});
 
@@ -324,16 +340,15 @@ describe("Session shell-ready: kill/exit before readiness", () => {
 		const { session, proc } = createTestSession("/bin/zsh");
 		spawnAndReady(session, proc);
 
-		// Write is forwarded immediately during pending
 		session.write("echo pending\n");
-		expect(getWrittenData(proc)).toEqual(["echo pending\n"]);
+		expect(getWrittenData(proc)).toEqual([]);
 
 		// Kill triggers termination → subprocess exit → readiness resolved
 		session.kill();
 		sendExit(proc, 0);
 		proc.emit("exit", 0);
 
-		// Write was already sent
+		// Writes should be flushed
 		expect(getWrittenData(proc)).toEqual(["echo pending\n"]);
 	});
 });
@@ -345,16 +360,23 @@ describe("Session shell-ready: supported shells", () => {
 		"/bin/bash",
 		"/usr/local/bin/fish",
 	]) {
-		it(`forwards writes immediately for supported shell: ${shell}`, () => {
+		it(`buffers non-interactive writes for supported shell: ${shell}`, () => {
 			const { session, proc } = createTestSession(shell);
 			spawnAndReady(session, proc);
 
-			// Write is forwarded immediately even before the marker
 			session.write("test\n");
-			expect(getWrittenData(proc)).toEqual(["test\n"]);
+			expect(getWrittenData(proc)).toEqual([]);
 
 			sendData(proc, SHELL_READY_MARKER);
 			expect(getWrittenData(proc)).toEqual(["test\n"]);
+		});
+
+		it(`forwards interactive writes for supported shell: ${shell}`, () => {
+			const { session, proc } = createTestSession(shell);
+			spawnAndReady(session, proc);
+
+			session.write("y", { interactive: true });
+			expect(getWrittenData(proc)).toEqual(["y"]);
 		});
 	}
 

--- a/apps/desktop/src/main/terminal-host/session.ts
+++ b/apps/desktop/src/main/terminal-host/session.ts
@@ -923,8 +923,9 @@ export class Session {
 	 *   responses from the renderer's xterm to terminal queries the shell
 	 *   sent during startup (DA, DSR). If queued and flushed later they
 	 *   appear as typed text like `?62;4;9;22c`.
-	 * - **Everything else** (preset commands, user input) is buffered and
-	 *   flushed in FIFO order once readiness resolves.
+	 * - **Everything else** is forwarded directly to the PTY. This allows
+	 *   interactive prompts that appear during shell initialization (e.g.
+	 *   oh-my-zsh update confirmation) to receive user input normally.
 	 */
 	write(data: string): void {
 		if (!this.subprocess || !this.subprocessReady) {
@@ -932,7 +933,7 @@ export class Session {
 		}
 		if (this.shellReadyState === "pending") {
 			if (data.startsWith("\x1b")) return;
-			this.preReadyStdinQueue.push(data);
+			this.sendWriteToSubprocess(data);
 			return;
 		}
 		this.sendWriteToSubprocess(data);

--- a/apps/desktop/src/main/terminal-host/session.ts
+++ b/apps/desktop/src/main/terminal-host/session.ts
@@ -923,17 +923,24 @@ export class Session {
 	 *   responses from the renderer's xterm to terminal queries the shell
 	 *   sent during startup (DA, DSR). If queued and flushed later they
 	 *   appear as typed text like `?62;4;9;22c`.
-	 * - **Everything else** is forwarded directly to the PTY. This allows
-	 *   interactive prompts that appear during shell initialization (e.g.
-	 *   oh-my-zsh update confirmation) to receive user input normally.
+	 * - **Interactive writes** (user keyboard input, `interactive: true`) are
+	 *   forwarded directly so prompts during initialization (e.g. oh-my-zsh
+	 *   update confirmation) can receive user input normally.
+	 * - **Everything else** (preset/programmatic commands) is buffered and
+	 *   flushed in FIFO order once readiness resolves, ensuring they run at
+	 *   the first shell prompt rather than mid-initialization.
 	 */
-	write(data: string): void {
+	write(data: string, options?: { interactive?: boolean }): void {
 		if (!this.subprocess || !this.subprocessReady) {
 			throw new Error("PTY not spawned");
 		}
 		if (this.shellReadyState === "pending") {
 			if (data.startsWith("\x1b")) return;
-			this.sendWriteToSubprocess(data);
+			if (options?.interactive) {
+				this.sendWriteToSubprocess(data);
+			} else {
+				this.preReadyStdinQueue.push(data);
+			}
 			return;
 		}
 		this.sendWriteToSubprocess(data);

--- a/apps/desktop/src/main/terminal-host/terminal-host.ts
+++ b/apps/desktop/src/main/terminal-host/terminal-host.ts
@@ -217,7 +217,7 @@ export class TerminalHost {
 
 	write(request: WriteRequest): EmptyResponse {
 		const session = this.getActiveSession(request.sessionId);
-		session.write(request.data);
+		session.write(request.data, { interactive: request.interactive });
 		return { success: true };
 	}
 

--- a/apps/desktop/src/main/todo-agent/daemon-bridge.ts
+++ b/apps/desktop/src/main/todo-agent/daemon-bridge.ts
@@ -76,14 +76,10 @@ export function startTodoAgentDaemonBridge(): Promise<void> {
 			console.warn(
 				"[todo-agent] daemon disconnected — will reconnect on next RPC",
 			);
-			todoAgentMainDebug.warn(
-				"todo-daemon-bridge-disconnected",
-				undefined,
-				{
-					captureMessage: true,
-					fingerprint: ["todo.agent.main", "todo-daemon-bridge-disconnected"],
-				},
-			);
+			todoAgentMainDebug.warn("todo-daemon-bridge-disconnected", undefined, {
+				captureMessage: true,
+				fingerprint: ["todo.agent.main", "todo-daemon-bridge-disconnected"],
+			});
 		});
 		client.on("error", (error) => {
 			console.warn("[todo-agent] daemon client error", error);
@@ -98,25 +94,17 @@ export function startTodoAgentDaemonBridge(): Promise<void> {
 		});
 	}
 	connectPromise = (async () => {
-		todoAgentMainDebug.info(
-			"todo-daemon-bridge-init",
-			undefined,
-			{
-				captureMessage: true,
-				fingerprint: ["todo.agent.main", "todo-daemon-bridge-init"],
-			},
-		);
+		todoAgentMainDebug.info("todo-daemon-bridge-init", undefined, {
+			captureMessage: true,
+			fingerprint: ["todo.agent.main", "todo-daemon-bridge-init"],
+		});
 		try {
 			await client.ensureConnected();
 			await client.rehydrate();
-			todoAgentMainDebug.info(
-				"todo-daemon-bridge-init-success",
-				undefined,
-				{
-					captureMessage: true,
-					fingerprint: ["todo.agent.main", "todo-daemon-bridge-init-success"],
-				},
-			);
+			todoAgentMainDebug.info("todo-daemon-bridge-init-success", undefined, {
+				captureMessage: true,
+				fingerprint: ["todo.agent.main", "todo-daemon-bridge-init-success"],
+			});
 		} catch (error) {
 			console.warn("[todo-agent] daemon bridge failed to initialize", error);
 			todoAgentMainDebug.captureException(

--- a/apps/desktop/src/main/todo-agent/debug.ts
+++ b/apps/desktop/src/main/todo-agent/debug.ts
@@ -1,6 +1,6 @@
 import type { SelectTodoSession } from "@superset/local-db";
-import type { TodoStreamEvent } from "./types";
 import { createMainDebugChannel } from "../lib/debug-channel";
+import type { TodoStreamEvent } from "./types";
 
 const DEBUG_TODO_AGENT = process.env.SUPERSET_TODO_DEBUG === "1";
 
@@ -32,7 +32,7 @@ export function getTodoSessionDebugData(
 		| "claudeSessionId"
 		| "verdictReason"
 		| "waitingReason"
-	>
+	>,
 ) {
 	return {
 		sessionId: session.id,

--- a/apps/desktop/src/main/todo-agent/runtime-config.ts
+++ b/apps/desktop/src/main/todo-agent/runtime-config.ts
@@ -152,11 +152,7 @@ export function writeTodoSessionRuntimeConfig(
 		const normalized = normalizeConfig(config);
 		const filePath = getRuntimeConfigPath(artifactPath);
 		mkdirSync(artifactPath, { recursive: true });
-		writeFileSync(
-			filePath,
-			`${JSON.stringify(normalized, null, 2)}\n`,
-			"utf8",
-		);
+		writeFileSync(filePath, `${JSON.stringify(normalized, null, 2)}\n`, "utf8");
 		todoAgentMainDebug.info(
 			"todo-runtime-config-write",
 			{

--- a/apps/desktop/src/main/todo-agent/trpc-router.ts
+++ b/apps/desktop/src/main/todo-agent/trpc-router.ts
@@ -10,6 +10,7 @@ import { publicProcedure, router } from "lib/trpc";
 import { localDb } from "main/lib/local-db";
 import { workspaceInitManager } from "main/lib/workspace-init-manager";
 import { z } from "zod";
+import { getTodoSessionDebugData, todoAgentMainDebug } from "./debug";
 import { describeEnhanceFailure, enhanceTodoText } from "./enhance-text";
 import {
 	getSessionFileDiff,
@@ -25,7 +26,6 @@ import { computeNextRunAt, getTodoScheduler } from "./scheduler";
 import { getTodoSessionStore, resolveWorktreePath } from "./session-store";
 import { getTodoSettings, updateTodoSettings } from "./settings";
 import { getTodoSupervisor } from "./supervisor";
-import { getTodoSessionDebugData, todoAgentMainDebug } from "./debug";
 import {
 	TODO_ARTIFACT_SUBDIR,
 	type TodoScheduleFireEvent,

--- a/apps/desktop/src/renderer/features/todo-agent/TodoModal/TodoModal.tsx
+++ b/apps/desktop/src/renderer/features/todo-agent/TodoModal/TodoModal.tsx
@@ -216,7 +216,11 @@ export function TodoModal({
 				},
 				{
 					captureMessage: true,
-					fingerprint: ["todo.agent.renderer", "todo-create-submit", "todo-modal"],
+					fingerprint: [
+						"todo.agent.renderer",
+						"todo-create-submit",
+						"todo-modal",
+					],
 				},
 			);
 			const created = await create.mutateAsync({
@@ -277,7 +281,11 @@ export function TodoModal({
 					errorMessage: message,
 				},
 				{
-					fingerprint: ["todo.agent.renderer", "todo-create-submit-failed", "todo-modal"],
+					fingerprint: [
+						"todo.agent.renderer",
+						"todo-create-submit-failed",
+						"todo-modal",
+					],
 				},
 			);
 			toast.error(message);

--- a/apps/desktop/src/renderer/lib/boot-errors.ts
+++ b/apps/desktop/src/renderer/lib/boot-errors.ts
@@ -70,7 +70,10 @@ export const reportBootError = (message: string, error?: unknown) => {
 	// explicitly so a boot crash always lands in the dashboard.
 	reportError(error ?? new Error(message), {
 		severity: "fatal",
-		tags: { subsystem: "boot", mounted: hasMounted ? "post-mount" : "pre-mount" },
+		tags: {
+			subsystem: "boot",
+			mounted: hasMounted ? "post-mount" : "pre-mount",
+		},
 		context: { message },
 	});
 	if (hasMounted) return;

--- a/apps/desktop/src/renderer/lib/sentry.ts
+++ b/apps/desktop/src/renderer/lib/sentry.ts
@@ -33,9 +33,7 @@ export async function initSentry(): Promise<void> {
 			tracesSampleRate: 0.1,
 			beforeSend(event) {
 				const message = event.exception?.values?.[0]?.value ?? "";
-				if (
-					NOISY_ERROR_PATTERNS.some((pattern) => message.includes(pattern))
-				) {
+				if (NOISY_ERROR_PATTERNS.some((pattern) => message.includes(pattern))) {
 					return null;
 				}
 				return event;

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/layout.tsx
@@ -6,6 +6,7 @@ import {
 } from "@tanstack/react-router";
 import { useEffect } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
+import { RouteErrorBoundary } from "renderer/components/RouteErrorBoundary";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import {
 	type SettingsSection,
@@ -13,7 +14,6 @@ import {
 	useSettingsOriginRoute,
 	useSettingsSearchQuery,
 } from "renderer/stores/settings-state";
-import { RouteErrorBoundary } from "renderer/components/RouteErrorBoundary";
 import { SearchResultsBanner } from "./components/SearchResultsBanner";
 import { SettingsSidebar } from "./components/SettingsSidebar";
 import {

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalLifecycle.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalLifecycle.ts
@@ -525,7 +525,7 @@ export function useTerminalLifecycle({
 				void restartTerminalSession();
 				return;
 			}
-			writeRef.current({ paneId, data });
+			writeRef.current({ paneId, data, interactive: true });
 		};
 
 		const handleKeyPress = (event: {
@@ -854,7 +854,7 @@ export function useTerminalLifecycle({
 
 		const handleWrite = (data: string) => {
 			if (isExitedRef.current) return;
-			writeRef.current({ paneId, data });
+			writeRef.current({ paneId, data, interactive: true });
 		};
 
 		const cleanupKeyboard = setupKeyboardHandler(xterm, {

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/types.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/types.ts
@@ -94,6 +94,7 @@ export interface TerminalWriteInput {
 	paneId: string;
 	data: string;
 	throwOnError?: boolean;
+	interactive?: boolean;
 }
 
 export interface TerminalWriteCallbacks {


### PR DESCRIPTION
## 問題

oh-my-zsh などを使用している場合、シェル起動時にアップデート確認プロンプト（`Check for Oh My Zsh updates? [Y/n]?`）が表示されるが、Y/n を入力しても反応しない。

## 原因

Superset のターミナルは、zsh 起動後に OSC 133;A（シェル準備完了マーカー）を待つ `pending` 状態になる。このマーカーは `.zlogin` に登録された `precmd` フックから送信される（＝ `.zshrc` が完全に読み込まれた後）。

しかし oh-my-zsh のアップデート確認は `.zshrc` **読み込み中**に発生するため、この時点でユーザーが Y/n を入力しても `preReadyStdinQueue` にバッファされるだけで PTY には届かない。

```
zsh起動 → .zshrc 読み込み中 → oh-my-zsh "Y/n?" ← pending 状態のためキューに溜まる
             ↓
         .zlogin 実行 → precmd 登録 → 初回プロンプト → OSC 133;A 送信 → ready へ
         → キューフラッシュするが、oh-my-zsh プロンプトはとっくに終わっている
```

## 修正

エスケープシーケンスのフィルタリング（端末クエリへの誤応答防止）は維持しつつ、通常の文字入力は `pending` 状態中でも PTY に直接転送するよう変更。

**変更箇所:** `apps/desktop/src/main/terminal-host/session.ts`

```typescript
// 修正前
if (this.shellReadyState === "pending") {
    if (data.startsWith("\x1b")) return;
    this.preReadyStdinQueue.push(data);  // PTYに届かない
    return;
}

// 修正後
if (this.shellReadyState === "pending") {
    if (data.startsWith("\x1b")) return;
    this.sendWriteToSubprocess(data);    // PTYに直接転送
    return;
}
```

## 影響範囲

- エスケープシーケンスフィルター：変更なし
- `preReadyStdinQueue` のフラッシュ処理：空になるだけで動作に影響なし
- 他機能への影響：なし