### PR TITLE
feat(desktop): PR3 — surface filtered CDP endpoint in Connect UI

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/browser-automation/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/browser-automation/index.ts
@@ -658,6 +658,61 @@ export const createBrowserAutomationRouter = () => {
 				return installMcp(input.targets, server);
 			}),
 
+		/**
+		 * Resolve the per-session filtered CDP endpoint directly from the
+		 * UI (no MCP round-trip). Used by the Connect dialog to show a
+		 * copy-ready URL and example commands for external browser MCPs.
+		 */
+		getCdpEndpointForSession: publicProcedure
+			.input(z.object({ sessionId: z.string() }))
+			.query(async ({ input }) => {
+				const binding = bindingStore.getBySessionId(input.sessionId);
+				if (!binding) {
+					return { available: false as const, reason: "not-bound" as const };
+				}
+				const { browserManager } = await import(
+					"main/lib/browser/browser-manager"
+				);
+				const targetId = browserManager.getCdpTargetId(binding.paneId);
+				if (!targetId) {
+					return {
+						available: false as const,
+						reason: "target-not-ready" as const,
+					};
+				}
+				const { resolveCdpPort } = await import(
+					"main/lib/browser-mcp-bridge/cdp-port"
+				);
+				const cdpPort = await resolveCdpPort();
+				if (!cdpPort) {
+					return {
+						available: false as const,
+						reason: "cdp-disabled" as const,
+					};
+				}
+				const { mintCdpToken } = await import(
+					"main/lib/browser-mcp-bridge/cdp-filter-proxy"
+				);
+				const token = mintCdpToken(input.sessionId);
+				const handle = (
+					await import("main/lib/browser-mcp-bridge/server")
+				).getBrowserMcpBridge();
+				const bridgePort = handle?.port;
+				if (!bridgePort) {
+					return {
+						available: false as const,
+						reason: "bridge-not-running" as const,
+					};
+				}
+				return {
+					available: true as const,
+					paneId: binding.paneId,
+					targetId,
+					httpBase: `http://127.0.0.1:${bridgePort}/cdp/${token}`,
+					wsEndpoint: `ws://127.0.0.1:${bridgePort}/cdp/${token}/devtools/page/${targetId}`,
+				};
+			}),
+
 		onBindingsChanged: publicProcedure.subscription(() => {
 			return observable<BrowserAutomationBinding[]>((emit) => {
 				emit.next(bindingStore.list());

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/components/SessionConnectModal/SessionConnectModal.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/components/SessionConnectModal/SessionConnectModal.tsx
@@ -20,6 +20,7 @@ import {
 	useBrowserAutomationStore,
 } from "renderer/stores/browser-automation";
 import { useTabsStore } from "renderer/stores/tabs/store";
+import { CdpEndpointCard } from "./components/CdpEndpointCard";
 import { McpInstallPanel } from "./components/McpInstallPanel";
 
 interface SessionConnectModalProps {
@@ -242,6 +243,7 @@ export function SessionConnectModal({
 											? (panes[assignedPaneIdForSelected]?.name ?? null)
 											: null
 									}
+									attachedToThisPane={session.id === currentBinding}
 								/>
 							) : (
 								<SetupPanel
@@ -414,21 +416,26 @@ function ReadyPanel({
 	paneName,
 	reassigning,
 	previousPaneName,
+	attachedToThisPane,
 }: {
 	session: AutomationSession;
 	paneName: string;
 	reassigning: boolean;
 	previousPaneName: string | null;
+	attachedToThisPane: boolean;
 }) {
 	return (
 		<div className="flex flex-col gap-3">
 			<div className="rounded-xl border p-3 bg-card/60">
 				<div className="text-xs font-semibold">
-					Selected session is ready to connect
+					{attachedToThisPane
+						? "Session is attached to this pane"
+						: "Selected session is ready to connect"}
 				</div>
 				<div className="mt-1 text-[11px] text-muted-foreground leading-relaxed">
-					This session already has the browser automation MCP entry, so the
-					connect action will immediately bind the pane to this owner.
+					{attachedToThisPane
+						? "Drive the pane from this session by pointing an external browser MCP at the CDP endpoint below."
+						: "This session already has the browser automation MCP entry, so the connect action will immediately bind the pane to this owner."}
 				</div>
 				<div className="mt-3 grid grid-cols-2 gap-2">
 					<DetailItem label="Owner">
@@ -443,6 +450,7 @@ function ReadyPanel({
 					</DetailItem>
 				</div>
 			</div>
+			{attachedToThisPane && <CdpEndpointCard sessionId={session.id} />}
 		</div>
 	);
 }

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/components/SessionConnectModal/components/CdpEndpointCard/CdpEndpointCard.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/components/SessionConnectModal/components/CdpEndpointCard/CdpEndpointCard.tsx
@@ -1,0 +1,161 @@
+import { Button } from "@superset/ui/button";
+import { toast } from "@superset/ui/sonner";
+import { LuCopy, LuExternalLink } from "react-icons/lu";
+import { electronTrpc } from "renderer/lib/electron-trpc";
+
+interface CdpEndpointCardProps {
+	sessionId: string;
+}
+
+/**
+ * Shows the filtered CDP endpoint for the pane bound to this LLM
+ * session, plus copy-ready setup commands for the common external
+ * browser-automation MCPs (chrome-devtools-mcp, browser-use,
+ * playwright-mcp). The whole point of the pane↔session binding is to
+ * delegate actual browser control to those tools, so this is the
+ * primary success-state UI once a pane is attached.
+ */
+export function CdpEndpointCard({ sessionId }: CdpEndpointCardProps) {
+	const { data, isLoading } =
+		electronTrpc.browserAutomation.getCdpEndpointForSession.useQuery(
+			{ sessionId },
+			{ refetchInterval: 5_000 },
+		);
+
+	const copy = async (value: string, label: string): Promise<void> => {
+		try {
+			await navigator.clipboard.writeText(value);
+			toast.success(`${label} copied`);
+		} catch {
+			toast.error(`Failed to copy ${label.toLowerCase()}`);
+		}
+	};
+
+	if (isLoading) {
+		return (
+			<div className="rounded-xl border p-3 bg-card/60 text-xs text-muted-foreground">
+				Resolving CDP endpoint…
+			</div>
+		);
+	}
+	if (!data || !data.available) {
+		const reason =
+			data?.reason === "target-not-ready"
+				? "Chromium has not finished attaching to this pane yet. Reload the pane and retry."
+				: data?.reason === "cdp-disabled"
+					? "This build did not enable --remote-debugging-port."
+					: data?.reason === "bridge-not-running"
+						? "The browser-mcp bridge is not running yet."
+						: "Bind a pane first to expose a CDP endpoint.";
+		return (
+			<div className="rounded-xl border p-3 bg-card/60">
+				<div className="text-xs font-semibold">CDP endpoint unavailable</div>
+				<div className="mt-1 text-[11px] text-muted-foreground leading-relaxed">
+					{reason}
+				</div>
+			</div>
+		);
+	}
+
+	const chromeDevtoolsCmd = `claude mcp add chrome-devtools-mcp -s user -- npx -y chrome-devtools-mcp --browser-url ${data.httpBase}`;
+	const browserUseCmd = `browser-use --cdp-url ${data.wsEndpoint}`;
+
+	return (
+		<div className="rounded-xl border p-3 bg-card/60 flex flex-col gap-3">
+			<div>
+				<div className="text-xs font-semibold">
+					External browser MCP endpoint
+				</div>
+				<div className="mt-1 text-[11px] text-muted-foreground leading-relaxed">
+					This session is bound to pane{" "}
+					<code className="rounded bg-muted px-1">{data.paneId}</code>. Point
+					any CDP-speaking browser MCP (chrome-devtools-mcp / browser-use /
+					playwright-mcp) at the URL below — it only exposes this pane.
+				</div>
+			</div>
+
+			<UrlRow
+				label="WebSocket"
+				value={data.wsEndpoint}
+				onCopy={() => copy(data.wsEndpoint, "WebSocket URL")}
+			/>
+			<UrlRow
+				label="HTTP base"
+				value={data.httpBase}
+				onCopy={() => copy(data.httpBase, "HTTP URL")}
+			/>
+
+			<div className="mt-1">
+				<div className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/70 mb-1">
+					Example setup
+				</div>
+				<CommandBlock
+					title="chrome-devtools-mcp (Claude Code)"
+					cmd={chromeDevtoolsCmd}
+					onCopy={() => copy(chromeDevtoolsCmd, "chrome-devtools-mcp command")}
+				/>
+				<CommandBlock
+					title="browser-use"
+					cmd={browserUseCmd}
+					onCopy={() => copy(browserUseCmd, "browser-use command")}
+				/>
+			</div>
+
+			<div className="text-[10px] text-muted-foreground flex items-start gap-1">
+				<LuExternalLink className="size-3 mt-0.5 shrink-0" />
+				<span>
+					Chrome DevTools Protocol is exposed via a per-session filter proxy, so
+					external tools never see sibling panes or the workspace shell.
+				</span>
+			</div>
+		</div>
+	);
+}
+
+function UrlRow({
+	label,
+	value,
+	onCopy,
+}: {
+	label: string;
+	value: string;
+	onCopy: () => void;
+}) {
+	return (
+		<div className="flex items-center gap-2">
+			<span className="text-[10px] uppercase tracking-wider text-muted-foreground/70 w-20 shrink-0">
+				{label}
+			</span>
+			<code className="flex-1 rounded bg-muted px-2 py-1 text-[11px] truncate">
+				{value}
+			</code>
+			<Button size="sm" variant="outline" onClick={onCopy}>
+				<LuCopy className="size-3" />
+			</Button>
+		</div>
+	);
+}
+
+function CommandBlock({
+	title,
+	cmd,
+	onCopy,
+}: {
+	title: string;
+	cmd: string;
+	onCopy: () => void;
+}) {
+	return (
+		<div className="mt-2">
+			<div className="text-[11px] font-medium">{title}</div>
+			<div className="mt-1 flex items-center gap-2">
+				<pre className="flex-1 rounded-md border bg-black/40 p-2 text-[11px] leading-relaxed whitespace-pre-wrap break-words">
+					{cmd}
+				</pre>
+				<Button size="sm" variant="outline" onClick={onCopy}>
+					<LuCopy className="size-3" />
+				</Button>
+			</div>
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/components/SessionConnectModal/components/CdpEndpointCard/index.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/components/SessionConnectModal/components/CdpEndpointCard/index.ts
@@ -1,0 +1,1 @@
+export { CdpEndpointCard } from "./CdpEndpointCard";


### PR DESCRIPTION
## Summary

plan.md の **PR3**: バインド済み session に対して、外部ブラウザ自動化 MCP (chrome-devtools-mcp / browser-use / playwright-mcp) をワンクリックで登録できるよう、filter proxy の URL と代表的な起動コマンドを Connect モーダル内に表示する。

### 追加

- tRPC \`browserAutomation.getCdpEndpointForSession({sessionId})\`
  - binding → targetId → bridge port を参照、mintCdpToken で token 発行、httpBase / wsEndpoint を返す
  - available=false ケースも reason 付き (\`not-bound\` / \`target-not-ready\` / \`cdp-disabled\` / \`bridge-not-running\`)
- UI: \`CdpEndpointCard\`
  - \`WebSocket URL\` / \`HTTP base\` の表示 + コピーボタン
  - chrome-devtools-mcp 用: \`claude mcp add chrome-devtools-mcp -s user -- npx -y chrome-devtools-mcp --browser-url <httpBase>\` をコピーボタン付き表示
  - browser-use 用: \`browser-use --cdp-url <wsEndpoint>\`
  - filter proxy 経由であることの注意書き
- \`ReadyPanel\`: 選択中の session が既に **この pane に attached** なら CdpEndpointCard を下に挿入。文言も attached 用に分岐

### Test plan

- [ ] Connect → session を bind → モーダルが開いたままだと CdpEndpointCard が \`Attached\` 状態に切り替わる
- [ ] WebSocket URL コピー → curl で \`/json/list\` 叩くと bound pane が 1 件
- [ ] chrome-devtools-mcp 登録コマンドをコピー → ターミナルで実行 → 別 Claude から pane が操作できる
- [ ] 別 pane に rebind すると CdpEndpointCard の URL の backing targetId が切り替わる (次の接続から)
- [ ] 未バインドセッションでは available=false + 理由表示

### 残り

PR4: 旧自作 tools の最終整理 (legacy \`desktop-mcp\` / \`evaluate_js\` 等の参照箇所を落とす)