### PR TITLE
feat(files): Files/Cmd+P 検索結果をコンパクト化、gitignore トグルを追加

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilesPane/components/WorkspaceFilesSearchResultItem/WorkspaceFilesSearchResultItem.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilesPane/components/WorkspaceFilesSearchResultItem/WorkspaceFilesSearchResultItem.tsx
@@ -63,21 +63,21 @@ export function WorkspaceFilesSearchResultItem({
 			type="button"
 		>
 			<span className="flex h-4 w-4 shrink-0 items-center justify-center" />
-			<div className="flex min-w-0 flex-1 flex-col gap-0.5">
+			<div className="flex min-w-0 flex-1 items-center gap-1.5">
+				<FileIcon
+					className="size-4 shrink-0"
+					fileName={entry.name}
+					isDirectory={entry.isDirectory}
+				/>
+				<span className="max-w-[60%] shrink-0 truncate text-xs">
+					{entry.name}
+				</span>
 				<span
-					className="truncate text-[10px] text-muted-foreground"
+					className="min-w-0 flex-1 truncate text-[11px] text-muted-foreground"
 					title={entry.relativePath}
 				>
 					{folderLabelDisplay}
 				</span>
-				<div className="flex min-w-0 items-center gap-1">
-					<FileIcon
-						className="size-4 shrink-0"
-						fileName={entry.name}
-						isDirectory={entry.isDirectory}
-					/>
-					<span className="min-w-0 flex-1 truncate text-xs">{entry.name}</span>
-				</div>
 			</div>
 		</button>
 	);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
@@ -734,6 +734,8 @@ function WorkspaceContent({
 				scope={commandPalette.scope}
 				searchResults={commandPalette.searchResults}
 				workspaceName={workspaceName}
+				includeIgnored={commandPalette.includeIgnored}
+				onToggleIncludeIgnored={commandPalette.toggleIncludeIgnored}
 			/>
 		</FileDocumentStoreProvider>
 	);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/workspace/$workspaceId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/workspace/$workspaceId/page.tsx
@@ -920,6 +920,8 @@ export function WorkspacePage({
 								)
 							: undefined
 					}
+					includeIgnored={commandPalette.includeIgnored}
+					onToggleIncludeIgnored={commandPalette.toggleIncludeIgnored}
 				/>
 				<UnsavedChangesDialog
 					open={pendingTabClose !== null}

--- a/apps/desktop/src/renderer/screens/main/components/CommandPalette/CommandPalette.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/CommandPalette/CommandPalette.tsx
@@ -1,5 +1,8 @@
+import { Button } from "@superset/ui/button";
 import { CommandSeparator } from "@superset/ui/command";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { useMemo } from "react";
+import { LuEye, LuEyeOff } from "react-icons/lu";
 import {
 	RECENT_DISPLAY_LIMIT,
 	type RecentFile,
@@ -47,6 +50,8 @@ interface CommandPaletteProps {
 	workspaceName?: string;
 	recentlyViewedFiles?: RecentFile[];
 	openFilePaths?: Set<string>;
+	includeIgnored?: boolean;
+	onToggleIncludeIgnored?: () => void;
 }
 
 export function CommandPalette({
@@ -68,6 +73,8 @@ export function CommandPalette({
 	workspaceName,
 	recentlyViewedFiles,
 	openFilePaths,
+	includeIgnored = false,
+	onToggleIncludeIgnored,
 }: CommandPaletteProps) {
 	const trimmedQuery = query.trim();
 	const hasQuery = trimmedQuery.length > 0;
@@ -157,11 +164,36 @@ export function CommandPalette({
 			preResultsSection={preResultsSection}
 			hasPreResults={filteredRecent.length > 0}
 			headerExtra={
-				<ScopeToggle
-					scope={scope}
-					onScopeChange={onScopeChange}
-					workspaceName={workspaceName}
-				/>
+				<div className="flex items-center gap-1">
+					{onToggleIncludeIgnored && (
+						<Tooltip>
+							<TooltipTrigger asChild>
+								<Button
+									variant="ghost"
+									size="icon"
+									className={`size-6 ${includeIgnored ? "bg-accent" : ""}`}
+									onClick={onToggleIncludeIgnored}
+								>
+									{includeIgnored ? (
+										<LuEye className="size-3.5" />
+									) : (
+										<LuEyeOff className="size-3.5" />
+									)}
+								</Button>
+							</TooltipTrigger>
+							<TooltipContent side="bottom">
+								{includeIgnored
+									? "Hide .gitignored & hidden files"
+									: "Show .gitignored & hidden files"}
+							</TooltipContent>
+						</Tooltip>
+					)}
+					<ScopeToggle
+						scope={scope}
+						onScopeChange={onScopeChange}
+						workspaceName={workspaceName}
+					/>
+				</div>
 			}
 			renderItem={(file) => {
 				return (

--- a/apps/desktop/src/renderer/screens/main/components/CommandPalette/CommandPalette.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/CommandPalette/CommandPalette.tsx
@@ -152,6 +152,8 @@ export function CommandPalette({
 			}
 			filtersOpen={filtersOpen}
 			onFiltersOpenChange={onFiltersOpenChange}
+			contentClassName="sm:max-w-5xl top-[12%] translate-y-0"
+			listClassName="max-h-[600px]"
 			includePattern={includePattern}
 			onIncludePatternChange={onIncludePatternChange}
 			excludePattern={excludePattern}

--- a/apps/desktop/src/renderer/screens/main/components/CommandPalette/useCommandPalette.ts
+++ b/apps/desktop/src/renderer/screens/main/components/CommandPalette/useCommandPalette.ts
@@ -5,6 +5,7 @@ import { electronTrpc } from "renderer/lib/electron-trpc";
 import { getWorkspaceDisplayName } from "renderer/lib/getWorkspaceDisplayName";
 import { navigateToWorkspace } from "renderer/routes/_authenticated/_dashboard/utils/workspace-navigation";
 import { useFileSearch } from "renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/hooks/useFileSearch/useFileSearch";
+import { useFileExplorerStore } from "renderer/stores/file-explorer";
 import {
 	type SearchScope,
 	useSearchDialogStore,
@@ -155,6 +156,11 @@ export function useCommandPalette({
 		[recentFilePathsKey],
 	);
 
+	const includeIgnored = useFileExplorerStore((s) => s.includeIgnored);
+	const toggleIncludeIgnored = useFileExplorerStore(
+		(s) => s.toggleIncludeIgnored,
+	);
+
 	// Single-workspace search (existing behavior)
 	const singleSearch = useFileSearch({
 		workspaceId: open && scope === "workspace" ? workspaceId : undefined,
@@ -165,6 +171,7 @@ export function useCommandPalette({
 		openFilePaths: openFilePathsList,
 		recentFilePaths: recentFilePathsList,
 		scopeId: "quick-open",
+		includeIgnored,
 	});
 
 	// Multi-workspace search. Note that MRU/open boosts aren't forwarded here
@@ -181,6 +188,7 @@ export function useCommandPalette({
 						excludePattern,
 						limit: SEARCH_LIMIT,
 						scopeId: "quick-open-global",
+						includeHidden: includeIgnored,
 					}),
 				)
 			: [],
@@ -306,5 +314,7 @@ export function useCommandPalette({
 		isFetching,
 		scope,
 		setScope,
+		includeIgnored,
+		toggleIncludeIgnored,
 	};
 }

--- a/apps/desktop/src/renderer/screens/main/components/SearchDialog/SearchDialog.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/SearchDialog/SearchDialog.tsx
@@ -8,6 +8,7 @@ import {
 } from "@superset/ui/command";
 import { Input } from "@superset/ui/input";
 import { Spinner } from "@superset/ui/spinner";
+import { cn } from "@superset/ui/utils";
 import type { ReactNode } from "react";
 import { LuChevronDown, LuChevronRight } from "react-icons/lu";
 
@@ -38,6 +39,10 @@ interface SearchDialogProps<TItem extends SearchDialogItem> {
 	headerExtra?: ReactNode;
 	preResultsSection?: ReactNode;
 	hasPreResults?: boolean;
+	/** Extra Tailwind classes for the DialogContent wrapper (size / position). */
+	contentClassName?: string;
+	/** Extra Tailwind classes for CommandList (controls result-area height). */
+	listClassName?: string;
 }
 
 export function SearchDialog<TItem extends SearchDialogItem>({
@@ -63,6 +68,8 @@ export function SearchDialog<TItem extends SearchDialogItem>({
 	headerExtra,
 	preResultsSection,
 	hasPreResults,
+	contentClassName,
+	listClassName,
 }: SearchDialogProps<TItem>) {
 	return (
 		<CommandDialog
@@ -73,6 +80,7 @@ export function SearchDialog<TItem extends SearchDialogItem>({
 			description={description}
 			showCloseButton={false}
 			commandProps={{ shouldFilter: false }}
+			className={contentClassName}
 		>
 			<div className="relative">
 				<CommandInput
@@ -121,7 +129,7 @@ export function SearchDialog<TItem extends SearchDialogItem>({
 				</div>
 			) : null}
 			{headerExtra}
-			<CommandList>
+			<CommandList className={cn(listClassName)}>
 				{query.trim().length > 0 &&
 					!isLoading &&
 					results.length === 0 &&

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/FilesView.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/FilesView.tsx
@@ -16,6 +16,7 @@ import { LuFile, LuFolder } from "react-icons/lu";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { useWorkspaceFileEvents } from "renderer/screens/main/components/WorkspaceView/hooks/useWorkspaceFileEvents";
 import { useWorkspaceId } from "renderer/screens/main/components/WorkspaceView/WorkspaceIdContext";
+import { useFileExplorerStore } from "renderer/stores/file-explorer";
 import { useTabsStore } from "renderer/stores/tabs/store";
 import {
 	retargetAbsolutePath,
@@ -407,6 +408,7 @@ export function FilesView() {
 			},
 		});
 
+	const includeIgnored = useFileExplorerStore((s) => s.includeIgnored);
 	const {
 		searchResults,
 		isFetching: isSearchFetching,
@@ -414,6 +416,7 @@ export function FilesView() {
 	} = useFileSearch({
 		workspaceId,
 		searchTerm,
+		includeIgnored,
 	});
 
 	const addFileViewerPane = useTabsStore((s) => s.addFileViewerPane);

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/components/FileSearchResultItem/FileSearchResultItem.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/components/FileSearchResultItem/FileSearchResultItem.tsx
@@ -137,21 +137,21 @@ export function FileSearchResultItem({
 			onKeyDown={handleKeyDown}
 		>
 			<span className="flex items-center justify-center w-4 h-4 shrink-0" />
-			<div className="flex flex-col min-w-0 flex-1 gap-0.5">
+			<div className="flex items-center gap-1.5 min-w-0 flex-1">
+				<FileIcon
+					fileName={entry.name}
+					isDirectory={entry.isDirectory}
+					className="size-4 shrink-0"
+				/>
+				<span className="shrink-0 text-xs truncate max-w-[60%]">
+					{entry.name}
+				</span>
 				<span
-					className="text-[10px] text-muted-foreground truncate"
+					className="flex-1 min-w-0 text-[11px] text-muted-foreground truncate"
 					title={entry.relativePath}
 				>
 					{folderLabelDisplay}
 				</span>
-				<div className="flex items-center gap-1 min-w-0">
-					<FileIcon
-						fileName={entry.name}
-						isDirectory={entry.isDirectory}
-						className="size-4 shrink-0"
-					/>
-					<span className="flex-1 min-w-0 text-xs truncate">{entry.name}</span>
-				</div>
 			</div>
 		</div>
 	);

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/components/FileTreeToolbar/FileTreeToolbar.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/components/FileTreeToolbar/FileTreeToolbar.tsx
@@ -4,6 +4,8 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { useCallback } from "react";
 import {
 	LuChevronsDownUp,
+	LuEye,
+	LuEyeOff,
 	LuFilePlus,
 	LuFolderPlus,
 	LuMessageSquareText,
@@ -31,7 +33,12 @@ export function FileTreeToolbar({
 	onRefresh,
 	isRefreshing = false,
 }: FileTreeToolbarProps) {
-	const { showFileTooltips, toggleFileTooltips } = useFileExplorerStore();
+	const {
+		showFileTooltips,
+		toggleFileTooltips,
+		includeIgnored,
+		toggleIncludeIgnored,
+	} = useFileExplorerStore();
 
 	// Debounce lives entirely in `useFileSearch` so the input stays responsive
 	// and we avoid the two-layer debounce chain that previously delayed renders
@@ -128,6 +135,28 @@ export function FileTreeToolbar({
 						</Button>
 					</TooltipTrigger>
 					<TooltipContent side="bottom">Refresh</TooltipContent>
+				</Tooltip>
+
+				<Tooltip>
+					<TooltipTrigger asChild>
+						<Button
+							variant="ghost"
+							size="icon"
+							className={`size-6 ${includeIgnored ? "bg-accent" : ""}`}
+							onClick={toggleIncludeIgnored}
+						>
+							{includeIgnored ? (
+								<LuEye className="size-3.5" />
+							) : (
+								<LuEyeOff className="size-3.5" />
+							)}
+						</Button>
+					</TooltipTrigger>
+					<TooltipContent side="bottom">
+						{includeIgnored
+							? "Hide .gitignored & hidden files"
+							: "Show .gitignored & hidden files"}
+					</TooltipContent>
 				</Tooltip>
 
 				<Tooltip>

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/constants.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/constants.ts
@@ -1,5 +1,5 @@
 export const ROW_HEIGHT = 28;
-export const SEARCH_RESULT_ROW_HEIGHT = 40;
+export const SEARCH_RESULT_ROW_HEIGHT = 24;
 export const TREE_INDENT = 10;
 export const OVERSCAN_COUNT = 10;
 export const SEARCH_DEBOUNCE_MS = 150;

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/hooks/useFileSearch/useFileSearch.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/hooks/useFileSearch/useFileSearch.ts
@@ -18,6 +18,12 @@ interface UseFileSearchParams {
 	 * when they land on the same workspace concurrently.
 	 */
 	scopeId?: string;
+	/**
+	 * When true, the search index drops dotfile and .gitignore filtering so
+	 * ignored files show up in results. Backend already caches both indexes
+	 * independently, so flipping this doesn't invalidate the other cache.
+	 */
+	includeIgnored?: boolean;
 }
 
 export function useFileSearch({
@@ -29,6 +35,7 @@ export function useFileSearch({
 	openFilePaths,
 	recentFilePaths,
 	scopeId = "files-tab",
+	includeIgnored = false,
 }: UseFileSearchParams) {
 	const trimmedQuery = searchTerm.trim();
 	const debouncedQuery = useDebouncedValue(trimmedQuery, 150);
@@ -46,6 +53,7 @@ export function useFileSearch({
 				openFilePaths,
 				recentFilePaths,
 				scopeId,
+				includeHidden: includeIgnored,
 			},
 			{
 				enabled: Boolean(workspaceId) && debouncedQuery.length > 0,

--- a/apps/desktop/src/renderer/stores/file-explorer.ts
+++ b/apps/desktop/src/renderer/stores/file-explorer.ts
@@ -11,6 +11,7 @@ interface FileExplorerState {
 	sortBy: SortBy;
 	sortDirection: SortDirection;
 	showFileTooltips: boolean;
+	includeIgnored: boolean;
 	toggleFolder: (worktreePath: string, folderId: string) => void;
 	setExpandedFolders: (worktreePath: string, folderIds: string[]) => void;
 	expandFolder: (worktreePath: string, folderId: string) => void;
@@ -24,6 +25,7 @@ interface FileExplorerState {
 	setSortBy: (sortBy: SortBy) => void;
 	setSortDirection: (direction: SortDirection) => void;
 	toggleFileTooltips: () => void;
+	toggleIncludeIgnored: () => void;
 }
 
 export const useFileExplorerStore = create<FileExplorerState>()(
@@ -36,6 +38,7 @@ export const useFileExplorerStore = create<FileExplorerState>()(
 				sortBy: "name",
 				sortDirection: "asc",
 				showFileTooltips: false,
+				includeIgnored: false,
 
 				toggleFolder: (worktreePath, folderId) => {
 					const current = get().expandedFolders[worktreePath] || [];
@@ -150,6 +153,10 @@ export const useFileExplorerStore = create<FileExplorerState>()(
 				toggleFileTooltips: () => {
 					set({ showFileTooltips: !get().showFileTooltips });
 				},
+
+				toggleIncludeIgnored: () => {
+					set({ includeIgnored: !get().includeIgnored });
+				},
 			}),
 			{
 				name: "file-explorer-store",
@@ -158,6 +165,7 @@ export const useFileExplorerStore = create<FileExplorerState>()(
 					sortDirection: state.sortDirection,
 					expandedFolders: state.expandedFolders,
 					showFileTooltips: state.showFileTooltips,
+					includeIgnored: state.includeIgnored,
 				}),
 			},
 		),


### PR DESCRIPTION
## Summary

右サイドバー Files タブおよび Cmd+P の検索 UX を 3 点改善する。Issues: #359 (一部)、#368。

### 1. 検索結果のコンパクト化

**Before:** 2 行レイアウト（上: フォルダパス、下: アイコン + ファイル名）、行高 40px。
**After:** 1 行レイアウト（アイコン + ファイル名 + 右側に相対パス）、行高 24px。

VSCode の検索結果行と同じ視覚密度に揃えた。パスは左から省略 (`truncatePathStart`) でファイル名側は可変幅なので長いファイル名でも潰れない。

### 2. `.gitignored` / hidden ファイルを含めるトグル

Files タブのツールバーと Cmd+P ヘッダに目玉アイコンのトグルを追加。オンにすると `node_modules` / `.git` を除く全ファイル（`.env`、`dist/`、ドットファイルなど）が検索対象に入る。

- バックエンド `workspace-fs` の `searchFiles` は既に `includeHidden` を受け取って visible 版 / hidden 版のインデックスを別々にキャッシュしているので、renderer から `includeHidden` を渡すだけで済む（新規インデックス構築コストは初回のみ）。
- 状態は `useFileExplorerStore.includeIgnored` に保存し、zustand `persist` で永続化。Files タブと Cmd+P で同じトグル状態を共有する。

### 3. Cmd+P ダイアログを 2 倍サイズに拡大 (#368)

- `DialogContent` を `sm:max-w-lg` (32rem) → `sm:max-w-5xl` (64rem) で横幅 2 倍
- `CommandList` を `max-h-[300px]` → `max-h-[600px]` で結果領域の縦も 2 倍
- 縦中央だと拡大したダイアログが下寄りに感じるので `top-[12%]` + `translate-y-0` で少し上寄せに配置
- `SearchDialog` に `contentClassName` / `listClassName` props を追加して Cmd+P からだけサイズを上書き（Search タブ側の挙動は変えない）

## Test plan

- [ ] Files タブの検索結果が 1 行レイアウトで表示され、以前より多く画面に収まる
- [ ] ツールバー右端の目玉アイコンをクリックすると `.env` / `dist/**` / `.DS_Store` などが検索にヒット
- [ ] Cmd+P を開き、右上の目玉アイコン（スコープトグルの左）をクリックすると同様の挙動
- [ ] トグル状態はアプリ再起動後も維持される（`file-explorer-store` に永続化）
- [ ] Cmd+P ダイアログが従来比で縦横 2 倍のサイズで開き、やや上寄りに表示される