### PR TITLE
fix(desktop): detect claude/codex CLIs running as node

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/browser-automation/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/browser-automation/index.ts
@@ -13,7 +13,11 @@ import { observable } from "@trpc/server/observable";
 import { and, eq, ne } from "drizzle-orm";
 import { app } from "electron";
 import { localDb } from "main/lib/local-db";
-import { getProcessName, getProcessTree } from "main/lib/terminal/port-scanner";
+import {
+	getProcessCommand,
+	getProcessName,
+	getProcessTree,
+} from "main/lib/terminal/port-scanner";
 import { getTerminalHostClient } from "main/lib/terminal-host/client";
 import { z } from "zod";
 import { publicProcedure, router } from "../..";
@@ -414,29 +418,61 @@ async function detectTerminalAgentSessions(): Promise<TerminalAgentSession[]> {
 		sessions.map(async (s) => {
 			if (!s.isAlive || typeof s.pid !== "number") return;
 			const pids = await getProcessTree(s.pid);
-			// Skip the shell itself (root pid) when matching names so typing
-			// `claude` at the prompt inside zsh does not cause the shell's
-			// argv to trigger a match.
-			const names = await Promise.all(
+			// Skip the shell itself (root pid). For each child we read BOTH
+			// comm (short name) AND args (full argv). Many claude / codex
+			// installs appear as comm=node with args=node /usr/local/.../claude,
+			// so a comm-only match misses them.
+			const probes = await Promise.all(
 				pids
 					.filter((p) => p !== s.pid)
-					.map(async (p) => ({ pid: p, name: await getProcessName(p) })),
+					.map(async (p) => {
+						const [name, command] = await Promise.all([
+							getProcessName(p),
+							getProcessCommand(p),
+						]);
+						return { pid: p, name, command };
+					}),
 			);
-			const match = names.find(
-				({ name }) => name === "claude" || name === "codex",
-			);
+			const match = probes.find((p) => classifyAgent(p.name, p.command));
 			if (!match) return;
+			const provider = classifyAgent(match.name, match.command);
+			if (!provider) return;
 			out.push({
 				paneId: s.paneId,
 				workspaceId: s.workspaceId,
 				pid: match.pid,
-				provider: match.name === "codex" ? "Codex" : "Claude",
+				provider,
 				command: match.name,
 				lastAttachedAt: s.lastAttachedAt,
 			});
 		}),
 	);
 	return out;
+}
+
+/**
+ * Is the process a `claude` or `codex` CLI? Checks both the short
+ * process name and the full argv. The CLIs are commonly installed as
+ * thin wrappers that `exec node /path/to/bin/claude ...`, which makes
+ * the short name "node" — argv catches that.
+ */
+function classifyAgent(
+	name: string,
+	command: string,
+): "Claude" | "Codex" | null {
+	const lname = name.toLowerCase();
+	if (lname === "codex") return "Codex";
+	if (lname === "claude") return "Claude";
+	// Fall back to argv matching. Only accept tokens whose basename is
+	// exactly claude / codex (so a random node script that has "claude"
+	// as a substring does not match).
+	const tokens = command.split(/\s+/).filter(Boolean);
+	for (const token of tokens) {
+		const base = token.replace(/\\/g, "/").split("/").pop() ?? token;
+		if (base === "codex" || base === "codex.js") return "Codex";
+		if (base === "claude" || base === "claude.js") return "Claude";
+	}
+	return null;
 }
 
 /**

--- a/apps/desktop/src/main/lib/browser-mcp-bridge/pane-resolver.ts
+++ b/apps/desktop/src/main/lib/browser-mcp-bridge/pane-resolver.ts
@@ -1,4 +1,8 @@
-import { getProcessName, getProcessTree } from "main/lib/terminal/port-scanner";
+import {
+	getProcessCommand,
+	getProcessName,
+	getProcessTree,
+} from "main/lib/terminal/port-scanner";
 import { getTerminalHostClient } from "main/lib/terminal-host/client";
 import { bindingStore } from "../../../lib/trpc/routers/browser-automation/index";
 
@@ -52,8 +56,20 @@ async function resolveFromTerminalPanes(
 		try {
 			const tree = await getProcessTree(s.pid);
 			if (!tree.includes(ppid)) continue;
-			const name = await getProcessName(ppid).catch(() => "");
-			if (name === "claude" || name === "codex" || name.includes("node")) {
+			// Accept the pane if our parent looks like claude / codex
+			// (either directly, or as a node-wrapped CLI we can spot by
+			// argv). comm alone is not enough because node CLIs commonly
+			// appear as comm=node with the real entrypoint in argv.
+			const [name, command] = await Promise.all([
+				getProcessName(ppid).catch(() => ""),
+				getProcessCommand(ppid).catch(() => ""),
+			]);
+			const lname = name.toLowerCase();
+			const looksAgent =
+				lname === "claude" ||
+				lname === "codex" ||
+				/\b(claude|codex)(?:\.js)?\b/.test(command);
+			if (looksAgent || lname.includes("node")) {
 				return {
 					sessionId: `terminal:${s.paneId}`,
 					kind: "terminal",

--- a/apps/desktop/src/main/lib/terminal/port-scanner.ts
+++ b/apps/desktop/src/main/lib/terminal/port-scanner.ts
@@ -243,3 +243,33 @@ export async function getProcessName(pid: number): Promise<string> {
 		return "unknown";
 	}
 }
+
+/**
+ * Full argv of a process (space-joined). Useful when `comm` alone is
+ * ambiguous — e.g. the `claude` / `codex` CLIs often appear under
+ * `comm=node` because they are spawned as `node /path/to/bin/claude …`.
+ */
+export async function getProcessCommand(pid: number): Promise<string> {
+	const platform = os.platform();
+	if (platform === "win32") {
+		try {
+			const { stdout } = await execAsync(
+				`wmic process where processid=${pid} get commandline 2>nul`,
+				{ timeout: EXEC_TIMEOUT_MS },
+			);
+			const lines = stdout.trim().split("\n");
+			return lines.length >= 2 ? lines.slice(1).join(" ").trim() : "";
+		} catch {
+			return "";
+		}
+	}
+	try {
+		const { stdout } = await execAsync(
+			`ps -p ${pid} -o args= 2>/dev/null || true`,
+			{ timeout: EXEC_TIMEOUT_MS },
+		);
+		return stdout.trim();
+	} catch {
+		return "";
+	}
+}


### PR DESCRIPTION
## 問題

Superset のターミナル pane で \`claude\` / \`codex\` を起動しても、Connect モーダルの Running sessions に出てこなかった。原因は CLI の実体が \`node /…/bin/claude\` のようなシム経由で、\`ps -o comm=\` が \`node\` を返し、現状の検出 (\`comm === \"claude\" | \"codex\"\`) を通らなかったこと。

## 修正

- \`port-scanner\` に \`getProcessCommand(pid)\` を追加。macOS/Linux は \`ps -o args=\`、Windows は \`wmic\` で full argv を返す。
- \`detectTerminalAgentSessions\`: 各子孫プロセスに対し comm と argv の両方を見る。短い名前が \`claude\` / \`codex\` で一致、または argv のトークンの basename が \`claude\` / \`codex\` と完全一致する場合に該当とみなす。偶然パスに含まれる文字列は拾わない。
- \`pane-resolver\`: MCP の PPID が node シムの場合でも argv 経由で agent として認識し、bound pane に解決できるように。

## Test plan

- [ ] \`claude --dangerously-skip-permissions\` で起動している Superset 内ターミナル pane が Running sessions に出る
- [ ] \`codex\` を起動したターミナル pane も同様に出る
- [ ] 関係ない node プロセス (例: vite dev server) は出ない
- [ ] Connect 実行後、/mcp/cdp-endpoint が 200 を返す