### PR TITLE
feat(desktop): PR1 — expose per-pane CDP endpoint for external browser MCPs

### DIFF
--- a/apps/desktop/src/lib/electron-app/factories/app/setup.ts
+++ b/apps/desktop/src/lib/electron-app/factories/app/setup.ts
@@ -1,5 +1,4 @@
 import { app, BrowserWindow, shell } from "electron";
-import { env } from "main/env.main";
 import { loadReactDevToolsExtension } from "main/lib/extensions";
 import { PLATFORM } from "shared/constants";
 import { makeAppId } from "shared/utils";
@@ -69,17 +68,18 @@ if (PLATFORM.IS_MAC) {
 
 PLATFORM.IS_WINDOWS &&
 	app.setAppUserModelId(
-		env.NODE_ENV === "development" ? process.execPath : makeAppId(),
+		process.env.NODE_ENV === "development" ? process.execPath : makeAppId(),
 	);
 
 app.commandLine.appendSwitch("force-color-profile", "srgb");
 
-// Only expose CDP in development when a port is explicitly configured.
-const cdpPort =
-	env.NODE_ENV === "development"
-		? process.env.DESKTOP_AUTOMATION_PORT
-		: undefined;
-if (cdpPort) {
-	app.commandLine.appendSwitch("remote-debugging-port", cdpPort);
-	app.commandLine.appendSwitch("remote-allow-origins", "*");
-}
+// Always expose CDP on a loopback port so the browser-mcp bridge can
+// hand external browser automation MCPs (chrome-devtools-mcp,
+// browser-use, playwright-mcp, …) a filtered per-pane CDP endpoint.
+// DESKTOP_AUTOMATION_PORT overrides the random-port default for the
+// existing desktop-automation integration. `*` here is safe because
+// the actual gate is at the browser-mcp-bridge proxy level
+// (token-authenticated, loopback-only).
+const cdpPort = process.env.DESKTOP_AUTOMATION_PORT ?? "0";
+app.commandLine.appendSwitch("remote-debugging-port", cdpPort);
+app.commandLine.appendSwitch("remote-allow-origins", "*");

--- a/apps/desktop/src/main/lib/browser-mcp-bridge/cdp-port.ts
+++ b/apps/desktop/src/main/lib/browser-mcp-bridge/cdp-port.ts
@@ -1,0 +1,55 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { app } from "electron";
+
+/**
+ * Resolve the port Chromium chose for `--remote-debugging-port=0`.
+ *
+ * When Chromium opens the CDP server it writes a file called
+ * `DevToolsActivePort` in the user data directory. Its first line is
+ * the assigned port number. We read that file with a small retry so
+ * the resolution works even if callers query before Chromium has
+ * finished writing it (the file appears after `app.whenReady()` but
+ * right around the same time startBrowserMcpBridge fires).
+ */
+const DEVTOOLS_FILE = "DevToolsActivePort";
+
+async function sleep(ms: number): Promise<void> {
+	return new Promise((resolve) => {
+		setTimeout(resolve, ms);
+	});
+}
+
+function readOnce(): number | null {
+	const path = join(app.getPath("userData"), DEVTOOLS_FILE);
+	if (!existsSync(path)) return null;
+	try {
+		const contents = readFileSync(path, "utf8").trim();
+		if (!contents) return null;
+		const firstLine = contents.split(/\r?\n/, 1)[0]?.trim();
+		if (!firstLine) return null;
+		const port = Number.parseInt(firstLine, 10);
+		return Number.isFinite(port) && port > 0 ? port : null;
+	} catch {
+		return null;
+	}
+}
+
+export async function resolveCdpPort(
+	timeoutMs = 5_000,
+): Promise<number | null> {
+	// When DESKTOP_AUTOMATION_PORT is explicitly set, trust it — Chromium
+	// is using that exact port, no file lookup needed.
+	const envPort = process.env.DESKTOP_AUTOMATION_PORT;
+	if (envPort) {
+		const parsed = Number.parseInt(envPort, 10);
+		if (Number.isFinite(parsed) && parsed > 0) return parsed;
+	}
+	const deadline = Date.now() + timeoutMs;
+	let port = readOnce();
+	while (!port && Date.now() < deadline) {
+		await sleep(100);
+		port = readOnce();
+	}
+	return port;
+}

--- a/apps/desktop/src/main/lib/browser-mcp-bridge/server.ts
+++ b/apps/desktop/src/main/lib/browser-mcp-bridge/server.ts
@@ -10,6 +10,7 @@ import { dirname, join } from "node:path";
 import { app } from "electron";
 import { SUPERSET_HOME_DIR } from "../app-environment";
 import { browserManager } from "../browser/browser-manager";
+import { resolveCdpPort } from "./cdp-port";
 import { getBoundPaneForSession, resolvePpidToSession } from "./pane-resolver";
 
 /**
@@ -125,6 +126,41 @@ export async function startBrowserMcpBridge(): Promise<BridgeHandle> {
 
 			if (req.method === "POST" && url.pathname === "/mcp/register") {
 				return send(res, 200, { ok: true });
+			}
+
+			if (req.method === "GET" && url.pathname === "/mcp/cdp-endpoint") {
+				const resolved = await resolvePaneFromRequest(req);
+				if ("error" in resolved)
+					return send(res, resolved.status, { error: resolved.error });
+				const targetId = browserManager.getCdpTargetId(resolved.paneId);
+				if (!targetId) {
+					return send(res, 503, {
+						error:
+							"CDP targetId for this pane has not been captured yet. Give the pane a moment to finish loading and retry.",
+					});
+				}
+				const cdpPort = await resolveCdpPort();
+				if (!cdpPort) {
+					return send(res, 503, {
+						error:
+							"Chromium CDP port is not available. This build did not start with --remote-debugging-port.",
+					});
+				}
+				const wc = browserManager.getWebContents(resolved.paneId);
+				return send(res, 200, {
+					paneId: resolved.paneId,
+					sessionId: resolved.sessionId,
+					targetId,
+					cdpPort,
+					httpBase: `http://127.0.0.1:${cdpPort}`,
+					webSocketDebuggerUrl: `ws://127.0.0.1:${cdpPort}/devtools/page/${targetId}`,
+					url: wc?.getURL() ?? null,
+					title: wc?.getTitle() ?? null,
+					// PR2 will wrap this behind a pane-filter proxy so other panes
+					// are invisible to the external MCP. For PR1 the endpoint is
+					// the raw Chromium CDP — callers see every target.
+					filtered: false,
+				});
 			}
 
 			if (req.method === "GET" && url.pathname === "/mcp/binding") {

--- a/apps/desktop/src/main/lib/browser/browser-manager.ts
+++ b/apps/desktop/src/main/lib/browser/browser-manager.ts
@@ -126,6 +126,10 @@ class BrowserManager extends EventEmitter {
 			}
 		}
 		this.paneWebContentsIds.set(paneId, webContentsId);
+		// Invalidate any stale targetId captured from a previous
+		// webContents so /mcp/cdp-endpoint never returns a URL pointing
+		// at a dead target while the async recapture is in flight.
+		this.paneTargetIds.delete(paneId);
 		const wc = webContents.fromId(webContentsId);
 		if (wc) {
 			// Keep throttling enabled so parked/offscreen persistent webviews don't
@@ -263,6 +267,7 @@ class BrowserManager extends EventEmitter {
 		wc: Electron.WebContents,
 	): Promise<void> {
 		if (wc.isDestroyed()) return;
+		const expectedWebContentsId = wc.id;
 		let attachedHere = false;
 		try {
 			if (!wc.debugger.isAttached()) {
@@ -273,7 +278,15 @@ class BrowserManager extends EventEmitter {
 				targetInfo?: { targetId?: string };
 			};
 			const targetId = info?.targetInfo?.targetId;
-			if (typeof targetId === "string" && targetId.length > 0) {
+			// Late-resolution guard: if the pane was unregistered or
+			// re-registered with a different webContents while we were
+			// awaiting, do not overwrite the current cache with stale data.
+			const currentId = this.paneWebContentsIds.get(paneId);
+			if (
+				typeof targetId === "string" &&
+				targetId.length > 0 &&
+				currentId === expectedWebContentsId
+			) {
 				this.paneTargetIds.set(paneId, targetId);
 			}
 		} catch (error) {

--- a/apps/desktop/src/main/lib/browser/browser-manager.ts
+++ b/apps/desktop/src/main/lib/browser/browser-manager.ts
@@ -85,6 +85,15 @@ function getChromeLikeUserAgent(userAgent: string): string {
 
 class BrowserManager extends EventEmitter {
 	private paneWebContentsIds = new Map<string, number>();
+	/**
+	 * Chromium CDP targetId for each pane's webview, captured once per
+	 * register(). The browser-mcp bridge uses this to hand out a
+	 * per-pane `ws://…/devtools/page/<targetId>` URL without probing
+	 * `/json/list` on every tool call. Stable for the lifetime of the
+	 * underlying webContents.
+	 */
+	private paneTargetIds = new Map<string, string>();
+	private paneIdMarkerListeners = new Map<string, () => void>();
 	private consoleLogs = new Map<string, ConsoleEntry[]>();
 	private consoleListeners = new Map<string, () => void>();
 	private contextMenuListeners = new Map<string, () => void>();
@@ -156,6 +165,8 @@ class BrowserManager extends EventEmitter {
 			this.setupConsoleCapture(paneId, wc);
 			this.setupContextMenu(paneId, wc);
 			this.setupFindInPage(paneId, wc);
+			this.setupPaneIdMarker(paneId, wc);
+			void this.captureCdpTargetId(paneId, wc);
 		}
 	}
 
@@ -166,6 +177,7 @@ class BrowserManager extends EventEmitter {
 			this.fullscreenListeners,
 			this.popupListeners,
 			this.findListeners,
+			this.paneIdMarkerListeners,
 		]) {
 			const cleanup = map.get(paneId);
 			if (cleanup) {
@@ -177,6 +189,7 @@ class BrowserManager extends EventEmitter {
 			this.fullscreenPaneId = null;
 		}
 		this.paneWebContentsIds.delete(paneId);
+		this.paneTargetIds.delete(paneId);
 		this.consoleLogs.delete(paneId);
 	}
 
@@ -192,6 +205,91 @@ class BrowserManager extends EventEmitter {
 		const wc = webContents.fromId(id);
 		if (!wc || wc.isDestroyed()) return null;
 		return wc;
+	}
+
+	/**
+	 * Chromium CDP targetId for the pane's webview, or null if we have
+	 * not finished capturing it yet. The browser-mcp bridge uses this to
+	 * hand external automation MCPs a per-pane ws://.../devtools/page/<id>
+	 * URL.
+	 */
+	getCdpTargetId(paneId: string): string | null {
+		return this.paneTargetIds.get(paneId) ?? null;
+	}
+
+	listPanesWithCdpTargets(): Array<{ paneId: string; targetId: string }> {
+		return Array.from(this.paneTargetIds.entries()).map(
+			([paneId, targetId]) => ({ paneId, targetId }),
+		);
+	}
+
+	/**
+	 * Inject `window.__supersetPaneId = '<paneId>'` into every top frame
+	 * of this pane, including after navigation. External CDP clients
+	 * (chrome-devtools-mcp etc.) that enumerate /json/list use this as
+	 * the ground-truth pane identifier via Runtime.evaluate.
+	 */
+	private setupPaneIdMarker(paneId: string, wc: Electron.WebContents): void {
+		const literal = JSON.stringify(paneId);
+		const inject = (): void => {
+			if (wc.isDestroyed()) return;
+			// executeJavaScript returns a promise we don't need to await.
+			void wc
+				.executeJavaScript(`window.__supersetPaneId = ${literal};`, false)
+				.catch(() => {
+					/* Pages like about:blank or in the middle of a redirect
+					   can reject — retry on the next did-navigate. */
+				});
+		};
+		wc.on("did-navigate", inject);
+		wc.on("did-navigate-in-page", inject);
+		wc.on("did-finish-load", inject);
+		inject();
+		this.paneIdMarkerListeners.set(paneId, () => {
+			wc.off("did-navigate", inject);
+			wc.off("did-navigate-in-page", inject);
+			wc.off("did-finish-load", inject);
+		});
+	}
+
+	/**
+	 * Briefly attach the Electron CDP debugger to this pane so we can
+	 * read `Target.getTargetInfo` and remember the Chromium-assigned
+	 * targetId. Detach right after so we do not conflict with external
+	 * CDP clients the user wires up later.
+	 */
+	private async captureCdpTargetId(
+		paneId: string,
+		wc: Electron.WebContents,
+	): Promise<void> {
+		if (wc.isDestroyed()) return;
+		let attachedHere = false;
+		try {
+			if (!wc.debugger.isAttached()) {
+				wc.debugger.attach("1.3");
+				attachedHere = true;
+			}
+			const info = (await wc.debugger.sendCommand("Target.getTargetInfo")) as {
+				targetInfo?: { targetId?: string };
+			};
+			const targetId = info?.targetInfo?.targetId;
+			if (typeof targetId === "string" && targetId.length > 0) {
+				this.paneTargetIds.set(paneId, targetId);
+			}
+		} catch (error) {
+			console.warn(
+				`[browser-manager] failed to capture CDP targetId for pane ${paneId}:`,
+				error,
+			);
+		} finally {
+			if (attachedHere) {
+				try {
+					wc.debugger.detach();
+				} catch {
+					/* already detached */
+				}
+			}
+		}
 	}
 
 	getPaneIdForWebContents(webContentsId: number): string | null {

--- a/packages/superset-browser-mcp/src/tools/index.ts
+++ b/packages/superset-browser-mcp/src/tools/index.ts
@@ -9,6 +9,18 @@ interface BindingResponse {
 	title: string | null;
 }
 
+interface CdpEndpointResponse {
+	paneId: string;
+	sessionId: string;
+	targetId: string;
+	cdpPort: number;
+	httpBase: string;
+	webSocketDebuggerUrl: string;
+	url: string | null;
+	title: string | null;
+	filtered: boolean;
+}
+
 /**
  * This MCP is intentionally kept minimal. The plan (see ./plan.md in
  * the repo root) is to expose the bound pane as a filtered CDP endpoint
@@ -18,6 +30,37 @@ interface BindingResponse {
  * endpoint itself ships in follow-up PRs.
  */
 export function registerTools(server: McpServer, client: BridgeClient): void {
+	server.registerTool(
+		"get_cdp_endpoint",
+		{
+			title: "Get CDP endpoint for the bound browser pane",
+			description:
+				"Return the Chrome DevTools Protocol (CDP) endpoint for the currently bound browser pane. Plug the returned `webSocketDebuggerUrl` (or `httpBase`) into any browser automation MCP that speaks CDP — chrome-devtools-mcp, browser-use, playwright-mcp, etc. — to drive the pane directly. PR1 stage: the endpoint is the raw Chromium CDP, so external tools will see every page target; a filter proxy is planned for the next PR.",
+			inputSchema: {},
+		},
+		async () => {
+			const data = await client.request<CdpEndpointResponse>(
+				"GET",
+				"/mcp/cdp-endpoint",
+			);
+			const summary = [
+				`CDP endpoint for pane ${data.paneId} (target ${data.targetId}):`,
+				`  wsEndpoint : ${data.webSocketDebuggerUrl}`,
+				`  httpBase   : ${data.httpBase}`,
+				data.url ? `  current URL: ${data.url}` : undefined,
+				data.title ? `  title      : ${data.title}` : undefined,
+				data.filtered
+					? ""
+					: "  NOTE: This endpoint exposes the full Chromium instance, not just this pane. Filter proxy is coming in a follow-up release.",
+			]
+				.filter(Boolean)
+				.join("\n");
+			return {
+				content: [{ type: "text", text: summary }],
+			};
+		},
+	);
+
 	server.registerTool(
 		"get_connected_pane",
 		{


### PR DESCRIPTION
## Summary

plan.md の **PR1**: browser pane を Chromium CDP targetId 単位でアドレスできるようにし、chrome-devtools-mcp / browser-use / playwright-mcp 等の外部ブラウザ自動化 MCP に pane ごとの CDP URL を渡せるようにする。

### 変更点

**app boot** — \`setup.ts\` で \`--remote-debugging-port\` を常時有効化 (\`DESKTOP_AUTOMATION_PORT\` で上書き可、未設定ならランダム port)。dev-only の制限を外して packaged build でも外部 MCP が使えるように。

**port 解決** — \`browser-mcp-bridge/cdp-port.ts\`: Chromium の \`DevToolsActivePort\` file を短いリトライループで読んで実際の port を返す。env 指定時はそれを優先。

**pane → targetId マッピング** — \`BrowserManager.register()\` が:
- \`window.__supersetPaneId = '<paneId>'\` を top frame に注入。did-navigate / did-navigate-in-page / did-finish-load で再注入。
- Electron debugger を一瞬だけ attach → \`Target.getTargetInfo\` で Chromium targetId を取得 → キャッシュ → detach。外部 CDP クライアントと衝突させない。
- 新 API \`getCdpTargetId(paneId)\` / \`listPanesWithCdpTargets()\`。
- unregister() で target id マップと marker listener をクリーンアップ。

**MCP bridge** — \`GET /mcp/cdp-endpoint\` 追加 (PPID → session → paneId → \`{ webSocketDebuggerUrl, httpBase, targetId, paneId, url, title, filtered: false }\`)。\`filtered: false\` は PR2 でフィルタプロキシが入ったら true になる目印。

**MCP tool** — \`get_cdp_endpoint\`: 人間可読な CDP URL ブロックを返し、現状は他 page target も見える旨の注意書きを添付。

### 意図的に今は出さないもの (後続 PR)

- PR2: CDP WebSocket フィルタプロキシ (pane 以外を見せない)
- PR3: UI に \"外部 MCP 接続ガイド\" (CDP URL コピー、chrome-devtools-mcp / browser-use の設定例)
- PR4: 旧自作 tools の最終整理 (今回 plan.md 通り \`get_cdp_endpoint\` + \`get_connected_pane\` のみ残す体制になる予定)

### Test plan

- [ ] dev 起動時 / packaged 起動時ともに \`DevToolsActivePort\` が書かれる
- [ ] \`get_cdp_endpoint\` が起動中 pane の targetId + wsEndpoint を返す
- [ ] 返った wsEndpoint に \`curl http://127.0.0.1:<port>/json/list\` で確認できる
- [ ] \`chrome-devtools-mcp --browser-url <httpBase>\` で接続できる
- [ ] pane で URL 遷移しても targetId は変わらず (webContents 不変)
- [ ] pane を閉じると listPanesWithCdpTargets() から消える