### PR TITLE
desktop: prevent tearoff duplicate command execution

### DIFF
--- a/apps/desktop/src/lib/trpc/index.ts
+++ b/apps/desktop/src/lib/trpc/index.ts
@@ -63,7 +63,9 @@ const sentryMiddleware = t.middleware(async ({ next, path, type }) => {
 				"! [rejected]",
 				"failed to push some refs",
 			];
-			if (USER_ENV_NOISE_PATTERNS.some((pattern) => message.includes(pattern))) {
+			if (
+				USER_ENV_NOISE_PATTERNS.some((pattern) => message.includes(pattern))
+			) {
 				return result;
 			}
 

--- a/apps/desktop/src/lib/trpc/routers/agent-command-execution/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/agent-command-execution/index.ts
@@ -1,0 +1,28 @@
+import { getAgentCommandExecutionCoordinator } from "main/lib/agent-command-execution-coordinator";
+import { z } from "zod";
+import { publicProcedure, router } from "../..";
+
+const claimInput = z.object({
+	commandId: z.string(),
+	timeoutAt: z.union([z.date(), z.string(), z.null()]).optional(),
+});
+
+const releaseInput = z.object({
+	commandId: z.string(),
+});
+
+export const createAgentCommandExecutionRouter = () => {
+	return router({
+		claim: publicProcedure.input(claimInput).mutation(({ input }) => {
+			const granted = getAgentCommandExecutionCoordinator().claim(
+				input.commandId,
+				input.timeoutAt,
+			);
+			return { granted };
+		}),
+		release: publicProcedure.input(releaseInput).mutation(({ input }) => {
+			getAgentCommandExecutionCoordinator().release(input.commandId);
+			return { released: true };
+		}),
+	});
+};

--- a/apps/desktop/src/lib/trpc/routers/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/index.ts
@@ -57,7 +57,7 @@ export const createAppRouter = (
 		auth: createAuthRouter(),
 		autoUpdate: createAutoUpdateRouter(),
 		cache: createCacheRouter(),
-		window: createWindowRouter(getWindow),
+		window: createWindowRouter(getWindow, wm),
 		projects: createProjectsRouter(getWindow),
 		workspaces: createWorkspacesRouter(),
 		terminal: createTerminalRouter(),

--- a/apps/desktop/src/lib/trpc/routers/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/index.ts
@@ -3,6 +3,7 @@ import type { WindowManager } from "main/lib/window-manager";
 // Fork-local: TODO autonomous agent feature.
 import { createTodoAgentRouter } from "main/todo-agent/trpc-router";
 import { router } from "..";
+import { createAgentCommandExecutionRouter } from "./agent-command-execution";
 import { createAivisRouter } from "./aivis";
 import { createAnalyticsRouter } from "./analytics";
 import { createAuthRouter } from "./auth";
@@ -48,6 +49,7 @@ export const createAppRouter = (
 	return router({
 		chatRuntimeService: createChatRuntimeServiceRouter(),
 		chatService: createChatServiceRouter(),
+		agentCommandExecution: createAgentCommandExecutionRouter(),
 		aivis: createAivisRouter(),
 		analytics: createAnalyticsRouter(),
 		browser: createBrowserRouter(),

--- a/apps/desktop/src/lib/trpc/routers/window.ts
+++ b/apps/desktop/src/lib/trpc/routers/window.ts
@@ -2,11 +2,15 @@ import fs from "node:fs/promises";
 import { homedir } from "node:os";
 import type { BrowserWindow } from "electron";
 import { dialog } from "electron";
+import type { WindowManager } from "main/lib/window-manager";
 import { getImageMimeType } from "shared/file-types";
 import { z } from "zod";
 import { publicProcedure, router } from "..";
 
-export const createWindowRouter = (getWindow: () => BrowserWindow | null) => {
+export const createWindowRouter = (
+	getWindow: () => BrowserWindow | null,
+	wm: WindowManager,
+) => {
 	return router({
 		minimize: publicProcedure.mutation(() => {
 			const window = getWindow();
@@ -41,6 +45,14 @@ export const createWindowRouter = (getWindow: () => BrowserWindow | null) => {
 
 		getPlatform: publicProcedure.query(() => {
 			return process.platform;
+		}),
+
+		shouldOwnSingletonEffects: publicProcedure.query(() => {
+			const window = getWindow();
+			if (!window) {
+				return false;
+			}
+			return wm.shouldWindowOwnSingletonEffects(window);
 		}),
 
 		getHomeDir: publicProcedure.query(() => {

--- a/apps/desktop/src/lib/trpc/routers/window.ts
+++ b/apps/desktop/src/lib/trpc/routers/window.ts
@@ -47,13 +47,15 @@ export const createWindowRouter = (
 			return process.platform;
 		}),
 
-		shouldOwnSingletonEffects: publicProcedure.query(() => {
-			const window = getWindow();
-			if (!window) {
-				return false;
-			}
-			return wm.shouldWindowOwnSingletonEffects(window);
-		}),
+		shouldOwnSingletonEffects: publicProcedure
+			.input(
+				z.object({
+					tearoffWindowId: z.string().nullable(),
+				}),
+			)
+			.query(({ input }) => {
+				return wm.shouldWindowIdOwnSingletonEffects(input.tearoffWindowId);
+			}),
 
 		getHomeDir: publicProcedure.query(() => {
 			return homedir();

--- a/apps/desktop/src/main/lib/agent-command-execution-coordinator.test.ts
+++ b/apps/desktop/src/main/lib/agent-command-execution-coordinator.test.ts
@@ -32,12 +32,16 @@ describe("AgentCommandExecutionCoordinator", () => {
 		expect(coordinator.isClaimed("cmd-3")).toBe(true);
 	});
 
-	it("keeps a fallback lease even when timeoutAt is already expired", () => {
-		const coordinator = new AgentCommandExecutionCoordinator(50);
+	it("uses a short grace lease when timeoutAt is already expired", async () => {
+		const coordinator = new AgentCommandExecutionCoordinator(50, 20);
 		const alreadyExpired = new Date(Date.now() - 1_000);
 
 		expect(coordinator.claim("cmd-4", alreadyExpired)).toBe(true);
 		expect(coordinator.claim("cmd-4", alreadyExpired)).toBe(false);
 		expect(coordinator.isClaimed("cmd-4")).toBe(true);
+
+		await Bun.sleep(30);
+
+		expect(coordinator.claim("cmd-4", alreadyExpired)).toBe(true);
 	});
 });

--- a/apps/desktop/src/main/lib/agent-command-execution-coordinator.test.ts
+++ b/apps/desktop/src/main/lib/agent-command-execution-coordinator.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "bun:test";
+import { AgentCommandExecutionCoordinator } from "./agent-command-execution-coordinator";
+
+describe("AgentCommandExecutionCoordinator", () => {
+	it("grants the first claim and rejects duplicates until release", () => {
+		const coordinator = new AgentCommandExecutionCoordinator(50);
+
+		expect(coordinator.claim("cmd-1")).toBe(true);
+		expect(coordinator.claim("cmd-1")).toBe(false);
+
+		coordinator.release("cmd-1");
+
+		expect(coordinator.claim("cmd-1")).toBe(true);
+	});
+
+	it("allows reclaim after the lease expires", async () => {
+		const coordinator = new AgentCommandExecutionCoordinator(20);
+		const expiredSoon = new Date(Date.now() + 20);
+
+		expect(coordinator.claim("cmd-2", expiredSoon)).toBe(true);
+		expect(coordinator.claim("cmd-2", expiredSoon)).toBe(false);
+
+		await Bun.sleep(30);
+
+		expect(coordinator.claim("cmd-2", expiredSoon)).toBe(true);
+	});
+
+	it("treats invalid timeout values as a fallback lease", () => {
+		const coordinator = new AgentCommandExecutionCoordinator(50);
+
+		expect(coordinator.claim("cmd-3", "invalid")).toBe(true);
+		expect(coordinator.isClaimed("cmd-3")).toBe(true);
+	});
+
+	it("keeps a fallback lease even when timeoutAt is already expired", () => {
+		const coordinator = new AgentCommandExecutionCoordinator(50);
+		const alreadyExpired = new Date(Date.now() - 1_000);
+
+		expect(coordinator.claim("cmd-4", alreadyExpired)).toBe(true);
+		expect(coordinator.claim("cmd-4", alreadyExpired)).toBe(false);
+		expect(coordinator.isClaimed("cmd-4")).toBe(true);
+	});
+});

--- a/apps/desktop/src/main/lib/agent-command-execution-coordinator.ts
+++ b/apps/desktop/src/main/lib/agent-command-execution-coordinator.ts
@@ -3,11 +3,15 @@ interface ClaimEntry {
 }
 
 const DEFAULT_CLAIM_TTL_MS = 5 * 60 * 1000;
+const DEFAULT_EXPIRED_TIMEOUT_GRACE_MS = 5_000;
 
 export class AgentCommandExecutionCoordinator {
 	private readonly claims = new Map<string, ClaimEntry>();
 
-	constructor(private readonly defaultClaimTtlMs = DEFAULT_CLAIM_TTL_MS) {}
+	constructor(
+		private readonly defaultClaimTtlMs = DEFAULT_CLAIM_TTL_MS,
+		private readonly expiredTimeoutGraceMs = DEFAULT_EXPIRED_TIMEOUT_GRACE_MS,
+	) {}
 
 	claim(commandId: string, timeoutAt?: Date | string | null): boolean {
 		this.pruneExpiredClaims();
@@ -43,7 +47,7 @@ export class AgentCommandExecutionCoordinator {
 	}
 
 	private resolveExpiry(timeoutAt?: Date | string | null): number {
-		const fallbackExpiry = Date.now() + this.defaultClaimTtlMs;
+		const now = Date.now();
 		const parsed =
 			timeoutAt instanceof Date
 				? timeoutAt.getTime()
@@ -51,9 +55,12 @@ export class AgentCommandExecutionCoordinator {
 					? Date.parse(timeoutAt)
 					: Number.NaN;
 		if (Number.isFinite(parsed)) {
-			return Math.max(parsed, fallbackExpiry);
+			if (parsed > now) {
+				return parsed;
+			}
+			return now + this.expiredTimeoutGraceMs;
 		}
-		return fallbackExpiry;
+		return now + this.defaultClaimTtlMs;
 	}
 }
 

--- a/apps/desktop/src/main/lib/agent-command-execution-coordinator.ts
+++ b/apps/desktop/src/main/lib/agent-command-execution-coordinator.ts
@@ -1,0 +1,67 @@
+interface ClaimEntry {
+	expiresAt: number;
+}
+
+const DEFAULT_CLAIM_TTL_MS = 5 * 60 * 1000;
+
+export class AgentCommandExecutionCoordinator {
+	private readonly claims = new Map<string, ClaimEntry>();
+
+	constructor(private readonly defaultClaimTtlMs = DEFAULT_CLAIM_TTL_MS) {}
+
+	claim(commandId: string, timeoutAt?: Date | string | null): boolean {
+		this.pruneExpiredClaims();
+
+		const existing = this.claims.get(commandId);
+		if (existing && existing.expiresAt > Date.now()) {
+			return false;
+		}
+
+		this.claims.set(commandId, {
+			expiresAt: this.resolveExpiry(timeoutAt),
+		});
+		return true;
+	}
+
+	release(commandId: string): void {
+		this.claims.delete(commandId);
+	}
+
+	isClaimed(commandId: string): boolean {
+		this.pruneExpiredClaims();
+		const entry = this.claims.get(commandId);
+		return !!entry && entry.expiresAt > Date.now();
+	}
+
+	private pruneExpiredClaims(): void {
+		const now = Date.now();
+		for (const [commandId, entry] of this.claims.entries()) {
+			if (entry.expiresAt <= now) {
+				this.claims.delete(commandId);
+			}
+		}
+	}
+
+	private resolveExpiry(timeoutAt?: Date | string | null): number {
+		const fallbackExpiry = Date.now() + this.defaultClaimTtlMs;
+		const parsed =
+			timeoutAt instanceof Date
+				? timeoutAt.getTime()
+				: typeof timeoutAt === "string"
+					? Date.parse(timeoutAt)
+					: Number.NaN;
+		if (Number.isFinite(parsed)) {
+			return Math.max(parsed, fallbackExpiry);
+		}
+		return fallbackExpiry;
+	}
+}
+
+let coordinator: AgentCommandExecutionCoordinator | null = null;
+
+export function getAgentCommandExecutionCoordinator(): AgentCommandExecutionCoordinator {
+	if (!coordinator) {
+		coordinator = new AgentCommandExecutionCoordinator();
+	}
+	return coordinator;
+}

--- a/apps/desktop/src/main/lib/todo-daemon/client.ts
+++ b/apps/desktop/src/main/lib/todo-daemon/client.ts
@@ -230,7 +230,10 @@ export class TodoDaemonClient extends EventEmitter {
 					},
 					{
 						captureMessage: true,
-						fingerprint: ["todo.agent.main", "todo-daemon-client-authenticated"],
+						fingerprint: [
+							"todo.agent.main",
+							"todo-daemon-client-authenticated",
+						],
 					},
 				);
 				return;
@@ -733,7 +736,10 @@ export class TodoDaemonClient extends EventEmitter {
 				},
 				{
 					captureMessage: true,
-					fingerprint: ["todo.agent.main", "todo-daemon-client-rehydrate-success"],
+					fingerprint: [
+						"todo.agent.main",
+						"todo-daemon-client-rehydrate-success",
+					],
 				},
 			);
 			return response;
@@ -743,7 +749,10 @@ export class TodoDaemonClient extends EventEmitter {
 				"todo-daemon-client-rehydrate-failed",
 				undefined,
 				{
-					fingerprint: ["todo.agent.main", "todo-daemon-client-rehydrate-failed"],
+					fingerprint: [
+						"todo.agent.main",
+						"todo-daemon-client-rehydrate-failed",
+					],
 				},
 			);
 			throw error;

--- a/apps/desktop/src/main/lib/window-manager/index.ts
+++ b/apps/desktop/src/main/lib/window-manager/index.ts
@@ -109,6 +109,40 @@ export class WindowManager {
 		return this.windows.get("main") ?? null;
 	}
 
+	private getWindowId(targetWindow: BrowserWindow): string | null {
+		for (const [windowId, window] of this.windows.entries()) {
+			if (window === targetWindow) {
+				return windowId;
+			}
+		}
+		return null;
+	}
+
+	shouldWindowOwnSingletonEffects(targetWindow: BrowserWindow): boolean {
+		const currentWindowId = this.getWindowId(targetWindow);
+		if (!currentWindowId) {
+			return false;
+		}
+
+		if (currentWindowId === "main") {
+			return true;
+		}
+
+		const mainWindow = this.getMain();
+		if (mainWindow && !mainWindow.isDestroyed()) {
+			return false;
+		}
+
+		const fallbackOwnerId = Array.from(this.windows.entries())
+			.filter(
+				([windowId, window]) => windowId !== "main" && !window.isDestroyed(),
+			)
+			.map(([windowId]) => windowId)
+			.sort()[0];
+
+		return fallbackOwnerId === currentWindowId;
+	}
+
 	getAll(): Map<string, BrowserWindow> {
 		return new Map(this.windows);
 	}

--- a/apps/desktop/src/main/lib/window-manager/index.ts
+++ b/apps/desktop/src/main/lib/window-manager/index.ts
@@ -109,23 +109,13 @@ export class WindowManager {
 		return this.windows.get("main") ?? null;
 	}
 
-	private getWindowId(targetWindow: BrowserWindow): string | null {
-		for (const [windowId, window] of this.windows.entries()) {
-			if (window === targetWindow) {
-				return windowId;
-			}
-		}
-		return null;
-	}
-
-	shouldWindowOwnSingletonEffects(targetWindow: BrowserWindow): boolean {
-		const currentWindowId = this.getWindowId(targetWindow);
-		if (!currentWindowId) {
-			return false;
-		}
-
-		if (currentWindowId === "main") {
+	shouldWindowIdOwnSingletonEffects(windowId: string | null): boolean {
+		if (!windowId || windowId === "main") {
 			return true;
+		}
+
+		if (!this.windows.has(windowId)) {
+			return false;
 		}
 
 		const mainWindow = this.getMain();
@@ -140,7 +130,7 @@ export class WindowManager {
 			.map(([windowId]) => windowId)
 			.sort()[0];
 
-		return fallbackOwnerId === currentWindowId;
+		return fallbackOwnerId === windowId;
 	}
 
 	getAll(): Map<string, BrowserWindow> {

--- a/apps/desktop/src/main/todo-agent/daemon-bridge.ts
+++ b/apps/desktop/src/main/todo-agent/daemon-bridge.ts
@@ -76,14 +76,10 @@ export function startTodoAgentDaemonBridge(): Promise<void> {
 			console.warn(
 				"[todo-agent] daemon disconnected — will reconnect on next RPC",
 			);
-			todoAgentMainDebug.warn(
-				"todo-daemon-bridge-disconnected",
-				undefined,
-				{
-					captureMessage: true,
-					fingerprint: ["todo.agent.main", "todo-daemon-bridge-disconnected"],
-				},
-			);
+			todoAgentMainDebug.warn("todo-daemon-bridge-disconnected", undefined, {
+				captureMessage: true,
+				fingerprint: ["todo.agent.main", "todo-daemon-bridge-disconnected"],
+			});
 		});
 		client.on("error", (error) => {
 			console.warn("[todo-agent] daemon client error", error);
@@ -98,25 +94,17 @@ export function startTodoAgentDaemonBridge(): Promise<void> {
 		});
 	}
 	connectPromise = (async () => {
-		todoAgentMainDebug.info(
-			"todo-daemon-bridge-init",
-			undefined,
-			{
-				captureMessage: true,
-				fingerprint: ["todo.agent.main", "todo-daemon-bridge-init"],
-			},
-		);
+		todoAgentMainDebug.info("todo-daemon-bridge-init", undefined, {
+			captureMessage: true,
+			fingerprint: ["todo.agent.main", "todo-daemon-bridge-init"],
+		});
 		try {
 			await client.ensureConnected();
 			await client.rehydrate();
-			todoAgentMainDebug.info(
-				"todo-daemon-bridge-init-success",
-				undefined,
-				{
-					captureMessage: true,
-					fingerprint: ["todo.agent.main", "todo-daemon-bridge-init-success"],
-				},
-			);
+			todoAgentMainDebug.info("todo-daemon-bridge-init-success", undefined, {
+				captureMessage: true,
+				fingerprint: ["todo.agent.main", "todo-daemon-bridge-init-success"],
+			});
 		} catch (error) {
 			console.warn("[todo-agent] daemon bridge failed to initialize", error);
 			todoAgentMainDebug.captureException(

--- a/apps/desktop/src/main/todo-agent/debug.ts
+++ b/apps/desktop/src/main/todo-agent/debug.ts
@@ -1,6 +1,6 @@
 import type { SelectTodoSession } from "@superset/local-db";
-import type { TodoStreamEvent } from "./types";
 import { createMainDebugChannel } from "../lib/debug-channel";
+import type { TodoStreamEvent } from "./types";
 
 const DEBUG_TODO_AGENT = process.env.SUPERSET_TODO_DEBUG === "1";
 
@@ -32,7 +32,7 @@ export function getTodoSessionDebugData(
 		| "claudeSessionId"
 		| "verdictReason"
 		| "waitingReason"
-	>
+	>,
 ) {
 	return {
 		sessionId: session.id,

--- a/apps/desktop/src/main/todo-agent/runtime-config.ts
+++ b/apps/desktop/src/main/todo-agent/runtime-config.ts
@@ -152,11 +152,7 @@ export function writeTodoSessionRuntimeConfig(
 		const normalized = normalizeConfig(config);
 		const filePath = getRuntimeConfigPath(artifactPath);
 		mkdirSync(artifactPath, { recursive: true });
-		writeFileSync(
-			filePath,
-			`${JSON.stringify(normalized, null, 2)}\n`,
-			"utf8",
-		);
+		writeFileSync(filePath, `${JSON.stringify(normalized, null, 2)}\n`, "utf8");
 		todoAgentMainDebug.info(
 			"todo-runtime-config-write",
 			{

--- a/apps/desktop/src/main/todo-agent/trpc-router.ts
+++ b/apps/desktop/src/main/todo-agent/trpc-router.ts
@@ -10,6 +10,7 @@ import { publicProcedure, router } from "lib/trpc";
 import { localDb } from "main/lib/local-db";
 import { workspaceInitManager } from "main/lib/workspace-init-manager";
 import { z } from "zod";
+import { getTodoSessionDebugData, todoAgentMainDebug } from "./debug";
 import { describeEnhanceFailure, enhanceTodoText } from "./enhance-text";
 import {
 	getSessionFileDiff,
@@ -25,7 +26,6 @@ import { computeNextRunAt, getTodoScheduler } from "./scheduler";
 import { getTodoSessionStore, resolveWorktreePath } from "./session-store";
 import { getTodoSettings, updateTodoSettings } from "./settings";
 import { getTodoSupervisor } from "./supervisor";
-import { getTodoSessionDebugData, todoAgentMainDebug } from "./debug";
 import {
 	TODO_ARTIFACT_SUBDIR,
 	type TodoScheduleFireEvent,

--- a/apps/desktop/src/renderer/features/todo-agent/TodoModal/TodoModal.tsx
+++ b/apps/desktop/src/renderer/features/todo-agent/TodoModal/TodoModal.tsx
@@ -216,7 +216,11 @@ export function TodoModal({
 				},
 				{
 					captureMessage: true,
-					fingerprint: ["todo.agent.renderer", "todo-create-submit", "todo-modal"],
+					fingerprint: [
+						"todo.agent.renderer",
+						"todo-create-submit",
+						"todo-modal",
+					],
 				},
 			);
 			const created = await create.mutateAsync({
@@ -277,7 +281,11 @@ export function TodoModal({
 					errorMessage: message,
 				},
 				{
-					fingerprint: ["todo.agent.renderer", "todo-create-submit-failed", "todo-modal"],
+					fingerprint: [
+						"todo.agent.renderer",
+						"todo-create-submit-failed",
+						"todo-modal",
+					],
 				},
 			);
 			toast.error(message);

--- a/apps/desktop/src/renderer/lib/boot-errors.ts
+++ b/apps/desktop/src/renderer/lib/boot-errors.ts
@@ -70,7 +70,10 @@ export const reportBootError = (message: string, error?: unknown) => {
 	// explicitly so a boot crash always lands in the dashboard.
 	reportError(error ?? new Error(message), {
 		severity: "fatal",
-		tags: { subsystem: "boot", mounted: hasMounted ? "post-mount" : "pre-mount" },
+		tags: {
+			subsystem: "boot",
+			mounted: hasMounted ? "post-mount" : "pre-mount",
+		},
 		context: { message },
 	});
 	if (hasMounted) return;

--- a/apps/desktop/src/renderer/lib/sentry.ts
+++ b/apps/desktop/src/renderer/lib/sentry.ts
@@ -33,9 +33,7 @@ export async function initSentry(): Promise<void> {
 			tracesSampleRate: 0.1,
 			beforeSend(event) {
 				const message = event.exception?.values?.[0]?.value ?? "";
-				if (
-					NOISY_ERROR_PATTERNS.some((pattern) => message.includes(pattern))
-				) {
+				if (NOISY_ERROR_PATTERNS.some((pattern) => message.includes(pattern))) {
 					return null;
 				}
 				return event;

--- a/apps/desktop/src/renderer/routes/_authenticated/components/AgentHooks/hooks/useCommandWatcher/useCommandWatcher.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/AgentHooks/hooks/useCommandWatcher/useCommandWatcher.ts
@@ -46,6 +46,10 @@ export function useCommandWatcher() {
 	const terminalCreateOrAttach =
 		electronTrpc.terminal.createOrAttach.useMutation();
 	const terminalWrite = electronTrpc.terminal.write.useMutation();
+	const claimCommandExecution =
+		electronTrpc.agentCommandExecution.claim.useMutation();
+	const releaseCommandExecution =
+		electronTrpc.agentCommandExecution.release.useMutation();
 
 	const { data: workspaces, refetch: refetchWorkspaces } =
 		electronTrpc.workspaces.getAll.useQuery();
@@ -140,7 +144,6 @@ export function useCommandWatcher() {
 					draft.executedAt = resolved.executedAt ?? null;
 				});
 				await tx.isPersisted.promise;
-				pendingPersistenceRef.current.delete(commandId);
 			} catch (error) {
 				console.error(
 					`[command-watcher] Failed to persist ${resolved.status}: ${commandId}`,
@@ -157,11 +160,20 @@ export function useCommandWatcher() {
 					}, COMMAND_PERSIST_RETRY_MS);
 					persistenceRetryTimersRef.current.set(commandId, retryTimer);
 				}
+				return;
 			} finally {
 				persistingCommandsRef.current.delete(commandId);
 			}
+
+			pendingPersistenceRef.current.delete(commandId);
+			void releaseCommandExecution.mutateAsync({ commandId }).catch((error) => {
+				console.error(
+					`[command-watcher] Failed to release claim: ${commandId}`,
+					error,
+				);
+			});
 		},
-		[collections.agentCommands],
+		[collections.agentCommands, releaseCommandExecution],
 	);
 
 	useEffect(() => {
@@ -179,6 +191,7 @@ export function useCommandWatcher() {
 			commandId: string,
 			tool: string,
 			params: Record<string, unknown> | null,
+			timeoutAt?: Date | string | null,
 		) => {
 			if (
 				handledCommandsRef.current.has(commandId) ||
@@ -187,6 +200,22 @@ export function useCommandWatcher() {
 				if (pendingPersistenceRef.current.has(commandId)) {
 					void persistResolvedCommand(commandId);
 				}
+				return;
+			}
+
+			let claimGranted = false;
+			try {
+				const claim = await claimCommandExecution.mutateAsync({
+					commandId,
+					timeoutAt,
+				});
+				claimGranted = claim.granted;
+			} catch (error) {
+				console.error(`[command-watcher] Failed to claim: ${commandId}`, error);
+				return;
+			}
+
+			if (!claimGranted) {
 				return;
 			}
 
@@ -241,7 +270,7 @@ export function useCommandWatcher() {
 			pendingPersistenceRef.current.set(commandId, resolvedState);
 			void persistResolvedCommand(commandId);
 		},
-		[persistResolvedCommand, toolContext],
+		[claimCommandExecution, persistResolvedCommand, toolContext],
 	);
 
 	useEffect(() => {
@@ -299,7 +328,7 @@ export function useCommandWatcher() {
 		});
 
 		for (const cmd of commandsForThisDevice) {
-			processCommand(cmd.id, cmd.tool, cmd.params);
+			processCommand(cmd.id, cmd.tool, cmd.params, cmd.timeoutAt ?? null);
 		}
 	}, [
 		shouldWatch,

--- a/apps/desktop/src/renderer/routes/_authenticated/components/MainWindowEffects/MainWindowEffects.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/MainWindowEffects/MainWindowEffects.tsx
@@ -1,0 +1,23 @@
+import { ScheduleFireToasts } from "renderer/features/todo-agent/ScheduleFireToasts";
+import { isTearoffWindow } from "renderer/hooks/useTearoffInit/useTearoffInit";
+import { WorkspaceInitEffects } from "renderer/screens/main/components/WorkspaceInitEffects";
+import { AgentHooks } from "../AgentHooks";
+
+/**
+ * Effects that must have a single renderer owner. Tear-off windows render the
+ * same authenticated tree but should stay read-only with respect to device-
+ * scoped orchestration and global toasts.
+ */
+export function MainWindowEffects() {
+	if (isTearoffWindow()) {
+		return null;
+	}
+
+	return (
+		<>
+			<AgentHooks />
+			<ScheduleFireToasts />
+			<WorkspaceInitEffects />
+		</>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/components/MainWindowEffects/MainWindowEffects.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/MainWindowEffects/MainWindowEffects.tsx
@@ -1,5 +1,6 @@
 import { ScheduleFireToasts } from "renderer/features/todo-agent/ScheduleFireToasts";
 import { isTearoffWindow } from "renderer/hooks/useTearoffInit/useTearoffInit";
+import { electronTrpc } from "renderer/lib/electron-trpc";
 import { WorkspaceInitEffects } from "renderer/screens/main/components/WorkspaceInitEffects";
 import { AgentHooks } from "../AgentHooks";
 
@@ -9,7 +10,14 @@ import { AgentHooks } from "../AgentHooks";
  * scoped orchestration and global toasts.
  */
 export function MainWindowEffects() {
-	if (isTearoffWindow()) {
+	const isTearoff = isTearoffWindow();
+	const { data: shouldOwnEffectsInTearoff } =
+		electronTrpc.window.shouldOwnSingletonEffects.useQuery(undefined, {
+			enabled: isTearoff,
+			refetchInterval: 1_000,
+		});
+
+	if (isTearoff && !shouldOwnEffectsInTearoff) {
 		return null;
 	}
 

--- a/apps/desktop/src/renderer/routes/_authenticated/components/MainWindowEffects/MainWindowEffects.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/MainWindowEffects/MainWindowEffects.tsx
@@ -11,11 +11,15 @@ import { AgentHooks } from "../AgentHooks";
  */
 export function MainWindowEffects() {
 	const isTearoff = isTearoffWindow();
+	const tearoffWindowId = window.App?.tearoffWindowId ?? null;
 	const { data: shouldOwnEffectsInTearoff } =
-		electronTrpc.window.shouldOwnSingletonEffects.useQuery(undefined, {
-			enabled: isTearoff,
-			refetchInterval: 1_000,
-		});
+		electronTrpc.window.shouldOwnSingletonEffects.useQuery(
+			{ tearoffWindowId },
+			{
+				enabled: isTearoff,
+				refetchInterval: 1_000,
+			},
+		);
 
 	if (isTearoff && !shouldOwnEffectsInTearoff) {
 		return null;

--- a/apps/desktop/src/renderer/routes/_authenticated/components/MainWindowEffects/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/MainWindowEffects/index.ts
@@ -1,0 +1,1 @@
+export { MainWindowEffects } from "./MainWindowEffects";

--- a/apps/desktop/src/renderer/routes/_authenticated/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/layout.tsx
@@ -15,7 +15,6 @@ import { NewWorkspaceModal } from "renderer/components/NewWorkspaceModal";
 import { Paywall } from "renderer/components/Paywall";
 import { useUpdateListener } from "renderer/components/UpdateToast";
 import { env } from "renderer/env.renderer";
-import { ScheduleFireToasts } from "renderer/features/todo-agent/ScheduleFireToasts";
 import { useIsV2CloudEnabled } from "renderer/hooks/useIsV2CloudEnabled";
 import { useOnlineStatus } from "renderer/hooks/useOnlineStatus";
 import { isTearoffWindow } from "renderer/hooks/useTearoffInit/useTearoffInit";
@@ -29,15 +28,14 @@ import { LanguageServicesProvider } from "renderer/providers/LanguageServicesPro
 import { InitGitDialog } from "renderer/react-query/projects/InitGitDialog";
 import { DashboardNewWorkspaceModal } from "renderer/routes/_authenticated/components/DashboardNewWorkspaceModal";
 import { GitOperationDialog } from "renderer/screens/main/components/GitOperationDialog";
-import { WorkspaceInitEffects } from "renderer/screens/main/components/WorkspaceInitEffects";
 import { useSettingsStore } from "renderer/stores/settings-state";
 import { useTabsStore } from "renderer/stores/tabs/store";
 import { useAgentHookListener } from "renderer/stores/tabs/useAgentHookListener";
 import { setPaneWorkspaceRunState } from "renderer/stores/tabs/workspace-run";
 import { useWorkspaceInitStore } from "renderer/stores/workspace-init";
 import { MOCK_ORG_ID, NOTIFICATION_EVENTS } from "shared/constants";
-import { AgentHooks } from "./components/AgentHooks";
 import { GlobalTerminalLifecycle } from "./components/GlobalTerminalLifecycle";
+import { MainWindowEffects } from "./components/MainWindowEffects";
 import { TeardownLogsDialog } from "./components/TeardownLogsDialog";
 import { createPierreWorker } from "./lib/pierreWorker";
 import { CollectionsProvider } from "./providers/CollectionsProvider";
@@ -222,10 +220,8 @@ function AuthenticatedLayout() {
 						poolOptions={{ workerFactory: createPierreWorker, poolSize: 8 }}
 						highlighterOptions={{ preferredHighlighter: "shiki-wasm" }}
 					>
-						<AgentHooks />
-						<ScheduleFireToasts />
+						<MainWindowEffects />
 						<Outlet />
-						<WorkspaceInitEffects />
 						{isV2CloudEnabled ? (
 							<DashboardNewWorkspaceModal />
 						) : (

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/layout.tsx
@@ -6,6 +6,7 @@ import {
 } from "@tanstack/react-router";
 import { useEffect } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
+import { RouteErrorBoundary } from "renderer/components/RouteErrorBoundary";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import {
 	type SettingsSection,
@@ -13,7 +14,6 @@ import {
 	useSettingsOriginRoute,
 	useSettingsSearchQuery,
 } from "renderer/stores/settings-state";
-import { RouteErrorBoundary } from "renderer/components/RouteErrorBoundary";
 import { SearchResultsBanner } from "./components/SearchResultsBanner";
 import { SettingsSidebar } from "./components/SettingsSidebar";
 import {


### PR DESCRIPTION
## 概要
- tearoff window でも authenticated tree 全体が mount される構成により、renderer 常駐の副作用が複数 window で同時に走りうる状態を解消します
- `apps/desktop` で device 向け pending command を複数 window が同時に拾い、Superset の一部機能や MCP 経由の操作が二重実行される余地を塞ぎます

## Root Cause
- `AgentHooks` / `ScheduleFireToasts` / `WorkspaceInitEffects` が main window と tearoff window の両方で mount されていました
- `useCommandWatcher` の重複防止は renderer ローカルの `ref` ベースで、window をまたぐ排他制御になっていませんでした
- そのため同一 device 向け command を別 window が同時に処理開始できる可能性がありました

## 変更内容
- main window のみで持つべき副作用を `MainWindowEffects` に集約
- ただし main window が存在しない場合は、tearoff 群のうち 1 window だけが singleton effects owner を引き継ぐように変更
- main process 側に `AgentCommandExecutionCoordinator` を追加し、command 単位の claim / release を一元管理
- electron tRPC に `agentCommandExecution` router を追加し、renderer から cross-window claim を取得してから実行するように変更
- claim は resolved 状態の永続化成功後に release するようにし、persist 前の再取得を防止
- claim expiry は有効な `timeoutAt` を尊重し、期限切れ時だけ短い grace lease に落とすよう調整
- review 指摘対応のため、singleton owner 判定は implicit な current window ではなく `tearoffWindowId` を main process に渡して行うように変更
- CI lint を安定して通すため、関連する desktop 側フォーマット崩れを整理し、最新 `main` も取り込み済み

## 影響
- tearoff window は通常時は read-only な副作用側に回り、device スコープの常駐 orchestration は 1 renderer だけが担当します
- main window を閉じても tearoff だけが残るケースでは、tearoff 側で owner を 1 つ選んで command orchestration を継続します
- device 向け pending command は 1 window のみが実行し、別 window は claim 失敗で実行を諦めます

## 検証
- `rtk bun test apps/desktop/src/main/lib/agent-command-execution-coordinator.test.ts`
- `rtk bun run lint`
- `rtk bun run typecheck`
- PR CI: `Lint` / `Sherif` / `Test` / `Typecheck` / `Build` pass
