### PR TITLE
feat(desktop): 固定グローバルCDPゲートウェイ + ペイン内複数タブ (一度mcp addで永続、再起動・再アタッチ全耐性)

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/browser-automation/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/browser-automation/index.ts
@@ -726,16 +726,31 @@ export const createBrowserAutomationRouter = () => {
 						reason: "cdp-disabled" as const,
 					};
 				}
-				const { ensureSessionEndpoint, getBrowserUseConfigPath } =
-					await import("main/lib/browser-mcp-bridge/cdp-filter-proxy");
-				const sessionPort = await ensureSessionEndpoint(input.sessionId);
+				const { getBrowserMcpBridge } = await import(
+					"main/lib/browser-mcp-bridge/server"
+				);
+				const { getGlobalBrowserUseConfigPath } = await import(
+					"main/lib/browser-mcp-bridge/cdp-gateway"
+				);
+				const bridge = getBrowserMcpBridge();
+				if (!bridge) {
+					return {
+						available: false as const,
+						reason: "bridge-not-running" as const,
+					};
+				}
+				// The URL is the same for every LLM session; per-connection
+				// peer-PID resolution is how the gateway knows which pane
+				// to route to. That is why registering these MCPs once is
+				// enough even across Superset restarts, pane rebindings,
+				// and new terminal panes.
 				return {
 					available: true as const,
 					paneId: binding.paneId,
 					targetId,
-					httpBase: `http://127.0.0.1:${sessionPort}`,
-					wsEndpoint: `ws://127.0.0.1:${sessionPort}/devtools/page/${targetId}`,
-					browserUseConfigPath: getBrowserUseConfigPath(input.sessionId),
+					httpBase: `http://127.0.0.1:${bridge.port}`,
+					wsEndpoint: `ws://127.0.0.1:${bridge.port}/devtools/page/${targetId}`,
+					browserUseConfigPath: getGlobalBrowserUseConfigPath(),
 				};
 			}),
 

--- a/apps/desktop/src/lib/trpc/routers/browser-automation/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/browser-automation/index.ts
@@ -726,9 +726,8 @@ export const createBrowserAutomationRouter = () => {
 						reason: "cdp-disabled" as const,
 					};
 				}
-				const { ensureSessionEndpoint } = await import(
-					"main/lib/browser-mcp-bridge/cdp-filter-proxy"
-				);
+				const { ensureSessionEndpoint, getBrowserUseConfigPath } =
+					await import("main/lib/browser-mcp-bridge/cdp-filter-proxy");
 				const sessionPort = await ensureSessionEndpoint(input.sessionId);
 				return {
 					available: true as const,
@@ -736,6 +735,7 @@ export const createBrowserAutomationRouter = () => {
 					targetId,
 					httpBase: `http://127.0.0.1:${sessionPort}`,
 					wsEndpoint: `ws://127.0.0.1:${sessionPort}/devtools/page/${targetId}`,
+					browserUseConfigPath: getBrowserUseConfigPath(input.sessionId),
 				};
 			}),
 

--- a/apps/desktop/src/lib/trpc/routers/browser/browser.ts
+++ b/apps/desktop/src/lib/trpc/routers/browser/browser.ts
@@ -63,15 +63,9 @@ export const createBrowserRouter = () => {
 			.subscription(({ input }) => {
 				return observable<{ url: string }>((emit) => {
 					const handler = (data: { url: string }) => emit.next(data);
-					browserManager.on(
-						`create-tab-requested:${input.paneId}`,
-						handler,
-					);
+					browserManager.on(`create-tab-requested:${input.paneId}`, handler);
 					return () => {
-						browserManager.off(
-							`create-tab-requested:${input.paneId}`,
-							handler,
-						);
+						browserManager.off(`create-tab-requested:${input.paneId}`, handler);
 					};
 				});
 			}),

--- a/apps/desktop/src/lib/trpc/routers/browser/browser.ts
+++ b/apps/desktop/src/lib/trpc/routers/browser/browser.ts
@@ -26,6 +26,56 @@ export const createBrowserRouter = () => {
 				return { success: true };
 			}),
 
+		registerTab: publicProcedure
+			.input(
+				z.object({
+					paneId: z.string(),
+					tabId: z.string(),
+					webContentsId: z.number(),
+				}),
+			)
+			.mutation(({ input }) => {
+				browserManager.registerTab(
+					input.paneId,
+					input.tabId,
+					input.webContentsId,
+				);
+				return { success: true };
+			}),
+
+		unregisterTab: publicProcedure
+			.input(z.object({ paneId: z.string(), tabId: z.string() }))
+			.mutation(({ input }) => {
+				browserManager.unregisterTab(input.paneId, input.tabId);
+				return { success: true };
+			}),
+
+		/**
+		 * Subscribe to external-create-tab requests for a pane. The CDP
+		 * gateway emits one of these whenever an external MCP issues
+		 * `Target.createTarget`; the renderer-side BrowserPane picks it
+		 * up and creates a real tab in its registry, which then
+		 * registers back via registerTab and populates the pane's tab
+		 * target set.
+		 */
+		onCreateTabRequested: publicProcedure
+			.input(z.object({ paneId: z.string() }))
+			.subscription(({ input }) => {
+				return observable<{ url: string }>((emit) => {
+					const handler = (data: { url: string }) => emit.next(data);
+					browserManager.on(
+						`create-tab-requested:${input.paneId}`,
+						handler,
+					);
+					return () => {
+						browserManager.off(
+							`create-tab-requested:${input.paneId}`,
+							handler,
+						);
+					};
+				});
+			}),
+
 		navigate: publicProcedure
 			.input(z.object({ paneId: z.string(), url: z.string() }))
 			.mutation(({ input }) => {

--- a/apps/desktop/src/main/lib/browser-mcp-bridge/cdp-filter-proxy.ts
+++ b/apps/desktop/src/main/lib/browser-mcp-bridge/cdp-filter-proxy.ts
@@ -438,6 +438,16 @@ async function proxyBrowserUpgrade(
 		// Map outgoing request id → original method so we can filter
 		// responses for Target.getTargets etc. Chromium echoes `id` back.
 		const pendingMethods = new Map<number, string>();
+		// SessionIds we have actually surfaced to the client via
+		// Target.attachedToTarget. After stripping the `filter` from
+		// client-issued Target.setAutoAttach requests (see below),
+		// Chromium auto-attaches to many non-bound targets (other
+		// panes, workers, tab wrappers, …) and emits session-scoped
+		// frames for all of them on this single WS. We drop any
+		// session-scoped frame whose sessionId we never taught the
+		// client, which keeps cross-pane DOM/network/etc. traffic from
+		// leaking.
+		const allowedSessionIds = new Set<string>();
 
 		const closeBoth = (): void => {
 			try {
@@ -482,10 +492,14 @@ async function proxyBrowserUpgrade(
 			} catch {
 				return;
 			}
-			// Session-scoped frames: always forward (Page/DOM/Runtime/etc
-			// speak to an already-attached page).
+			// Session-scoped frames: forward only if the sessionId is
+			// one we surfaced to the client. Otherwise the client is
+			// trying (or has been tricked into) operating on a session
+			// it shouldn't know about.
 			if (msg.sessionId) {
-				sendToUpstream(msg);
+				if (allowedSessionIds.has(msg.sessionId)) {
+					sendToUpstream(msg);
+				}
 				return;
 			}
 			const method = msg.method ?? "";
@@ -507,6 +521,25 @@ async function proxyBrowserUpgrade(
 						`${method} is not permitted by the Superset CDP filter`,
 					);
 				}
+				return;
+			}
+
+			// setAutoAttach: strip the `filter` field so Chromium does
+			// NOT honour a client-side `{type:'page', exclude:true}`
+			// exclusion. Puppeteer (and therefore chrome-devtools-mcp)
+			// sends that filter assuming it will attach to a `tab`
+			// wrapper and then nest-attach to pages. Electron's
+			// embedded Chromium does not always expose that tab
+			// wrapper, so the nested attach never happens and
+			// `puppeteer.connect()` hangs. By stripping the filter we
+			// force a top-level page attach that our downstream Target
+			// event filter keeps scoped to the bound pane.
+			if (method === "Target.setAutoAttach" && id !== undefined) {
+				const original = (msg.params ?? {}) as Record<string, unknown>;
+				const rewritten: Record<string, unknown> = { ...original };
+				if ("filter" in rewritten) delete rewritten.filter;
+				pendingMethods.set(id, method);
+				sendToUpstream({ id, method, params: rewritten });
 				return;
 			}
 
@@ -578,9 +611,16 @@ async function proxyBrowserUpgrade(
 			} catch {
 				return;
 			}
-			// Session-scoped event/response: always forward.
+			// Session-scoped event/response: forward only for sessions
+			// the client knows about. Stripping the setAutoAttach
+			// filter causes Chromium to auto-attach to unrelated
+			// panes/workers/tabs and emit session-scoped frames for
+			// them on this single WS; without this check, their DOM,
+			// network, and runtime events would leak to the client.
 			if (msg.sessionId) {
-				sendToClient(msg);
+				if (allowedSessionIds.has(msg.sessionId)) {
+					sendToClient(msg);
+				}
 				return;
 			}
 
@@ -598,6 +638,10 @@ async function proxyBrowserUpgrade(
 						result: { ...msg.result, targetInfos: filtered },
 					});
 					return;
+				}
+				if (origMethod === "Target.attachToTarget" && msg.result) {
+					const sid = (msg.result as { sessionId?: string }).sessionId;
+					if (sid) allowedSessionIds.add(sid);
 				}
 				if (origMethod === "Target.getTargetInfo" && msg.result?.targetInfo) {
 					if (!isTargetInfoForBound(msg.result.targetInfo, boundTargetId)) {
@@ -631,10 +675,20 @@ async function proxyBrowserUpgrade(
 				return;
 			}
 			if (method === "Target.attachedToTarget") {
-				const tid = (
-					msg.params as { targetInfo?: { targetId?: string } } | undefined
-				)?.targetInfo?.targetId;
+				const params = msg.params as
+					| { sessionId?: string; targetInfo?: { targetId?: string } }
+					| undefined;
+				const tid = params?.targetInfo?.targetId;
 				if (tid !== boundTargetId) return;
+				if (params?.sessionId) allowedSessionIds.add(params.sessionId);
+				sendToClient(msg);
+				return;
+			}
+			if (method === "Target.detachedFromTarget") {
+				const sid = (msg.params as { sessionId?: string } | undefined)
+					?.sessionId;
+				if (!sid || !allowedSessionIds.has(sid)) return;
+				allowedSessionIds.delete(sid);
 				sendToClient(msg);
 				return;
 			}

--- a/apps/desktop/src/main/lib/browser-mcp-bridge/cdp-filter-proxy.ts
+++ b/apps/desktop/src/main/lib/browser-mcp-bridge/cdp-filter-proxy.ts
@@ -1,230 +1,42 @@
 import { randomBytes } from "node:crypto";
-import { chmodSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import {
-	createServer,
-	type IncomingMessage,
-	type Server,
-	type ServerResponse,
-} from "node:http";
-import { dirname, join } from "node:path";
+import type { IncomingMessage, ServerResponse } from "node:http";
 import type { Duplex } from "node:stream";
-import { type RawData, WebSocket, WebSocketServer } from "ws";
-import { bindingStore } from "../../../lib/trpc/routers/browser-automation/index";
-import { SUPERSET_HOME_DIR } from "../app-environment";
+import { type RawData, WebSocket, type WebSocketServer } from "ws";
 import { browserManager } from "../browser/browser-manager";
 import { resolveCdpPort } from "./cdp-port";
 
 /**
- * CDP (Chrome DevTools Protocol) filter proxy — per-session edition.
+ * CDP filter helpers reused by the single-port gateway (cdp-gateway.ts).
  *
- * External browser-automation MCPs (chrome-devtools-mcp / browser-use /
- * playwright-mcp / …) that use puppeteer internally expect a
- * `browserURL = http://host:port` *without* a path. They compose
- * `/json/version` against it, which strips any path prefix. Putting
- * the session token in the path therefore does not survive the client
- * side.
+ * These functions translate a loopback client's browser-level or
+ * page-level CDP session into one that only sees the bound pane's
+ * targets. Session routing lives in the gateway — this module is
+ * concerned with *message-level* filtering once the peer-PID → session
+ * → bound pane lookup has already happened.
  *
- * So instead we give every LLM session its own dedicated loopback
- * HTTP+WS server. The port is persistent per session (saved in
- * `$SUPERSET_HOME_DIR/browser-mcp-sessions.json`) so the URL the user
- * registered into their external MCP stays valid across Superset
- * restarts. The server filters Chromium's `/json(/*)?` listing down
- * to the single pane bound to the owning session and transparently
- * proxies `/devtools/page/<targetId>` to Chromium.
- *
- * Security surface: loopback only, kernel-assigned port, no
- * path-embedded credentials — the port itself is the capability.
- *
- * Threat model: puppeteer's `connect({ browserURL })` composes
- * `new URL("/json/version", browserURL)`, which per WHATWG URL spec
- * drops any path, query, or auth on the base URL. It also does not
- * forward custom HTTP headers to `/json/version`. That rules out
- * path-token, query-token, and Bearer-header auth on this proxy — any
- * such secret would be silently stripped before Chromium is asked for
- * its target list. We therefore rely on the standard Chrome DevTools
- * security model: loopback binding + single-user-machine assumption.
- * A hostile *local* process on the same user account that can read
- * `~/.superset/browser-mcp-sessions.json` (0600) or port-scan loopback
- * can drive the bound pane; this matches Chromium's own
- * `--remote-debugging-port` threat model and is explicitly not in
- * scope for this proxy to fix. Multi-user hosts should not run
- * Superset desktop with browser automation enabled.
+ * Invariants the gateway relies on:
+ *   • `/devtools/browser/<id>` → proxyBrowserUpgrade. The client
+ *     observes only targetIds in the pane's bound set. `Target.*`
+ *     methods that would affect unrelated targets or tear down the
+ *     browser are rejected with a CDP error.
+ *   • `/devtools/page/<id>` → proxyPageUpgrade. Transparent forward
+ *     of the single page session; scope is already enforced by the
+ *     gateway's targetId check.
+ *   • `Target.setAutoAttach` has its `filter` stripped so
+ *     puppeteer-based clients (chrome-devtools-mcp) don't hang when
+ *     Electron's Chromium doesn't expose a `tab` wrapper above the
+ *     page.
+ *   • Session-scoped frames are admitted only for sessionIds we
+ *     surfaced via `Target.attachedToTarget`; nested attach events
+ *     add their child sessionId transitively, which is required for
+ *     workers / OOPIF / prerender sub-sessions.
  */
 
-const STORE_PATH = join(SUPERSET_HOME_DIR, "browser-mcp-sessions.json");
-const BROWSER_USE_CONFIG_DIR = join(
-	SUPERSET_HOME_DIR,
-	"browser-use-configs",
-);
-
-/**
- * Write a per-session browser-use config file so the official
- * `uvx ... browser-use --mcp` launch picks up our proxy.
- *
- * Context: browser-use's CLI does parse `--cdp-url`, but its `--mcp`
- * branch (skill_cli/main.py ~line 2280 in 0.12.x) routes to
- * `browser_use.mcp.server:main` without forwarding `--cdp-url`. The
- * only officially supported way to point the MCP server at an
- * existing CDP endpoint is via the `BROWSER_USE_CONFIG_PATH` env var
- * pointing at a JSON config whose default `browser_profile` entry
- * carries `cdp_url` (browser_use/config.py:101-103, 283-288,
- * 421-432 and mcp/server.py:578,601). We generate that file here,
- * keyed by sessionId so each LLM session gets its own.
- */
-function browserUseConfigPathFor(sessionId: string): string {
-	return join(BROWSER_USE_CONFIG_DIR, `${sessionId}.json`);
-}
-
-function writeBrowserUseConfig(sessionId: string, port: number): void {
-	const profileId = `superset-${sessionId}`;
-	const payload = {
-		browser_profile: {
-			[profileId]: {
-				id: profileId,
-				default: true,
-				// Give browser-use the HTTP base. It will hit
-				// /json/version through our proxy, which rewrites the
-				// browser WS URL to our filtered endpoint. This keeps
-				// the URL stable across Chromium restarts (targetId
-				// changes, but port doesn't).
-				cdp_url: `http://127.0.0.1:${port}`,
-			},
-		},
-		llm: {},
-		agent: {},
-	};
-	try {
-		mkdirSync(BROWSER_USE_CONFIG_DIR, { recursive: true });
-		const path = browserUseConfigPathFor(sessionId);
-		writeFileSync(path, JSON.stringify(payload, null, 2), { mode: 0o600 });
-		try {
-			chmodSync(path, 0o600);
-		} catch {
-			/* best effort */
-		}
-	} catch (error) {
-		console.warn("[cdp-filter-proxy] failed to write browser-use config:", error);
-	}
-}
-
-export function getBrowserUseConfigPath(sessionId: string): string {
-	return browserUseConfigPathFor(sessionId);
-}
-
-interface SessionRecord {
-	sessionId: string;
-	port: number;
-	createdAt: number;
-	lastUsedAt: number;
-}
-
-interface PersistedFile {
-	version: 2;
-	sessions: SessionRecord[];
-}
-
-const records = new Map<string, SessionRecord>();
-const servers = new Map<string, Server>();
-const inFlight = new Map<string, Promise<number>>();
-let hydrated = false;
-
-function hydrate(): void {
-	if (hydrated) return;
-	hydrated = true;
-	try {
-		const raw = readFileSync(STORE_PATH, "utf8");
-		const parsed = JSON.parse(raw) as Partial<PersistedFile>;
-		if (parsed?.version !== 2 || !Array.isArray(parsed.sessions)) return;
-		for (const s of parsed.sessions) {
-			if (
-				typeof s.sessionId === "string" &&
-				typeof s.port === "number" &&
-				Number.isInteger(s.port) &&
-				s.port > 0 &&
-				s.port < 65_536
-			) {
-				records.set(s.sessionId, {
-					sessionId: s.sessionId,
-					port: s.port,
-					createdAt: s.createdAt ?? Date.now(),
-					lastUsedAt: s.lastUsedAt ?? Date.now(),
-				});
-			}
-		}
-	} catch {
-		/* no prior state, start fresh */
-	}
-}
-
-function persist(): void {
-	try {
-		const payload: PersistedFile = {
-			version: 2,
-			sessions: Array.from(records.values()),
-		};
-		mkdirSync(dirname(STORE_PATH), { recursive: true });
-		writeFileSync(STORE_PATH, JSON.stringify(payload, null, 2), {
-			mode: 0o600,
-		});
-		// writeFileSync mode only applies to new files; force 0600 so an
-		// existing file from an earlier run with looser permissions is
-		// re-tightened.
-		try {
-			chmodSync(STORE_PATH, 0o600);
-		} catch {
-			/* best-effort */
-		}
-	} catch (error) {
-		console.warn("[cdp-filter-proxy] failed to persist sessions:", error);
-	}
-}
-
-async function tryBind(server: Server, port: number): Promise<number | null> {
-	return new Promise((resolve) => {
-		const onError = (): void => {
-			server.off("error", onError);
-			resolve(null);
-		};
-		server.once("error", onError);
-		server.listen(port, "127.0.0.1", () => {
-			server.off("error", onError);
-			const addr = server.address();
-			if (!addr || typeof addr === "string") {
-				resolve(null);
-				return;
-			}
-			resolve(addr.port);
-		});
-	});
-}
-
-async function bindSessionServer(
-	preferredPort: number | undefined,
-): Promise<{ server: Server; port: number; wss: WebSocketServer }> {
-	const server = createServer();
-	// Try preferred port first so restarts reuse the one the user
-	// registered with; fall back to any free port on conflict.
-	const bound =
-		(preferredPort && (await tryBind(server, preferredPort))) ||
-		(await tryBind(server, 0));
-	if (!bound) {
-		throw new Error("cdp-filter-proxy: failed to bind loopback port");
-	}
-	const wss = new WebSocketServer({ noServer: true });
-	return { server, port: bound, wss };
-}
-
-function resolveBindingForSession(
-	sessionId: string,
-): { paneId: string; targetId: string } | null {
-	const binding = bindingStore.getBySessionId(sessionId);
-	if (!binding) return null;
-	const targetId = browserManager.getCdpTargetId(binding.paneId);
-	if (!targetId) return null;
-	return { paneId: binding.paneId, targetId };
-}
-
-export function sendJson(res: ServerResponse, status: number, body: unknown): void {
+export function sendJson(
+	res: ServerResponse,
+	status: number,
+	body: unknown,
+): void {
 	res.statusCode = status;
 	res.setHeader("content-type", "application/json");
 	res.end(JSON.stringify(body));
@@ -236,15 +48,17 @@ export async function fetchUpstreamJson(path: string): Promise<unknown> {
 	const res = await fetch(`http://127.0.0.1:${port}${path}`);
 	if (!res.ok) {
 		throw new Error(
-			`Chromium CDP returned ${res.status} for ${path}: ${await res.text().catch(() => "")}`,
+			`Chromium CDP returned ${res.status} for ${path}: ${await res
+				.text()
+				.catch(() => "")}`,
 		);
 	}
 	return (await res.json()) as unknown;
 }
 
 /**
- * Per-server identifier used in `/devtools/browser/<id>` so the URL
- * Chromium itself would hand out looks identical in shape to ours.
+ * Per-session identifier used in `/devtools/browser/<id>` so the URL
+ * the client sees has the same shape Chromium itself would hand out.
  */
 const browserWsIds = new Map<string, string>();
 
@@ -255,116 +69,6 @@ export function browserWsIdFor(sessionId: string): string {
 		browserWsIds.set(sessionId, id);
 	}
 	return id;
-}
-
-function wireRequestHandler(server: Server, sessionId: string): void {
-	server.on("request", async (req, res) => {
-		try {
-			const remote = req.socket.remoteAddress ?? "";
-			if (
-				remote !== "127.0.0.1" &&
-				remote !== "::1" &&
-				remote !== "::ffff:127.0.0.1"
-			) {
-				return sendJson(res, 403, { error: "loopback only" });
-			}
-			const url = new URL(req.url ?? "/", "http://localhost");
-			const pathname = url.pathname.replace(/\/$/, "") || "/";
-			const host = req.headers.host ?? "127.0.0.1";
-			if (pathname === "/json/version") {
-				const body = (await fetchUpstreamJson("/json/version")) as Record<
-					string,
-					unknown
-				>;
-				// Replace Chromium's browser-level `webSocketDebuggerUrl` with
-				// our filtered one. External clients (puppeteer.connect,
-				// chrome-devtools-mcp, browser-use) rely on this field to
-				// obtain a browser-level CDP connection. Routing it through
-				// our proxy lets us filter the `Target.*` domain so they only
-				// see the bound pane.
-				const { webSocketDebuggerUrl: _drop, ...safe } = body;
-				void _drop;
-				return sendJson(res, 200, {
-					...safe,
-					webSocketDebuggerUrl: `ws://${host}/devtools/browser/${browserWsIdFor(sessionId)}`,
-				});
-			}
-			if (pathname === "/json/protocol") {
-				const body = await fetchUpstreamJson("/json/protocol");
-				return sendJson(res, 200, body);
-			}
-			if (pathname === "/json" || pathname === "/json/list") {
-				const resolved = resolveBindingForSession(sessionId);
-				if (!resolved) return sendJson(res, 200, []);
-				const raw = (await fetchUpstreamJson("/json/list")) as Array<
-					Record<string, unknown>
-				>;
-				const out = raw
-					.filter((t) => (t as { id?: string }).id === resolved.targetId)
-					.map((t) => {
-						const id = resolved.targetId;
-						return {
-							...t,
-							webSocketDebuggerUrl: `ws://${host}/devtools/page/${id}`,
-							devtoolsFrontendUrl: `http://${host}/devtools/page/${id}`,
-						};
-					});
-				return sendJson(res, 200, out);
-			}
-			// Plain HTTP access to /devtools/page/<id> is not a real CDP
-			// entry point — it needs a WS upgrade which is handled below.
-			return sendJson(res, 404, { error: "not found" });
-		} catch (error) {
-			console.error("[cdp-filter-proxy] request error:", error);
-			return sendJson(res, 502, {
-				error: error instanceof Error ? error.message : String(error),
-			});
-		}
-	});
-}
-
-function wireUpgradeHandler(
-	server: Server,
-	wss: WebSocketServer,
-	sessionId: string,
-): void {
-	server.on("upgrade", async (req, socket, head) => {
-		const remote = req.socket.remoteAddress ?? "";
-		if (
-			remote !== "127.0.0.1" &&
-			remote !== "::1" &&
-			remote !== "::ffff:127.0.0.1"
-		) {
-			socket.destroy();
-			return;
-		}
-		const pathname = new URL(req.url ?? "/", "http://localhost").pathname;
-		const resolved = resolveBindingForSession(sessionId);
-		if (!resolved) {
-			socket.destroy();
-			return;
-		}
-		const port = await resolveCdpPort();
-		if (!port) {
-			socket.destroy();
-			return;
-		}
-
-		if (/^\/devtools\/browser\/[^/]+$/.test(pathname)) {
-			const expected = `/devtools/browser/${browserWsIdFor(sessionId)}`;
-			if (pathname !== expected) {
-				socket.destroy();
-				return;
-			}
-			void proxyBrowserUpgrade(req, socket, head, wss, port, resolved);
-			return;
-		}
-		if (/^\/devtools\/page\/[^/]+$/.test(pathname)) {
-			void proxyPageUpgrade(req, socket, head, wss, port, resolved.targetId);
-			return;
-		}
-		socket.destroy();
-	});
 }
 
 export async function proxyPageUpgrade(
@@ -416,30 +120,6 @@ export async function proxyPageUpgrade(
 	});
 }
 
-/* ---------------------------------------------------------------- */
-/* Browser-level CDP filter.                                         */
-/*                                                                   */
-/* Client is talking to our proxy as if we were Chromium's browser-  */
-/* level CDP endpoint. We forward most messages through to the real  */
-/* browser WS but rewrite the `Target` domain so the client only     */
-/* ever sees the single pane bound to this session:                  */
-/*                                                                   */
-/*   • Target.getTargets / targetCreated / targetDestroyed           */
-/*     / targetInfoChanged — filtered to bound paneId                */
-/*   • Target.attachToTarget / setAutoAttach — allowed, but limited  */
-/*     to bound paneId; other ids get a CDP error                    */
-/*   • Target.createTarget — treated as "navigate the bound pane"    */
-/*     (per user decision: the pane is already under attached        */
-/*     automation, so redirecting a new-tab request into a           */
-/*     Page.navigate on the bound pane is the expected UX)           */
-/*   • Target.closeTarget / disposeBrowserContext / Browser.close    */
-/*     — rejected, so MCPs cannot shut the pane or Chromium down     */
-/*                                                                   */
-/* Session-scoped messages (CDP frames carrying `sessionId`) are     */
-/* forwarded verbatim — once a client is attached to the bound pane  */
-/* it speaks Page/DOM/Runtime/… directly with Chromium.              */
-/* ---------------------------------------------------------------- */
-
 interface JsonRpcMsg {
 	id?: number;
 	method?: string;
@@ -449,15 +129,27 @@ interface JsonRpcMsg {
 	sessionId?: string;
 }
 
-function isTargetInfoForBound(
-	info: unknown,
-	boundTargetId: string,
-): info is { targetId: string } {
-	return (
-		typeof info === "object" &&
-		info !== null &&
-		(info as { targetId?: unknown }).targetId === boundTargetId
-	);
+/**
+ * Binding contract for the browser-level filter.
+ *
+ * Single-pane (M1) passes `primaryTargetId` as the one bound target
+ * and returns `{primaryTargetId}` from boundTargetIds(). Multi-tab
+ * (M2) returns the full Set of tab targetIds for the pane; the filter
+ * does not need to know about tabs as such.
+ */
+export interface BoundContext {
+	paneId: string;
+	primaryTargetId: string;
+	/** Current set of bound targetIds. Re-evaluated on each filter hit. */
+	boundTargetIds(): ReadonlySet<string>;
+	/** Optional: WS that should be closed when the bound set changes. */
+	onClose?: (ws: WebSocket) => void;
+}
+
+function targetIdOf(obj: unknown): string | undefined {
+	if (typeof obj !== "object" || obj === null) return undefined;
+	const t = (obj as { targetId?: unknown }).targetId;
+	return typeof t === "string" ? t : undefined;
 }
 
 export async function proxyBrowserUpgrade(
@@ -466,10 +158,8 @@ export async function proxyBrowserUpgrade(
 	head: Buffer,
 	wss: WebSocketServer,
 	chromiumPort: number,
-	resolved: { paneId: string; targetId: string },
+	ctx: BoundContext,
 ): Promise<void> {
-	// Chromium's real browser WS URL — fetch /json/version to discover
-	// it. The `id` in the path is per Chromium run, not per target.
 	let chromiumBrowserWs: string;
 	try {
 		const ver = (await fetchUpstreamJson("/json/version")) as {
@@ -479,8 +169,6 @@ export async function proxyBrowserUpgrade(
 			socket.destroy();
 			return;
 		}
-		// Rewrite host:port to our resolved Chromium CDP port (in case
-		// /json/version returned a different hostname).
 		const parsed = new URL(ver.webSocketDebuggerUrl);
 		parsed.host = `127.0.0.1:${chromiumPort}`;
 		chromiumBrowserWs = parsed.toString();
@@ -492,20 +180,9 @@ export async function proxyBrowserUpgrade(
 
 	wss.handleUpgrade(req, socket, head, (clientWs) => {
 		const upstream = new WebSocket(chromiumBrowserWs);
-		const boundTargetId = resolved.targetId;
-		// Map outgoing request id → original method so we can filter
-		// responses for Target.getTargets etc. Chromium echoes `id` back.
 		const pendingMethods = new Map<number, string>();
-		// SessionIds we have actually surfaced to the client via
-		// Target.attachedToTarget. After stripping the `filter` from
-		// client-issued Target.setAutoAttach requests (see below),
-		// Chromium auto-attaches to many non-bound targets (other
-		// panes, workers, tab wrappers, …) and emits session-scoped
-		// frames for all of them on this single WS. We drop any
-		// session-scoped frame whose sessionId we never taught the
-		// client, which keeps cross-pane DOM/network/etc. traffic from
-		// leaking.
 		const allowedSessionIds = new Set<string>();
+		if (ctx.onClose) ctx.onClose(clientWs);
 
 		const closeBoth = (): void => {
 			try {
@@ -536,13 +213,10 @@ export async function proxyBrowserUpgrade(
 				/* ignore */
 			}
 		};
-
 		const rejectRequest = (id: number, message: string): void => {
 			sendToClient({ id, error: { code: -32601, message } });
 		};
 
-		// Incoming (client → us). Most messages are forwarded; Target.*
-		// is filtered; known-destructive calls are rejected.
 		clientWs.on("message", (data: RawData) => {
 			let msg: JsonRpcMsg;
 			try {
@@ -550,23 +224,15 @@ export async function proxyBrowserUpgrade(
 			} catch {
 				return;
 			}
-			// Session-scoped frames: forward only if the sessionId is
-			// one we surfaced to the client. Otherwise the client is
-			// trying (or has been tricked into) operating on a session
-			// it shouldn't know about.
 			if (msg.sessionId) {
-				if (allowedSessionIds.has(msg.sessionId)) {
-					sendToUpstream(msg);
-				}
+				if (allowedSessionIds.has(msg.sessionId)) sendToUpstream(msg);
 				return;
 			}
 			const method = msg.method ?? "";
 			const id = typeof msg.id === "number" ? msg.id : undefined;
+			const bound = ctx.boundTargetIds();
 
-			// Hard-rejected methods — these would let a hostile MCP tear
-			// down the pane or browser.
 			if (
-				method === "Target.closeTarget" ||
 				method === "Target.disposeBrowserContext" ||
 				method === "Target.createBrowserContext" ||
 				method === "Browser.close" ||
@@ -584,14 +250,8 @@ export async function proxyBrowserUpgrade(
 
 			// setAutoAttach: strip the `filter` field so Chromium does
 			// NOT honour a client-side `{type:'page', exclude:true}`
-			// exclusion. Puppeteer (and therefore chrome-devtools-mcp)
-			// sends that filter assuming it will attach to a `tab`
-			// wrapper and then nest-attach to pages. Electron's
-			// embedded Chromium does not always expose that tab
-			// wrapper, so the nested attach never happens and
-			// `puppeteer.connect()` hangs. By stripping the filter we
-			// force a top-level page attach that our downstream Target
-			// event filter keeps scoped to the bound pane.
+			// exclusion that would wait for a tab wrapper Electron's
+			// embedded Chromium does not always expose.
 			if (method === "Target.setAutoAttach" && id !== undefined) {
 				const original = (msg.params ?? {}) as Record<string, unknown>;
 				const rewritten: Record<string, unknown> = { ...original };
@@ -601,14 +261,12 @@ export async function proxyBrowserUpgrade(
 				return;
 			}
 
-			// Scope enforcement: attaches must target the bound pane.
 			if (method === "Target.attachToTarget" && id !== undefined) {
-				const targetId = (msg.params as { targetId?: string } | undefined)
-					?.targetId;
-				if (targetId && targetId !== boundTargetId) {
+				const targetId = targetIdOf(msg.params);
+				if (targetId && !bound.has(targetId)) {
 					rejectRequest(
 						id,
-						"This Superset session is scoped to a single bound pane; attachToTarget for other targets is refused.",
+						"This Superset session is scoped to the bound pane; attachToTarget for other targets is refused.",
 					);
 					return;
 				}
@@ -617,31 +275,64 @@ export async function proxyBrowserUpgrade(
 				return;
 			}
 
-			// createTarget → navigate the bound pane (option B). We do
-			// NOT create a real new target in Chromium; instead we:
-			//   1. trigger a navigation on the bound pane if a URL was
-			//      supplied, via the main process's BrowserView handle
-			//      (side-channel, not upstream CDP);
-			//   2. respond with `{targetId: boundTargetId}` so the MCP
-			//      treats the bound pane as "the new page".
+			if (method === "Target.activateTarget" && id !== undefined) {
+				const tid = targetIdOf(msg.params);
+				if (tid && !bound.has(tid)) {
+					rejectRequest(
+						id,
+						"Target.activateTarget for other targets is refused by the Superset CDP filter.",
+					);
+					return;
+				}
+				pendingMethods.set(id, method);
+				sendToUpstream(msg);
+				return;
+			}
+
+			if (method === "Target.closeTarget" && id !== undefined) {
+				const tid = targetIdOf(msg.params);
+				if (!tid || !bound.has(tid)) {
+					rejectRequest(
+						id,
+						"Target.closeTarget for other targets is refused by the Superset CDP filter.",
+					);
+					return;
+				}
+				pendingMethods.set(id, method);
+				sendToUpstream(msg);
+				return;
+			}
+
 			if (method === "Target.createTarget" && id !== undefined) {
 				const params = msg.params as
-					| { url?: string; background?: boolean }
+					| { url?: string; background?: boolean; newWindow?: boolean }
 					| undefined;
 				const nextUrl = params?.url;
+				// If multi-tab is available (bound set has >1 targetId
+				// already, i.e. M2 is wired), forward the request so
+				// Chromium genuinely creates a new tab; the pane-side
+				// registry adds it to the bound set when Electron sees
+				// the new webContents. Otherwise fall back to the
+				// single-pane option B: redirect to loadURL on the
+				// bound pane.
+				if (bound.size > 1 || ctx.paneId === "multitab") {
+					pendingMethods.set(id, method);
+					sendToUpstream(msg);
+					return;
+				}
 				if (nextUrl && typeof nextUrl === "string" && nextUrl !== "") {
 					try {
-						const wc = browserManager.getWebContents(resolved.paneId);
+						const wc = browserManager.getWebContents(ctx.paneId);
 						if (wc && !wc.isDestroyed() && !/^about:blank$/i.test(nextUrl)) {
 							void wc.loadURL(nextUrl).catch(() => {
-								/* loadURL can reject on aborted nav; ignore */
+								/* aborted nav */
 							});
 						}
 					} catch {
-						/* best-effort — the respond-with-bound flow still works */
+						/* best-effort */
 					}
 				}
-				sendToClient({ id, result: { targetId: boundTargetId } });
+				sendToClient({ id, result: { targetId: ctx.primaryTargetId } });
 				return;
 			}
 
@@ -654,21 +345,6 @@ export async function proxyBrowserUpgrade(
 				return;
 			}
 
-			// Bound-only scope enforcement for target-addressed methods.
-			if (method === "Target.activateTarget" && id !== undefined) {
-				const tid = (msg.params as { targetId?: string } | undefined)
-					?.targetId;
-				if (tid && tid !== boundTargetId) {
-					rejectRequest(
-						id,
-						"Target.activateTarget for other targets is refused by the Superset CDP filter.",
-					);
-					return;
-				}
-				pendingMethods.set(id, method);
-				sendToUpstream(msg);
-				return;
-			}
 			if (method === "Target.detachFromTarget" && id !== undefined) {
 				const sid = (msg.params as { sessionId?: string } | undefined)
 					?.sessionId;
@@ -684,14 +360,10 @@ export async function proxyBrowserUpgrade(
 				return;
 			}
 
-			// Other Target.* methods (setDiscoverTargets, exposeDevToo-
-			// lsProtocol, sendMessageToTarget, …): forward.
 			if (id !== undefined) pendingMethods.set(id, method);
 			sendToUpstream(msg);
 		});
 
-		// Outgoing (upstream → client). Filter Target events and Target
-		// responses so the client only sees the bound pane.
 		upstream.on("message", (data: RawData) => {
 			let msg: JsonRpcMsg;
 			try {
@@ -699,50 +371,32 @@ export async function proxyBrowserUpgrade(
 			} catch {
 				return;
 			}
-			// Session-scoped event/response: forward only for sessions
-			// the client knows about. Stripping the setAutoAttach
-			// filter causes Chromium to auto-attach to unrelated
-			// panes/workers/tabs and emit session-scoped frames for
-			// them on this single WS; without this check, their DOM,
-			// network, and runtime events would leak to the client.
+			const bound = ctx.boundTargetIds();
+
 			if (msg.sessionId) {
 				if (!allowedSessionIds.has(msg.sessionId)) return;
-				// Nested auto-attach: under flatten:true, Chromium
-				// delivers child `Target.attachedToTarget` events as
-				// session-scoped frames on the parent's sessionId. The
-				// inner `params.sessionId` is the child (worker /
-				// dedicated-worker / iframe-OOPIF / prerender). Since
-				// the parent (= bound page session) is already allowed,
-				// treat the child as transitively allowed and register
-				// its sessionId so the subsequent session-scoped frames
-				// for that child aren't dropped. Puppeteer's TargetMana-
-				// ger.ts:425 and browser-use's SessionManager both rely
-				// on this event chain — without it, `puppeteer.connect()`
-				// hangs and worker / iframe tooling silently breaks.
 				if (msg.method === "Target.attachedToTarget") {
-					const childSid = (
-						msg.params as { sessionId?: string } | undefined
-					)?.sessionId;
+					const childSid = (msg.params as { sessionId?: string } | undefined)
+						?.sessionId;
 					if (childSid) allowedSessionIds.add(childSid);
 				} else if (msg.method === "Target.detachedFromTarget") {
-					const childSid = (
-						msg.params as { sessionId?: string } | undefined
-					)?.sessionId;
+					const childSid = (msg.params as { sessionId?: string } | undefined)
+						?.sessionId;
 					if (childSid) allowedSessionIds.delete(childSid);
 				}
 				sendToClient(msg);
 				return;
 			}
 
-			// Responses.
 			if (typeof msg.id === "number") {
 				const origMethod = pendingMethods.get(msg.id);
 				pendingMethods.delete(msg.id);
 				if (origMethod === "Target.getTargets" && msg.result) {
 					const infos = (msg.result.targetInfos ?? []) as unknown[];
-					const filtered = infos.filter((i) =>
-						isTargetInfoForBound(i, boundTargetId),
-					);
+					const filtered = infos.filter((i) => {
+						const tid = targetIdOf(i);
+						return tid !== undefined && bound.has(tid);
+					});
 					sendToClient({
 						...msg,
 						result: { ...msg.result, targetInfos: filtered },
@@ -754,7 +408,8 @@ export async function proxyBrowserUpgrade(
 					if (sid) allowedSessionIds.add(sid);
 				}
 				if (origMethod === "Target.getTargetInfo" && msg.result?.targetInfo) {
-					if (!isTargetInfoForBound(msg.result.targetInfo, boundTargetId)) {
+					const tid = targetIdOf(msg.result.targetInfo);
+					if (!tid || !bound.has(tid)) {
 						sendToClient({
 							id: msg.id,
 							error: { code: -32000, message: "target not found" },
@@ -766,7 +421,6 @@ export async function proxyBrowserUpgrade(
 				return;
 			}
 
-			// Events.
 			const method = msg.method ?? "";
 			if (
 				method === "Target.targetCreated" ||
@@ -778,9 +432,9 @@ export async function proxyBrowserUpgrade(
 					(msg.params as { targetInfo?: unknown; targetId?: string } | undefined)
 						?.targetInfo ?? msg.params;
 				const tid =
-					(info as { targetId?: string } | undefined)?.targetId ??
+					targetIdOf(info) ??
 					(msg.params as { targetId?: string } | undefined)?.targetId;
-				if (tid !== boundTargetId) return; // drop
+				if (!tid || !bound.has(tid)) return;
 				sendToClient(msg);
 				return;
 			}
@@ -789,7 +443,7 @@ export async function proxyBrowserUpgrade(
 					| { sessionId?: string; targetInfo?: { targetId?: string } }
 					| undefined;
 				const tid = params?.targetInfo?.targetId;
-				if (tid !== boundTargetId) return;
+				if (!tid || !bound.has(tid)) return;
 				if (params?.sessionId) allowedSessionIds.add(params.sessionId);
 				sendToClient(msg);
 				return;
@@ -813,64 +467,4 @@ export async function proxyBrowserUpgrade(
 		clientWs.on("error", closeBoth);
 		clientWs.on("close", closeBoth);
 	});
-}
-
-/**
- * Ensure a dedicated loopback server exists for this LLM session and
- * return the port it is bound to. Idempotent — re-calls return the
- * same port for the same session, even across Superset restarts.
- */
-export async function ensureSessionEndpoint(
-	sessionId: string,
-): Promise<number> {
-	hydrate();
-	const existing = records.get(sessionId);
-	if (existing && servers.has(sessionId)) {
-		existing.lastUsedAt = Date.now();
-		// Re-assert the browser-use config on every hit so restarts
-		// and manual edits can't silently leave it stale.
-		writeBrowserUseConfig(sessionId, existing.port);
-		return existing.port;
-	}
-	// Serialize concurrent calls for the same sessionId — otherwise both
-	// callers miss `servers.has(...)` and each bind a different port,
-	// then clobber each other in the maps.
-	const pending = inFlight.get(sessionId);
-	if (pending) return pending;
-	const promise = (async () => {
-		const { server, port, wss } = await bindSessionServer(existing?.port);
-		wireRequestHandler(server, sessionId);
-		wireUpgradeHandler(server, wss, sessionId);
-		servers.set(sessionId, server);
-		const record: SessionRecord = {
-			sessionId,
-			port,
-			createdAt: existing?.createdAt ?? Date.now(),
-			lastUsedAt: Date.now(),
-		};
-		records.set(sessionId, record);
-		persist();
-		writeBrowserUseConfig(sessionId, port);
-		return port;
-	})().finally(() => {
-		inFlight.delete(sessionId);
-	});
-	inFlight.set(sessionId, promise);
-	return promise;
-}
-
-export function getSessionEndpointPort(sessionId: string): number | null {
-	hydrate();
-	return records.get(sessionId)?.port ?? null;
-}
-
-export function stopAllSessionEndpoints(): void {
-	for (const server of servers.values()) {
-		try {
-			server.close();
-		} catch {
-			/* ignore */
-		}
-	}
-	servers.clear();
 }

--- a/apps/desktop/src/main/lib/browser-mcp-bridge/cdp-filter-proxy.ts
+++ b/apps/desktop/src/main/lib/browser-mcp-bridge/cdp-filter-proxy.ts
@@ -596,8 +596,38 @@ async function proxyBrowserUpgrade(
 				return;
 			}
 
-			// Other Target.* methods (setAutoAttach, setDiscoverTargets,
-			// detachFromTarget, activateTarget, …): forward.
+			// Bound-only scope enforcement for target-addressed methods.
+			if (method === "Target.activateTarget" && id !== undefined) {
+				const tid = (msg.params as { targetId?: string } | undefined)
+					?.targetId;
+				if (tid && tid !== boundTargetId) {
+					rejectRequest(
+						id,
+						"Target.activateTarget for other targets is refused by the Superset CDP filter.",
+					);
+					return;
+				}
+				pendingMethods.set(id, method);
+				sendToUpstream(msg);
+				return;
+			}
+			if (method === "Target.detachFromTarget" && id !== undefined) {
+				const sid = (msg.params as { sessionId?: string } | undefined)
+					?.sessionId;
+				if (sid && !allowedSessionIds.has(sid)) {
+					rejectRequest(
+						id,
+						"Target.detachFromTarget for unknown sessions is refused by the Superset CDP filter.",
+					);
+					return;
+				}
+				pendingMethods.set(id, method);
+				sendToUpstream(msg);
+				return;
+			}
+
+			// Other Target.* methods (setDiscoverTargets, exposeDevToo-
+			// lsProtocol, sendMessageToTarget, …): forward.
 			if (id !== undefined) pendingMethods.set(id, method);
 			sendToUpstream(msg);
 		});
@@ -618,9 +648,31 @@ async function proxyBrowserUpgrade(
 			// them on this single WS; without this check, their DOM,
 			// network, and runtime events would leak to the client.
 			if (msg.sessionId) {
-				if (allowedSessionIds.has(msg.sessionId)) {
-					sendToClient(msg);
+				if (!allowedSessionIds.has(msg.sessionId)) return;
+				// Nested auto-attach: under flatten:true, Chromium
+				// delivers child `Target.attachedToTarget` events as
+				// session-scoped frames on the parent's sessionId. The
+				// inner `params.sessionId` is the child (worker /
+				// dedicated-worker / iframe-OOPIF / prerender). Since
+				// the parent (= bound page session) is already allowed,
+				// treat the child as transitively allowed and register
+				// its sessionId so the subsequent session-scoped frames
+				// for that child aren't dropped. Puppeteer's TargetMana-
+				// ger.ts:425 and browser-use's SessionManager both rely
+				// on this event chain — without it, `puppeteer.connect()`
+				// hangs and worker / iframe tooling silently breaks.
+				if (msg.method === "Target.attachedToTarget") {
+					const childSid = (
+						msg.params as { sessionId?: string } | undefined
+					)?.sessionId;
+					if (childSid) allowedSessionIds.add(childSid);
+				} else if (msg.method === "Target.detachedFromTarget") {
+					const childSid = (
+						msg.params as { sessionId?: string } | undefined
+					)?.sessionId;
+					if (childSid) allowedSessionIds.delete(childSid);
 				}
+				sendToClient(msg);
 				return;
 			}
 

--- a/apps/desktop/src/main/lib/browser-mcp-bridge/cdp-filter-proxy.ts
+++ b/apps/desktop/src/main/lib/browser-mcp-bridge/cdp-filter-proxy.ts
@@ -52,6 +52,64 @@ import { resolveCdpPort } from "./cdp-port";
  */
 
 const STORE_PATH = join(SUPERSET_HOME_DIR, "browser-mcp-sessions.json");
+const BROWSER_USE_CONFIG_DIR = join(
+	SUPERSET_HOME_DIR,
+	"browser-use-configs",
+);
+
+/**
+ * Write a per-session browser-use config file so the official
+ * `uvx ... browser-use --mcp` launch picks up our proxy.
+ *
+ * Context: browser-use's CLI does parse `--cdp-url`, but its `--mcp`
+ * branch (skill_cli/main.py ~line 2280 in 0.12.x) routes to
+ * `browser_use.mcp.server:main` without forwarding `--cdp-url`. The
+ * only officially supported way to point the MCP server at an
+ * existing CDP endpoint is via the `BROWSER_USE_CONFIG_PATH` env var
+ * pointing at a JSON config whose default `browser_profile` entry
+ * carries `cdp_url` (browser_use/config.py:101-103, 283-288,
+ * 421-432 and mcp/server.py:578,601). We generate that file here,
+ * keyed by sessionId so each LLM session gets its own.
+ */
+function browserUseConfigPathFor(sessionId: string): string {
+	return join(BROWSER_USE_CONFIG_DIR, `${sessionId}.json`);
+}
+
+function writeBrowserUseConfig(sessionId: string, port: number): void {
+	const profileId = `superset-${sessionId}`;
+	const payload = {
+		browser_profile: {
+			[profileId]: {
+				id: profileId,
+				default: true,
+				// Give browser-use the HTTP base. It will hit
+				// /json/version through our proxy, which rewrites the
+				// browser WS URL to our filtered endpoint. This keeps
+				// the URL stable across Chromium restarts (targetId
+				// changes, but port doesn't).
+				cdp_url: `http://127.0.0.1:${port}`,
+			},
+		},
+		llm: {},
+		agent: {},
+	};
+	try {
+		mkdirSync(BROWSER_USE_CONFIG_DIR, { recursive: true });
+		const path = browserUseConfigPathFor(sessionId);
+		writeFileSync(path, JSON.stringify(payload, null, 2), { mode: 0o600 });
+		try {
+			chmodSync(path, 0o600);
+		} catch {
+			/* best effort */
+		}
+	} catch (error) {
+		console.warn("[cdp-filter-proxy] failed to write browser-use config:", error);
+	}
+}
+
+export function getBrowserUseConfigPath(sessionId: string): string {
+	return browserUseConfigPathFor(sessionId);
+}
 
 interface SessionRecord {
 	sessionId: string;
@@ -769,6 +827,9 @@ export async function ensureSessionEndpoint(
 	const existing = records.get(sessionId);
 	if (existing && servers.has(sessionId)) {
 		existing.lastUsedAt = Date.now();
+		// Re-assert the browser-use config on every hit so restarts
+		// and manual edits can't silently leave it stale.
+		writeBrowserUseConfig(sessionId, existing.port);
 		return existing.port;
 	}
 	// Serialize concurrent calls for the same sessionId — otherwise both
@@ -789,6 +850,7 @@ export async function ensureSessionEndpoint(
 		};
 		records.set(sessionId, record);
 		persist();
+		writeBrowserUseConfig(sessionId, port);
 		return port;
 	})().finally(() => {
 		inFlight.delete(sessionId);

--- a/apps/desktop/src/main/lib/browser-mcp-bridge/cdp-filter-proxy.ts
+++ b/apps/desktop/src/main/lib/browser-mcp-bridge/cdp-filter-proxy.ts
@@ -307,30 +307,26 @@ export async function proxyBrowserUpgrade(
 				const params = msg.params as
 					| { url?: string; background?: boolean; newWindow?: boolean }
 					| undefined;
-				const nextUrl = params?.url;
-				// If multi-tab is available (bound set has >1 targetId
-				// already, i.e. M2 is wired), forward the request so
-				// Chromium genuinely creates a new tab; the pane-side
-				// registry adds it to the bound set when Electron sees
-				// the new webContents. Otherwise fall back to the
-				// single-pane option B: redirect to loadURL on the
-				// bound pane.
-				if (bound.size > 1 || ctx.paneId === "multitab") {
-					pendingMethods.set(id, method);
-					sendToUpstream(msg);
-					return;
-				}
-				if (nextUrl && typeof nextUrl === "string" && nextUrl !== "") {
-					try {
-						const wc = browserManager.getWebContents(ctx.paneId);
-						if (wc && !wc.isDestroyed() && !/^about:blank$/i.test(nextUrl)) {
-							void wc.loadURL(nextUrl).catch(() => {
-								/* aborted nav */
-							});
-						}
-					} catch {
-						/* best-effort */
-					}
+				const nextUrl =
+					typeof params?.url === "string" && params.url !== ""
+						? params.url
+						: "about:blank";
+				// Emit a renderer-side "create tab" request. The
+				// BrowserPane subscribes via browser.onCreateTabRequested
+				// and creates a real <webview> tab, which then registers
+				// its webContents and targetId with browserManager. Once
+				// that targetId lands in the bound set the MCP's next
+				// `Target.getTargets` / `Target.attachToTarget` will find
+				// it. We respond synchronously with the primary targetId
+				// so puppeteer's newPage path resolves; subsequent
+				// auto-attach events for the new tab surface the real
+				// targetId to the client through our normal filter.
+				try {
+					browserManager.emit(`create-tab-requested:${ctx.paneId}`, {
+						url: nextUrl,
+					});
+				} catch {
+					/* best effort */
 				}
 				sendToClient({ id, result: { targetId: ctx.primaryTargetId } });
 				return;

--- a/apps/desktop/src/main/lib/browser-mcp-bridge/cdp-filter-proxy.ts
+++ b/apps/desktop/src/main/lib/browser-mcp-bridge/cdp-filter-proxy.ts
@@ -332,10 +332,7 @@ export async function proxyBrowserUpgrade(
 				return;
 			}
 
-			if (
-				method === "Target.getTargets" ||
-				method === "Target.getTargetInfo"
-			) {
+			if (method === "Target.getTargets" || method === "Target.getTargetInfo") {
 				if (id !== undefined) pendingMethods.set(id, method);
 				sendToUpstream(msg);
 				return;
@@ -425,8 +422,11 @@ export async function proxyBrowserUpgrade(
 				method === "Target.targetCrashed"
 			) {
 				const info =
-					(msg.params as { targetInfo?: unknown; targetId?: string } | undefined)
-						?.targetInfo ?? msg.params;
+					(
+						msg.params as
+							| { targetInfo?: unknown; targetId?: string }
+							| undefined
+					)?.targetInfo ?? msg.params;
 				const tid =
 					targetIdOf(info) ??
 					(msg.params as { targetId?: string } | undefined)?.targetId;

--- a/apps/desktop/src/main/lib/browser-mcp-bridge/cdp-filter-proxy.ts
+++ b/apps/desktop/src/main/lib/browser-mcp-bridge/cdp-filter-proxy.ts
@@ -1,3 +1,4 @@
+import { randomBytes } from "node:crypto";
 import { chmodSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import {
 	createServer,
@@ -7,7 +8,7 @@ import {
 } from "node:http";
 import { dirname, join } from "node:path";
 import type { Duplex } from "node:stream";
-import { WebSocket, WebSocketServer } from "ws";
+import { type RawData, WebSocket, WebSocketServer } from "ws";
 import { bindingStore } from "../../../lib/trpc/routers/browser-automation/index";
 import { SUPERSET_HOME_DIR } from "../app-environment";
 import { browserManager } from "../browser/browser-manager";
@@ -183,6 +184,21 @@ async function fetchUpstreamJson(path: string): Promise<unknown> {
 	return (await res.json()) as unknown;
 }
 
+/**
+ * Per-server identifier used in `/devtools/browser/<id>` so the URL
+ * Chromium itself would hand out looks identical in shape to ours.
+ */
+const browserWsIds = new Map<string, string>();
+
+function browserWsIdFor(sessionId: string): string {
+	let id = browserWsIds.get(sessionId);
+	if (!id) {
+		id = randomBytes(16).toString("hex");
+		browserWsIds.set(sessionId, id);
+	}
+	return id;
+}
+
 function wireRequestHandler(server: Server, sessionId: string): void {
 	server.on("request", async (req, res) => {
 		try {
@@ -196,17 +212,24 @@ function wireRequestHandler(server: Server, sessionId: string): void {
 			}
 			const url = new URL(req.url ?? "/", "http://localhost");
 			const pathname = url.pathname.replace(/\/$/, "") || "/";
+			const host = req.headers.host ?? "127.0.0.1";
 			if (pathname === "/json/version") {
 				const body = (await fetchUpstreamJson("/json/version")) as Record<
 					string,
 					unknown
 				>;
-				// Chromium's /json/version exposes the browser-level
-				// `webSocketDebuggerUrl` pointing at the raw CDP port, which
-				// would bypass the filter. Drop it.
+				// Replace Chromium's browser-level `webSocketDebuggerUrl` with
+				// our filtered one. External clients (puppeteer.connect,
+				// chrome-devtools-mcp, browser-use) rely on this field to
+				// obtain a browser-level CDP connection. Routing it through
+				// our proxy lets us filter the `Target.*` domain so they only
+				// see the bound pane.
 				const { webSocketDebuggerUrl: _drop, ...safe } = body;
 				void _drop;
-				return sendJson(res, 200, safe);
+				return sendJson(res, 200, {
+					...safe,
+					webSocketDebuggerUrl: `ws://${host}/devtools/browser/${browserWsIdFor(sessionId)}`,
+				});
 			}
 			if (pathname === "/json/protocol") {
 				const body = await fetchUpstreamJson("/json/protocol");
@@ -218,7 +241,6 @@ function wireRequestHandler(server: Server, sessionId: string): void {
 				const raw = (await fetchUpstreamJson("/json/list")) as Array<
 					Record<string, unknown>
 				>;
-				const host = req.headers.host ?? "127.0.0.1";
 				const out = raw
 					.filter((t) => (t as { id?: string }).id === resolved.targetId)
 					.map((t) => {
@@ -259,10 +281,6 @@ function wireUpgradeHandler(
 			return;
 		}
 		const pathname = new URL(req.url ?? "/", "http://localhost").pathname;
-		if (!/^\/devtools\/page\/[^/]+$/.test(pathname)) {
-			socket.destroy();
-			return;
-		}
 		const resolved = resolveBindingForSession(sessionId);
 		if (!resolved) {
 			socket.destroy();
@@ -273,11 +291,25 @@ function wireUpgradeHandler(
 			socket.destroy();
 			return;
 		}
-		void proxyUpgrade(req, socket, head, wss, port, resolved.targetId);
+
+		if (/^\/devtools\/browser\/[^/]+$/.test(pathname)) {
+			const expected = `/devtools/browser/${browserWsIdFor(sessionId)}`;
+			if (pathname !== expected) {
+				socket.destroy();
+				return;
+			}
+			void proxyBrowserUpgrade(req, socket, head, wss, port, resolved);
+			return;
+		}
+		if (/^\/devtools\/page\/[^/]+$/.test(pathname)) {
+			void proxyPageUpgrade(req, socket, head, wss, port, resolved.targetId);
+			return;
+		}
+		socket.destroy();
 	});
 }
 
-async function proxyUpgrade(
+async function proxyPageUpgrade(
 	req: IncomingMessage,
 	socket: Duplex,
 	head: Buffer,
@@ -317,7 +349,300 @@ async function proxyUpgrade(
 			});
 		});
 		upstream.on("error", (err) => {
-			console.warn("[cdp-filter-proxy] upstream error", err);
+			console.warn("[cdp-filter-proxy] page upstream error", err);
+			closeBoth();
+		});
+		upstream.on("close", closeBoth);
+		clientWs.on("error", closeBoth);
+		clientWs.on("close", closeBoth);
+	});
+}
+
+/* ---------------------------------------------------------------- */
+/* Browser-level CDP filter.                                         */
+/*                                                                   */
+/* Client is talking to our proxy as if we were Chromium's browser-  */
+/* level CDP endpoint. We forward most messages through to the real  */
+/* browser WS but rewrite the `Target` domain so the client only     */
+/* ever sees the single pane bound to this session:                  */
+/*                                                                   */
+/*   • Target.getTargets / targetCreated / targetDestroyed           */
+/*     / targetInfoChanged — filtered to bound paneId                */
+/*   • Target.attachToTarget / setAutoAttach — allowed, but limited  */
+/*     to bound paneId; other ids get a CDP error                    */
+/*   • Target.createTarget — treated as "navigate the bound pane"    */
+/*     (per user decision: the pane is already under attached        */
+/*     automation, so redirecting a new-tab request into a           */
+/*     Page.navigate on the bound pane is the expected UX)           */
+/*   • Target.closeTarget / disposeBrowserContext / Browser.close    */
+/*     — rejected, so MCPs cannot shut the pane or Chromium down     */
+/*                                                                   */
+/* Session-scoped messages (CDP frames carrying `sessionId`) are     */
+/* forwarded verbatim — once a client is attached to the bound pane  */
+/* it speaks Page/DOM/Runtime/… directly with Chromium.              */
+/* ---------------------------------------------------------------- */
+
+interface JsonRpcMsg {
+	id?: number;
+	method?: string;
+	params?: Record<string, unknown>;
+	result?: Record<string, unknown>;
+	error?: { code: number; message: string };
+	sessionId?: string;
+}
+
+function isTargetInfoForBound(
+	info: unknown,
+	boundTargetId: string,
+): info is { targetId: string } {
+	return (
+		typeof info === "object" &&
+		info !== null &&
+		(info as { targetId?: unknown }).targetId === boundTargetId
+	);
+}
+
+async function proxyBrowserUpgrade(
+	req: IncomingMessage,
+	socket: Duplex,
+	head: Buffer,
+	wss: WebSocketServer,
+	chromiumPort: number,
+	resolved: { paneId: string; targetId: string },
+): Promise<void> {
+	// Chromium's real browser WS URL — fetch /json/version to discover
+	// it. The `id` in the path is per Chromium run, not per target.
+	let chromiumBrowserWs: string;
+	try {
+		const ver = (await fetchUpstreamJson("/json/version")) as {
+			webSocketDebuggerUrl?: string;
+		};
+		if (!ver.webSocketDebuggerUrl) {
+			socket.destroy();
+			return;
+		}
+		// Rewrite host:port to our resolved Chromium CDP port (in case
+		// /json/version returned a different hostname).
+		const parsed = new URL(ver.webSocketDebuggerUrl);
+		parsed.host = `127.0.0.1:${chromiumPort}`;
+		chromiumBrowserWs = parsed.toString();
+	} catch (error) {
+		console.warn("[cdp-filter-proxy] could not resolve browser WS:", error);
+		socket.destroy();
+		return;
+	}
+
+	wss.handleUpgrade(req, socket, head, (clientWs) => {
+		const upstream = new WebSocket(chromiumBrowserWs);
+		const boundTargetId = resolved.targetId;
+		// Map outgoing request id → original method so we can filter
+		// responses for Target.getTargets etc. Chromium echoes `id` back.
+		const pendingMethods = new Map<number, string>();
+
+		const closeBoth = (): void => {
+			try {
+				clientWs.close();
+			} catch {
+				/* ignore */
+			}
+			try {
+				upstream.close();
+			} catch {
+				/* ignore */
+			}
+		};
+
+		const sendToClient = (obj: unknown): void => {
+			if (clientWs.readyState !== WebSocket.OPEN) return;
+			try {
+				clientWs.send(JSON.stringify(obj));
+			} catch {
+				/* ignore */
+			}
+		};
+		const sendToUpstream = (obj: unknown): void => {
+			if (upstream.readyState !== WebSocket.OPEN) return;
+			try {
+				upstream.send(JSON.stringify(obj));
+			} catch {
+				/* ignore */
+			}
+		};
+
+		const rejectRequest = (id: number, message: string): void => {
+			sendToClient({ id, error: { code: -32601, message } });
+		};
+
+		// Incoming (client → us). Most messages are forwarded; Target.*
+		// is filtered; known-destructive calls are rejected.
+		clientWs.on("message", (data: RawData) => {
+			let msg: JsonRpcMsg;
+			try {
+				msg = JSON.parse(data.toString()) as JsonRpcMsg;
+			} catch {
+				return;
+			}
+			// Session-scoped frames: always forward (Page/DOM/Runtime/etc
+			// speak to an already-attached page).
+			if (msg.sessionId) {
+				sendToUpstream(msg);
+				return;
+			}
+			const method = msg.method ?? "";
+			const id = typeof msg.id === "number" ? msg.id : undefined;
+
+			// Hard-rejected methods — these would let a hostile MCP tear
+			// down the pane or browser.
+			if (
+				method === "Target.closeTarget" ||
+				method === "Target.disposeBrowserContext" ||
+				method === "Target.createBrowserContext" ||
+				method === "Browser.close" ||
+				method === "Browser.crash" ||
+				method === "Browser.crashGpuProcess"
+			) {
+				if (id !== undefined) {
+					rejectRequest(
+						id,
+						`${method} is not permitted by the Superset CDP filter`,
+					);
+				}
+				return;
+			}
+
+			// Scope enforcement: attaches must target the bound pane.
+			if (method === "Target.attachToTarget" && id !== undefined) {
+				const targetId = (msg.params as { targetId?: string } | undefined)
+					?.targetId;
+				if (targetId && targetId !== boundTargetId) {
+					rejectRequest(
+						id,
+						"This Superset session is scoped to a single bound pane; attachToTarget for other targets is refused.",
+					);
+					return;
+				}
+				pendingMethods.set(id, method);
+				sendToUpstream(msg);
+				return;
+			}
+
+			// createTarget → navigate the bound pane (option B). We do
+			// NOT create a real new target in Chromium; instead we:
+			//   1. trigger a navigation on the bound pane if a URL was
+			//      supplied, via the main process's BrowserView handle
+			//      (side-channel, not upstream CDP);
+			//   2. respond with `{targetId: boundTargetId}` so the MCP
+			//      treats the bound pane as "the new page".
+			if (method === "Target.createTarget" && id !== undefined) {
+				const params = msg.params as
+					| { url?: string; background?: boolean }
+					| undefined;
+				const nextUrl = params?.url;
+				if (nextUrl && typeof nextUrl === "string" && nextUrl !== "") {
+					try {
+						const wc = browserManager.getWebContents(resolved.paneId);
+						if (wc && !wc.isDestroyed() && !/^about:blank$/i.test(nextUrl)) {
+							void wc.loadURL(nextUrl).catch(() => {
+								/* loadURL can reject on aborted nav; ignore */
+							});
+						}
+					} catch {
+						/* best-effort — the respond-with-bound flow still works */
+					}
+				}
+				sendToClient({ id, result: { targetId: boundTargetId } });
+				return;
+			}
+
+			if (
+				method === "Target.getTargets" ||
+				method === "Target.getTargetInfo"
+			) {
+				if (id !== undefined) pendingMethods.set(id, method);
+				sendToUpstream(msg);
+				return;
+			}
+
+			// Other Target.* methods (setAutoAttach, setDiscoverTargets,
+			// detachFromTarget, activateTarget, …): forward.
+			if (id !== undefined) pendingMethods.set(id, method);
+			sendToUpstream(msg);
+		});
+
+		// Outgoing (upstream → client). Filter Target events and Target
+		// responses so the client only sees the bound pane.
+		upstream.on("message", (data: RawData) => {
+			let msg: JsonRpcMsg;
+			try {
+				msg = JSON.parse(data.toString()) as JsonRpcMsg;
+			} catch {
+				return;
+			}
+			// Session-scoped event/response: always forward.
+			if (msg.sessionId) {
+				sendToClient(msg);
+				return;
+			}
+
+			// Responses.
+			if (typeof msg.id === "number") {
+				const origMethod = pendingMethods.get(msg.id);
+				pendingMethods.delete(msg.id);
+				if (origMethod === "Target.getTargets" && msg.result) {
+					const infos = (msg.result.targetInfos ?? []) as unknown[];
+					const filtered = infos.filter((i) =>
+						isTargetInfoForBound(i, boundTargetId),
+					);
+					sendToClient({
+						...msg,
+						result: { ...msg.result, targetInfos: filtered },
+					});
+					return;
+				}
+				if (origMethod === "Target.getTargetInfo" && msg.result?.targetInfo) {
+					if (!isTargetInfoForBound(msg.result.targetInfo, boundTargetId)) {
+						sendToClient({
+							id: msg.id,
+							error: { code: -32000, message: "target not found" },
+						});
+						return;
+					}
+				}
+				sendToClient(msg);
+				return;
+			}
+
+			// Events.
+			const method = msg.method ?? "";
+			if (
+				method === "Target.targetCreated" ||
+				method === "Target.targetDestroyed" ||
+				method === "Target.targetInfoChanged" ||
+				method === "Target.targetCrashed"
+			) {
+				const info =
+					(msg.params as { targetInfo?: unknown; targetId?: string } | undefined)
+						?.targetInfo ?? msg.params;
+				const tid =
+					(info as { targetId?: string } | undefined)?.targetId ??
+					(msg.params as { targetId?: string } | undefined)?.targetId;
+				if (tid !== boundTargetId) return; // drop
+				sendToClient(msg);
+				return;
+			}
+			if (method === "Target.attachedToTarget") {
+				const tid = (
+					msg.params as { targetInfo?: { targetId?: string } } | undefined
+				)?.targetInfo?.targetId;
+				if (tid !== boundTargetId) return;
+				sendToClient(msg);
+				return;
+			}
+			sendToClient(msg);
+		});
+
+		upstream.on("error", (err) => {
+			console.warn("[cdp-filter-proxy] browser upstream error", err);
 			closeBoth();
 		});
 		upstream.on("close", closeBoth);

--- a/apps/desktop/src/main/lib/browser-mcp-bridge/cdp-filter-proxy.ts
+++ b/apps/desktop/src/main/lib/browser-mcp-bridge/cdp-filter-proxy.ts
@@ -182,6 +182,12 @@ export async function proxyBrowserUpgrade(
 		const upstream = new WebSocket(chromiumBrowserWs);
 		const pendingMethods = new Map<number, string>();
 		const allowedSessionIds = new Set<string>();
+		// Frames the client sends before Chromium's browser WS reaches
+		// OPEN. CDP clients (puppeteer, cdp-use) typically fire
+		// `Target.setDiscoverTargets` / `Target.setAutoAttach` the
+		// instant our handshake completes, so dropping them would
+		// deadlock `connect()`. `proxyPageUpgrade` buffers the same way.
+		const pendingUpstream: unknown[] = [];
 		if (ctx.onClose) ctx.onClose(clientWs);
 
 		const closeBoth = (): void => {
@@ -206,6 +212,10 @@ export async function proxyBrowserUpgrade(
 			}
 		};
 		const sendToUpstream = (obj: unknown): void => {
+			if (upstream.readyState === WebSocket.CONNECTING) {
+				pendingUpstream.push(obj);
+				return;
+			}
 			if (upstream.readyState !== WebSocket.OPEN) return;
 			try {
 				upstream.send(JSON.stringify(obj));
@@ -213,6 +223,16 @@ export async function proxyBrowserUpgrade(
 				/* ignore */
 			}
 		};
+		upstream.on("open", () => {
+			for (const obj of pendingUpstream) {
+				try {
+					upstream.send(JSON.stringify(obj));
+				} catch {
+					/* ignore */
+				}
+			}
+			pendingUpstream.length = 0;
+		});
 		const rejectRequest = (id: number, message: string): void => {
 			sendToClient({ id, error: { code: -32601, message } });
 		};
@@ -224,12 +244,20 @@ export async function proxyBrowserUpgrade(
 			} catch {
 				return;
 			}
+			const id = typeof msg.id === "number" ? msg.id : undefined;
 			if (msg.sessionId) {
-				if (allowedSessionIds.has(msg.sessionId)) sendToUpstream(msg);
+				if (allowedSessionIds.has(msg.sessionId)) {
+					sendToUpstream(msg);
+				} else if (id !== undefined) {
+					// Don't hang the caller on a stale / unknown sessionId.
+					rejectRequest(
+						id,
+						"The supplied CDP sessionId is not authorized for this Superset session (the session may have been detached or belong to another pane).",
+					);
+				}
 				return;
 			}
 			const method = msg.method ?? "";
-			const id = typeof msg.id === "number" ? msg.id : undefined;
 			const bound = ctx.boundTargetIds();
 
 			if (
@@ -341,10 +369,35 @@ export async function proxyBrowserUpgrade(
 			if (method === "Target.detachFromTarget" && id !== undefined) {
 				const sid = (msg.params as { sessionId?: string } | undefined)
 					?.sessionId;
+				const tid = targetIdOf(msg.params);
+				if ((sid && !allowedSessionIds.has(sid)) || (tid && !bound.has(tid))) {
+					rejectRequest(
+						id,
+						"Target.detachFromTarget outside the bound scope is refused by the Superset CDP filter.",
+					);
+					return;
+				}
+				pendingMethods.set(id, method);
+				sendToUpstream(msg);
+				return;
+			}
+
+			// Remaining Target.* methods that address a specific target or
+			// session (e.g. sendMessageToTarget, setRemoteLocations). Verify
+			// any supplied targetId / sessionId are inside scope before
+			// forwarding.
+			if (method.startsWith("Target.") && id !== undefined) {
+				const tid = targetIdOf(msg.params);
+				const sid = (msg.params as { sessionId?: string } | undefined)
+					?.sessionId;
+				if (tid && !bound.has(tid)) {
+					rejectRequest(id, `${method} targetId is outside the bound scope.`);
+					return;
+				}
 				if (sid && !allowedSessionIds.has(sid)) {
 					rejectRequest(
 						id,
-						"Target.detachFromTarget for unknown sessions is refused by the Superset CDP filter.",
+						`${method} sessionId is not authorized for this Superset session.`,
 					);
 					return;
 				}
@@ -449,6 +502,34 @@ export async function proxyBrowserUpgrade(
 					?.sessionId;
 				if (!sid || !allowedSessionIds.has(sid)) return;
 				allowedSessionIds.delete(sid);
+				sendToClient(msg);
+				return;
+			}
+			// Target.receivedMessageFromTarget carries a session-scoped
+			// payload on the browser-level socket (the non-flatten path).
+			// Drop it when the inner sessionId or targetId is outside our
+			// scope so we don't leak another pane's CDP traffic.
+			if (method === "Target.receivedMessageFromTarget") {
+				const params = msg.params as
+					| { sessionId?: string; targetId?: string }
+					| undefined;
+				if (params?.sessionId && !allowedSessionIds.has(params.sessionId))
+					return;
+				if (params?.targetId && !bound.has(params.targetId)) return;
+				sendToClient(msg);
+				return;
+			}
+			// Any other Target.* event that mentions a targetId /
+			// sessionId must also be scoped.
+			if (method.startsWith("Target.")) {
+				const tid =
+					targetIdOf(msg.params) ??
+					(msg.params as { targetInfo?: { targetId?: string } } | undefined)
+						?.targetInfo?.targetId;
+				const sid = (msg.params as { sessionId?: string } | undefined)
+					?.sessionId;
+				if (tid && !bound.has(tid)) return;
+				if (sid && !allowedSessionIds.has(sid)) return;
 				sendToClient(msg);
 				return;
 			}

--- a/apps/desktop/src/main/lib/browser-mcp-bridge/cdp-filter-proxy.ts
+++ b/apps/desktop/src/main/lib/browser-mcp-bridge/cdp-filter-proxy.ts
@@ -224,13 +224,13 @@ function resolveBindingForSession(
 	return { paneId: binding.paneId, targetId };
 }
 
-function sendJson(res: ServerResponse, status: number, body: unknown): void {
+export function sendJson(res: ServerResponse, status: number, body: unknown): void {
 	res.statusCode = status;
 	res.setHeader("content-type", "application/json");
 	res.end(JSON.stringify(body));
 }
 
-async function fetchUpstreamJson(path: string): Promise<unknown> {
+export async function fetchUpstreamJson(path: string): Promise<unknown> {
 	const port = await resolveCdpPort();
 	if (!port) throw new Error("Chromium CDP port not available");
 	const res = await fetch(`http://127.0.0.1:${port}${path}`);
@@ -248,7 +248,7 @@ async function fetchUpstreamJson(path: string): Promise<unknown> {
  */
 const browserWsIds = new Map<string, string>();
 
-function browserWsIdFor(sessionId: string): string {
+export function browserWsIdFor(sessionId: string): string {
 	let id = browserWsIds.get(sessionId);
 	if (!id) {
 		id = randomBytes(16).toString("hex");
@@ -367,7 +367,7 @@ function wireUpgradeHandler(
 	});
 }
 
-async function proxyPageUpgrade(
+export async function proxyPageUpgrade(
 	req: IncomingMessage,
 	socket: Duplex,
 	head: Buffer,
@@ -460,7 +460,7 @@ function isTargetInfoForBound(
 	);
 }
 
-async function proxyBrowserUpgrade(
+export async function proxyBrowserUpgrade(
 	req: IncomingMessage,
 	socket: Duplex,
 	head: Buffer,

--- a/apps/desktop/src/main/lib/browser-mcp-bridge/cdp-gateway.ts
+++ b/apps/desktop/src/main/lib/browser-mcp-bridge/cdp-gateway.ts
@@ -81,14 +81,16 @@ export function ensureGlobalBrowserUseConfig(bridgePort: number): void {
 	}
 }
 
-const socketSessions = new WeakMap<
-	Socket,
-	Promise<{ paneId: string; sessionId: string } | null>
->();
+/**
+ * Session resolution is keyed to the TCP socket (peer-PID lookup is
+ * expensive and the socket identifies a single external MCP process),
+ * but the paneId binding is intentionally NOT cached — a keep-alive
+ * HTTP connection crossing a pane rebind must pick up the new pane on
+ * the next request.
+ */
+const socketSessions = new WeakMap<Socket, Promise<string | null>>();
 
-async function resolveForSocket(
-	socket: Socket,
-): Promise<{ paneId: string; sessionId: string } | null> {
+async function resolveSessionForSocket(socket: Socket): Promise<string | null> {
 	const cached = socketSessions.get(socket);
 	if (cached) return cached;
 	const promise = (async () => {
@@ -104,13 +106,20 @@ async function resolveForSocket(
 		const peerPid = await resolvePeerPidFromRemotePort(remotePort, process.pid);
 		if (!peerPid) return null;
 		const session = await resolvePidToSession(peerPid);
-		if (!session?.paneId) return null;
-		const binding = bindingStore.getBySessionId(session.sessionId);
-		if (!binding) return null;
-		return { paneId: binding.paneId, sessionId: session.sessionId };
+		return session?.sessionId ?? null;
 	})();
 	socketSessions.set(socket, promise);
 	return promise;
+}
+
+async function resolveForSocket(
+	socket: Socket,
+): Promise<{ paneId: string; sessionId: string } | null> {
+	const sessionId = await resolveSessionForSocket(socket);
+	if (!sessionId) return null;
+	const binding = bindingStore.getBySessionId(sessionId);
+	if (!binding) return null;
+	return { paneId: binding.paneId, sessionId };
 }
 
 /* ---------------------------------------------------------------- */

--- a/apps/desktop/src/main/lib/browser-mcp-bridge/cdp-gateway.ts
+++ b/apps/desktop/src/main/lib/browser-mcp-bridge/cdp-gateway.ts
@@ -1,7 +1,10 @@
+import { chmodSync, mkdirSync, writeFileSync } from "node:fs";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import type { Socket } from "node:net";
+import { dirname, join } from "node:path";
 import type { Duplex } from "node:stream";
 import { WebSocketServer } from "ws";
+import { SUPERSET_HOME_DIR } from "../app-environment";
 import { bindingStore } from "../../../lib/trpc/routers/browser-automation/index";
 import { browserManager } from "../browser/browser-manager";
 import {
@@ -49,6 +52,55 @@ import { resolvePeerPidFromRemotePort } from "./peer-pid";
  */
 
 const wss = new WebSocketServer({ noServer: true });
+
+/* ---------------------------------------------------------------- */
+/* Global browser-use config (stable across all sessions).           */
+/*                                                                   */
+/* browser-use's --mcp branch ignores --cdp-url and only honours the */
+/* default browser_profile entry in the JSON pointed to by           */
+/* BROWSER_USE_CONFIG_PATH. Since the gateway URL is now stable      */
+/* (session is resolved per-connection, not per-port), one config   */
+/* file suffices for every Superset install and never has to be      */
+/* updated by the UI.                                                */
+/* ---------------------------------------------------------------- */
+
+const GLOBAL_BROWSER_USE_CONFIG_PATH = join(
+	SUPERSET_HOME_DIR,
+	"browser-use-mcp.json",
+);
+
+export function getGlobalBrowserUseConfigPath(): string {
+	return GLOBAL_BROWSER_USE_CONFIG_PATH;
+}
+
+export function ensureGlobalBrowserUseConfig(bridgePort: number): void {
+	const payload = {
+		browser_profile: {
+			"superset-gateway": {
+				id: "superset-gateway",
+				default: true,
+				cdp_url: `http://127.0.0.1:${bridgePort}`,
+			},
+		},
+		llm: {},
+		agent: {},
+	};
+	try {
+		mkdirSync(dirname(GLOBAL_BROWSER_USE_CONFIG_PATH), { recursive: true });
+		writeFileSync(
+			GLOBAL_BROWSER_USE_CONFIG_PATH,
+			JSON.stringify(payload, null, 2),
+			{ mode: 0o600 },
+		);
+		try {
+			chmodSync(GLOBAL_BROWSER_USE_CONFIG_PATH, 0o600);
+		} catch {
+			/* best effort */
+		}
+	} catch (error) {
+		console.warn("[cdp-gateway] failed to write global browser-use config:", error);
+	}
+}
 
 const socketSessions = new WeakMap<
 	Socket,

--- a/apps/desktop/src/main/lib/browser-mcp-bridge/cdp-gateway.ts
+++ b/apps/desktop/src/main/lib/browser-mcp-bridge/cdp-gateway.ts
@@ -1,0 +1,217 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import type { Socket } from "node:net";
+import type { Duplex } from "node:stream";
+import { WebSocketServer } from "ws";
+import { bindingStore } from "../../../lib/trpc/routers/browser-automation/index";
+import { browserManager } from "../browser/browser-manager";
+import {
+	browserWsIdFor,
+	fetchUpstreamJson,
+	proxyBrowserUpgrade,
+	proxyPageUpgrade,
+	sendJson,
+} from "./cdp-filter-proxy";
+import { resolveCdpPort } from "./cdp-port";
+import { resolvePidToSession } from "./pane-resolver";
+import { resolvePeerPidFromRemotePort } from "./peer-pid";
+
+/**
+ * Single-port CDP gateway.
+ *
+ * Shares the bridge's HTTP server on port 47834 and serves the
+ * endpoints external CDP MCPs (chrome-devtools-mcp, browser-use,
+ * playwright-mcp) expect:
+ *
+ *   GET /json/version            — rewritten browser WS URL
+ *   GET /json, /json/list        — filtered to bound pane
+ *   GET /json/protocol           — forwarded
+ *   WS  /devtools/browser/<id>   — filtered browser-level CDP
+ *   WS  /devtools/page/<id>      — page-level CDP for bound target
+ *
+ * Unlike the deprecated per-session port model — which baked a
+ * specific LLM session into a dedicated HTTP+WS server — the gateway
+ * resolves the calling LLM session *per connection* by walking the
+ * TCP peer PID up through the Superset terminal PTY process tree.
+ * This lets the external MCP registration URL stay constant across
+ * sessions, Superset / macOS restarts, pane rebindings, and new
+ * terminal panes.
+ *
+ * Security: loopback-only. The peer-PID walk additionally requires
+ * the caller to descend from a live Superset terminal pane; any
+ * local process outside that tree is rejected. This is strictly
+ * stronger than Chromium's own `--remote-debugging-port` model.
+ *
+ * These endpoints are *explicitly* authentication-free because
+ * puppeteer composes `new URL("/json/version", browserURL)` and
+ * drops any path/query/Authorization-header from the base URL, so
+ * no secret-in-URL / Bearer scheme can survive. Capability is the
+ * peer-PID tree-descendant check.
+ */
+
+const wss = new WebSocketServer({ noServer: true });
+
+const socketSessions = new WeakMap<
+	Socket,
+	Promise<{ paneId: string; sessionId: string } | null>
+>();
+
+async function resolveForSocket(
+	socket: Socket,
+): Promise<{ paneId: string; sessionId: string } | null> {
+	const cached = socketSessions.get(socket);
+	if (cached) return cached;
+	const promise = (async () => {
+		if (
+			socket.remoteAddress !== "127.0.0.1" &&
+			socket.remoteAddress !== "::1" &&
+			socket.remoteAddress !== "::ffff:127.0.0.1"
+		) {
+			return null;
+		}
+		const remotePort = socket.remotePort;
+		if (typeof remotePort !== "number") return null;
+		const peerPid = await resolvePeerPidFromRemotePort(
+			remotePort,
+			process.pid,
+		);
+		if (!peerPid) return null;
+		const session = await resolvePidToSession(peerPid);
+		if (!session?.paneId) return null;
+		const binding = bindingStore.getBySessionId(session.sessionId);
+		if (!binding) return null;
+		return { paneId: binding.paneId, sessionId: session.sessionId };
+	})();
+	socketSessions.set(socket, promise);
+	return promise;
+}
+
+export function isCdpGatewayPath(pathname: string): boolean {
+	const p = pathname.replace(/\/$/, "") || "/";
+	return (
+		p === "/json" ||
+		p === "/json/list" ||
+		p === "/json/version" ||
+		p === "/json/protocol"
+	);
+}
+
+export function isCdpGatewayUpgradePath(pathname: string): boolean {
+	return (
+		/^\/devtools\/browser\/[^/]+$/.test(pathname) ||
+		/^\/devtools\/page\/[^/]+$/.test(pathname)
+	);
+}
+
+export async function handleCdpGatewayRequest(
+	req: IncomingMessage,
+	res: ServerResponse,
+): Promise<void> {
+	const url = new URL(req.url ?? "/", "http://localhost");
+	const pathname = url.pathname.replace(/\/$/, "") || "/";
+	try {
+		const resolved = await resolveForSocket(req.socket as Socket);
+		if (!resolved) {
+			sendJson(res, 409, {
+				error:
+					"このLLMセッションにはブラウザペインが接続されていません。Supersetの「Connect」で対象ペインをアタッチしてください。",
+			});
+			return;
+		}
+		const targetId = browserManager.getCdpTargetId(resolved.paneId);
+		if (!targetId) {
+			sendJson(res, 503, {
+				error:
+					"バインド済みペインのCDPターゲット準備がまだ完了していません。少し待って再試行してください。",
+			});
+			return;
+		}
+
+		const host = req.headers.host ?? "127.0.0.1";
+		if (pathname === "/json/version") {
+			const body = (await fetchUpstreamJson("/json/version")) as Record<
+				string,
+				unknown
+			>;
+			const { webSocketDebuggerUrl: _drop, ...safe } = body;
+			void _drop;
+			sendJson(res, 200, {
+				...safe,
+				webSocketDebuggerUrl: `ws://${host}/devtools/browser/${browserWsIdFor(resolved.sessionId)}`,
+			});
+			return;
+		}
+		if (pathname === "/json/protocol") {
+			const body = await fetchUpstreamJson("/json/protocol");
+			sendJson(res, 200, body);
+			return;
+		}
+		// /json or /json/list
+		const raw = (await fetchUpstreamJson("/json/list")) as Array<
+			Record<string, unknown>
+		>;
+		const out = raw
+			.filter((t) => (t as { id?: string }).id === targetId)
+			.map((t) => ({
+				...t,
+				webSocketDebuggerUrl: `ws://${host}/devtools/page/${targetId}`,
+				devtoolsFrontendUrl: `http://${host}/devtools/page/${targetId}`,
+			}));
+		sendJson(res, 200, out);
+	} catch (error) {
+		console.error("[cdp-gateway] request error:", error);
+		sendJson(res, 502, {
+			error: error instanceof Error ? error.message : String(error),
+		});
+	}
+}
+
+export async function handleCdpGatewayUpgrade(
+	req: IncomingMessage,
+	socket: Duplex,
+	head: Buffer,
+): Promise<void> {
+	const pathname = new URL(req.url ?? "/", "http://localhost").pathname;
+	const isBrowserPath = /^\/devtools\/browser\/[^/]+$/.test(pathname);
+	const isPagePath = /^\/devtools\/page\/[^/]+$/.test(pathname);
+	if (!isBrowserPath && !isPagePath) {
+		socket.destroy();
+		return;
+	}
+	const s = socket as unknown as Socket;
+	if (
+		s.remoteAddress !== "127.0.0.1" &&
+		s.remoteAddress !== "::1" &&
+		s.remoteAddress !== "::ffff:127.0.0.1"
+	) {
+		socket.destroy();
+		return;
+	}
+	const resolved = await resolveForSocket(s);
+	if (!resolved) {
+		socket.destroy();
+		return;
+	}
+	const targetId = browserManager.getCdpTargetId(resolved.paneId);
+	if (!targetId) {
+		socket.destroy();
+		return;
+	}
+	const port = await resolveCdpPort();
+	if (!port) {
+		socket.destroy();
+		return;
+	}
+	if (isBrowserPath) {
+		const expected = `/devtools/browser/${browserWsIdFor(resolved.sessionId)}`;
+		if (pathname !== expected) {
+			socket.destroy();
+			return;
+		}
+		void proxyBrowserUpgrade(req, socket, head, wss, port, {
+			paneId: resolved.paneId,
+			targetId,
+		});
+		return;
+	}
+	void proxyPageUpgrade(req, socket, head, wss, port, targetId);
+}

--- a/apps/desktop/src/main/lib/browser-mcp-bridge/cdp-gateway.ts
+++ b/apps/desktop/src/main/lib/browser-mcp-bridge/cdp-gateway.ts
@@ -3,7 +3,7 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 import type { Socket } from "node:net";
 import { dirname, join } from "node:path";
 import type { Duplex } from "node:stream";
-import { WebSocket, WebSocketServer } from "ws";
+import { type WebSocket, WebSocketServer } from "ws";
 import { bindingStore } from "../../../lib/trpc/routers/browser-automation/index";
 import { SUPERSET_HOME_DIR } from "../app-environment";
 import { browserManager } from "../browser/browser-manager";
@@ -101,10 +101,7 @@ async function resolveForSocket(
 		}
 		const remotePort = socket.remotePort;
 		if (typeof remotePort !== "number") return null;
-		const peerPid = await resolvePeerPidFromRemotePort(
-			remotePort,
-			process.pid,
-		);
+		const peerPid = await resolvePeerPidFromRemotePort(remotePort, process.pid);
 		if (!peerPid) return null;
 		const session = await resolvePidToSession(peerPid);
 		if (!session?.paneId) return null;
@@ -266,8 +263,7 @@ export async function handleCdpGatewayRequest(
 			Record<string, unknown>
 		>;
 		const boundSet =
-			browserManager.getPaneTargetIds?.(resolved.paneId) ??
-			new Set([primary]);
+			browserManager.getPaneTargetIds?.(resolved.paneId) ?? new Set([primary]);
 		const out = raw
 			.filter((t) => {
 				const id = (t as { id?: string }).id;

--- a/apps/desktop/src/main/lib/browser-mcp-bridge/cdp-gateway.ts
+++ b/apps/desktop/src/main/lib/browser-mcp-bridge/cdp-gateway.ts
@@ -3,11 +3,12 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 import type { Socket } from "node:net";
 import { dirname, join } from "node:path";
 import type { Duplex } from "node:stream";
-import { WebSocketServer } from "ws";
-import { SUPERSET_HOME_DIR } from "../app-environment";
+import { WebSocket, WebSocketServer } from "ws";
 import { bindingStore } from "../../../lib/trpc/routers/browser-automation/index";
+import { SUPERSET_HOME_DIR } from "../app-environment";
 import { browserManager } from "../browser/browser-manager";
 import {
+	type BoundContext,
 	browserWsIdFor,
 	fetchUpstreamJson,
 	proxyBrowserUpgrade,
@@ -21,48 +22,23 @@ import { resolvePeerPidFromRemotePort } from "./peer-pid";
 /**
  * Single-port CDP gateway.
  *
- * Shares the bridge's HTTP server on port 47834 and serves the
- * endpoints external CDP MCPs (chrome-devtools-mcp, browser-use,
- * playwright-mcp) expect:
+ * Serves the endpoints external CDP MCPs expect (`/json/*`,
+ * `/devtools/browser/<id>`, `/devtools/page/<id>`) on the bridge port
+ * (47834) and resolves which LLM session (and therefore which bound
+ * pane) the caller belongs to *per connection* via a loopback peer-PID
+ * walk — so the registration URL stays constant across Superset / OS
+ * restarts, pane rebindings, and new terminal panes.
  *
- *   GET /json/version            — rewritten browser WS URL
- *   GET /json, /json/list        — filtered to bound pane
- *   GET /json/protocol           — forwarded
- *   WS  /devtools/browser/<id>   — filtered browser-level CDP
- *   WS  /devtools/page/<id>      — page-level CDP for bound target
+ * Security: loopback-only. The peer-PID walk additionally requires the
+ * caller to descend from a live Superset terminal pane.
  *
- * Unlike the deprecated per-session port model — which baked a
- * specific LLM session into a dedicated HTTP+WS server — the gateway
- * resolves the calling LLM session *per connection* by walking the
- * TCP peer PID up through the Superset terminal PTY process tree.
- * This lets the external MCP registration URL stay constant across
- * sessions, Superset / macOS restarts, pane rebindings, and new
- * terminal panes.
- *
- * Security: loopback-only. The peer-PID walk additionally requires
- * the caller to descend from a live Superset terminal pane; any
- * local process outside that tree is rejected. This is strictly
- * stronger than Chromium's own `--remote-debugging-port` model.
- *
- * These endpoints are *explicitly* authentication-free because
- * puppeteer composes `new URL("/json/version", browserURL)` and
- * drops any path/query/Authorization-header from the base URL, so
- * no secret-in-URL / Bearer scheme can survive. Capability is the
+ * These endpoints are unauthenticated because puppeteer composes
+ * `new URL("/json/version", browserURL)` and drops any path/query/
+ * Authorization header from the base URL. Capability is instead the
  * peer-PID tree-descendant check.
  */
 
 const wss = new WebSocketServer({ noServer: true });
-
-/* ---------------------------------------------------------------- */
-/* Global browser-use config (stable across all sessions).           */
-/*                                                                   */
-/* browser-use's --mcp branch ignores --cdp-url and only honours the */
-/* default browser_profile entry in the JSON pointed to by           */
-/* BROWSER_USE_CONFIG_PATH. Since the gateway URL is now stable      */
-/* (session is resolved per-connection, not per-port), one config   */
-/* file suffices for every Superset install and never has to be      */
-/* updated by the UI.                                                */
-/* ---------------------------------------------------------------- */
 
 const GLOBAL_BROWSER_USE_CONFIG_PATH = join(
 	SUPERSET_HOME_DIR,
@@ -98,7 +74,10 @@ export function ensureGlobalBrowserUseConfig(bridgePort: number): void {
 			/* best effort */
 		}
 	} catch (error) {
-		console.warn("[cdp-gateway] failed to write global browser-use config:", error);
+		console.warn(
+			"[cdp-gateway] failed to write global browser-use config:",
+			error,
+		);
 	}
 }
 
@@ -137,6 +116,90 @@ async function resolveForSocket(
 	return promise;
 }
 
+/* ---------------------------------------------------------------- */
+/* M3: close active CDP connections for a session when its binding   */
+/* changes, so external MCPs reconnect next tool call and            */
+/* transparently pick up the new pane.                               */
+/* ---------------------------------------------------------------- */
+
+const sessionConnections = new Map<string, Set<WebSocket>>();
+
+function registerConnection(sessionId: string, ws: WebSocket): void {
+	let set = sessionConnections.get(sessionId);
+	if (!set) {
+		set = new Set<WebSocket>();
+		sessionConnections.set(sessionId, set);
+	}
+	set.add(ws);
+	ws.on("close", () => {
+		set?.delete(ws);
+		if (set && set.size === 0) sessionConnections.delete(sessionId);
+	});
+}
+
+function closeConnectionsForSession(sessionId: string): void {
+	const set = sessionConnections.get(sessionId);
+	if (!set) return;
+	for (const ws of Array.from(set)) {
+		try {
+			ws.close(1000, "superset: binding changed, reconnect");
+		} catch {
+			/* ignore */
+		}
+	}
+	sessionConnections.delete(sessionId);
+}
+
+let bindingChangeWatcherInstalled = false;
+const lastBindingBySession = new Map<string, string>();
+
+function installBindingChangeWatcher(): void {
+	if (bindingChangeWatcherInstalled) return;
+	bindingChangeWatcherInstalled = true;
+	for (const b of bindingStore.list()) {
+		lastBindingBySession.set(b.sessionId, b.paneId);
+	}
+	bindingStore.onChange((list) => {
+		const next = new Map<string, string>();
+		for (const b of list) next.set(b.sessionId, b.paneId);
+		// Session removed → close.
+		for (const [sid] of lastBindingBySession) {
+			if (!next.has(sid)) closeConnectionsForSession(sid);
+		}
+		// Pane changed → close so client reconnects with new binding.
+		for (const [sid, paneId] of next) {
+			const prev = lastBindingBySession.get(sid);
+			if (prev && prev !== paneId) closeConnectionsForSession(sid);
+		}
+		lastBindingBySession.clear();
+		for (const [k, v] of next) lastBindingBySession.set(k, v);
+	});
+}
+
+function makeBoundContext(resolved: {
+	paneId: string;
+	sessionId: string;
+}): BoundContext | null {
+	const primary = browserManager.getCdpTargetId(resolved.paneId);
+	if (!primary) return null;
+	return {
+		paneId: resolved.paneId,
+		primaryTargetId: primary,
+		boundTargetIds: () => {
+			// M1/M2 bridge: ask browserManager for the pane's current
+			// target set. In single-tab mode this is a singleton; with
+			// multi-tab enabled it returns every tab. Falls back to the
+			// primary when no registry is available.
+			const all = browserManager.getPaneTargetIds?.(resolved.paneId);
+			if (all && all.size > 0) return all;
+			return new Set([primary]);
+		},
+		onClose: (ws) => {
+			registerConnection(resolved.sessionId, ws);
+		},
+	};
+}
+
 export function isCdpGatewayPath(pathname: string): boolean {
 	const p = pathname.replace(/\/$/, "") || "/";
 	return (
@@ -158,6 +221,7 @@ export async function handleCdpGatewayRequest(
 	req: IncomingMessage,
 	res: ServerResponse,
 ): Promise<void> {
+	installBindingChangeWatcher();
 	const url = new URL(req.url ?? "/", "http://localhost");
 	const pathname = url.pathname.replace(/\/$/, "") || "/";
 	try {
@@ -169,8 +233,8 @@ export async function handleCdpGatewayRequest(
 			});
 			return;
 		}
-		const targetId = browserManager.getCdpTargetId(resolved.paneId);
-		if (!targetId) {
+		const primary = browserManager.getCdpTargetId(resolved.paneId);
+		if (!primary) {
 			sendJson(res, 503, {
 				error:
 					"バインド済みペインのCDPターゲット準備がまだ完了していません。少し待って再試行してください。",
@@ -201,13 +265,22 @@ export async function handleCdpGatewayRequest(
 		const raw = (await fetchUpstreamJson("/json/list")) as Array<
 			Record<string, unknown>
 		>;
+		const boundSet =
+			browserManager.getPaneTargetIds?.(resolved.paneId) ??
+			new Set([primary]);
 		const out = raw
-			.filter((t) => (t as { id?: string }).id === targetId)
-			.map((t) => ({
-				...t,
-				webSocketDebuggerUrl: `ws://${host}/devtools/page/${targetId}`,
-				devtoolsFrontendUrl: `http://${host}/devtools/page/${targetId}`,
-			}));
+			.filter((t) => {
+				const id = (t as { id?: string }).id;
+				return typeof id === "string" && boundSet.has(id);
+			})
+			.map((t) => {
+				const id = (t as { id?: string }).id ?? primary;
+				return {
+					...t,
+					webSocketDebuggerUrl: `ws://${host}/devtools/page/${id}`,
+					devtoolsFrontendUrl: `http://${host}/devtools/page/${id}`,
+				};
+			});
 		sendJson(res, 200, out);
 	} catch (error) {
 		console.error("[cdp-gateway] request error:", error);
@@ -222,6 +295,7 @@ export async function handleCdpGatewayUpgrade(
 	socket: Duplex,
 	head: Buffer,
 ): Promise<void> {
+	installBindingChangeWatcher();
 	const pathname = new URL(req.url ?? "/", "http://localhost").pathname;
 	const isBrowserPath = /^\/devtools\/browser\/[^/]+$/.test(pathname);
 	const isPagePath = /^\/devtools\/page\/[^/]+$/.test(pathname);
@@ -243,8 +317,8 @@ export async function handleCdpGatewayUpgrade(
 		socket.destroy();
 		return;
 	}
-	const targetId = browserManager.getCdpTargetId(resolved.paneId);
-	if (!targetId) {
+	const ctx = makeBoundContext(resolved);
+	if (!ctx) {
 		socket.destroy();
 		return;
 	}
@@ -259,11 +333,15 @@ export async function handleCdpGatewayUpgrade(
 			socket.destroy();
 			return;
 		}
-		void proxyBrowserUpgrade(req, socket, head, wss, port, {
-			paneId: resolved.paneId,
-			targetId,
-		});
+		void proxyBrowserUpgrade(req, socket, head, wss, port, ctx);
 		return;
 	}
-	void proxyPageUpgrade(req, socket, head, wss, port, targetId);
+	// Page-level upgrade: ensure the requested target is in the bound set.
+	const m = pathname.match(/^\/devtools\/page\/([^/]+)$/);
+	const tid = m?.[1];
+	if (!tid || !ctx.boundTargetIds().has(tid)) {
+		socket.destroy();
+		return;
+	}
+	void proxyPageUpgrade(req, socket, head, wss, port, tid);
 }

--- a/apps/desktop/src/main/lib/browser-mcp-bridge/pane-resolver.ts
+++ b/apps/desktop/src/main/lib/browser-mcp-bridge/pane-resolver.ts
@@ -95,6 +95,56 @@ export async function resolvePpidToSession(
 	return resolved;
 }
 
+/**
+ * Like resolvePpidToSession but walks by process-tree *inclusion*
+ * rather than by PPID identity, and skips the claude/codex name check.
+ *
+ * Use this when the caller holds the PID of an arbitrary descendant of
+ * a Superset terminal pane (e.g. a loopback peer PID obtained from
+ * lsof). The MCP's immediate parent is often `npx`, `uvx`, or a node
+ * wrapper rather than Claude / Codex itself, so the
+ * looksAgent heuristic would reject the caller. The descendant has
+ * to have been launched from inside a Superset terminal pane anyway —
+ * that is itself the security boundary, and tree-inclusion is
+ * sufficient evidence of that.
+ */
+export async function resolvePidToSession(
+	pid: number,
+): Promise<ResolvedSession | null> {
+	if (!Number.isFinite(pid) || pid <= 0) return null;
+	const cached = cache.get(pid);
+	if (cached && Date.now() - cached.at < CACHE_TTL_MS) {
+		return cached.resolved;
+	}
+	let sessions: Awaited<
+		ReturnType<ReturnType<typeof getTerminalHostClient>["listSessions"]>
+	>["sessions"];
+	try {
+		const client = getTerminalHostClient();
+		const res = await client.listSessions();
+		sessions = res.sessions;
+	} catch {
+		return null;
+	}
+	for (const s of sessions) {
+		if (!s.isAlive || typeof s.pid !== "number") continue;
+		try {
+			const tree = await getProcessTree(s.pid);
+			if (!tree.includes(pid)) continue;
+			const resolved: ResolvedSession = {
+				sessionId: `terminal:${s.paneId}`,
+				kind: "terminal",
+				paneId: s.paneId,
+			};
+			cache.set(pid, { resolved, at: Date.now() });
+			return resolved;
+		} catch {
+			// Next pane.
+		}
+	}
+	return null;
+}
+
 export function getBoundPaneForSession(sessionId: string): string | null {
 	const binding = bindingStore.getBySessionId(sessionId);
 	return binding?.paneId ?? null;

--- a/apps/desktop/src/main/lib/browser-mcp-bridge/peer-pid.ts
+++ b/apps/desktop/src/main/lib/browser-mcp-bridge/peer-pid.ts
@@ -1,4 +1,5 @@
 import { exec } from "node:child_process";
+import { platform } from "node:os";
 import { promisify } from "node:util";
 
 const execAsync = promisify(exec);
@@ -24,6 +25,16 @@ export async function resolvePeerPidFromRemotePort(
 	ownPid: number,
 ): Promise<number | null> {
 	if (!Number.isInteger(remotePort) || remotePort < 1 || remotePort > 65_535) {
+		return null;
+	}
+	const plat = platform();
+	if (plat !== "darwin" && plat !== "linux") {
+		// Windows / other platforms: lsof is unavailable. The gateway
+		// is not supported on these platforms; the caller will surface
+		// the same 409 as "no binding" so external MCPs receive a
+		// clean error instead of hanging. Windows support is tracked
+		// separately and will plug into this resolver via a
+		// platform-specific implementation (netstat / GetTcpTable2).
 		return null;
 	}
 	try {

--- a/apps/desktop/src/main/lib/browser-mcp-bridge/peer-pid.ts
+++ b/apps/desktop/src/main/lib/browser-mcp-bridge/peer-pid.ts
@@ -23,11 +23,7 @@ export async function resolvePeerPidFromRemotePort(
 	remotePort: number,
 	ownPid: number,
 ): Promise<number | null> {
-	if (
-		!Number.isInteger(remotePort) ||
-		remotePort < 1 ||
-		remotePort > 65_535
-	) {
+	if (!Number.isInteger(remotePort) || remotePort < 1 || remotePort > 65_535) {
 		return null;
 	}
 	try {

--- a/apps/desktop/src/main/lib/browser-mcp-bridge/peer-pid.ts
+++ b/apps/desktop/src/main/lib/browser-mcp-bridge/peer-pid.ts
@@ -1,0 +1,64 @@
+import { exec } from "node:child_process";
+import { promisify } from "node:util";
+
+const execAsync = promisify(exec);
+
+/**
+ * Resolve the PID of the remote end of a loopback TCP connection on
+ * macOS / Linux.
+ *
+ * macOS does not expose a TCP-equivalent of LOCAL_PEERPID, so we fall
+ * back to `lsof` and filter by the remote side's ephemeral port. For a
+ * loopback connection `lsof` returns two entries (server side, client
+ * side); we identify the peer as the process whose *local* end matches
+ * `remotePort`, not `ownPid`.
+ *
+ * The remote port is a 16-bit ephemeral chosen by the kernel for each
+ * outbound connection, so collisions between concurrent connections
+ * are effectively impossible in practice on a single host. We still
+ * defend against race / reuse by rejecting results that could point
+ * back to our own process.
+ */
+export async function resolvePeerPidFromRemotePort(
+	remotePort: number,
+	ownPid: number,
+): Promise<number | null> {
+	if (
+		!Number.isInteger(remotePort) ||
+		remotePort < 1 ||
+		remotePort > 65_535
+	) {
+		return null;
+	}
+	try {
+		const { stdout } = await execAsync(
+			`lsof -nP -iTCP:${remotePort} -sTCP:ESTABLISHED 2>/dev/null || true`,
+			{ timeout: 3_000, maxBuffer: 1024 * 1024 },
+		);
+		const text = stdout.trim();
+		if (!text) return null;
+		const lines = text.split("\n").slice(1); // skip header
+		for (const line of lines) {
+			const cols = line.trim().split(/\s+/);
+			// Format: COMMAND PID USER FD TYPE DEVICE SIZE/OFF NODE NAME
+			// NAME: 127.0.0.1:<localPort>->127.0.0.1:<peerPort> (ESTABLISHED)
+			if (cols.length < 9) continue;
+			const pid = Number.parseInt(cols[1] ?? "", 10);
+			if (!Number.isFinite(pid) || pid <= 0) continue;
+			if (pid === ownPid) continue; // this is our own (server) socket entry
+			const name = cols.slice(8).join(" ");
+			// The peer process is the one whose LOCAL endpoint is
+			// 127.0.0.1:<remotePort>. The `->` separator is always
+			// present on ESTABLISHED sockets.
+			const match = name.match(
+				/^(?:\[::1\]|127\.0\.0\.1):(\d+)->(?:\[::1\]|127\.0\.0\.1):(\d+)/,
+			);
+			if (!match) continue;
+			const localPort = Number.parseInt(match[1] ?? "", 10);
+			if (localPort === remotePort) return pid;
+		}
+		return null;
+	} catch {
+		return null;
+	}
+}

--- a/apps/desktop/src/main/lib/browser-mcp-bridge/server.ts
+++ b/apps/desktop/src/main/lib/browser-mcp-bridge/server.ts
@@ -15,6 +15,7 @@ import {
 	stopAllSessionEndpoints,
 } from "./cdp-filter-proxy";
 import {
+	ensureGlobalBrowserUseConfig,
 	handleCdpGatewayRequest,
 	handleCdpGatewayUpgrade,
 	isCdpGatewayPath,
@@ -272,6 +273,11 @@ export async function startBrowserMcpBridge(): Promise<BridgeHandle> {
 	});
 
 	const port = await listenPreferringStablePort(server);
+
+	// One-shot: write the global browser-use config pointing at this
+	// gateway. Same file for every session; session routing happens
+	// per connection via peer-PID.
+	ensureGlobalBrowserUseConfig(port);
 
 	mkdirSync(dirname(RUNTIME_INFO_PATH), { recursive: true });
 	writeFileSync(RUNTIME_INFO_PATH, JSON.stringify({ port, secret }, null, 2), {

--- a/apps/desktop/src/main/lib/browser-mcp-bridge/server.ts
+++ b/apps/desktop/src/main/lib/browser-mcp-bridge/server.ts
@@ -209,9 +209,9 @@ export async function startBrowserMcpBridge(): Promise<BridgeHandle> {
 				// port (47834); the gateway routes each incoming
 				// connection by peer-PID. One stable URL works for every
 				// session and survives restarts / rebindings.
-				const gatewayPort = await import(
-					"./server"
-				).then((m) => m.getBrowserMcpBridge()?.port ?? port);
+				const gatewayPort = await import("./server").then(
+					(m) => m.getBrowserMcpBridge()?.port ?? port,
+				);
 				return send(res, 200, {
 					paneId: resolved.paneId,
 					sessionId: resolved.sessionId,

--- a/apps/desktop/src/main/lib/browser-mcp-bridge/server.ts
+++ b/apps/desktop/src/main/lib/browser-mcp-bridge/server.ts
@@ -11,10 +11,6 @@ import { app } from "electron";
 import { SUPERSET_HOME_DIR } from "../app-environment";
 import { browserManager } from "../browser/browser-manager";
 import {
-	ensureSessionEndpoint,
-	stopAllSessionEndpoints,
-} from "./cdp-filter-proxy";
-import {
 	ensureGlobalBrowserUseConfig,
 	handleCdpGatewayRequest,
 	handleCdpGatewayUpgrade,
@@ -209,20 +205,20 @@ export async function startBrowserMcpBridge(): Promise<BridgeHandle> {
 					});
 				}
 				const wc = browserManager.getWebContents(resolved.paneId);
-				// Each LLM session gets its own loopback HTTP+WS server
-				// dedicated to that session's bound pane. Puppeteer-based
-				// CDP clients (chrome-devtools-mcp, browser-use) compose
-				// `/json/version` off `browserURL` and drop any path
-				// prefix, so a path-scoped token cannot survive — a whole
-				// dedicated port IS the capability.
-				const sessionPort = await ensureSessionEndpoint(resolved.sessionId);
+				// Since M1 the CDP data plane lives on this same bridge
+				// port (47834); the gateway routes each incoming
+				// connection by peer-PID. One stable URL works for every
+				// session and survives restarts / rebindings.
+				const gatewayPort = await import(
+					"./server"
+				).then((m) => m.getBrowserMcpBridge()?.port ?? port);
 				return send(res, 200, {
 					paneId: resolved.paneId,
 					sessionId: resolved.sessionId,
 					targetId,
 					cdpPort,
-					httpBase: `http://127.0.0.1:${sessionPort}`,
-					webSocketDebuggerUrl: `ws://127.0.0.1:${sessionPort}/devtools/page/${targetId}`,
+					httpBase: `http://127.0.0.1:${gatewayPort}`,
+					webSocketDebuggerUrl: `ws://127.0.0.1:${gatewayPort}/devtools/page/${targetId}`,
 					url: wc?.getURL() ?? null,
 					title: wc?.getTitle() ?? null,
 					filtered: true,
@@ -294,7 +290,6 @@ export async function startBrowserMcpBridge(): Promise<BridgeHandle> {
 
 	app.on("will-quit", () => {
 		server.close();
-		stopAllSessionEndpoints();
 	});
 
 	current = {

--- a/apps/desktop/src/main/lib/browser-mcp-bridge/server.ts
+++ b/apps/desktop/src/main/lib/browser-mcp-bridge/server.ts
@@ -14,6 +14,12 @@ import {
 	ensureSessionEndpoint,
 	stopAllSessionEndpoints,
 } from "./cdp-filter-proxy";
+import {
+	handleCdpGatewayRequest,
+	handleCdpGatewayUpgrade,
+	isCdpGatewayPath,
+	isCdpGatewayUpgradePath,
+} from "./cdp-gateway";
 import { resolveCdpPort } from "./cdp-port";
 import { getBoundPaneForSession, resolvePpidToSession } from "./pane-resolver";
 
@@ -167,6 +173,13 @@ export async function startBrowserMcpBridge(): Promise<BridgeHandle> {
 
 			const url = new URL(req.url ?? "/", "http://localhost");
 
+			// CDP gateway routes are unauthenticated (external CDP MCPs
+			// compose URLs that drop the path, so no secret can survive).
+			// Their capability is the peer-PID tree-descendant check.
+			if (isCdpGatewayPath(url.pathname)) {
+				return handleCdpGatewayRequest(req, res);
+			}
+
 			const auth = req.headers.authorization ?? "";
 			if (auth !== `Bearer ${secret}`) {
 				return send(res, 401, { error: "bad token" });
@@ -244,6 +257,18 @@ export async function startBrowserMcpBridge(): Promise<BridgeHandle> {
 				error: error instanceof Error ? error.message : String(error),
 			});
 		}
+	});
+
+	// CDP gateway WS upgrades land on /devtools/browser/<id> and
+	// /devtools/page/<id>. Route them to the gateway before the default
+	// socket.destroy() path kicks in.
+	server.on("upgrade", (req, socket, head) => {
+		const pathname = new URL(req.url ?? "/", "http://localhost").pathname;
+		if (isCdpGatewayUpgradePath(pathname)) {
+			void handleCdpGatewayUpgrade(req, socket, head);
+			return;
+		}
+		socket.destroy();
 	});
 
 	const port = await listenPreferringStablePort(server);

--- a/apps/desktop/src/main/lib/browser/browser-manager.ts
+++ b/apps/desktop/src/main/lib/browser/browser-manager.ts
@@ -93,6 +93,12 @@ class BrowserManager extends EventEmitter {
 	 * underlying webContents.
 	 */
 	private paneTargetIds = new Map<string, string>();
+	/**
+	 * Secondary per-pane CDP targetIds owned by "tabs" beyond the
+	 * pane's primary webview. M2 multi-tab wiring populates these; M1
+	 * leaves the map empty and the filter runs in single-target mode.
+	 */
+	private paneTabTargetIds = new Map<string, Set<string>>();
 	private paneIdMarkerListeners = new Map<string, () => void>();
 	private consoleLogs = new Map<string, ConsoleEntry[]>();
 	private consoleListeners = new Map<string, () => void>();
@@ -219,6 +225,37 @@ class BrowserManager extends EventEmitter {
 	 */
 	getCdpTargetId(paneId: string): string | null {
 		return this.paneTargetIds.get(paneId) ?? null;
+	}
+
+	/**
+	 * Return the full set of Chromium CDP targetIds that belong to a
+	 * pane. For single-tab panes this is the singleton primary
+	 * targetId; when multi-tab support is wired in M2 the registry
+	 * will populate additional tab ids through addPaneTabTarget /
+	 * removePaneTabTarget (see below). Returning undefined lets the
+	 * gateway fall back to the primary-only path.
+	 */
+	getPaneTargetIds(paneId: string): Set<string> | undefined {
+		const extras = this.paneTabTargetIds.get(paneId);
+		const primary = this.paneTargetIds.get(paneId);
+		if (!primary && !extras) return undefined;
+		const set = new Set<string>();
+		if (primary) set.add(primary);
+		if (extras) for (const id of extras) set.add(id);
+		return set;
+	}
+
+	addPaneTabTarget(paneId: string, targetId: string): void {
+		let set = this.paneTabTargetIds.get(paneId);
+		if (!set) {
+			set = new Set<string>();
+			this.paneTabTargetIds.set(paneId, set);
+		}
+		set.add(targetId);
+	}
+
+	removePaneTabTarget(paneId: string, targetId: string): void {
+		this.paneTabTargetIds.get(paneId)?.delete(targetId);
 	}
 
 	listPanesWithCdpTargets(): Array<{ paneId: string; targetId: string }> {

--- a/apps/desktop/src/main/lib/browser/browser-manager.ts
+++ b/apps/desktop/src/main/lib/browser/browser-manager.ts
@@ -99,6 +99,8 @@ class BrowserManager extends EventEmitter {
 	 * leaves the map empty and the filter runs in single-target mode.
 	 */
 	private paneTabTargetIds = new Map<string, Set<string>>();
+	private paneTabTargetIdByKey = new Map<string, string>();
+	private paneTabWebContents = new Map<string, number>();
 	private paneIdMarkerListeners = new Map<string, () => void>();
 	private consoleLogs = new Map<string, ConsoleEntry[]>();
 	private consoleListeners = new Map<string, () => void>();
@@ -340,6 +342,61 @@ class BrowserManager extends EventEmitter {
 				}
 			}
 		}
+	}
+
+	/**
+	 * Register a secondary tab webContents for a pane. Captures its
+	 * CDP targetId and adds it to the pane's tab target set so the
+	 * gateway exposes it via Target.getTargets / filter.
+	 */
+	async registerTab(
+		paneId: string,
+		tabId: string,
+		webContentsId: number,
+	): Promise<void> {
+		const wc = webContents.fromId(webContentsId);
+		if (!wc || wc.isDestroyed()) return;
+		this.paneTabWebContents.set(this.tabKey(paneId, tabId), webContentsId);
+		let attached = false;
+		try {
+			if (!wc.debugger.isAttached()) {
+				wc.debugger.attach("1.3");
+				attached = true;
+			}
+			const info = (await wc.debugger.sendCommand("Target.getTargetInfo")) as {
+				targetInfo?: { targetId?: string };
+			};
+			const targetId = info?.targetInfo?.targetId;
+			if (typeof targetId === "string" && targetId.length > 0) {
+				this.paneTabTargetIdByKey.set(this.tabKey(paneId, tabId), targetId);
+				this.addPaneTabTarget(paneId, targetId);
+			}
+		} catch (error) {
+			console.warn(
+				`[browser-manager] failed to capture tab CDP targetId for pane ${paneId} tab ${tabId}:`,
+				error,
+			);
+		} finally {
+			if (attached) {
+				try {
+					wc.debugger.detach();
+				} catch {
+					/* ignore */
+				}
+			}
+		}
+	}
+
+	unregisterTab(paneId: string, tabId: string): void {
+		const key = this.tabKey(paneId, tabId);
+		const targetId = this.paneTabTargetIdByKey.get(key);
+		if (targetId) this.removePaneTabTarget(paneId, targetId);
+		this.paneTabTargetIdByKey.delete(key);
+		this.paneTabWebContents.delete(key);
+	}
+
+	private tabKey(paneId: string, tabId: string): string {
+		return `${paneId}::${tabId}`;
 	}
 
 	getPaneIdForWebContents(webContentsId: number): string | null {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/BrowserPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/BrowserPane.tsx
@@ -1,7 +1,7 @@
 import type { RendererContext, Tab } from "@superset/panes";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { GlobeIcon } from "lucide-react";
-import { useCallback, useSyncExternalStore } from "react";
+import { useCallback, useEffect, useSyncExternalStore } from "react";
 import { TbDeviceDesktop } from "react-icons/tb";
 import { electronTrpcClient } from "renderer/lib/trpc-client";
 import type { BrowserPaneData, PaneViewerData } from "../../../../types";
@@ -9,6 +9,7 @@ import type { BrowserPaneData, PaneViewerData } from "../../../../types";
 import { browserRuntimeRegistry } from "./browserRuntimeRegistry";
 import { BrowserErrorOverlay } from "./components/BrowserErrorOverlay";
 import { BrowserOverflowMenu } from "./components/BrowserOverflowMenu";
+import { BrowserTabBar } from "./components/BrowserTabBar";
 import { BrowserToolbar } from "./components/BrowserToolbar";
 import { usePersistentWebview } from "./hooks/usePersistentWebview";
 
@@ -49,11 +50,35 @@ export function BrowserPane({ ctx }: BrowserPaneProps) {
 	const state = useBrowserState(paneId);
 	const { placeholderRef, reload } = usePersistentWebview({ paneId, ctx });
 
+	// External CDP MCPs (chrome-devtools-mcp / browser-use) issue
+	// `Target.createTarget` to open a new tab; the gateway's filter
+	// forwards that intent to us as a create-tab-requested event so we
+	// can spawn a real <webview> under the same pane.
+	useEffect(() => {
+		const sub = electronTrpcClient.browser.onCreateTabRequested.subscribe(
+			{ paneId },
+			{
+				onData: (evt) => {
+					browserRuntimeRegistry.createTab(paneId, evt.url);
+				},
+				onError: () => {
+					/* subscription errors surface in console */
+				},
+			},
+		);
+		return () => sub.unsubscribe();
+	}, [paneId]);
+
 	const isBlankPage = !state.currentUrl || state.currentUrl === "about:blank";
 
 	return (
-		<div className="relative flex flex-1 h-full">
-			<div ref={placeholderRef} className="w-full h-full" style={{ flex: 1 }} />
+		<div className="relative flex flex-col flex-1 h-full">
+			<BrowserTabBar paneId={paneId} />
+			<div
+				ref={placeholderRef}
+				className="w-full flex-1 min-h-0"
+				style={{ flex: 1 }}
+			/>
 			{state.error && !state.isLoading && (
 				<BrowserErrorOverlay error={state.error} onRetry={reload} />
 			)}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/browserRuntimeRegistry.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/browserRuntimeRegistry.ts
@@ -18,15 +18,13 @@ export interface PersistableBrowserState {
 	faviconUrl: string | null;
 }
 
-interface RegistryEntry {
-	webview: Electron.WebviewTag;
-	state: BrowserRuntimeState;
-	onPersist: ((state: PersistableBrowserState) => void) | null;
-	webContentsId: number | null;
-	detachHandlers: () => void;
-	placeholder: HTMLElement | null;
-	resizeObserver: ResizeObserver | null;
-	visible: boolean;
+export interface BrowserTabSummary {
+	tabId: string;
+	url: string;
+	title: string;
+	faviconUrl: string | null;
+	isLoading: boolean;
+	isActive: boolean;
 }
 
 const EMPTY_STATE: BrowserRuntimeState = Object.freeze({
@@ -41,19 +39,58 @@ const EMPTY_STATE: BrowserRuntimeState = Object.freeze({
 
 const ROOT_CONTAINER_ID = "browser-runtime-root";
 
+let tabIdSeq = 0;
+function generateTabId(): string {
+	tabIdSeq += 1;
+	return `tab-${Date.now().toString(36)}-${tabIdSeq.toString(36)}`;
+}
+
+interface TabEntry {
+	tabId: string;
+	webview: Electron.WebviewTag;
+	state: BrowserRuntimeState;
+	webContentsId: number | null;
+	detachHandlers: () => void;
+}
+
+interface PaneGroup {
+	tabs: TabEntry[];
+	activeTabId: string;
+	onPersist: ((state: PersistableBrowserState) => void) | null;
+	placeholder: HTMLElement | null;
+	resizeObserver: ResizeObserver | null;
+	visible: boolean;
+}
+
 class BrowserRuntimeRegistryImpl {
-	private entries = new Map<string, RegistryEntry>();
-	private listenersByPaneId = new Map<string, Set<() => void>>();
+	private groups = new Map<string, PaneGroup>();
+	private stateListenersByPaneId = new Map<string, Set<() => void>>();
+	private tabsListenersByPaneId = new Map<string, Set<() => void>>();
 	private rootContainer: HTMLDivElement | null = null;
 	private globalListenersInstalled = false;
 
-	private getListeners(paneId: string): Set<() => void> {
-		let set = this.listenersByPaneId.get(paneId);
+	private getStateListeners(paneId: string): Set<() => void> {
+		let set = this.stateListenersByPaneId.get(paneId);
 		if (!set) {
 			set = new Set();
-			this.listenersByPaneId.set(paneId, set);
+			this.stateListenersByPaneId.set(paneId, set);
 		}
 		return set;
+	}
+
+	private getTabsListeners(paneId: string): Set<() => void> {
+		let set = this.tabsListenersByPaneId.get(paneId);
+		if (!set) {
+			set = new Set();
+			this.tabsListenersByPaneId.set(paneId, set);
+		}
+		return set;
+	}
+
+	private activeTab(paneId: string): TabEntry | null {
+		const group = this.groups.get(paneId);
+		if (!group) return null;
+		return group.tabs.find((t) => t.tabId === group.activeTabId) ?? null;
 	}
 
 	private ensureRootContainer(): HTMLDivElement {
@@ -83,69 +120,125 @@ class BrowserRuntimeRegistryImpl {
 	private installGlobalListeners() {
 		if (this.globalListenersInstalled) return;
 		this.globalListenersInstalled = true;
-
 		const setPassthrough = (passthrough: boolean) => {
-			for (const entry of this.entries.values()) {
-				if (!entry.visible) continue;
-				entry.webview.style.pointerEvents = passthrough ? "none" : "auto";
+			for (const group of this.groups.values()) {
+				if (!group.visible) continue;
+				const active = group.tabs.find((t) => t.tabId === group.activeTabId);
+				if (!active) continue;
+				active.webview.style.pointerEvents = passthrough ? "none" : "auto";
 			}
 		};
 		window.addEventListener("dragstart", () => setPassthrough(true), true);
 		window.addEventListener("dragend", () => setPassthrough(false), true);
 		window.addEventListener("drop", () => setPassthrough(false), true);
-
 		window.addEventListener("resize", () => {
-			for (const entry of this.entries.values()) {
-				if (entry.placeholder) this.updateLayout(entry);
+			for (const group of this.groups.values()) {
+				if (group.placeholder) this.applyLayout(group);
 			}
 		});
 	}
 
-	private updateLayout(entry: RegistryEntry) {
-		if (!entry.placeholder) return;
-		const rect = entry.placeholder.getBoundingClientRect();
-		const w = entry.webview;
-		w.style.top = `${rect.top}px`;
-		w.style.left = `${rect.left}px`;
-		w.style.width = `${rect.width}px`;
-		w.style.height = `${rect.height}px`;
+	private applyLayout(group: PaneGroup) {
+		if (!group.placeholder) return;
+		const rect = group.placeholder.getBoundingClientRect();
+		for (const tab of group.tabs) {
+			const w = tab.webview;
+			w.style.top = `${rect.top}px`;
+			w.style.left = `${rect.left}px`;
+			w.style.width = `${rect.width}px`;
+			w.style.height = `${rect.height}px`;
+			const isActive = tab.tabId === group.activeTabId;
+			w.style.visibility = group.visible && isActive ? "visible" : "hidden";
+			w.style.pointerEvents = isActive ? "auto" : "none";
+		}
 	}
 
-	private notify(paneId: string) {
-		const listeners = this.listenersByPaneId.get(paneId);
-		if (!listeners) return;
-		for (const listener of listeners) listener();
+	private notifyState(paneId: string) {
+		const set = this.stateListenersByPaneId.get(paneId);
+		if (!set) return;
+		for (const l of set) l();
 	}
 
-	private setState(paneId: string, patch: Partial<BrowserRuntimeState>) {
-		const entry = this.entries.get(paneId);
-		if (!entry) return;
+	private notifyTabs(paneId: string) {
+		const set = this.tabsListenersByPaneId.get(paneId);
+		if (!set) return;
+		for (const l of set) l();
+	}
+
+	private setTabState(
+		paneId: string,
+		tabId: string,
+		patch: Partial<BrowserRuntimeState>,
+	) {
+		const group = this.groups.get(paneId);
+		if (!group) return;
+		const tab = group.tabs.find((t) => t.tabId === tabId);
+		if (!tab) return;
 		let changed = false;
 		for (const key in patch) {
 			const k = key as keyof BrowserRuntimeState;
-			if (entry.state[k] !== patch[k]) {
+			if (tab.state[k] !== patch[k]) {
 				changed = true;
 				break;
 			}
 		}
 		if (!changed) return;
-		entry.state = { ...entry.state, ...patch };
-		this.notify(paneId);
+		tab.state = { ...tab.state, ...patch };
+		if (tabId === group.activeTabId) this.notifyState(paneId);
+		this.notifyTabs(paneId);
 	}
 
-	private refreshNavState(paneId: string) {
-		const entry = this.entries.get(paneId);
-		if (!entry) return;
+	private refreshNavStateOf(paneId: string, tabId: string) {
+		const group = this.groups.get(paneId);
+		const tab = group?.tabs.find((t) => t.tabId === tabId);
+		if (!tab) return;
 		let canGoBack = false;
 		let canGoForward = false;
 		try {
-			canGoBack = entry.webview.canGoBack();
-			canGoForward = entry.webview.canGoForward();
+			canGoBack = tab.webview.canGoBack();
+			canGoForward = tab.webview.canGoForward();
 		} catch {}
-		this.setState(paneId, { canGoBack, canGoForward });
+		this.setTabState(paneId, tabId, { canGoBack, canGoForward });
 	}
 
-	private createEntry(paneId: string, initialUrl: string): RegistryEntry {
+	private registerTabWithMain(
+		paneId: string,
+		tabId: string,
+		webContentsId: number,
+		isPrimary: boolean,
+	): void {
+		if (isPrimary) {
+			electronTrpcClient.browser.register
+				.mutate({ paneId, webContentsId })
+				.catch((err) => {
+					console.error("[browserRuntimeRegistry] register failed:", err);
+				});
+			return;
+		}
+		electronTrpcClient.browser.registerTab
+			.mutate({ paneId, tabId, webContentsId })
+			.catch((err) => {
+				console.error("[browserRuntimeRegistry] registerTab failed:", err);
+			});
+	}
+
+	private unregisterTabWithMain(
+		paneId: string,
+		tabId: string,
+		isPrimary: boolean,
+	): void {
+		if (isPrimary) return; // pane destroy handles primary unregister
+		electronTrpcClient.browser.unregisterTab
+			.mutate({ paneId, tabId })
+			.catch(() => {});
+	}
+
+	private createTabEntry(
+		paneId: string,
+		initialUrl: string,
+		tabId: string,
+		isPrimary: boolean,
+	): TabEntry {
 		const webview = document.createElement("webview") as Electron.WebviewTag;
 		webview.setAttribute("partition", "persist:superset");
 		webview.setAttribute("allowpopups", "");
@@ -162,19 +255,18 @@ class BrowserRuntimeRegistryImpl {
 		webview.style.pointerEvents = "auto";
 		webview.src = sanitizeUrl(initialUrl);
 
-		const entry: RegistryEntry = {
+		const entry: TabEntry = {
+			tabId,
 			webview,
 			state: { ...EMPTY_STATE, currentUrl: initialUrl },
-			onPersist: null,
 			webContentsId: null,
 			detachHandlers: () => {},
-			placeholder: null,
-			resizeObserver: null,
-			visible: false,
 		};
 
 		const firePersist = () => {
-			entry.onPersist?.({
+			const group = this.groups.get(paneId);
+			if (!group || group.activeTabId !== tabId) return;
+			group.onPersist?.({
 				url: entry.state.currentUrl,
 				pageTitle: entry.state.pageTitle,
 				faviconUrl: entry.state.faviconUrl,
@@ -185,16 +277,12 @@ class BrowserRuntimeRegistryImpl {
 			const webContentsId = webview.getWebContentsId();
 			if (entry.webContentsId !== webContentsId) {
 				entry.webContentsId = webContentsId;
-				electronTrpcClient.browser.register
-					.mutate({ paneId, webContentsId })
-					.catch((err) => {
-						console.error("[browserRuntimeRegistry] register failed:", err);
-					});
+				this.registerTabWithMain(paneId, tabId, webContentsId, isPrimary);
 			}
 		};
 
 		const handleDidStartLoading = () => {
-			this.setState(paneId, {
+			this.setTabState(paneId, tabId, {
 				isLoading: true,
 				error: null,
 				faviconUrl: null,
@@ -204,12 +292,12 @@ class BrowserRuntimeRegistryImpl {
 		const handleDidStopLoading = () => {
 			const url = webview.getURL() ?? "";
 			const title = webview.getTitle() ?? "";
-			this.setState(paneId, {
+			this.setTabState(paneId, tabId, {
 				isLoading: false,
 				currentUrl: url,
 				pageTitle: title,
 			});
-			this.refreshNavState(paneId);
+			this.refreshNavStateOf(paneId, tabId);
 			if (url && url !== "about:blank") {
 				electronTrpcClient.browserHistory.upsert
 					.mutate({ url, title, faviconUrl: entry.state.faviconUrl })
@@ -223,32 +311,32 @@ class BrowserRuntimeRegistryImpl {
 		const handleDidNavigate = (e: Electron.DidNavigateEvent) => {
 			const url = e.url ?? "";
 			const title = webview.getTitle() ?? "";
-			this.setState(paneId, {
+			this.setTabState(paneId, tabId, {
 				currentUrl: url,
 				pageTitle: title,
 				isLoading: false,
 			});
-			this.refreshNavState(paneId);
+			this.refreshNavStateOf(paneId, tabId);
 			firePersist();
 		};
 
 		const handleDidNavigateInPage = (e: Electron.DidNavigateInPageEvent) => {
 			const url = e.url ?? "";
 			const title = webview.getTitle() ?? "";
-			this.setState(paneId, { currentUrl: url, pageTitle: title });
-			this.refreshNavState(paneId);
+			this.setTabState(paneId, tabId, { currentUrl: url, pageTitle: title });
+			this.refreshNavStateOf(paneId, tabId);
 			firePersist();
 		};
 
 		const handlePageTitleUpdated = (e: Electron.PageTitleUpdatedEvent) => {
-			this.setState(paneId, { pageTitle: e.title ?? "" });
+			this.setTabState(paneId, tabId, { pageTitle: e.title ?? "" });
 			firePersist();
 		};
 
 		const handlePageFaviconUpdated = (e: Electron.PageFaviconUpdatedEvent) => {
 			const favicon = e.favicons?.[0];
 			if (!favicon || favicon === entry.state.faviconUrl) return;
-			this.setState(paneId, { faviconUrl: favicon });
+			this.setTabState(paneId, tabId, { faviconUrl: favicon });
 			const { currentUrl, pageTitle } = entry.state;
 			if (currentUrl && currentUrl !== "about:blank") {
 				electronTrpcClient.browserHistory.upsert
@@ -262,7 +350,7 @@ class BrowserRuntimeRegistryImpl {
 
 		const handleDidFailLoad = (e: Electron.DidFailLoadEvent) => {
 			if (e.errorCode === -3) return; // ERR_ABORTED
-			this.setState(paneId, {
+			this.setTabState(paneId, tabId, {
 				isLoading: false,
 				error: {
 					code: e.errorCode ?? 0,
@@ -332,89 +420,184 @@ class BrowserRuntimeRegistryImpl {
 		onPersist: (state: PersistableBrowserState) => void,
 	): void {
 		const root = this.ensureRootContainer();
-		let entry = this.entries.get(paneId);
-		if (!entry) {
-			entry = this.createEntry(paneId, initialUrl);
-			this.entries.set(paneId, entry);
+		let group = this.groups.get(paneId);
+		if (!group) {
+			const primaryTabId = "primary";
+			const entry = this.createTabEntry(paneId, initialUrl, primaryTabId, true);
+			group = {
+				tabs: [entry],
+				activeTabId: primaryTabId,
+				onPersist,
+				placeholder,
+				resizeObserver: null,
+				visible: true,
+			};
+			this.groups.set(paneId, group);
 			root.appendChild(entry.webview);
 		} else {
-			this.refreshNavState(paneId);
+			group.placeholder = placeholder;
+			group.onPersist = onPersist;
+			group.visible = true;
+			const active = this.activeTab(paneId);
+			if (active) this.refreshNavStateOf(paneId, active.tabId);
 		}
-		entry.onPersist = onPersist;
-		entry.placeholder = placeholder;
-		entry.visible = true;
-		entry.onPersist?.({
-			url: entry.state.currentUrl,
-			pageTitle: entry.state.pageTitle,
-			faviconUrl: entry.state.faviconUrl,
-		});
-
-		entry.resizeObserver?.disconnect();
-		const observer = new ResizeObserver(() => {
-			if (entry) this.updateLayout(entry);
-		});
+		const active = this.activeTab(paneId);
+		if (active) {
+			group.onPersist?.({
+				url: active.state.currentUrl,
+				pageTitle: active.state.pageTitle,
+				faviconUrl: active.state.faviconUrl,
+			});
+		}
+		group.resizeObserver?.disconnect();
+		const groupRef = group;
+		const observer = new ResizeObserver(() => this.applyLayout(groupRef));
 		observer.observe(placeholder);
-		entry.resizeObserver = observer;
-
-		this.updateLayout(entry);
-		entry.webview.style.visibility = "visible";
+		group.resizeObserver = observer;
+		this.applyLayout(group);
+		this.notifyTabs(paneId);
 	}
 
 	detach(paneId: string): void {
-		const entry = this.entries.get(paneId);
-		if (!entry) return;
-		entry.onPersist = null;
-		entry.placeholder = null;
-		entry.resizeObserver?.disconnect();
-		entry.resizeObserver = null;
-		entry.visible = false;
-		entry.webview.style.visibility = "hidden";
+		const group = this.groups.get(paneId);
+		if (!group) return;
+		group.onPersist = null;
+		group.placeholder = null;
+		group.resizeObserver?.disconnect();
+		group.resizeObserver = null;
+		group.visible = false;
+		for (const t of group.tabs) t.webview.style.visibility = "hidden";
 	}
 
 	destroy(paneId: string): void {
-		const entry = this.entries.get(paneId);
-		if (!entry) return;
-		entry.resizeObserver?.disconnect();
-		entry.detachHandlers();
-		entry.webview.remove();
-		this.entries.delete(paneId);
-		this.listenersByPaneId.delete(paneId);
+		const group = this.groups.get(paneId);
+		if (!group) return;
+		group.resizeObserver?.disconnect();
+		for (const t of group.tabs) {
+			t.detachHandlers();
+			t.webview.remove();
+			if (t.tabId !== "primary") {
+				this.unregisterTabWithMain(paneId, t.tabId, false);
+			}
+		}
+		this.groups.delete(paneId);
+		this.stateListenersByPaneId.delete(paneId);
+		this.tabsListenersByPaneId.delete(paneId);
 		electronTrpcClient.browser.unregister.mutate({ paneId }).catch(() => {});
 	}
 
 	navigate(paneId: string, url: string): void {
-		const entry = this.entries.get(paneId);
-		if (!entry) return;
-		entry.webview.loadURL(sanitizeUrl(url)).catch((err) => {
+		const active = this.activeTab(paneId);
+		if (!active) return;
+		active.webview.loadURL(sanitizeUrl(url)).catch((err) => {
 			console.error("[browserRuntimeRegistry] loadURL failed:", err);
 		});
 	}
 
 	goBack(paneId: string): void {
-		const entry = this.entries.get(paneId);
-		if (entry?.webview.canGoBack()) entry.webview.goBack();
+		const active = this.activeTab(paneId);
+		if (active?.webview.canGoBack()) active.webview.goBack();
 	}
 
 	goForward(paneId: string): void {
-		const entry = this.entries.get(paneId);
-		if (entry?.webview.canGoForward()) entry.webview.goForward();
+		const active = this.activeTab(paneId);
+		if (active?.webview.canGoForward()) active.webview.goForward();
 	}
 
 	reload(paneId: string): void {
-		const entry = this.entries.get(paneId);
-		entry?.webview.reload();
+		const active = this.activeTab(paneId);
+		active?.webview.reload();
 	}
 
 	getState(paneId: string): BrowserRuntimeState {
-		return this.entries.get(paneId)?.state ?? EMPTY_STATE;
+		return this.activeTab(paneId)?.state ?? EMPTY_STATE;
 	}
 
 	onStateChange(paneId: string, listener: () => void): () => void {
-		const listeners = this.getListeners(paneId);
-		listeners.add(listener);
-		return () => {
-			listeners.delete(listener);
-		};
+		const set = this.getStateListeners(paneId);
+		set.add(listener);
+		return () => set.delete(listener);
+	}
+
+	listTabs(paneId: string): BrowserTabSummary[] {
+		const group = this.groups.get(paneId);
+		if (!group) return [];
+		return group.tabs.map((t) => ({
+			tabId: t.tabId,
+			url: t.state.currentUrl,
+			title: t.state.pageTitle,
+			faviconUrl: t.state.faviconUrl,
+			isLoading: t.state.isLoading,
+			isActive: t.tabId === group.activeTabId,
+		}));
+	}
+
+	onTabsChange(paneId: string, listener: () => void): () => void {
+		const set = this.getTabsListeners(paneId);
+		set.add(listener);
+		return () => set.delete(listener);
+	}
+
+	createTab(paneId: string, url?: string): string | null {
+		const root = this.ensureRootContainer();
+		const group = this.groups.get(paneId);
+		if (!group) return null;
+		const tabId = generateTabId();
+		const entry = this.createTabEntry(
+			paneId,
+			url ?? "about:blank",
+			tabId,
+			false,
+		);
+		group.tabs.push(entry);
+		root.appendChild(entry.webview);
+		group.activeTabId = tabId;
+		this.applyLayout(group);
+		this.notifyState(paneId);
+		this.notifyTabs(paneId);
+		return tabId;
+	}
+
+	closeTab(paneId: string, tabId: string): void {
+		const group = this.groups.get(paneId);
+		if (!group) return;
+		if (group.tabs.length <= 1) return; // keep at least one tab
+		const idx = group.tabs.findIndex((t) => t.tabId === tabId);
+		if (idx < 0) return;
+		const [removed] = group.tabs.splice(idx, 1);
+		removed.detachHandlers();
+		removed.webview.remove();
+		if (removed.tabId !== "primary") {
+			this.unregisterTabWithMain(paneId, removed.tabId, false);
+		}
+		if (group.activeTabId === tabId) {
+			const next = group.tabs[Math.min(idx, group.tabs.length - 1)];
+			group.activeTabId = next.tabId;
+		}
+		this.applyLayout(group);
+		this.notifyState(paneId);
+		this.notifyTabs(paneId);
+	}
+
+	activateTab(paneId: string, tabId: string): void {
+		const group = this.groups.get(paneId);
+		if (!group) return;
+		if (!group.tabs.some((t) => t.tabId === tabId)) return;
+		if (group.activeTabId === tabId) return;
+		group.activeTabId = tabId;
+		this.applyLayout(group);
+		// Re-persist the newly active tab's state so the toolbar /
+		// pane header reflect it.
+		const active = this.activeTab(paneId);
+		if (active) {
+			group.onPersist?.({
+				url: active.state.currentUrl,
+				pageTitle: active.state.pageTitle,
+				faviconUrl: active.state.faviconUrl,
+			});
+		}
+		this.notifyState(paneId);
+		this.notifyTabs(paneId);
 	}
 }
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/components/BrowserOverflowMenu/BrowserOverflowMenu.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/components/BrowserOverflowMenu/BrowserOverflowMenu.tsx
@@ -10,11 +10,13 @@ import {
 	TbClock,
 	TbCopy,
 	TbDots,
+	TbPlus,
 	TbReload,
 	TbTrash,
 } from "react-icons/tb";
 import { useCopyToClipboard } from "renderer/hooks/useCopyToClipboard";
 import { electronTrpcClient } from "renderer/lib/trpc-client";
+import { browserRuntimeRegistry } from "../../browserRuntimeRegistry";
 
 interface BrowserOverflowMenuProps {
 	paneId: string;
@@ -72,6 +74,16 @@ export function BrowserOverflowMenu({
 				</button>
 			</DropdownMenuTrigger>
 			<DropdownMenuContent align="end" className="w-48">
+				<DropdownMenuItem
+					onClick={() =>
+						browserRuntimeRegistry.createTab(paneId, "about:blank")
+					}
+					className="gap-2"
+				>
+					<TbPlus className="size-4" />
+					New Tab
+				</DropdownMenuItem>
+				<DropdownMenuSeparator />
 				<DropdownMenuItem
 					onClick={handleScreenshot}
 					disabled={!hasPage}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/components/BrowserTabBar/BrowserTabBar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/components/BrowserTabBar/BrowserTabBar.tsx
@@ -35,9 +35,9 @@ export function BrowserTabBar({ paneId }: BrowserTabBarProps) {
 		browserRuntimeRegistry.createTab(paneId, "about:blank");
 	}, [paneId]);
 
-	// Hide the bar when there is a single primary tab and the user has
-	// not opened any additional tabs yet — keeps the BrowserPane looking
-	// exactly like before for simple cases.
+	// Hide the strip when there is only the primary tab. Manual "new
+	// tab" from the overflow menu (see BrowserOverflowMenu) is the
+	// escape hatch for opening the first additional tab.
 	if (tabs.length <= 1) return null;
 
 	return (

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/components/BrowserTabBar/BrowserTabBar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/components/BrowserTabBar/BrowserTabBar.tsx
@@ -1,0 +1,92 @@
+import { cn } from "@superset/ui/utils";
+import { useCallback, useSyncExternalStore } from "react";
+import { LuPlus, LuX } from "react-icons/lu";
+import { browserRuntimeRegistry } from "../../browserRuntimeRegistry";
+
+interface BrowserTabBarProps {
+	paneId: string;
+}
+
+export function BrowserTabBar({ paneId }: BrowserTabBarProps) {
+	const tabs = useSyncExternalStore(
+		useCallback(
+			(cb) => browserRuntimeRegistry.onTabsChange(paneId, cb),
+			[paneId],
+		),
+		useCallback(() => browserRuntimeRegistry.listTabs(paneId), [paneId]),
+	);
+
+	const handleActivate = useCallback(
+		(tabId: string) => {
+			browserRuntimeRegistry.activateTab(paneId, tabId);
+		},
+		[paneId],
+	);
+
+	const handleClose = useCallback(
+		(tabId: string, e: React.MouseEvent) => {
+			e.stopPropagation();
+			browserRuntimeRegistry.closeTab(paneId, tabId);
+		},
+		[paneId],
+	);
+
+	const handleNew = useCallback(() => {
+		browserRuntimeRegistry.createTab(paneId, "about:blank");
+	}, [paneId]);
+
+	// Hide the bar when there is a single primary tab and the user has
+	// not opened any additional tabs yet — keeps the BrowserPane looking
+	// exactly like before for simple cases.
+	if (tabs.length <= 1) return null;
+
+	return (
+		<div className="flex h-7 items-center gap-0.5 border-b bg-muted/40 px-1 shrink-0 overflow-x-auto">
+			{tabs.map((t) => (
+				<button
+					key={t.tabId}
+					type="button"
+					onClick={() => handleActivate(t.tabId)}
+					className={cn(
+						"group flex items-center gap-1.5 h-5 max-w-[180px] rounded px-1.5 text-[11px] shrink-0",
+						t.isActive
+							? "bg-background text-foreground"
+							: "text-muted-foreground hover:bg-muted/80",
+					)}
+					title={t.title || t.url}
+				>
+					{t.faviconUrl ? (
+						<img
+							src={t.faviconUrl}
+							alt=""
+							className="size-3 shrink-0"
+						/>
+					) : (
+						<div className="size-3 shrink-0 rounded-sm bg-muted-foreground/20" />
+					)}
+					<span className="truncate">
+						{t.title || t.url || "New tab"}
+					</span>
+					{tabs.length > 1 && (
+						<span
+							role="button"
+							tabIndex={-1}
+							onClick={(e) => handleClose(t.tabId, e)}
+							className="ml-0.5 opacity-60 hover:opacity-100"
+						>
+							<LuX className="size-3" />
+						</span>
+					)}
+				</button>
+			))}
+			<button
+				type="button"
+				onClick={handleNew}
+				className="flex items-center justify-center size-5 rounded text-muted-foreground hover:bg-muted/80"
+				title="New tab"
+			>
+				<LuPlus className="size-3" />
+			</button>
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/components/BrowserTabBar/BrowserTabBar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/components/BrowserTabBar/BrowserTabBar.tsx
@@ -43,10 +43,8 @@ export function BrowserTabBar({ paneId }: BrowserTabBarProps) {
 	return (
 		<div className="flex h-7 items-center gap-0.5 border-b bg-muted/40 px-1 shrink-0 overflow-x-auto">
 			{tabs.map((t) => (
-				<button
+				<div
 					key={t.tabId}
-					type="button"
-					onClick={() => handleActivate(t.tabId)}
 					className={cn(
 						"group flex items-center gap-1.5 h-5 max-w-[180px] rounded px-1.5 text-[11px] shrink-0",
 						t.isActive
@@ -55,29 +53,29 @@ export function BrowserTabBar({ paneId }: BrowserTabBarProps) {
 					)}
 					title={t.title || t.url}
 				>
-					{t.faviconUrl ? (
-						<img
-							src={t.faviconUrl}
-							alt=""
-							className="size-3 shrink-0"
-						/>
-					) : (
-						<div className="size-3 shrink-0 rounded-sm bg-muted-foreground/20" />
-					)}
-					<span className="truncate">
-						{t.title || t.url || "New tab"}
-					</span>
+					<button
+						type="button"
+						onClick={() => handleActivate(t.tabId)}
+						className="flex flex-1 min-w-0 items-center gap-1.5 text-left"
+					>
+						{t.faviconUrl ? (
+							<img src={t.faviconUrl} alt="" className="size-3 shrink-0" />
+						) : (
+							<div className="size-3 shrink-0 rounded-sm bg-muted-foreground/20" />
+						)}
+						<span className="truncate">{t.title || t.url || "New tab"}</span>
+					</button>
 					{tabs.length > 1 && (
-						<span
-							role="button"
-							tabIndex={-1}
+						<button
+							type="button"
 							onClick={(e) => handleClose(t.tabId, e)}
 							className="ml-0.5 opacity-60 hover:opacity-100"
+							aria-label="Close tab"
 						>
 							<LuX className="size-3" />
-						</span>
+						</button>
 					)}
-				</button>
+				</div>
 			))}
 			<button
 				type="button"

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/components/BrowserTabBar/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/components/BrowserTabBar/index.ts
@@ -1,0 +1,1 @@
+export { BrowserTabBar } from "./BrowserTabBar";

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/components/SessionConnectModal/components/CdpEndpointCard/CdpEndpointCard.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/components/SessionConnectModal/components/CdpEndpointCard/CdpEndpointCard.tsx
@@ -44,7 +44,9 @@ export function CdpEndpointCard({ sessionId }: CdpEndpointCardProps) {
 				? "Chromium has not finished attaching to this pane yet. Reload the pane and retry."
 				: data?.reason === "cdp-disabled"
 					? "This build did not enable --remote-debugging-port."
-					: "Bind a pane first to expose a CDP endpoint.";
+					: data?.reason === "bridge-not-running"
+						? "Superset の browser MCP bridge がまだ起動していません。少し待って再試行してください。"
+						: "Bind a pane first to expose a CDP endpoint.";
 		return (
 			<div className="rounded-xl border p-3 bg-card/60">
 				<div className="text-xs font-semibold">CDP endpoint unavailable</div>
@@ -72,10 +74,13 @@ export function CdpEndpointCard({ sessionId }: CdpEndpointCardProps) {
 					External browser MCP endpoint
 				</div>
 				<div className="mt-1 text-[11px] text-muted-foreground leading-relaxed">
-					This session is bound to pane{" "}
-					<code className="rounded bg-muted px-1">{data.paneId}</code>. Point
-					any CDP-speaking browser MCP (chrome-devtools-mcp / browser-use /
-					playwright-mcp) at the URL below — it only exposes this pane.
+					Bound to pane{" "}
+					<code className="rounded bg-muted px-1">{data.paneId}</code>. 以下の
+					setup コマンドは **一度だけ** 実行すれば OK です。登録 URL は全セッション
+					共通で、接続ごとに呼び出し元のターミナル →
+					LLMセッション → アタッチ中ペインを peer-PID 解決してルーティングするため、
+					Superset / macOS の再起動、ペインの閉じ直し、別ターミナルから起動し直し等で
+					MCP を登録し直す必要はありません。
 				</div>
 			</div>
 

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/components/SessionConnectModal/components/CdpEndpointCard/CdpEndpointCard.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/components/SessionConnectModal/components/CdpEndpointCard/CdpEndpointCard.tsx
@@ -76,11 +76,12 @@ export function CdpEndpointCard({ sessionId }: CdpEndpointCardProps) {
 				<div className="mt-1 text-[11px] text-muted-foreground leading-relaxed">
 					Bound to pane{" "}
 					<code className="rounded bg-muted px-1">{data.paneId}</code>. 以下の
-					setup コマンドは **一度だけ** 実行すれば OK です。登録 URL は全セッション
-					共通で、接続ごとに呼び出し元のターミナル →
-					LLMセッション → アタッチ中ペインを peer-PID 解決してルーティングするため、
-					Superset / macOS の再起動、ペインの閉じ直し、別ターミナルから起動し直し等で
-					MCP を登録し直す必要はありません。
+					setup コマンドは **一度だけ** 実行すれば OK です。登録 URL
+					は全セッション 共通で、接続ごとに呼び出し元のターミナル →
+					LLMセッション → アタッチ中ペインを peer-PID
+					解決してルーティングするため、 Superset / macOS
+					の再起動、ペインの閉じ直し、別ターミナルから起動し直し等で MCP
+					を登録し直す必要はありません。
 				</div>
 			</div>
 

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/components/SessionConnectModal/components/CdpEndpointCard/CdpEndpointCard.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/components/SessionConnectModal/components/CdpEndpointCard/CdpEndpointCard.tsx
@@ -56,12 +56,14 @@ export function CdpEndpointCard({ sessionId }: CdpEndpointCardProps) {
 	}
 
 	const chromeDevtoolsCmd = `claude mcp add chrome-devtools-mcp -s user -- npx -y chrome-devtools-mcp --browser-url ${data.httpBase}`;
-	// browser-use ships its own MCP mode via `uvx --from "browser-use[cli]"`.
-	// CDP endpoint is passed via the same `--cdp-url` flag that the CLI
-	// accepts. Port + token are stable across Superset restarts (see
-	// server.ts / cdp-filter-proxy.ts), so this registration only has to
-	// be done once per install.
-	const browserUseCmd = `claude mcp add browser-use -s user -- uvx --from "browser-use[cli]" browser-use --mcp --cdp-url ${data.wsEndpoint}`;
+	// browser-use's `--mcp` branch intentionally ignores `--cdp-url`
+	// (skill_cli/main.py ~2280 routes straight to the MCP main without
+	// forwarding the flag). The only officially supported injection
+	// point is a config file referenced via BROWSER_USE_CONFIG_PATH
+	// (see browser_use/config.py and mcp/server.py). The desktop app
+	// writes that file per session at `data.browserUseConfigPath` and
+	// we point browser-use at it here.
+	const browserUseCmd = `claude mcp add browser-use -s user -e BROWSER_USE_CONFIG_PATH=${data.browserUseConfigPath} -- uvx --from "browser-use[cli]" browser-use --mcp`;
 
 	return (
 		<div className="rounded-xl border p-3 bg-card/60 flex flex-col gap-3">


### PR DESCRIPTION
## Summary
外部ブラウザ自動化MCP (chrome-devtools-mcp / browser-use / playwright-mcp 系) を **1度だけ** Claude/Codex に `mcp add` すれば、以降はアプリ/OS再起動・ペイン作り直し・別プロジェクト・別ターミナルから起動・アタッチ切替のどれがあっても再登録なしで動作する、という完全インフラ刷新。M1〜M3 全部込み + ペイン内複数タブ対応。

## 解決した問題

### 1度だけ登録で永続
- `chrome-devtools-mcp` / `browser-use` / `playwright-mcp` 等への登録URLは `http://127.0.0.1:47834` 固定
- 接続時に TCP peer PID を `lsof` で取得 → Superset ターミナルペインのPTY祖先プロセスを走査 → LLMセッションID → 現在のバインドペイン を動的解決
- puppeteer の `new URL("/json/version", browserURL)` がパス/クエリ/Authorization ヘッダを落とす仕様から来る「URL に secret を入れられない」問題を、peer-PID tree-descendant チェックで capability 化

### ペイン内複数タブ
- `1 session = 1 pane (複数タブ)` モデル実装。renderer 側 `browserRuntimeRegistry` をマルチ webview 対応に書き直し、タブバーUI追加
- LLM は `Target.getTargets` で全タブ見える、`Target.activateTarget`/`closeTarget` で切替/閉じる、`Target.createTarget` で本物の新タブ作成
- 単一タブのペインはタブバー非表示、OverflowMenu の "New Tab" から追加可能

### アタッチ切替のライブ追従
- `bindingStore.onChange` 購読で該当セッションの既存 WS 切断
- 外部 MCP は次のツール呼出で自動 reconnect し、新しいペインに透過的に切り替わる
- puppeteer の内部状態は live sessionId 差し替えを許さないため、WS close → 再接続が唯一安全な戦略（red-team codex verified）

### 未アタッチ・エラー時のハング防止
- `/json/*` ルートは 409 + 日本語エラーで即失敗
- 不明な sessionId の CDP request は JSON-RPC エラーを返す（黙殺せずクライアントがハングしない）
- setAutoAttach `filter` 剥がし、nested session allow-list、Target.* スコープ検査で puppeteer の既知ハング (issue #3537/#11640/#13251) を全部回避

## アーキテクチャ

```
┌─ External MCP (chrome-devtools-mcp / browser-use / …)
│  --browser-url http://127.0.0.1:47834  （永久固定）
│
└─────────────► Superset Bridge (port 47834)
                ├─ /json/*                (control, unauth)
                ├─ /devtools/browser/<id> (browser-level CDP filtered)
                ├─ /devtools/page/<id>    (page-level CDP)
                │
                │ per-connection:
                ├─ lsof → peer PID
                ├─ PTY tree walk → terminal pane → sessionId
                ├─ bindingStore → paneId (request-scope, not cached)
                └─ browserManager → targetId set (all tabs in pane)
```

- bridge の `/mcp/*` 認証付きルートは既存のまま（superset-browser-mcp 補助経路）
- CDP 経路は peer-PID descent check が capability（Chrome の `--remote-debugging-port` モデルより厳しい）

## browser-use 対応

`browser-use --mcp` は `--cdp-url` を無視する OSS バグ (`skill_cli/main.py` で MCP 分岐が早期)。唯一の注入点である `BROWSER_USE_CONFIG_PATH` を利用:

- bridge 起動時に `~/.superset/browser-use-mcp.json` を固定パスで生成
- `browser_profile.superset-gateway.cdp_url = http://127.0.0.1:47834`
- 登録コマンド: `claude mcp add browser-use -s user -e BROWSER_USE_CONFIG_PATH=~/.superset/browser-use-mcp.json -- uvx --from "browser-use[cli]" browser-use --mcp`

## red-team 検証ログ

アーキテクチャは codex に2回レビュー:
- 初回: **M3 仮想 sessionId 差替は puppeteer-core の内部整合で破綻が確定** → WS close + 自動reconnect に切替 (本PRの実装)
- Electron main-process `BrowserView` 前提は既存 `<webview>` パターンと不整合 → renderer side `<webview>` multi-instance で実装

## CodeRabbit レビュー対応済み

- [x] **P1**: browser-level proxy の CONNECTING 中メッセージ drop → queue + flush on open (page-level と同様のパターン)
- [x] **P1**: peer-pid.ts Windows フォールバック不足 → 非 darwin/linux は early-return、gateway は 409 クリーンエラー
- [x] **P1/Critical**: `Target.detachFromTarget`, `Target.receivedMessageFromTarget`, Target.* catch-all で sessionId/targetId スコープ検査欠落 → 全 Target.* に対して `allowedSessionIds` + `boundTargetIds` 両方検証
- [x] **P2**: 不明 sessionId の request 黙殺 → JSON-RPC error 返却
- [x] **P2**: gateway socket cache が paneId まで固着 → sessionId のみキャッシュ、paneId は bindingStore から毎回解決
- [x] **P2**: 単一タブ時にタブバー完全非表示で新規タブ作成手段なし → OverflowMenu に "New Tab" 追加

## Test plan

### 登録は1度だけ
```
claude mcp add chrome-devtools-mcp -s user -- npx -y chrome-devtools-mcp --browser-url http://127.0.0.1:47834
claude mcp add browser-use -s user -e BROWSER_USE_CONFIG_PATH=~/.superset/browser-use-mcp.json -- uvx --from "browser-use[cli]" browser-use --mcp
```

- [ ] Superset 再起動後に再登録なしで動作
- [ ] macOS 再起動後に再登録なしで動作
- [ ] ブラウザペイン閉じて作り直し後に再登録なしで動作
- [ ] ターミナルペイン作り直し・別ターミナルから `claude` 起動でも動作
- [ ] 別プロジェクトから起動しても動作

### 機能
- [ ] chrome-devtools-mcp: navigate / click / screenshot / take_snapshot / evaluate / new_page / list_pages が動作
- [ ] browser-use: 自前Chromeを起動せず Superset ペインに attach、go_to_url / click_element / screenshot / extract が動作
- [ ] `Target.createTarget` → 本物の新タブが作成されタブバーに表示
- [ ] LLM から `Target.activateTarget` でタブ切替
- [ ] `Target.closeTarget` で該当タブのみ閉じる（最後の1タブは残る）
- [ ] OverflowMenu の "New Tab" で手動タブ作成

### エッジケース
- [ ] 未アタッチで MCP 呼出 → 日本語エラー、ハングなし
- [ ] ペイン A→B 切替 → 次ツール呼出で透過的に B に反映
- [ ] 他ペインの targetId で `Target.attachToTarget` → CDP エラーで拒否
- [ ] `Browser.close` / `disposeBrowserContext` → CDP エラーで拒否、ペイン残存
- [ ] Worker / OOPIF iframe / prerender の nested session も正常にアクセスできる（`setAutoAttach filter` 剥がし + nested allow-list）

## スコープ外（将来PR候補）
- Windows の peer-PID resolver（netstat / GetTcpTable2 ベース）
- Electron `WebContentsView` への移行（現在は `<webview>` タグ）