### PR TITLE
fix(desktop): resolve actual desktop-mcp bin path for setup snippet

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/browser-automation/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/browser-automation/index.ts
@@ -1,7 +1,7 @@
 import { EventEmitter } from "node:events";
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import {
 	browserAutomationBindings,
 	projects,
@@ -11,6 +11,7 @@ import {
 } from "@superset/local-db";
 import { observable } from "@trpc/server/observable";
 import { and, eq, ne } from "drizzle-orm";
+import { app } from "electron";
 import { localDb } from "main/lib/local-db";
 import { getProcessName, getProcessTree } from "main/lib/terminal/port-scanner";
 import { getTerminalHostClient } from "main/lib/terminal-host/client";
@@ -288,6 +289,33 @@ const CLAUDE_SETTINGS_JSON_PATH = join(homedir(), ".claude", "settings.json");
 const CLAUDE_CONFIG_PATHS = [CLAUDE_USER_JSON_PATH, CLAUDE_SETTINGS_JSON_PATH];
 const CODEX_CONFIG_PATH = join(homedir(), ".codex", "config.toml");
 
+/**
+ * Resolve the absolute command Claude / Codex should spawn to start the
+ * superset-browser MCP server. `desktop-mcp` is a workspace-private bin
+ * (TypeScript, no compiled output), so it is not on PATH. We point
+ * users at `bun <repo>/packages/desktop-mcp/src/bin.ts` instead — bun
+ * can execute TypeScript directly.
+ *
+ * In packaged production builds the source tree isn't available, so we
+ * fall back to the bare `desktop-mcp` name and let the user pick the
+ * command themselves. (Browser automation is dev-only today.)
+ */
+function resolveDesktopMcpCommand(): {
+	command: string;
+	args: string[];
+	available: boolean;
+} {
+	if (!app.isPackaged) {
+		// `app.getAppPath()` is the `apps/desktop` directory in dev.
+		const repoRoot = resolve(app.getAppPath(), "../..");
+		const binPath = join(repoRoot, "packages/desktop-mcp/src/bin.ts");
+		if (existsSync(binPath)) {
+			return { command: "bun", args: [binPath], available: true };
+		}
+	}
+	return { command: "desktop-mcp", args: [], available: false };
+}
+
 export interface TerminalAgentSession {
 	paneId: string;
 	workspaceId: string;
@@ -374,12 +402,14 @@ export const createBrowserAutomationRouter = () => {
 				claudeReadyByWorkspaceId[workspaceId] = localScope || projectScope;
 			}
 			const codexReady = detectCodexMcp(CODEX_CONFIG_PATH);
+			const serverCommand = resolveDesktopMcpCommand();
 			return {
 				claudeHomeReady,
 				claudeReadyByWorkspaceId,
 				codexReady,
 				claudeConfigPath: CLAUDE_USER_JSON_PATH,
 				codexConfigPath: CODEX_CONFIG_PATH,
+				serverCommand,
 			};
 		}),
 

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/components/SessionConnectModal/SessionConnectModal.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/components/SessionConnectModal/SessionConnectModal.tsx
@@ -16,6 +16,7 @@ import { electronTrpc } from "renderer/lib/electron-trpc";
 import {
 	type AutomationSession,
 	getSnippetForSession,
+	type ServerCommand,
 	useBrowserAutomationStore,
 } from "renderer/stores/browser-automation";
 import { useTabsStore } from "renderer/stores/tabs/store";
@@ -143,10 +144,14 @@ export function SessionConnectModal({
 		}
 	};
 
+	const serverCommand = mcpStatus?.serverCommand;
+
 	const handleCopySnippet = async () => {
 		if (!session) return;
 		try {
-			await navigator.clipboard.writeText(getSnippetForSession(session));
+			await navigator.clipboard.writeText(
+				getSnippetForSession(session, serverCommand),
+			);
 			toast.success("Configuration snippet copied");
 		} catch {
 			toast.error("Failed to copy snippet");
@@ -244,6 +249,7 @@ export function SessionConnectModal({
 											? (mcpStatus?.codexConfigPath ?? null)
 											: (mcpStatus?.claudeConfigPath ?? null)
 									}
+									serverCommand={serverCommand}
 									onCopy={handleCopySnippet}
 								/>
 							)
@@ -448,13 +454,15 @@ function DetailItem({
 function SetupPanel({
 	session,
 	mcpConfigPath,
+	serverCommand,
 	onCopy,
 }: {
 	session: AutomationSession;
 	mcpConfigPath: string | null;
+	serverCommand?: ServerCommand;
 	onCopy: () => void;
 }) {
-	const snippet = getSnippetForSession(session);
+	const snippet = getSnippetForSession(session, serverCommand);
 	return (
 		<div className="flex flex-col gap-3">
 			<div className="rounded-xl border p-3 bg-card/60">

--- a/apps/desktop/src/renderer/stores/browser-automation.ts
+++ b/apps/desktop/src/renderer/stores/browser-automation.ts
@@ -64,18 +64,36 @@ export const useBrowserAutomationStore = create<BrowserAutomationUiState>(
 	}),
 );
 
-export function getSnippetForSession(session: AutomationSession): string {
+export interface ServerCommand {
+	command: string;
+	args: string[];
+	available: boolean;
+}
+
+function tomlString(value: string): string {
+	return `"${value.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+}
+
+function shellQuote(value: string): string {
+	return /^[\w@./:+-]+$/.test(value)
+		? value
+		: `'${value.replace(/'/g, "'\\''")}'`;
+}
+
+export function getSnippetForSession(
+	session: AutomationSession,
+	server?: ServerCommand,
+): string {
+	const cmd = server?.command ?? "desktop-mcp";
+	const args = server?.args ?? [];
 	if (session.provider === "Codex") {
-		// TOML is section-based, so appending this block to an existing
-		// config.toml is safe. The bin comes from packages/desktop-mcp.
+		const argsToml = args.map(tomlString).join(", ");
 		return `[mcp_servers.superset-browser]
-command = "desktop-mcp"
-args = []`;
+command = ${tomlString(cmd)}
+args = [${argsToml}]`;
 	}
-	// For Claude Code we recommend `claude mcp add` so the user's
-	// ~/.claude.json is updated in-place instead of manually merging a
-	// standalone JSON document (which would produce invalid JSON).
-	return `claude mcp add superset-browser -s local -- desktop-mcp`;
+	const parts = [cmd, ...args].map(shellQuote).join(" ");
+	return `claude mcp add superset-browser -s local -- ${parts}`;
 }
 
 function formatRelativeTime(ts: number | null | undefined): string {


### PR DESCRIPTION
## Summary

PR #345 でセットアップ snippet に \`desktop-mcp\` という裸のコマンドを出していたが、これは monorepo 内部のプライベート TS bin (\`packages/desktop-mcp/src/bin.ts\`) でグローバル PATH に無く、\`claude mcp add ... -- desktop-mcp\` を実行すると Claude 側で \`/mcp\` が \`failed\` になっていた。

修正:

- \`browserAutomation.getMcpStatus\` が main process で bin を解決して \`serverCommand: { command, args, available }\` を返す
  - dev: \`{ command: "bun", args: ["<repo>/packages/desktop-mcp/src/bin.ts"] }\`
  - packaged: \`{ command: "desktop-mcp", args: [], available: false }\` (フォールバック、ブラウザ自動化は現状 dev only)
- \`getSnippetForSession(session, serverCommand)\` で実 argv を使った snippet を生成
  - Claude: \`claude mcp add superset-browser -s local -- bun <abs>\`
  - Codex: \`[mcp_servers.superset-browser]\` + \`command\` / \`args\` を TOML エスケープ
- SessionConnectModal が serverCommand を SetupPanel に受け渡し

## 背景 — この PR の出し方について

元々 PR #345 のレビュー対応中に同じ修正を直接 main に push してしまい、レビューなしで入ってしまった (commit b925620c2)。その commit を revert した上でこの PR に切り出し直している。内容は revert 前と同じ。

## Test plan

- [ ] dev ビルドで browser pane → Connect → セッション選択 → MCP 未設定時に出る snippet に \`bun /Volumes/sub/github/superset/packages/desktop-mcp/src/bin.ts\` が含まれる
- [ ] 上記コマンドを Claude CLI に貼って実行すると \`/mcp\` で \`superset-browser\` が \`running\` になる
- [ ] Codex 側の TOML snippet も \`command = \"bun\"\` + \`args = [\"<abs>\"]\` で生成される

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ブラウザ自動化セッション接続情報の生成が改善されました。開発環境とパッケージ版の両方に対応したサーバーコマンド情報を自動で検出し、セッション接続スニペットに反映されるようになりました。

* **改善**
  * セッション接続モーダルで生成されるコマンドスニペットがMCPサーバーの設定をより正確に反映するようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->