### PR TITLE
fix(desktop): Agent Manager の重複表示除去とタイムスタンプ追加

### DIFF
--- a/apps/desktop/src/renderer/features/todo-agent/TodoManager/TodoManager.tsx
+++ b/apps/desktop/src/renderer/features/todo-agent/TodoManager/TodoManager.tsx
@@ -1989,7 +1989,57 @@ function buildStreamTree(events: TodoStreamEvent[]): StreamItem[] {
 		}
 		roots.push(item);
 	}
-	return roots;
+	return deduplicateStreamItems(roots);
+}
+
+/**
+ * Remove redundant items from a StreamItem list (and recursively from
+ * tool-node children):
+ *
+ * 1. Drop `assistant_text` whose text is identical to a `result` at the
+ *    same level — Claude Code emits the final assistant turn both as an
+ *    `assistant` message AND as `result.result`, producing a visible
+ *    duplicate in the UI.
+ * 2. Drop `result` items whose text is empty / the placeholder fallback
+ *    "（空の結果）" — they add a blank green box above the real content.
+ */
+function deduplicateStreamItems(items: StreamItem[]): StreamItem[] {
+	const resultTexts = new Set<string>();
+	for (const item of items) {
+		if (
+			item.type === "message" &&
+			item.event.kind === "result" &&
+			item.event.text &&
+			item.event.text !== "（空の結果）"
+		) {
+			resultTexts.add(item.event.text);
+		}
+	}
+
+	return items
+		.filter((item) => {
+			if (item.type === "message") {
+				if (
+					item.event.kind === "assistant_text" &&
+					resultTexts.has(item.event.text)
+				) {
+					return false;
+				}
+				if (
+					item.event.kind === "result" &&
+					(!item.event.text || item.event.text === "（空の結果）")
+				) {
+					return false;
+				}
+			}
+			return true;
+		})
+		.map((item) => {
+			if (item.type === "tool" && item.children.length > 0) {
+				return { ...item, children: deduplicateStreamItems(item.children) };
+			}
+			return item;
+		});
 }
 
 function StreamView({ events }: { events: TodoStreamEvent[] }) {
@@ -2404,9 +2454,15 @@ function MessageRow({ event }: { event: TodoStreamEvent }) {
 		);
 	}
 	if (event.kind === "result") {
+		const time = new Date(event.ts).toLocaleTimeString("ja-JP", {
+			hour: "2-digit",
+			minute: "2-digit",
+			second: "2-digit",
+		});
 		return (
 			<div className="group/result border-l-2 border-emerald-500/50 bg-emerald-500/5 pl-2 pr-1 py-1 text-xs my-1 rounded-r relative">
 				<MarkdownRenderer content={event.text} scrollable={false} />
+				<div className="text-[10px] text-emerald-400/60 mt-0.5">{time}</div>
 				<div className="absolute top-0 right-0 opacity-0 invisible group-hover/result:opacity-100 group-hover/result:visible transition-opacity">
 					<CopyIconButton
 						value={event.text}

--- a/apps/desktop/src/renderer/features/todo-agent/TodoManager/TodoManager.tsx
+++ b/apps/desktop/src/renderer/features/todo-agent/TodoManager/TodoManager.tsx
@@ -1996,15 +1996,18 @@ function buildStreamTree(events: TodoStreamEvent[]): StreamItem[] {
  * Remove redundant items from a StreamItem list (and recursively from
  * tool-node children):
  *
- * 1. Drop `assistant_text` whose text is identical to a `result` at the
- *    same level — Claude Code emits the final assistant turn both as an
- *    `assistant` message AND as `result.result`, producing a visible
- *    duplicate in the UI.
+ * 1. Drop `assistant_text` whose text is identical to a `result` **in the
+ *    same iteration** — Claude Code emits the final assistant turn both as
+ *    an `assistant` message AND as `result.result`, producing a visible
+ *    duplicate in the UI. Scoping to the same iteration avoids false
+ *    positives when a later turn happens to produce the same reply text
+ *    as an earlier turn whose result was empty/null.
  * 2. Drop `result` items whose text is empty / the placeholder fallback
  *    "（空の結果）" — they add a blank green box above the real content.
  */
 function deduplicateStreamItems(items: StreamItem[]): StreamItem[] {
-	const resultTexts = new Set<string>();
+	// Map iteration → set of non-empty result texts for that iteration.
+	const resultTextsByIteration = new Map<number, Set<string>>();
 	for (const item of items) {
 		if (
 			item.type === "message" &&
@@ -2012,18 +2015,20 @@ function deduplicateStreamItems(items: StreamItem[]): StreamItem[] {
 			item.event.text &&
 			item.event.text !== "（空の結果）"
 		) {
-			resultTexts.add(item.event.text);
+			const iter = item.event.iteration;
+			if (!resultTextsByIteration.has(iter)) {
+				resultTextsByIteration.set(iter, new Set());
+			}
+			resultTextsByIteration.get(iter)?.add(item.event.text);
 		}
 	}
 
 	return items
 		.filter((item) => {
 			if (item.type === "message") {
-				if (
-					item.event.kind === "assistant_text" &&
-					resultTexts.has(item.event.text)
-				) {
-					return false;
+				if (item.event.kind === "assistant_text") {
+					const resultTexts = resultTextsByIteration.get(item.event.iteration);
+					if (resultTexts?.has(item.event.text)) return false;
 				}
 				if (
 					item.event.kind === "result" &&

--- a/apps/desktop/src/renderer/features/todo-agent/TodoManager/TodoManager.tsx
+++ b/apps/desktop/src/renderer/features/todo-agent/TodoManager/TodoManager.tsx
@@ -1996,18 +1996,26 @@ function buildStreamTree(events: TodoStreamEvent[]): StreamItem[] {
  * Remove redundant items from a StreamItem list (and recursively from
  * tool-node children):
  *
- * 1. Drop `assistant_text` whose text is identical to a `result` **in the
- *    same iteration** — Claude Code emits the final assistant turn both as
- *    an `assistant` message AND as `result.result`, producing a visible
- *    duplicate in the UI. Scoping to the same iteration avoids false
- *    positives when a later turn happens to produce the same reply text
- *    as an earlier turn whose result was empty/null.
+ * 1. Drop the **last** `assistant_text` per (iteration × result-text) pair
+ *    — Claude Code emits the final assistant turn both as an `assistant`
+ *    message AND as `result.result`, producing a visible duplicate in the
+ *    UI. We only remove the last occurrence so that intermediate status
+ *    lines that happen to share the same wording are preserved.
  * 2. Drop `result` items whose text is empty / the placeholder fallback
  *    "（空の結果）" — they add a blank green box above the real content.
  */
 function deduplicateStreamItems(items: StreamItem[]): StreamItem[] {
-	// Map iteration → set of non-empty result texts for that iteration.
-	const resultTextsByIteration = new Map<number, Set<string>>();
+	// For each (iteration, resultText) pair, record the id of the LAST
+	// assistant_text item that matches, so only that one is suppressed.
+	const lastAssistantIdByKey = new Map<string, string>();
+	for (const item of items) {
+		if (item.type === "message" && item.event.kind === "assistant_text") {
+			const key = `${item.event.iteration}:${item.event.text}`;
+			lastAssistantIdByKey.set(key, item.id);
+		}
+	}
+
+	const idsToRemove = new Set<string>();
 	for (const item of items) {
 		if (
 			item.type === "message" &&
@@ -2015,21 +2023,16 @@ function deduplicateStreamItems(items: StreamItem[]): StreamItem[] {
 			item.event.text &&
 			item.event.text !== "（空の結果）"
 		) {
-			const iter = item.event.iteration;
-			if (!resultTextsByIteration.has(iter)) {
-				resultTextsByIteration.set(iter, new Set());
-			}
-			resultTextsByIteration.get(iter)?.add(item.event.text);
+			const key = `${item.event.iteration}:${item.event.text}`;
+			const lastId = lastAssistantIdByKey.get(key);
+			if (lastId) idsToRemove.add(lastId);
 		}
 	}
 
 	return items
 		.filter((item) => {
 			if (item.type === "message") {
-				if (item.event.kind === "assistant_text") {
-					const resultTexts = resultTextsByIteration.get(item.event.iteration);
-					if (resultTexts?.has(item.event.text)) return false;
-				}
+				if (idsToRemove.has(item.id)) return false;
 				if (
 					item.event.kind === "result" &&
 					(!item.event.text || item.event.text === "（空の結果）")


### PR DESCRIPTION
## 変更内容

Issue #351 の修正。

### 問題

Agent Manager のストリームビューで Claude の最終応答が二重表示されていた。

**原因:** Claude Code の `--output-format stream-json` は最終アシスタント応答を2箇所に含める:
1. `assistant` type メッセージ → `assistant_text` イベント（通常テキスト表示）
2. `result` type メッセージ → `result` イベント（緑ボーダー表示）

この2つが同じテキストを持つため UI で重複して見えていた。また `result.result` が null の場合は `result` イベントが「（空の結果）」という空の緑ボックスになり、`assistant_text` だけが上に表示されるケースも発生していた。

### 修正

- `buildStreamTree` の戻り値に `deduplicateStreamItems` を適用
  - `result` と同一テキストの `assistant_text` を除去（`result` の緑表示を優先）
  - 空/プレースホルダー（「（空の結果）」）の `result` イベントを除去
  - ツールノードの `children`（サブエージェント）にも再帰的に適用
- `result` イベントの表示にタイムスタンプ（`event.ts`）を追加

## テスト

- lint/typecheck: パス