### PR TITLE
feat(desktop): add Kimi Code VS Code extension support

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/browser-permissions/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/browser-permissions/index.ts
@@ -1,0 +1,66 @@
+import { observable } from "@trpc/server/observable";
+import {
+	PERMISSION_TOGGLE_KEYS,
+	PERMISSION_TOGGLE_META,
+	type PermissionConfig,
+	type PermissionToggleKey,
+	permissionStore,
+} from "main/lib/browser-mcp-bridge/permissions";
+import { z } from "zod";
+import { publicProcedure, router } from "../..";
+
+const togglesSchema = z
+	.record(z.string(), z.boolean())
+	.transform((v): Partial<Record<PermissionToggleKey, boolean>> => {
+		const out: Partial<Record<PermissionToggleKey, boolean>> = {};
+		for (const k of PERMISSION_TOGGLE_KEYS) {
+			if (k in v) out[k] = v[k];
+		}
+		return out;
+	});
+
+export const createBrowserPermissionsRouter = () => {
+	return router({
+		getConfig: publicProcedure.query(() => permissionStore.getConfig()),
+		getToggleMeta: publicProcedure.query(() => PERMISSION_TOGGLE_META),
+		setActive: publicProcedure
+			.input(z.object({ presetId: z.string() }))
+			.mutation(({ input }) => {
+				permissionStore.setActive(input.presetId);
+				return permissionStore.getConfig();
+			}),
+		savePreset: publicProcedure
+			.input(
+				z.object({
+					id: z.string().optional(),
+					name: z.string().min(1).max(64),
+					toggles: togglesSchema,
+				}),
+			)
+			.mutation(({ input }) => {
+				return permissionStore.savePreset({
+					id: input.id,
+					name: input.name,
+					toggles: input.toggles,
+				});
+			}),
+		deletePreset: publicProcedure
+			.input(z.object({ id: z.string() }))
+			.mutation(({ input }) => {
+				permissionStore.deletePreset(input.id);
+				return permissionStore.getConfig();
+			}),
+		onChange: publicProcedure.subscription(() => {
+			return observable<PermissionConfig>((emit) => {
+				const handler = (config: PermissionConfig) => emit.next(config);
+				permissionStore.on("change", handler);
+				// Prime the subscription so clients get current state
+				// without an extra query round-trip.
+				emit.next(permissionStore.getConfig());
+				return () => {
+					permissionStore.off("change", handler);
+				};
+			});
+		}),
+	});
+};

--- a/apps/desktop/src/lib/trpc/routers/browser/browser.ts
+++ b/apps/desktop/src/lib/trpc/routers/browser/browser.ts
@@ -61,12 +61,42 @@ export const createBrowserRouter = () => {
 		onCreateTabRequested: publicProcedure
 			.input(z.object({ paneId: z.string() }))
 			.subscription(({ input }) => {
-				return observable<{ url: string; requestId?: string }>((emit) => {
-					const handler = (data: { url: string; requestId?: string }) =>
-						emit.next(data);
+				return observable<{
+					url: string;
+					requestId?: string;
+					background?: boolean;
+				}>((emit) => {
+					const handler = (data: {
+						url: string;
+						requestId?: string;
+						background?: boolean;
+					}) => emit.next(data);
 					browserManager.on(`create-tab-requested:${input.paneId}`, handler);
 					return () => {
 						browserManager.off(`create-tab-requested:${input.paneId}`, handler);
+					};
+				});
+			}),
+
+		/**
+		 * Subscribe to MCP-driven tab activation requests for a pane.
+		 * The CDP filter emits these when an external MCP sends
+		 * Target.activateTarget or Page.bringToFront; the renderer
+		 * flips its tab-bar UI to match. tabId=null means the pane's
+		 * primary (the non-secondary tab managed by
+		 * usePersistentWebview).
+		 */
+		onActivateTabRequested: publicProcedure
+			.input(z.object({ paneId: z.string() }))
+			.subscription(({ input }) => {
+				return observable<{ tabId: string | null }>((emit) => {
+					const handler = (data: { tabId: string | null }) => emit.next(data);
+					browserManager.on(`activate-tab-requested:${input.paneId}`, handler);
+					return () => {
+						browserManager.off(
+							`activate-tab-requested:${input.paneId}`,
+							handler,
+						);
 					};
 				});
 			}),
@@ -135,6 +165,42 @@ export const createBrowserRouter = () => {
 			.mutation(async ({ input }) => {
 				const base64 = await browserManager.screenshot(input.paneId);
 				return { base64 };
+			}),
+
+		print: publicProcedure
+			.input(z.object({ paneId: z.string() }))
+			.mutation(({ input }) => {
+				browserManager.print(input.paneId);
+				return { success: true };
+			}),
+
+		onDownload: publicProcedure
+			.input(z.object({ paneId: z.string() }))
+			.subscription(({ input }) => {
+				return observable<{
+					kind: "started" | "finished";
+					filename: string;
+					targetPath: string;
+					url?: string;
+					state?: string;
+				}>((emit) => {
+					const started = (data: {
+						filename: string;
+						targetPath: string;
+						url: string;
+					}) => emit.next({ kind: "started", ...data });
+					const finished = (data: {
+						filename: string;
+						targetPath: string;
+						state: string;
+					}) => emit.next({ kind: "finished", ...data });
+					browserManager.on(`download-started:${input.paneId}`, started);
+					browserManager.on(`download-finished:${input.paneId}`, finished);
+					return () => {
+						browserManager.off(`download-started:${input.paneId}`, started);
+						browserManager.off(`download-finished:${input.paneId}`, finished);
+					};
+				});
 			}),
 
 		evaluateJS: publicProcedure

--- a/apps/desktop/src/lib/trpc/routers/browser/browser.ts
+++ b/apps/desktop/src/lib/trpc/routers/browser/browser.ts
@@ -61,13 +61,37 @@ export const createBrowserRouter = () => {
 		onCreateTabRequested: publicProcedure
 			.input(z.object({ paneId: z.string() }))
 			.subscription(({ input }) => {
-				return observable<{ url: string }>((emit) => {
-					const handler = (data: { url: string }) => emit.next(data);
+				return observable<{ url: string; requestId?: string }>((emit) => {
+					const handler = (data: { url: string; requestId?: string }) =>
+						emit.next(data);
 					browserManager.on(`create-tab-requested:${input.paneId}`, handler);
 					return () => {
 						browserManager.off(`create-tab-requested:${input.paneId}`, handler);
 					};
 				});
+			}),
+
+		/**
+		 * Called by the renderer after spawning the secondary tab so
+		 * the gateway can correlate concurrent Target.createTarget
+		 * requests with their respective new tab targetIds. `requestId`
+		 * came in on the matching create-tab-requested event.
+		 */
+		acknowledgeTabCreated: publicProcedure
+			.input(
+				z.object({
+					paneId: z.string(),
+					requestId: z.string(),
+					tabId: z.string(),
+				}),
+			)
+			.mutation(({ input }) => {
+				browserManager.acknowledgeTabCreated(
+					input.paneId,
+					input.requestId,
+					input.tabId,
+				);
+				return { success: true };
 			}),
 
 		navigate: publicProcedure

--- a/apps/desktop/src/lib/trpc/routers/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/index.ts
@@ -11,6 +11,7 @@ import { createAutoUpdateRouter } from "./auto-update";
 import { createBrowserRouter } from "./browser/browser";
 import { createBrowserAutomationRouter } from "./browser-automation";
 import { createBrowserHistoryRouter } from "./browser-history";
+import { createBrowserPermissionsRouter } from "./browser-permissions";
 import { createCacheRouter } from "./cache";
 import { createChangesRouter } from "./changes";
 import { createChatRuntimeServiceRouter } from "./chat-runtime-service";
@@ -56,6 +57,7 @@ export const createAppRouter = (
 		browser: createBrowserRouter(),
 		browserAutomation: createBrowserAutomationRouter(),
 		browserHistory: createBrowserHistoryRouter(),
+		browserPermissions: createBrowserPermissionsRouter(),
 		auth: createAuthRouter(),
 		autoUpdate: createAutoUpdateRouter(),
 		cache: createCacheRouter(),

--- a/apps/desktop/src/lib/trpc/routers/vscode-extensions/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/vscode-extensions/index.ts
@@ -41,6 +41,15 @@ const KNOWN_EXTENSIONS = [
 			"https://marketplace.visualstudio.com/items?itemName=openai.chatgpt",
 		viewType: "chatgpt.sidebarView",
 	},
+	{
+		id: "moonshot-ai.kimi-code",
+		name: "Kimi Code",
+		publisher: "Moonshot AI",
+		description: "AI coding assistant by Moonshot AI",
+		marketplaceUrl:
+			"https://marketplace.visualstudio.com/items?itemName=moonshot-ai.kimi-code",
+		viewType: "kimi.webview",
+	},
 ] as const;
 
 function getExtensionsDir(): string {
@@ -514,11 +523,17 @@ export const createVscodeExtensionsRouter = () => {
 					leftUri: string;
 					rightUri: string;
 					title?: string;
+					leftContent?: string;
 				}>((emit) => {
 					const manager = getExtensionHostManager();
 					const handler = (
 						wsId: string,
-						data: { leftUri: string; rightUri: string; title?: string },
+						data: {
+							leftUri: string;
+							rightUri: string;
+							title?: string;
+							leftContent?: string;
+						},
 					) => {
 						if (input?.workspaceId && wsId !== input.workspaceId) return;
 						emit.next(data);

--- a/apps/desktop/src/main/extension-host-worker/index.ts
+++ b/apps/desktop/src/main/extension-host-worker/index.ts
@@ -95,6 +95,7 @@ async function main() {
 			leftUri: data.leftUri,
 			rightUri: data.rightUri,
 			title: data.title,
+			leftContent: data.leftContent,
 		});
 	});
 
@@ -102,7 +103,7 @@ async function main() {
 	const SUPPORTED_EXTENSIONS = new Set(
 		(
 			process.env.EXTENSION_HOST_SUPPORTED_IDS ??
-			"anthropic.claude-code,openai.chatgpt"
+			"anthropic.claude-code,openai.chatgpt,moonshot-ai.kimi-code"
 		)
 			.split(",")
 			.map((s) => s.trim()),

--- a/apps/desktop/src/main/lib/browser-mcp-bridge/cdp-filter-proxy.ts
+++ b/apps/desktop/src/main/lib/browser-mcp-bridge/cdp-filter-proxy.ts
@@ -283,6 +283,10 @@ export async function proxyBrowserUpgrade(
 		const upstream = new WebSocket(chromiumBrowserWs);
 		const pendingMethods = new Map<number, string>();
 		const allowedSessionIds = new Set<string>();
+		// Track the targetId each admitted child session belongs to so
+		// session-scoped methods (Page.bringToFront, Page.navigate, …)
+		// can be routed back to a pane when UI bridging is needed.
+		const sessionIdToTargetId = new Map<string, string>();
 		// Allowed targetIds: starts as the bound set, but grows
 		// transitively: any target whose `openerId` is already allowed
 		// is admitted too. Without this, real children of the bound
@@ -449,6 +453,19 @@ export async function proxyBrowserUpgrade(
 					`[cdp #${connId}] →up sid=${shortSid(msg.sessionId)} id=${id ?? "-"} ${method}${summary ? ` ${summary}` : ""}${allowed ? "" : " [DROPPED unknown sid]"}`,
 				);
 				if (allowed) {
+					// Page.bringToFront is session-scoped; surface it as
+					// a renderer-side tab activation so the tab bar
+					// follows the MCP.
+					if (method === "Page.bringToFront") {
+						const tid = sessionIdToTargetId.get(msg.sessionId);
+						if (tid) {
+							const paneForTid = browserManager.getPaneIdForTarget(tid);
+							if (paneForTid) {
+								const tabId = browserManager.getTabIdForTarget(paneForTid, tid);
+								browserManager.requestTabActivation(paneForTid, tabId);
+							}
+						}
+					}
 					sendToUpstream(msg);
 				} else if (id !== undefined) {
 					rejectRequest(
@@ -544,6 +561,18 @@ export async function proxyBrowserUpgrade(
 						"Target.activateTarget for other targets is refused by the Superset CDP filter.",
 					);
 					return;
+				}
+				// Bridge MCP-driven tab activation into the renderer
+				// tab-bar so the user sees the same tab the MCP is
+				// driving (matches Chrome's tab-strip-follows-CDP
+				// behaviour). The renderer flips its activeTabId on
+				// receipt of the activate-tab-requested event.
+				if (tid) {
+					const paneForTid = browserManager.getPaneIdForTarget(tid);
+					if (paneForTid) {
+						const tabId = browserManager.getTabIdForTarget(paneForTid, tid);
+						browserManager.requestTabActivation(paneForTid, tabId);
+					}
 				}
 				pendingMethods.set(id, method);
 				sendToUpstream(msg);
@@ -677,6 +706,7 @@ export async function proxyBrowserUpgrade(
 					browserManager.emit(`create-tab-requested:${ctx.paneId}`, {
 						url: nextUrl,
 						requestId,
+						background: params?.background === true,
 					});
 				} catch {
 					/* best effort */
@@ -1044,6 +1074,9 @@ export async function proxyBrowserUpgrade(
 					return;
 				}
 				if (params?.sessionId) allowedSessionIds.add(params.sessionId);
+				if (params?.sessionId && tid) {
+					sessionIdToTargetId.set(params.sessionId, tid);
+				}
 				console.log(
 					`[cdp #${connId}] ←dn (root) attachedToTarget tid=${shortTid(tid)} sid=${shortSid(params?.sessionId)} (allowed=${allowedSessionIds.size})`,
 				);

--- a/apps/desktop/src/main/lib/browser-mcp-bridge/cdp-filter-proxy.ts
+++ b/apps/desktop/src/main/lib/browser-mcp-bridge/cdp-filter-proxy.ts
@@ -160,6 +160,14 @@ export async function proxyBrowserUpgrade(
 	chromiumPort: number,
 	ctx: BoundContext,
 ): Promise<void> {
+	console.log(
+		"[cdp-filter-proxy] proxyBrowserUpgrade pane",
+		ctx.paneId,
+		"primaryTargetId",
+		ctx.primaryTargetId,
+		"boundSet",
+		Array.from(ctx.boundTargetIds()),
+	);
 	let chromiumBrowserWs: string;
 	try {
 		const ver = (await fetchUpstreamJson("/json/version")) as {

--- a/apps/desktop/src/main/lib/browser-mcp-bridge/cdp-filter-proxy.ts
+++ b/apps/desktop/src/main/lib/browser-mcp-bridge/cdp-filter-proxy.ts
@@ -258,6 +258,10 @@ export async function proxyBrowserUpgrade(
 		const INTERNAL_REQ_BASE = 0x7fff_0000;
 		let internalReqSeq = 0;
 		const internalPendingIds = new Set<number>();
+		// Timers for in-flight Target.createTarget waits; cleared on
+		// WS close so a tardy renderer response can't leak timers /
+		// resolve a dead connection.
+		const pendingCreateTimers = new Set<NodeJS.Timeout>();
 		const refreshBound = (): void => {
 			for (const tid of ctx.boundTargetIds()) allowedTargetIds.add(tid);
 		};
@@ -291,6 +295,8 @@ export async function proxyBrowserUpgrade(
 		if (ctx.onClose) ctx.onClose(clientWs);
 
 		const closeBoth = (): void => {
+			for (const t of pendingCreateTimers) clearTimeout(t);
+			pendingCreateTimers.clear();
 			try {
 				clientWs.close();
 			} catch {
@@ -536,33 +542,47 @@ export async function proxyBrowserUpgrade(
 				// MCP attaches to whatever id we hand back and ends up
 				// driving the wrong tab (the user-reported "新しいタブで
 				// 検索すると最初のタブで検索される" behaviour).
+				// Correlate this createTarget with the renderer reply
+				// so concurrent createTarget calls (e.g. browser-use
+				// and chrome-devtools-mcp opening tabs at the same
+				// time) don't race each other onto the same new-tab
+				// event.
+				const requestId = `req-${connId}-${Date.now().toString(36)}-${id}`;
 				const waitForNewTab = (): Promise<string> => {
 					return new Promise((resolveTarget) => {
-						const handler = (newTargetId: string) => {
+						const handler = (payload: {
+							requestId?: string;
+							targetId: string;
+						}) => {
+							if (payload.requestId !== requestId) return;
 							browserManager.off(eventName, handler);
 							clearTimeout(timer);
+							pendingCreateTimers.delete(timer);
 							console.log(
-								`[cdp #${connId}] createTarget: new tab targetId=${shortTid(newTargetId)} (full=${newTargetId})`,
+								`[cdp #${connId}] createTarget: new tab targetId=${shortTid(payload.targetId)} (req=${requestId})`,
 							);
-							resolveTarget(newTargetId);
+							resolveTarget(payload.targetId);
 						};
-						const eventName = `tab-target-added:${ctx.paneId}`;
+						const eventName = `tab-target-added-for:${ctx.paneId}`;
 						browserManager.on(eventName, handler);
 						const timer = setTimeout(() => {
 							browserManager.off(eventName, handler);
+							pendingCreateTimers.delete(timer);
 							console.warn(
-								`[cdp #${connId}] createTarget: TIMEOUT waiting for new tab; falling back to primary`,
+								`[cdp #${connId}] createTarget: TIMEOUT waiting for new tab req=${requestId}`,
 							);
 							resolveTarget(ctx.primaryTargetId);
 						}, 8000);
+						pendingCreateTimers.add(timer);
 					});
 				};
 				console.log(
-					`[cdp #${connId}] createTarget: spawning new tab with url=${nextUrl}, waiting for tab-target-added on pane ${ctx.paneId}`,
+					`[cdp #${connId}] createTarget: spawning new tab url=${nextUrl} req=${requestId}`,
 				);
 				try {
 					browserManager.emit(`create-tab-requested:${ctx.paneId}`, {
 						url: nextUrl,
+						requestId,
 					});
 				} catch {
 					/* best effort */

--- a/apps/desktop/src/main/lib/browser-mcp-bridge/cdp-filter-proxy.ts
+++ b/apps/desktop/src/main/lib/browser-mcp-bridge/cdp-filter-proxy.ts
@@ -473,6 +473,16 @@ export async function proxyBrowserUpgrade(
 							return tid !== undefined && bound.has(tid);
 						})
 						.map((i) => rewriteTargetInfoType(i));
+					console.log(
+						"[cdp-filter-proxy] Target.getTargets upstream returned",
+						infos.length,
+						"infos | bound set",
+						Array.from(bound),
+						"| filtered to",
+						filtered.length,
+						"| upstream ids:",
+						infos.map((i) => `${i.type}:${targetIdOf(i)}`),
+					);
 					sendToClient({
 						...msg,
 						result: { ...msg.result, targetInfos: filtered },
@@ -598,8 +608,25 @@ export async function proxyBrowserUpgrade(
 			console.warn("[cdp-filter-proxy] browser upstream error", err);
 			closeBoth();
 		});
-		upstream.on("close", closeBoth);
-		clientWs.on("error", closeBoth);
-		clientWs.on("close", closeBoth);
+		upstream.on("close", (code, reason) => {
+			console.log(
+				"[cdp-filter-proxy] upstream WS closed",
+				code,
+				reason?.toString?.() ?? "",
+			);
+			closeBoth();
+		});
+		clientWs.on("error", (err) => {
+			console.warn("[cdp-filter-proxy] client WS error", err);
+			closeBoth();
+		});
+		clientWs.on("close", (code, reason) => {
+			console.log(
+				"[cdp-filter-proxy] client WS closed",
+				code,
+				reason?.toString?.() ?? "",
+			);
+			closeBoth();
+		});
 	});
 }

--- a/apps/desktop/src/main/lib/browser-mcp-bridge/cdp-filter-proxy.ts
+++ b/apps/desktop/src/main/lib/browser-mcp-bridge/cdp-filter-proxy.ts
@@ -384,6 +384,7 @@ export async function proxyBrowserUpgrade(
 			if (
 				method === "Target.disposeBrowserContext" ||
 				method === "Target.createBrowserContext" ||
+				method === "Target.getBrowserContexts" ||
 				method === "Browser.close" ||
 				method === "Browser.crash" ||
 				method === "Browser.crashGpuProcess" ||
@@ -393,7 +394,25 @@ export async function proxyBrowserUpgrade(
 				method === "Page.setWebLifecycleState" ||
 				// Page.close terminates the underlying webContents — same
 				// concern as Browser.close at page granularity.
-				method === "Page.close"
+				method === "Page.close" ||
+				// BrowserContext-addressed storage / permission APIs.
+				// Every Superset pane shares the `persist:superset`
+				// Electron partition, so honouring these would silently
+				// apply the client's cookies/storage/permission deltas
+				// to every other pane in the workspace. Reject until we
+				// ship per-pane partitions.
+				method === "Browser.grantPermissions" ||
+				method === "Browser.resetPermissions" ||
+				method === "Browser.setPermission" ||
+				method === "Storage.clearDataForOrigin" ||
+				method === "Storage.clearDataForStorageKey" ||
+				method === "Storage.clearCookies" ||
+				method === "Storage.setCookies" ||
+				method === "Storage.setCookie" ||
+				method === "Network.clearBrowserCookies" ||
+				method === "Network.clearBrowserCache" ||
+				method === "Network.setCookies" ||
+				method === "Network.setCookie"
 			) {
 				if (id !== undefined) {
 					rejectRequest(
@@ -781,6 +800,7 @@ export async function proxyBrowserUpgrade(
 								type?: string;
 								targetId?: string;
 								openerId?: string;
+								attached?: boolean;
 							};
 							targetId?: string;
 					  }
@@ -797,6 +817,43 @@ export async function proxyBrowserUpgrade(
 				console.log(
 					`[cdp #${connId}] ←dn (root) ${method} tid=${shortTid(tid)} type=${info?.type ?? "?"}`,
 				);
+				// Chromium's own auto-attach logic can miss Electron-
+				// hosted targets (webview-derived pages, Service
+				// Workers / Shared Workers / Dedicated Workers scoped
+				// to the bound page, popup windows, prerender targets)
+				// — puppeteer and playwright both only materialise
+				// Page / Worker / ServiceWorker objects from
+				// attachedToTarget, so a target that is merely
+				// announced via targetCreated but never attached stays
+				// invisible to the MCP. Proactively attach any
+				// newly-created target whose type is one of the
+				// relevant kinds and which we have not already
+				// attached to. Chromium emits the real
+				// attachedToTarget that our filter then forwards.
+				const t = info?.type;
+				if (
+					method === "Target.targetCreated" &&
+					tid &&
+					info?.attached !== true &&
+					(t === "page" ||
+						t === "service_worker" ||
+						t === "shared_worker" ||
+						t === "worker" ||
+						t === "prerender" ||
+						t === "webview")
+				) {
+					internalReqSeq += 1;
+					const internalId = INTERNAL_REQ_BASE + internalReqSeq;
+					internalPendingIds.add(internalId);
+					console.log(
+						`[cdp #${connId}] proactive attach tid=${shortTid(tid)} type=${t} internalId=${internalId}`,
+					);
+					sendToUpstream({
+						id: internalId,
+						method: "Target.attachToTarget",
+						params: { targetId: tid, flatten: true },
+					});
+				}
 				if (info) {
 					sendToClient({
 						...msg,

--- a/apps/desktop/src/main/lib/browser-mcp-bridge/cdp-filter-proxy.ts
+++ b/apps/desktop/src/main/lib/browser-mcp-bridge/cdp-filter-proxy.ts
@@ -2,6 +2,7 @@ import { randomBytes } from "node:crypto";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import type { Duplex } from "node:stream";
 import { type RawData, WebSocket, type WebSocketServer } from "ws";
+import { webContents as electronWebContents } from "electron";
 import { browserManager } from "../browser/browser-manager";
 import { resolveCdpPort } from "./cdp-port";
 import {
@@ -463,6 +464,41 @@ export async function proxyBrowserUpgrade(
 							if (paneForTid) {
 								const tabId = browserManager.getTabIdForTarget(paneForTid, tid);
 								browserManager.requestTabActivation(paneForTid, tabId);
+							}
+						}
+					}
+					// Electron quirk: session-scoped CDP Input.* events
+					// SHOULD target the session's renderer, but on some
+					// platforms Chromium delivers synthetic key/mouse
+					// events to whichever widget currently holds
+					// Chromium-internal focus. If the user clicked the
+					// Superset terminal pane (xterm.js), the browser
+					// pane's webContents has lost internal focus and
+					// MCP keystrokes land in the terminal instead of
+					// the page. Force-focus the bound webContents right
+					// before forwarding Input.* so the synthetic events
+					// hit the intended target.
+					if (method.startsWith("Input.")) {
+						const tid = sessionIdToTargetId.get(msg.sessionId);
+						if (tid) {
+							const paneForTid = browserManager.getPaneIdForTarget(tid);
+							if (paneForTid) {
+								const tabId = browserManager.getTabIdForTarget(
+									paneForTid,
+									tid,
+								);
+								const wcId = browserManager.getWebContentsIdForTab(
+									paneForTid,
+									tabId,
+								);
+								if (wcId != null) {
+									const wc = electronWebContents.fromId(wcId);
+									try {
+										wc?.focus();
+									} catch {
+										/* webContents may be gone */
+									}
+								}
 							}
 						}
 					}

--- a/apps/desktop/src/main/lib/browser-mcp-bridge/cdp-filter-proxy.ts
+++ b/apps/desktop/src/main/lib/browser-mcp-bridge/cdp-filter-proxy.ts
@@ -249,6 +249,15 @@ export async function proxyBrowserUpgrade(
 		// target is destroyed.
 		const allowedTargetIds = new Set<string>(ctx.boundTargetIds());
 		const childToParent = new Map<string, string>();
+		// Internal requests the proxy issues (e.g. to proactively
+		// attach to a newly-spawned secondary tab so Chromium emits
+		// Target.attachedToTarget even when its own auto-attach logic
+		// skips Electron <webview>-sourced targets). Responses with
+		// these ids must NOT reach the client because it never knew
+		// about them.
+		const INTERNAL_REQ_BASE = 0x7fff_0000;
+		let internalReqSeq = 0;
+		const internalPendingIds = new Set<number>();
 		const refreshBound = (): void => {
 			for (const tid of ctx.boundTargetIds()) allowedTargetIds.add(tid);
 		};
@@ -543,7 +552,29 @@ export async function proxyBrowserUpgrade(
 					console.log(
 						`[cdp #${connId}] createTarget: responding id=${id} targetId=${shortTid(newTargetId)}`,
 					);
+					// Admit the new tab into the scope so subsequent
+					// events (attachedToTarget, targetInfoChanged,
+					// Page.frameNavigated, …) survive the root filter.
+					allowedTargetIds.add(newTargetId);
+					childToParent.set(newTargetId, ctx.primaryTargetId);
 					sendToClient({ id, result: { targetId: newTargetId } });
+					// Chromium's auto-attach does not fire for Electron
+					// <webview> targets we just created via the renderer
+					// side-channel, so puppeteer's newPage() would hang
+					// forever waiting for Target.attachedToTarget.
+					// Proactively attach here (via an internal id the
+					// client will never see a response for) so Chromium
+					// emits the attachedToTarget event that our filter
+					// then forwards to the client as if auto-attach had
+					// produced it.
+					internalReqSeq += 1;
+					const internalId = INTERNAL_REQ_BASE + internalReqSeq;
+					internalPendingIds.add(internalId);
+					sendToUpstream({
+						id: internalId,
+						method: "Target.attachToTarget",
+						params: { targetId: newTargetId, flatten: true },
+					});
 				});
 				return;
 			}
@@ -662,6 +693,22 @@ export async function proxyBrowserUpgrade(
 			}
 
 			if (typeof msg.id === "number") {
+				if (internalPendingIds.has(msg.id)) {
+					internalPendingIds.delete(msg.id);
+					// Proactive Target.attachToTarget reply. The
+					// resulting Target.attachedToTarget event has
+					// already been delivered separately and is what
+					// the client actually cares about; swallow the
+					// response to avoid forwarding an id the client
+					// never issued.
+					const sid = (msg.result as { sessionId?: string } | undefined)
+						?.sessionId;
+					if (sid) allowedSessionIds.add(sid);
+					console.log(
+						`[cdp #${connId}] internal attach response id=${msg.id} sid=${shortSid(sid)} consumed`,
+					);
+					return;
+				}
 				const origMethod = pendingMethods.get(msg.id);
 				pendingMethods.delete(msg.id);
 				console.log(

--- a/apps/desktop/src/main/lib/browser-mcp-bridge/cdp-filter-proxy.ts
+++ b/apps/desktop/src/main/lib/browser-mcp-bridge/cdp-filter-proxy.ts
@@ -239,6 +239,40 @@ export async function proxyBrowserUpgrade(
 		const upstream = new WebSocket(chromiumBrowserWs);
 		const pendingMethods = new Map<number, string>();
 		const allowedSessionIds = new Set<string>();
+		// Allowed targetIds: starts as the bound set, but grows
+		// transitively: any target whose `openerId` is already allowed
+		// is admitted too. Without this, real children of the bound
+		// page (popups, OOPIF iframes, dedicated/service workers
+		// scoped to the page, prerender) are dropped at the root
+		// filter even though clients legitimately need to interact
+		// with them. childToParent lets us prune the closure when a
+		// target is destroyed.
+		const allowedTargetIds = new Set<string>(ctx.boundTargetIds());
+		const childToParent = new Map<string, string>();
+		const refreshBound = (): void => {
+			for (const tid of ctx.boundTargetIds()) allowedTargetIds.add(tid);
+		};
+		const isAllowedTarget = (
+			info: { targetId?: string; openerId?: string } | undefined,
+			fallbackTargetId?: string,
+		): boolean => {
+			refreshBound();
+			const tid = info?.targetId ?? fallbackTargetId;
+			if (!tid) return false;
+			if (allowedTargetIds.has(tid)) return true;
+			const opener = info?.openerId;
+			if (opener && allowedTargetIds.has(opener)) {
+				allowedTargetIds.add(tid);
+				childToParent.set(tid, opener);
+				return true;
+			}
+			return false;
+		};
+		const dropTarget = (tid: string | undefined): void => {
+			if (!tid) return;
+			allowedTargetIds.delete(tid);
+			childToParent.delete(tid);
+		};
 		// Frames the client sends before Chromium's browser WS reaches
 		// OPEN. CDP clients (puppeteer, cdp-use) typically fire
 		// `Target.setDiscoverTargets` / `Target.setAutoAttach` the
@@ -290,8 +324,13 @@ export async function proxyBrowserUpgrade(
 			}
 			pendingUpstream.length = 0;
 		});
+		// Use -32000 (server error) instead of -32601 (method not
+		// found) so CDP clients (puppeteer / cdp-use) treat the
+		// rejection as a normal protocol failure instead of falling
+		// back to "method does not exist on this version of Chromium"
+		// retry/normalization paths.
 		const rejectRequest = (id: number, message: string): void => {
-			sendToClient({ id, error: { code: -32601, message } });
+			sendToClient({ id, error: { code: -32000, message } });
 		};
 
 		clientWs.on("message", (data: RawData) => {
@@ -322,14 +361,30 @@ export async function proxyBrowserUpgrade(
 			console.log(
 				`[cdp #${connId}] →up (root) id=${id ?? "-"} ${method}${summary ? ` ${summary}` : ""}`,
 			);
-			const bound = ctx.boundTargetIds();
+			refreshBound();
+			// `bound` here is the dynamic allow-list (bound primary +
+			// pane tab targets + transitively-admitted children of any
+			// of those via openerId). Children are added by the
+			// attachedToTarget event handler below; checking against
+			// this set instead of the static ctx.boundTargetIds()
+			// admits popups, OOPIF iframes, dedicated/service workers
+			// scoped to the bound page, and prerender targets that
+			// puppeteer / cdp-use legitimately need to drive.
+			const bound = allowedTargetIds;
 
 			if (
 				method === "Target.disposeBrowserContext" ||
 				method === "Target.createBrowserContext" ||
 				method === "Browser.close" ||
 				method === "Browser.crash" ||
-				method === "Browser.crashGpuProcess"
+				method === "Browser.crashGpuProcess" ||
+				// Page.setWebLifecycleState lets the client move the
+				// page into "frozen" or "discarded" state, which would
+				// trash the user-visible pane out from under them.
+				method === "Page.setWebLifecycleState" ||
+				// Page.close terminates the underlying webContents — same
+				// concern as Browser.close at page granularity.
+				method === "Page.close"
 			) {
 				if (id !== undefined) {
 					rejectRequest(
@@ -415,8 +470,32 @@ export async function proxyBrowserUpgrade(
 
 			if (method === "Target.createTarget" && id !== undefined) {
 				const params = msg.params as
-					| { url?: string; background?: boolean; newWindow?: boolean }
+					| {
+							url?: string;
+							background?: boolean;
+							newWindow?: boolean;
+							browserContextId?: string;
+							forTab?: boolean;
+					  }
 					| undefined;
+				// Reject the browserContextId / newWindow / forTab
+				// flavours: Superset doesn't expose multiple browser
+				// contexts (incognito) and never opens its own OS
+				// window for an MCP, so honouring those params would
+				// silently lie to the client about what was created.
+				// Tell the truth instead so puppeteer / playwright
+				// surface a clean error.
+				if (
+					params?.browserContextId ||
+					params?.newWindow === true ||
+					params?.forTab !== undefined
+				) {
+					rejectRequest(
+						id,
+						"Target.createTarget with browserContextId / newWindow / forTab is not supported by the Superset CDP filter; tabs are always created inside the bound pane.",
+					);
+					return;
+				}
 				const nextUrl =
 					typeof params?.url === "string" && params.url !== ""
 						? params.url
@@ -526,7 +605,16 @@ export async function proxyBrowserUpgrade(
 			} catch {
 				return;
 			}
-			const bound = ctx.boundTargetIds();
+			refreshBound();
+			// `bound` here is the dynamic allow-list (bound primary +
+			// pane tab targets + transitively-admitted children of any
+			// of those via openerId). Children are added by the
+			// attachedToTarget event handler below; checking against
+			// this set instead of the static ctx.boundTargetIds()
+			// admits popups, OOPIF iframes, dedicated/service workers
+			// scoped to the bound page, and prerender targets that
+			// puppeteer / cdp-use legitimately need to drive.
+			const bound = allowedTargetIds;
 			const summary = summarizeParams(msg.method ?? "", msg.params);
 
 			if (msg.sessionId) {
@@ -540,13 +628,34 @@ export async function proxyBrowserUpgrade(
 					`[cdp #${connId}] ←dn sid=${shortSid(msg.sessionId)} id=${msg.id ?? "-"} ${msg.method ?? "(response)"}${summary ? ` ${summary}` : ""}`,
 				);
 				if (msg.method === "Target.attachedToTarget") {
-					const childSid = (msg.params as { sessionId?: string } | undefined)
-						?.sessionId;
+					// Nested attach (worker / iframe / prerender of a
+					// target the parent session already owns). Trust
+					// the parent: admit both the child sessionId AND
+					// the child targetId via openerId so subsequent
+					// session-scoped frames + root events reach the
+					// client cleanly.
+					const params = msg.params as
+						| {
+								sessionId?: string;
+								targetInfo?: { targetId?: string; openerId?: string };
+						  }
+						| undefined;
+					const childSid = params?.sessionId;
 					if (childSid) allowedSessionIds.add(childSid);
+					const childTid = params?.targetInfo?.targetId;
+					if (childTid) {
+						allowedTargetIds.add(childTid);
+						const opener = params?.targetInfo?.openerId;
+						if (opener) childToParent.set(childTid, opener);
+					}
 				} else if (msg.method === "Target.detachedFromTarget") {
-					const childSid = (msg.params as { sessionId?: string } | undefined)
-						?.sessionId;
+					const params = msg.params as
+						| { sessionId?: string; targetId?: string }
+						| undefined;
+					const childSid = params?.sessionId;
 					if (childSid) allowedSessionIds.delete(childSid);
+					const childTid = params?.targetId;
+					if (childTid) dropTarget(childTid);
 				}
 				sendToClient(msg);
 				return;
@@ -615,19 +724,24 @@ export async function proxyBrowserUpgrade(
 			const method = msg.method ?? "";
 			if (
 				method === "Target.targetCreated" ||
-				method === "Target.targetDestroyed" ||
-				method === "Target.targetInfoChanged" ||
-				method === "Target.targetCrashed"
+				method === "Target.targetInfoChanged"
 			) {
+				// Admit the target if it is in scope OR if its
+				// `openerId` is in scope (popups, child pages, etc.).
 				const params = msg.params as
 					| {
-							targetInfo?: { type?: string; targetId?: string };
+							targetInfo?: {
+								type?: string;
+								targetId?: string;
+								openerId?: string;
+							};
 							targetId?: string;
 					  }
 					| undefined;
 				const info = params?.targetInfo;
+				const allowed = isAllowedTarget(info, params?.targetId);
 				const tid = info?.targetId ?? params?.targetId;
-				if (!tid || !bound.has(tid)) {
+				if (!allowed) {
 					console.log(
 						`[cdp #${connId}] ←dn (root) ${method} tid=${shortTid(tid)} [DROPPED not in bound]`,
 					);
@@ -649,15 +763,55 @@ export async function proxyBrowserUpgrade(
 				}
 				return;
 			}
+			if (
+				method === "Target.targetDestroyed" ||
+				method === "Target.targetCrashed"
+			) {
+				const params = msg.params as
+					| {
+							targetInfo?: { type?: string; targetId?: string };
+							targetId?: string;
+					  }
+					| undefined;
+				const info = params?.targetInfo;
+				const tid = info?.targetId ?? params?.targetId;
+				if (!tid || !bound.has(tid)) {
+					console.log(
+						`[cdp #${connId}] ←dn (root) ${method} tid=${shortTid(tid)} [DROPPED not in bound]`,
+					);
+					return;
+				}
+				console.log(
+					`[cdp #${connId}] ←dn (root) ${method} tid=${shortTid(tid)} type=${info?.type ?? "?"}`,
+				);
+				dropTarget(tid);
+				if (info) {
+					sendToClient({
+						...msg,
+						params: {
+							...params,
+							targetInfo: rewriteTargetInfoType(info),
+						},
+					});
+				} else {
+					sendToClient(msg);
+				}
+				return;
+			}
 			if (method === "Target.attachedToTarget") {
 				const params = msg.params as
 					| {
 							sessionId?: string;
-							targetInfo?: { type?: string; targetId?: string };
+							targetInfo?: {
+								type?: string;
+								targetId?: string;
+								openerId?: string;
+							};
 					  }
 					| undefined;
+				const allowed = isAllowedTarget(params?.targetInfo);
 				const tid = params?.targetInfo?.targetId;
-				if (!tid || !bound.has(tid)) {
+				if (!allowed) {
 					console.log(
 						`[cdp #${connId}] ←dn (root) attachedToTarget tid=${shortTid(tid)} [DROPPED not in bound]`,
 					);
@@ -670,8 +824,8 @@ export async function proxyBrowserUpgrade(
 				sendToClient({
 					...msg,
 					params: {
-						...params,
-						targetInfo: rewriteTargetInfoType(params.targetInfo),
+						...(params ?? {}),
+						targetInfo: rewriteTargetInfoType(params?.targetInfo),
 					},
 				});
 				return;

--- a/apps/desktop/src/main/lib/browser-mcp-bridge/cdp-filter-proxy.ts
+++ b/apps/desktop/src/main/lib/browser-mcp-bridge/cdp-filter-proxy.ts
@@ -739,6 +739,9 @@ export async function proxyBrowserUpgrade(
 					`[cdp #${connId}] createTarget: spawning new tab url=${nextUrl} req=${requestId}`,
 				);
 				try {
+					console.log(
+						`[tab-diag] createTarget→emit pane=${ctx.paneId} url=${nextUrl} req=${requestId} bg=${params?.background === true}`,
+					);
 					browserManager.emit(`create-tab-requested:${ctx.paneId}`, {
 						url: nextUrl,
 						requestId,

--- a/apps/desktop/src/main/lib/browser-mcp-bridge/cdp-filter-proxy.ts
+++ b/apps/desktop/src/main/lib/browser-mcp-bridge/cdp-filter-proxy.ts
@@ -170,6 +170,38 @@ function rewriteTargetInfoType<T extends { type?: string } | undefined>(
 	return info;
 }
 
+function shortSid(sid: string | undefined): string {
+	if (!sid) return "(root)";
+	return sid.slice(0, 8);
+}
+
+function shortTid(tid: string | undefined): string {
+	if (!tid) return "?";
+	return tid.slice(0, 8);
+}
+
+function summarizeParams(method: string, params: unknown): string {
+	if (!params || typeof params !== "object") return "";
+	const p = params as Record<string, unknown>;
+	const parts: string[] = [];
+	if (typeof p.url === "string") parts.push(`url=${p.url.slice(0, 60)}`);
+	if (typeof p.targetId === "string") parts.push(`tid=${shortTid(p.targetId)}`);
+	if (typeof p.sessionId === "string")
+		parts.push(`sid=${shortSid(p.sessionId)}`);
+	if (typeof p.expression === "string")
+		parts.push(`js=${p.expression.slice(0, 40)}…`);
+	if (typeof p.text === "string") parts.push(`text=${p.text.slice(0, 30)}`);
+	if (typeof p.x === "number" && typeof p.y === "number")
+		parts.push(`xy=${p.x},${p.y}`);
+	if (typeof p.newWindow === "boolean") parts.push(`newWindow=${p.newWindow}`);
+	if (typeof p.background === "boolean")
+		parts.push(`background=${p.background}`);
+	void method;
+	return parts.join(" ");
+}
+
+let cdpConnSeq = 0;
+
 export async function proxyBrowserUpgrade(
 	req: IncomingMessage,
 	socket: Duplex,
@@ -178,13 +210,12 @@ export async function proxyBrowserUpgrade(
 	chromiumPort: number,
 	ctx: BoundContext,
 ): Promise<void> {
+	cdpConnSeq += 1;
+	const connId = cdpConnSeq;
 	console.log(
-		"[cdp-filter-proxy] proxyBrowserUpgrade pane",
-		ctx.paneId,
-		"primaryTargetId",
-		ctx.primaryTargetId,
-		"boundSet",
-		Array.from(ctx.boundTargetIds()),
+		`[cdp #${connId}] proxyBrowserUpgrade pane=${ctx.paneId} primary=${shortTid(
+			ctx.primaryTargetId,
+		)} bound=${Array.from(ctx.boundTargetIds()).map(shortTid).join(",")}`,
 	);
 	let chromiumBrowserWs: string;
 	try {
@@ -271,11 +302,15 @@ export async function proxyBrowserUpgrade(
 				return;
 			}
 			const id = typeof msg.id === "number" ? msg.id : undefined;
+			const summary = summarizeParams(msg.method ?? "", msg.params);
 			if (msg.sessionId) {
-				if (allowedSessionIds.has(msg.sessionId)) {
+				const allowed = allowedSessionIds.has(msg.sessionId);
+				console.log(
+					`[cdp #${connId}] →up sid=${shortSid(msg.sessionId)} id=${id ?? "-"} ${msg.method ?? "?"}${summary ? ` ${summary}` : ""}${allowed ? "" : " [DROPPED unknown sid]"}`,
+				);
+				if (allowed) {
 					sendToUpstream(msg);
 				} else if (id !== undefined) {
-					// Don't hang the caller on a stale / unknown sessionId.
 					rejectRequest(
 						id,
 						"The supplied CDP sessionId is not authorized for this Superset session (the session may have been detached or belong to another pane).",
@@ -284,6 +319,9 @@ export async function proxyBrowserUpgrade(
 				return;
 			}
 			const method = msg.method ?? "";
+			console.log(
+				`[cdp #${connId}] →up (root) id=${id ?? "-"} ${method}${summary ? ` ${summary}` : ""}`,
+			);
 			const bound = ctx.boundTargetIds();
 
 			if (
@@ -378,6 +416,9 @@ export async function proxyBrowserUpgrade(
 						const handler = (newTargetId: string) => {
 							browserManager.off(eventName, handler);
 							clearTimeout(timer);
+							console.log(
+								`[cdp #${connId}] createTarget: new tab targetId=${shortTid(newTargetId)} (full=${newTargetId})`,
+							);
 							resolveTarget(newTargetId);
 						};
 						const eventName = `tab-target-added:${ctx.paneId}`;
@@ -385,12 +426,15 @@ export async function proxyBrowserUpgrade(
 						const timer = setTimeout(() => {
 							browserManager.off(eventName, handler);
 							console.warn(
-								"[cdp-filter-proxy] Target.createTarget timed out waiting for new tab; falling back to primary",
+								`[cdp #${connId}] createTarget: TIMEOUT waiting for new tab; falling back to primary`,
 							);
 							resolveTarget(ctx.primaryTargetId);
 						}, 8000);
 					});
 				};
+				console.log(
+					`[cdp #${connId}] createTarget: spawning new tab with url=${nextUrl}, waiting for tab-target-added on pane ${ctx.paneId}`,
+				);
 				try {
 					browserManager.emit(`create-tab-requested:${ctx.paneId}`, {
 						url: nextUrl,
@@ -399,6 +443,9 @@ export async function proxyBrowserUpgrade(
 					/* best effort */
 				}
 				void waitForNewTab().then((newTargetId) => {
+					console.log(
+						`[cdp #${connId}] createTarget: responding id=${id} targetId=${shortTid(newTargetId)}`,
+					);
 					sendToClient({ id, result: { targetId: newTargetId } });
 				});
 				return;
@@ -462,9 +509,18 @@ export async function proxyBrowserUpgrade(
 				return;
 			}
 			const bound = ctx.boundTargetIds();
+			const summary = summarizeParams(msg.method ?? "", msg.params);
 
 			if (msg.sessionId) {
-				if (!allowedSessionIds.has(msg.sessionId)) return;
+				if (!allowedSessionIds.has(msg.sessionId)) {
+					console.log(
+						`[cdp #${connId}] ←dn sid=${shortSid(msg.sessionId)} ${msg.method ?? "?"} [DROPPED unknown sid]`,
+					);
+					return;
+				}
+				console.log(
+					`[cdp #${connId}] ←dn sid=${shortSid(msg.sessionId)} id=${msg.id ?? "-"} ${msg.method ?? "(response)"}${summary ? ` ${summary}` : ""}`,
+				);
 				if (msg.method === "Target.attachedToTarget") {
 					const childSid = (msg.params as { sessionId?: string } | undefined)
 						?.sessionId;
@@ -481,6 +537,9 @@ export async function proxyBrowserUpgrade(
 			if (typeof msg.id === "number") {
 				const origMethod = pendingMethods.get(msg.id);
 				pendingMethods.delete(msg.id);
+				console.log(
+					`[cdp #${connId}] ←dn (root) id=${msg.id} response-to=${origMethod ?? "?"}${msg.error ? ` ERROR=${msg.error.message}` : ""}`,
+				);
 				if (origMethod === "Target.getTargets" && msg.result) {
 					const infos = (msg.result.targetInfos ?? []) as Array<
 						{ type?: string } & Record<string, unknown>
@@ -550,7 +609,15 @@ export async function proxyBrowserUpgrade(
 					| undefined;
 				const info = params?.targetInfo;
 				const tid = info?.targetId ?? params?.targetId;
-				if (!tid || !bound.has(tid)) return;
+				if (!tid || !bound.has(tid)) {
+					console.log(
+						`[cdp #${connId}] ←dn (root) ${method} tid=${shortTid(tid)} [DROPPED not in bound]`,
+					);
+					return;
+				}
+				console.log(
+					`[cdp #${connId}] ←dn (root) ${method} tid=${shortTid(tid)} type=${info?.type ?? "?"}`,
+				);
 				if (info) {
 					sendToClient({
 						...msg,
@@ -572,8 +639,16 @@ export async function proxyBrowserUpgrade(
 					  }
 					| undefined;
 				const tid = params?.targetInfo?.targetId;
-				if (!tid || !bound.has(tid)) return;
+				if (!tid || !bound.has(tid)) {
+					console.log(
+						`[cdp #${connId}] ←dn (root) attachedToTarget tid=${shortTid(tid)} [DROPPED not in bound]`,
+					);
+					return;
+				}
 				if (params?.sessionId) allowedSessionIds.add(params.sessionId);
+				console.log(
+					`[cdp #${connId}] ←dn (root) attachedToTarget tid=${shortTid(tid)} sid=${shortSid(params?.sessionId)} (allowed=${allowedSessionIds.size})`,
+				);
 				sendToClient({
 					...msg,
 					params: {
@@ -588,6 +663,9 @@ export async function proxyBrowserUpgrade(
 					?.sessionId;
 				if (!sid || !allowedSessionIds.has(sid)) return;
 				allowedSessionIds.delete(sid);
+				console.log(
+					`[cdp #${connId}] ←dn (root) detachedFromTarget sid=${shortSid(sid)} (allowed=${allowedSessionIds.size})`,
+				);
 				sendToClient(msg);
 				return;
 			}

--- a/apps/desktop/src/main/lib/browser-mcp-bridge/cdp-filter-proxy.ts
+++ b/apps/desktop/src/main/lib/browser-mcp-bridge/cdp-filter-proxy.ts
@@ -4,6 +4,11 @@ import type { Duplex } from "node:stream";
 import { type RawData, WebSocket, type WebSocketServer } from "ws";
 import { browserManager } from "../browser/browser-manager";
 import { resolveCdpPort } from "./cdp-port";
+import {
+	checkMethodPermitted,
+	isPrivilegedSchemeAllowed,
+	permissionStore,
+} from "./permissions";
 
 /**
  * CDP filter helpers reused by the single-port gateway (cdp-gateway.ts).
@@ -196,8 +201,47 @@ function summarizeParams(method: string, params: unknown): string {
 	if (typeof p.newWindow === "boolean") parts.push(`newWindow=${p.newWindow}`);
 	if (typeof p.background === "boolean")
 		parts.push(`background=${p.background}`);
+	// Input/keyboard/focus diagnostics for the "keys leaked into the
+	// Superset terminal pane" bug. Knowing whether the MCP sent the
+	// event as root-scoped vs child-session-scoped is the key signal:
+	// root-scoped Input.* targets whichever webContents currently
+	// holds OS focus in the host BrowserWindow, which on a
+	// multi-pane Superset window can be the xterm.js terminal pane
+	// instead of the bound <webview>.
+	if (method.startsWith("Input.")) {
+		if (typeof p.type === "string") parts.push(`ev=${p.type}`);
+		if (typeof p.key === "string") parts.push(`key=${p.key}`);
+		if (typeof p.code === "string") parts.push(`code=${p.code}`);
+		if (typeof p.windowsVirtualKeyCode === "number")
+			parts.push(`vk=${p.windowsVirtualKeyCode}`);
+		if (typeof p.button === "string") parts.push(`btn=${p.button}`);
+	}
 	void method;
 	return parts.join(" ");
+}
+
+/**
+ * Method names whose dispatch we want explicit, high-visibility
+ * logging for. These are the CDP calls implicated in the reported
+ * "MCP typed into the terminal pane instead of the browser" bug:
+ * - Input.* delivers synthetic keyboard/mouse events. If sent on the
+ *   root session (no `sessionId` / `msg.sessionId`) they hit the host
+ *   BrowserWindow's focused webContents, which may be Superset's own
+ *   terminal pane rather than the bound <webview>.
+ * - Page.bringToFront / Target.activateTarget can pull OS focus over
+ *   from the bound <webview> onto another webContents, setting up
+ *   the focus-miss for the next Input.* call.
+ * - DOM.focus / Runtime.evaluate("element.focus()") can have the
+ *   same effect but are harder to detect; we log them at normal
+ *   verbosity only.
+ */
+function isFocusAffectingMethod(method: string): boolean {
+	return (
+		method.startsWith("Input.") ||
+		method === "Page.bringToFront" ||
+		method === "Target.activateTarget" ||
+		method === "Emulation.setFocusEmulationEnabled"
+	);
 }
 
 let cdpConnSeq = 0;
@@ -283,8 +327,28 @@ export async function proxyBrowserUpgrade(
 		};
 		const dropTarget = (tid: string | undefined): void => {
 			if (!tid) return;
-			allowedTargetIds.delete(tid);
-			childToParent.delete(tid);
+			// Recursively drop descendants: childToParent maps child
+			// targetId -> parent targetId, so any entry whose parent
+			// is (transitively) tid should also be evicted. Without
+			// this, popup/worker/prerender children of a closed tab
+			// stay in allowedTargetIds forever, leaking scope
+			// long-term on long-lived MCP connections.
+			const queue: string[] = [tid];
+			const visited = new Set<string>();
+			while (queue.length > 0) {
+				const cur = queue.shift() as string;
+				if (visited.has(cur)) continue;
+				visited.add(cur);
+				allowedTargetIds.delete(cur);
+				for (const [child, parent] of childToParent) {
+					if (parent === cur && !visited.has(child)) queue.push(child);
+				}
+				childToParent.delete(cur);
+			}
+			// Also clear any childToParent entry whose parent is now gone.
+			for (const [child, parent] of Array.from(childToParent)) {
+				if (visited.has(parent)) childToParent.delete(child);
+			}
 		};
 		// Frames the client sends before Chromium's browser WS reaches
 		// OPEN. CDP clients (puppeteer, cdp-use) typically fire
@@ -356,11 +420,33 @@ export async function proxyBrowserUpgrade(
 				return;
 			}
 			const id = typeof msg.id === "number" ? msg.id : undefined;
-			const summary = summarizeParams(msg.method ?? "", msg.params);
+			const method = msg.method ?? "";
+			const summary = summarizeParams(method, msg.params);
+			const paramsSid =
+				typeof (msg.params as { sessionId?: unknown } | undefined)
+					?.sessionId === "string"
+					? ((msg.params as { sessionId?: string }).sessionId as string)
+					: undefined;
+			if (isFocusAffectingMethod(method)) {
+				// High-visibility log line for focus/input-related calls.
+				// We care specifically whether the MCP carried the event
+				// on the webview's child session (msg.sessionId set, or
+				// params.sessionId set for non-flatten paths) or on the
+				// root session. Root-scoped Input.* is the smoking gun
+				// for the terminal-leak bug.
+				const scope = msg.sessionId
+					? `child-flatten sid=${shortSid(msg.sessionId)}`
+					: paramsSid
+						? `child-params sid=${shortSid(paramsSid)}`
+						: "ROOT";
+				console.warn(
+					`[cdp #${connId}] [focus/input] →up ${method} scope=${scope} id=${id ?? "-"}${summary ? ` ${summary}` : ""}`,
+				);
+			}
 			if (msg.sessionId) {
 				const allowed = allowedSessionIds.has(msg.sessionId);
 				console.log(
-					`[cdp #${connId}] →up sid=${shortSid(msg.sessionId)} id=${id ?? "-"} ${msg.method ?? "?"}${summary ? ` ${summary}` : ""}${allowed ? "" : " [DROPPED unknown sid]"}`,
+					`[cdp #${connId}] →up sid=${shortSid(msg.sessionId)} id=${id ?? "-"} ${method}${summary ? ` ${summary}` : ""}${allowed ? "" : " [DROPPED unknown sid]"}`,
 				);
 				if (allowed) {
 					sendToUpstream(msg);
@@ -372,7 +458,6 @@ export async function proxyBrowserUpgrade(
 				}
 				return;
 			}
-			const method = msg.method ?? "";
 			console.log(
 				`[cdp #${connId}] →up (root) id=${id ?? "-"} ${method}${summary ? ` ${summary}` : ""}`,
 			);
@@ -387,43 +472,20 @@ export async function proxyBrowserUpgrade(
 			// puppeteer / cdp-use legitimately need to drive.
 			const bound = allowedTargetIds;
 
-			if (
-				method === "Target.disposeBrowserContext" ||
-				method === "Target.createBrowserContext" ||
-				method === "Target.getBrowserContexts" ||
-				method === "Browser.close" ||
-				method === "Browser.crash" ||
-				method === "Browser.crashGpuProcess" ||
-				// Page.setWebLifecycleState lets the client move the
-				// page into "frozen" or "discarded" state, which would
-				// trash the user-visible pane out from under them.
-				method === "Page.setWebLifecycleState" ||
-				// Page.close terminates the underlying webContents — same
-				// concern as Browser.close at page granularity.
-				method === "Page.close" ||
-				// BrowserContext-addressed storage / permission APIs.
-				// Every Superset pane shares the `persist:superset`
-				// Electron partition, so honouring these would silently
-				// apply the client's cookies/storage/permission deltas
-				// to every other pane in the workspace. Reject until we
-				// ship per-pane partitions.
-				method === "Browser.grantPermissions" ||
-				method === "Browser.resetPermissions" ||
-				method === "Browser.setPermission" ||
-				method === "Storage.clearDataForOrigin" ||
-				method === "Storage.clearDataForStorageKey" ||
-				method === "Storage.clearCookies" ||
-				method === "Storage.setCookies" ||
-				method === "Storage.setCookie" ||
-				method === "Network.clearBrowserCookies" ||
-				method === "Network.clearBrowserCache" ||
-				method === "Network.setCookies" ||
-				method === "Network.setCookie"
-			) {
+			// Permission check: consults the active preset's toggles.
+			// Always-denied methods (Browser.close, Page.close, etc.)
+			// are baked into permissions.ts; toggle-gated methods flip
+			// with user-selected preset.
+			const perm = checkMethodPermitted(
+				method,
+				permissionStore.getActiveToggles(),
+			);
+			if (!perm.allowed) {
 				if (id !== undefined) {
 					rejectRequest(
 						id,
-						`${method} is not permitted by the Superset CDP filter`,
+						perm.reason ??
+							`${method} is not permitted by the Superset CDP filter`,
 					);
 				}
 				return;
@@ -534,6 +596,32 @@ export async function proxyBrowserUpgrade(
 					typeof params?.url === "string" && params.url !== ""
 						? params.url
 						: "about:blank";
+				// Allow only http(s) and about:blank by default. The
+				// "privilegedSchemes" permission toggle lets the user
+				// opt in to file://, chrome://, devtools://,
+				// javascript:, data: — these either escape the pane
+				// (privileged schemes) or let the client execute
+				// arbitrary code with the bound origin's privileges.
+				if (nextUrl !== "about:blank") {
+					let parsed: URL | null = null;
+					try {
+						parsed = new URL(nextUrl);
+					} catch {
+						parsed = null;
+					}
+					const scheme = parsed?.protocol ?? "";
+					const isSafeScheme = scheme === "http:" || scheme === "https:";
+					if (
+						!isSafeScheme &&
+						!isPrivilegedSchemeAllowed(permissionStore.getActiveToggles())
+					) {
+						rejectRequest(
+							id,
+							`Target.createTarget url scheme ${scheme || "(invalid)"} requires the "privilegedSchemes" permission toggle.`,
+						);
+						return;
+					}
+				}
 				// Tell the renderer to spawn a real new <webview> tab
 				// for this pane. Wait for browser-manager to register
 				// the new targetId (via addPaneTabTarget → tab-target-
@@ -548,7 +636,7 @@ export async function proxyBrowserUpgrade(
 				// time) don't race each other onto the same new-tab
 				// event.
 				const requestId = `req-${connId}-${Date.now().toString(36)}-${id}`;
-				const waitForNewTab = (): Promise<string> => {
+				const waitForNewTab = (): Promise<string | null> => {
 					return new Promise((resolveTarget) => {
 						const handler = (payload: {
 							requestId?: string;
@@ -571,7 +659,13 @@ export async function proxyBrowserUpgrade(
 							console.warn(
 								`[cdp #${connId}] createTarget: TIMEOUT waiting for new tab req=${requestId}`,
 							);
-							resolveTarget(ctx.primaryTargetId);
+							// Surface a real error rather than silently
+							// falling back to the primary targetId. A
+							// fallback makes the client think a new tab
+							// was created and then drive the primary,
+							// which looks like "the MCP opened a tab
+							// but then searched in the old one".
+							resolveTarget(null);
 						}, 8000);
 						pendingCreateTimers.add(timer);
 					});
@@ -588,6 +682,13 @@ export async function proxyBrowserUpgrade(
 					/* best effort */
 				}
 				void waitForNewTab().then((newTargetId) => {
+					if (!newTargetId) {
+						rejectRequest(
+							id,
+							"Target.createTarget timed out waiting for the renderer to spawn a new tab.",
+						);
+						return;
+					}
 					console.log(
 						`[cdp #${connId}] createTarget: responding id=${id} targetId=${shortTid(newTargetId)}`,
 					);
@@ -856,6 +957,7 @@ export async function proxyBrowserUpgrade(
 					tid &&
 					info?.attached !== true &&
 					(t === "page" ||
+						t === "iframe" ||
 						t === "service_worker" ||
 						t === "shared_worker" ||
 						t === "worker" ||

--- a/apps/desktop/src/main/lib/browser-mcp-bridge/cdp-filter-proxy.ts
+++ b/apps/desktop/src/main/lib/browser-mcp-bridge/cdp-filter-proxy.ts
@@ -152,6 +152,24 @@ function targetIdOf(obj: unknown): string | undefined {
 	return typeof t === "string" ? t : undefined;
 }
 
+/**
+ * Electron's BrowserView / <webview> shows up in Chromium's CDP as
+ * `type: "webview"`. puppeteer-core's `browser.pages()` filters by
+ * `type === "page"`, so the unchanged type would make chrome-devtools-
+ * mcp's `list_pages` / `evaluate_script` see zero pages even when the
+ * bound pane is alive. We rewrite "webview" to "page" on the way out
+ * so external CDP clients treat the pane as a normal page target.
+ */
+function rewriteTargetInfoType<T extends { type?: string } | undefined>(
+	info: T,
+): T {
+	if (!info) return info;
+	if (info.type === "webview") {
+		return { ...info, type: "page" } as T;
+	}
+	return info;
+}
+
 export async function proxyBrowserUpgrade(
 	req: IncomingMessage,
 	socket: Duplex,
@@ -446,11 +464,15 @@ export async function proxyBrowserUpgrade(
 				const origMethod = pendingMethods.get(msg.id);
 				pendingMethods.delete(msg.id);
 				if (origMethod === "Target.getTargets" && msg.result) {
-					const infos = (msg.result.targetInfos ?? []) as unknown[];
-					const filtered = infos.filter((i) => {
-						const tid = targetIdOf(i);
-						return tid !== undefined && bound.has(tid);
-					});
+					const infos = (msg.result.targetInfos ?? []) as Array<
+						{ type?: string } & Record<string, unknown>
+					>;
+					const filtered = infos
+						.filter((i) => {
+							const tid = targetIdOf(i);
+							return tid !== undefined && bound.has(tid);
+						})
+						.map((i) => rewriteTargetInfoType(i));
 					sendToClient({
 						...msg,
 						result: { ...msg.result, targetInfos: filtered },
@@ -470,6 +492,16 @@ export async function proxyBrowserUpgrade(
 						});
 						return;
 					}
+					sendToClient({
+						...msg,
+						result: {
+							...msg.result,
+							targetInfo: rewriteTargetInfoType(
+								msg.result.targetInfo as { type?: string },
+							),
+						},
+					});
+					return;
 				}
 				sendToClient(msg);
 				return;
@@ -482,27 +514,45 @@ export async function proxyBrowserUpgrade(
 				method === "Target.targetInfoChanged" ||
 				method === "Target.targetCrashed"
 			) {
-				const info =
-					(
-						msg.params as
-							| { targetInfo?: unknown; targetId?: string }
-							| undefined
-					)?.targetInfo ?? msg.params;
-				const tid =
-					targetIdOf(info) ??
-					(msg.params as { targetId?: string } | undefined)?.targetId;
+				const params = msg.params as
+					| {
+							targetInfo?: { type?: string; targetId?: string };
+							targetId?: string;
+					  }
+					| undefined;
+				const info = params?.targetInfo;
+				const tid = info?.targetId ?? params?.targetId;
 				if (!tid || !bound.has(tid)) return;
-				sendToClient(msg);
+				if (info) {
+					sendToClient({
+						...msg,
+						params: {
+							...params,
+							targetInfo: rewriteTargetInfoType(info),
+						},
+					});
+				} else {
+					sendToClient(msg);
+				}
 				return;
 			}
 			if (method === "Target.attachedToTarget") {
 				const params = msg.params as
-					| { sessionId?: string; targetInfo?: { targetId?: string } }
+					| {
+							sessionId?: string;
+							targetInfo?: { type?: string; targetId?: string };
+					  }
 					| undefined;
 				const tid = params?.targetInfo?.targetId;
 				if (!tid || !bound.has(tid)) return;
 				if (params?.sessionId) allowedSessionIds.add(params.sessionId);
-				sendToClient(msg);
+				sendToClient({
+					...msg,
+					params: {
+						...params,
+						targetInfo: rewriteTargetInfoType(params.targetInfo),
+					},
+				});
 				return;
 			}
 			if (method === "Target.detachedFromTarget") {

--- a/apps/desktop/src/main/lib/browser-mcp-bridge/cdp-filter-proxy.ts
+++ b/apps/desktop/src/main/lib/browser-mcp-bridge/cdp-filter-proxy.ts
@@ -340,11 +340,29 @@ export async function proxyBrowserUpgrade(
 				return;
 			}
 
-			// setAutoAttach: strip the `filter` field so Chromium does
-			// NOT honour a client-side `{type:'page', exclude:true}`
-			// exclusion that would wait for a tab wrapper Electron's
-			// embedded Chromium does not always expose.
-			if (method === "Target.setAutoAttach" && id !== undefined) {
+			// Strip the `filter` field from Target.setAutoAttach AND
+			// Target.setDiscoverTargets:
+			// - puppeteer (chrome-devtools-mcp) sends setAutoAttach with
+			//   `[{type:'page', exclude:true}]` waiting for a `tab`
+			//   wrapper Electron does not expose, which would hang
+			//   `connect()`.
+			// - browser-use (cdp-use) sends setDiscoverTargets with
+			//   `[{type:'page'}]`. Electron's <webview> is reported as
+			//   `type:'webview'`, so the bound primary is excluded from
+			//   discovery, Target.getTargets returns no matches, and
+			//   browser-use's SessionManager errors with "Root CDP
+			//   client not initialized" — the user-reported "セッション
+			//   が切れている" symptom.
+			// Removing the filter forces Chromium to surface every type;
+			// our downstream Target event/result filter still scopes
+			// the client's view to bound targetIds and rewrites
+			// type=webview → page so puppeteer/cdp-use treat it as a
+			// regular page.
+			if (
+				(method === "Target.setAutoAttach" ||
+					method === "Target.setDiscoverTargets") &&
+				id !== undefined
+			) {
 				const original = (msg.params ?? {}) as Record<string, unknown>;
 				const rewritten: Record<string, unknown> = { ...original };
 				if ("filter" in rewritten) delete rewritten.filter;

--- a/apps/desktop/src/main/lib/browser-mcp-bridge/cdp-filter-proxy.ts
+++ b/apps/desktop/src/main/lib/browser-mcp-bridge/cdp-filter-proxy.ts
@@ -365,16 +365,32 @@ export async function proxyBrowserUpgrade(
 					typeof params?.url === "string" && params.url !== ""
 						? params.url
 						: "about:blank";
-				// Emit a renderer-side "create tab" request. The
-				// BrowserPane subscribes via browser.onCreateTabRequested
-				// and creates a real <webview> tab, which then registers
-				// its webContents and targetId with browserManager. Once
-				// that targetId lands in the bound set the MCP's next
-				// `Target.getTargets` / `Target.attachToTarget` will find
-				// it. We respond synchronously with the primary targetId
-				// so puppeteer's newPage path resolves; subsequent
-				// auto-attach events for the new tab surface the real
-				// targetId to the client through our normal filter.
+				// Tell the renderer to spawn a real new <webview> tab
+				// for this pane. Wait for browser-manager to register
+				// the new targetId (via addPaneTabTarget → tab-target-
+				// added event) before responding, so the MCP gets the
+				// new tab's id and not the primary's. Without this the
+				// MCP attaches to whatever id we hand back and ends up
+				// driving the wrong tab (the user-reported "新しいタブで
+				// 検索すると最初のタブで検索される" behaviour).
+				const waitForNewTab = (): Promise<string> => {
+					return new Promise((resolveTarget) => {
+						const handler = (newTargetId: string) => {
+							browserManager.off(eventName, handler);
+							clearTimeout(timer);
+							resolveTarget(newTargetId);
+						};
+						const eventName = `tab-target-added:${ctx.paneId}`;
+						browserManager.on(eventName, handler);
+						const timer = setTimeout(() => {
+							browserManager.off(eventName, handler);
+							console.warn(
+								"[cdp-filter-proxy] Target.createTarget timed out waiting for new tab; falling back to primary",
+							);
+							resolveTarget(ctx.primaryTargetId);
+						}, 8000);
+					});
+				};
 				try {
 					browserManager.emit(`create-tab-requested:${ctx.paneId}`, {
 						url: nextUrl,
@@ -382,7 +398,9 @@ export async function proxyBrowserUpgrade(
 				} catch {
 					/* best effort */
 				}
-				sendToClient({ id, result: { targetId: ctx.primaryTargetId } });
+				void waitForNewTab().then((newTargetId) => {
+					sendToClient({ id, result: { targetId: newTargetId } });
+				});
 				return;
 			}
 

--- a/apps/desktop/src/main/lib/browser-mcp-bridge/cdp-gateway.ts
+++ b/apps/desktop/src/main/lib/browser-mcp-bridge/cdp-gateway.ts
@@ -170,6 +170,12 @@ function registerConnection(sessionId: string, ws: WebSocket): void {
 function closeConnectionsForSession(sessionId: string): void {
 	const set = sessionConnections.get(sessionId);
 	if (!set) return;
+	console.log(
+		"[cdp-gateway] M3 closing",
+		set.size,
+		"connections for session",
+		sessionId,
+	);
 	for (const ws of Array.from(set)) {
 		try {
 			ws.close(1000, "superset: binding changed, reconnect");

--- a/apps/desktop/src/main/lib/browser-mcp-bridge/cdp-gateway.ts
+++ b/apps/desktop/src/main/lib/browser-mcp-bridge/cdp-gateway.ts
@@ -99,14 +99,38 @@ async function resolveSessionForSocket(socket: Socket): Promise<string | null> {
 			socket.remoteAddress !== "::1" &&
 			socket.remoteAddress !== "::ffff:127.0.0.1"
 		) {
+			console.log("[cdp-gateway] reject non-loopback", socket.remoteAddress);
 			return null;
 		}
 		const remotePort = socket.remotePort;
 		if (typeof remotePort !== "number") return null;
 		const peerPid = await resolvePeerPidFromRemotePort(remotePort, process.pid);
-		if (!peerPid) return null;
+		if (!peerPid) {
+			console.log(
+				"[cdp-gateway] peer-PID lookup failed for remotePort",
+				remotePort,
+			);
+			return null;
+		}
 		const session = await resolvePidToSession(peerPid);
-		return session?.sessionId ?? null;
+		if (!session?.sessionId) {
+			console.log(
+				"[cdp-gateway] peerPid",
+				peerPid,
+				"did not resolve to any Superset terminal pane",
+			);
+			return null;
+		}
+		const binding = bindingStore.getBySessionId(session.sessionId);
+		console.log(
+			"[cdp-gateway] resolved peerPid",
+			peerPid,
+			"→ session",
+			session.sessionId,
+			"binding=",
+			binding ? binding.paneId : "(none)",
+		);
+		return session.sessionId;
 	})();
 	socketSessions.set(socket, promise);
 	return promise;
@@ -233,6 +257,12 @@ export async function handleCdpGatewayRequest(
 	try {
 		const resolved = await resolveForSocket(req.socket as Socket);
 		if (!resolved) {
+			console.log(
+				"[cdp-gateway] 409 for",
+				pathname,
+				"| current bindings:",
+				bindingStore.list().map((b) => `${b.sessionId}→${b.paneId}`),
+			);
 			sendJson(res, 409, {
 				error:
 					"このLLMセッションにはブラウザペインが接続されていません。Supersetの「Connect」で対象ペインをアタッチしてください。",

--- a/apps/desktop/src/main/lib/browser-mcp-bridge/cdp-gateway.ts
+++ b/apps/desktop/src/main/lib/browser-mcp-bridge/cdp-gateway.ts
@@ -310,8 +310,17 @@ export async function handleCdpGatewayRequest(
 			})
 			.map((t) => {
 				const id = (t as { id?: string }).id ?? primary;
+				// Electron exposes its <webview> / BrowserView tags as
+				// `type: "webview"` in /json/list. puppeteer-core's
+				// `browser.pages()` only counts targets whose type is
+				// `page`, so leaving "webview" through would make
+				// chrome-devtools-mcp's `list_pages` / `evaluate_script`
+				// return empty even when the bound pane is alive. Rewrite
+				// the type on the way out.
+				const type = (t as { type?: string }).type;
 				return {
 					...t,
+					type: type === "webview" ? "page" : type,
 					webSocketDebuggerUrl: `ws://${host}/devtools/page/${id}`,
 					devtoolsFrontendUrl: `http://${host}/devtools/page/${id}`,
 				};

--- a/apps/desktop/src/main/lib/browser-mcp-bridge/cdp-gateway.ts
+++ b/apps/desktop/src/main/lib/browser-mcp-bridge/cdp-gateway.ts
@@ -18,6 +18,7 @@ import {
 import { resolveCdpPort } from "./cdp-port";
 import { resolvePidToSession } from "./pane-resolver";
 import { resolvePeerPidFromRemotePort } from "./peer-pid";
+import { permissionStore } from "./permissions";
 
 /**
  * Single-port CDP gateway.
@@ -221,9 +222,28 @@ function ensurePaneTargetWatcher(paneId: string): void {
 	});
 }
 
+function closeAllConnections(reason: string): void {
+	const sessionIds = Array.from(sessionConnections.keys());
+	if (sessionIds.length === 0) return;
+	console.log(
+		`[cdp-gateway] ${reason} → closing all connections across ${sessionIds.length} session(s)`,
+	);
+	for (const sid of sessionIds) closeConnectionsForSession(sid);
+}
+
+let permissionWatcherInstalled = false;
+function installPermissionWatcher(): void {
+	if (permissionWatcherInstalled) return;
+	permissionWatcherInstalled = true;
+	permissionStore.on("activeChanged", (presetId) => {
+		closeAllConnections(`permission preset changed to ${presetId}`);
+	});
+}
+
 function installBindingChangeWatcher(): void {
 	if (bindingChangeWatcherInstalled) return;
 	bindingChangeWatcherInstalled = true;
+	installPermissionWatcher();
 	for (const b of bindingStore.list()) {
 		lastBindingBySession.set(b.sessionId, b.paneId);
 		ensurePaneTargetWatcher(b.paneId);

--- a/apps/desktop/src/main/lib/browser-mcp-bridge/cdp-gateway.ts
+++ b/apps/desktop/src/main/lib/browser-mcp-bridge/cdp-gateway.ts
@@ -93,7 +93,7 @@ const socketSessions = new WeakMap<Socket, Promise<string | null>>();
 async function resolveSessionForSocket(socket: Socket): Promise<string | null> {
 	const cached = socketSessions.get(socket);
 	if (cached) return cached;
-	const promise = (async () => {
+	const attempt = (async () => {
 		if (
 			socket.remoteAddress !== "127.0.0.1" &&
 			socket.remoteAddress !== "::1" &&
@@ -132,8 +132,12 @@ async function resolveSessionForSocket(socket: Socket): Promise<string | null> {
 		);
 		return session.sessionId;
 	})();
-	socketSessions.set(socket, promise);
-	return promise;
+	// Only memoise positive resolutions. A negative result can be a
+	// transient race (claude still forking, lsof evicted) and we
+	// don't want to poison a long-lived keep-alive socket forever.
+	const result = await attempt;
+	if (result) socketSessions.set(socket, Promise.resolve(result));
+	return result;
 }
 
 async function resolveForSocket(
@@ -188,16 +192,48 @@ function closeConnectionsForSession(sessionId: string): void {
 
 let bindingChangeWatcherInstalled = false;
 const lastBindingBySession = new Map<string, string>();
+const paneTargetWatchersInstalled = new Set<string>();
+
+function closeConnectionsForPane(paneId: string): void {
+	const sessions = bindingStore
+		.list()
+		.filter((b) => b.paneId === paneId)
+		.map((b) => b.sessionId);
+	if (sessions.length === 0) return;
+	console.log(
+		"[cdp-gateway] pane-target-set-changed → closing connections for",
+		sessions.length,
+		"session(s) bound to pane",
+		paneId,
+	);
+	for (const sid of sessions) closeConnectionsForSession(sid);
+}
+
+function ensurePaneTargetWatcher(paneId: string): void {
+	if (paneTargetWatchersInstalled.has(paneId)) return;
+	paneTargetWatchersInstalled.add(paneId);
+	browserManager.on(`pane-target-set-changed:${paneId}`, () => {
+		// Any shrink / grow / primary-swap of the pane's target set
+		// invalidates the per-connection allow-list snapshot held by
+		// existing proxy connections. Force them to close so the next
+		// tool call reconnects with a fresh bound set.
+		closeConnectionsForPane(paneId);
+	});
+}
 
 function installBindingChangeWatcher(): void {
 	if (bindingChangeWatcherInstalled) return;
 	bindingChangeWatcherInstalled = true;
 	for (const b of bindingStore.list()) {
 		lastBindingBySession.set(b.sessionId, b.paneId);
+		ensurePaneTargetWatcher(b.paneId);
 	}
 	bindingStore.onChange((list) => {
 		const next = new Map<string, string>();
-		for (const b of list) next.set(b.sessionId, b.paneId);
+		for (const b of list) {
+			next.set(b.sessionId, b.paneId);
+			ensurePaneTargetWatcher(b.paneId);
+		}
 		// Session removed → close.
 		for (const [sid] of lastBindingBySession) {
 			if (!next.has(sid)) closeConnectionsForSession(sid);

--- a/apps/desktop/src/main/lib/browser-mcp-bridge/pane-resolver.ts
+++ b/apps/desktop/src/main/lib/browser-mcp-bridge/pane-resolver.ts
@@ -163,7 +163,11 @@ export async function resolvePidToSession(
 			cache.set(pid, { resolved, at: Date.now() });
 			return resolved;
 		} catch (err) {
-			console.log("[pane-resolver] getProcessTree failed for pane", s.paneId, err);
+			console.log(
+				"[pane-resolver] getProcessTree failed for pane",
+				s.paneId,
+				err,
+			);
 		}
 	}
 	console.log("[pane-resolver] pid", pid, "not found in any pane tree");

--- a/apps/desktop/src/main/lib/browser-mcp-bridge/pane-resolver.ts
+++ b/apps/desktop/src/main/lib/browser-mcp-bridge/pane-resolver.ts
@@ -114,6 +114,7 @@ export async function resolvePidToSession(
 	if (!Number.isFinite(pid) || pid <= 0) return null;
 	const cached = cache.get(pid);
 	if (cached && Date.now() - cached.at < CACHE_TTL_MS) {
+		console.log("[pane-resolver] cache hit for pid", pid, "→", cached.resolved);
 		return cached.resolved;
 	}
 	let sessions: Awaited<
@@ -123,13 +124,36 @@ export async function resolvePidToSession(
 		const client = getTerminalHostClient();
 		const res = await client.listSessions();
 		sessions = res.sessions;
-	} catch {
+	} catch (err) {
+		console.log("[pane-resolver] listSessions failed:", err);
 		return null;
 	}
+	console.log(
+		"[pane-resolver] resolvePidToSession pid",
+		pid,
+		"sessions:",
+		sessions.map((s) => ({
+			paneId: s.paneId,
+			pid: s.pid,
+			isAlive: s.isAlive,
+		})),
+	);
 	for (const s of sessions) {
 		if (!s.isAlive || typeof s.pid !== "number") continue;
 		try {
 			const tree = await getProcessTree(s.pid);
+			console.log(
+				"[pane-resolver] pane",
+				s.paneId,
+				"pty pid",
+				s.pid,
+				"tree size",
+				tree.length,
+				"includes target?",
+				tree.includes(pid),
+				"tree sample:",
+				tree.slice(0, 10),
+			);
 			if (!tree.includes(pid)) continue;
 			const resolved: ResolvedSession = {
 				sessionId: `terminal:${s.paneId}`,
@@ -138,10 +162,11 @@ export async function resolvePidToSession(
 			};
 			cache.set(pid, { resolved, at: Date.now() });
 			return resolved;
-		} catch {
-			// Next pane.
+		} catch (err) {
+			console.log("[pane-resolver] getProcessTree failed for pane", s.paneId, err);
 		}
 	}
+	console.log("[pane-resolver] pid", pid, "not found in any pane tree");
 	return null;
 }
 

--- a/apps/desktop/src/main/lib/browser-mcp-bridge/peer-pid.ts
+++ b/apps/desktop/src/main/lib/browser-mcp-bridge/peer-pid.ts
@@ -38,32 +38,56 @@ export async function resolvePeerPidFromRemotePort(
 		return null;
 	}
 	try {
-		const { stdout } = await execAsync(
-			`lsof -nP -iTCP:${remotePort} -sTCP:ESTABLISHED 2>/dev/null || true`,
-			{ timeout: 3_000, maxBuffer: 1024 * 1024 },
-		);
+		const cmd = `lsof -nP -iTCP:${remotePort} -sTCP:ESTABLISHED 2>/dev/null || true`;
+		const { stdout } = await execAsync(cmd, {
+			timeout: 3_000,
+			maxBuffer: 1024 * 1024,
+		});
 		const text = stdout.trim();
+		console.log(
+			"[peer-pid] lsof for remotePort",
+			remotePort,
+			"ownPid",
+			ownPid,
+			"\n",
+			text || "(empty)",
+		);
 		if (!text) return null;
 		const lines = text.split("\n").slice(1); // skip header
 		for (const line of lines) {
 			const cols = line.trim().split(/\s+/);
-			// Format: COMMAND PID USER FD TYPE DEVICE SIZE/OFF NODE NAME
-			// NAME: 127.0.0.1:<localPort>->127.0.0.1:<peerPort> (ESTABLISHED)
 			if (cols.length < 9) continue;
 			const pid = Number.parseInt(cols[1] ?? "", 10);
 			if (!Number.isFinite(pid) || pid <= 0) continue;
-			if (pid === ownPid) continue; // this is our own (server) socket entry
+			if (pid === ownPid) continue;
 			const name = cols.slice(8).join(" ");
-			// The peer process is the one whose LOCAL endpoint is
-			// 127.0.0.1:<remotePort>. The `->` separator is always
-			// present on ESTABLISHED sockets.
 			const match = name.match(
 				/^(?:\[::1\]|127\.0\.0\.1):(\d+)->(?:\[::1\]|127\.0\.0\.1):(\d+)/,
 			);
-			if (!match) continue;
+			if (!match) {
+				console.log(
+					"[peer-pid] skip entry without loopback arrow: pid",
+					pid,
+					"name",
+					name,
+				);
+				continue;
+			}
 			const localPort = Number.parseInt(match[1] ?? "", 10);
+			console.log(
+				"[peer-pid] candidate pid",
+				pid,
+				"localPort",
+				localPort,
+				"remotePort target",
+				remotePort,
+			);
 			if (localPort === remotePort) return pid;
 		}
+		console.log(
+			"[peer-pid] no entry matched localPort === remotePort",
+			remotePort,
+		);
 		return null;
 	} catch {
 		return null;

--- a/apps/desktop/src/main/lib/browser-mcp-bridge/permissions.ts
+++ b/apps/desktop/src/main/lib/browser-mcp-bridge/permissions.ts
@@ -1,0 +1,501 @@
+import { EventEmitter } from "node:events";
+import {
+	chmodSync,
+	existsSync,
+	mkdirSync,
+	readFileSync,
+	writeFileSync,
+} from "node:fs";
+import { dirname, join } from "node:path";
+import { SUPERSET_HOME_DIR } from "../app-environment";
+
+/**
+ * CDP permission presets.
+ *
+ * The filter proxy's deny list used to be fully hardcoded, which was
+ * too rigid: it broke legitimate frontend-dev workflows (can't read
+ * cookies from a local app under MCP automation) while still not
+ * covering every edge case.
+ *
+ * The new model: a small set of capability toggles, grouped into
+ * user-named presets. The user switches the active preset from the
+ * Connect modal; the filter re-reads toggles on every request and
+ * active proxies are force-closed so the MCP reconnects under the
+ * fresh scope.
+ *
+ * Some CDP methods are ALWAYS denied (Browser.close, Page.close,
+ * Target.createBrowserContext, …). These are not part of the toggle
+ * set because honouring them would trash the user-visible pane or
+ * escape the pane sandbox entirely; they have no legitimate use in
+ * automation against a Superset-managed pane.
+ */
+
+export type PermissionToggleKey =
+	| "cookieRead"
+	| "cookieWrite"
+	| "storageWrite"
+	| "permissions"
+	| "privilegedSchemes"
+	| "downloadOverride"
+	| "uaOverride"
+	| "debugger"
+	| "networkIntercept";
+
+export const PERMISSION_TOGGLE_KEYS: PermissionToggleKey[] = [
+	"cookieRead",
+	"cookieWrite",
+	"storageWrite",
+	"permissions",
+	"privilegedSchemes",
+	"downloadOverride",
+	"uaOverride",
+	"debugger",
+	"networkIntercept",
+];
+
+export interface PermissionToggleMeta {
+	key: PermissionToggleKey;
+	label: string;
+	description: string;
+	/** CDP methods this toggle controls (documentation only). */
+	methods: string[];
+}
+
+export const PERMISSION_TOGGLE_META: Record<
+	PermissionToggleKey,
+	PermissionToggleMeta
+> = {
+	cookieRead: {
+		key: "cookieRead",
+		label: "Cookie 読み取り",
+		description:
+			"Cookie 一覧の取得を許可します。フロント開発で認証 Cookie を確認したいときに有効化。",
+		methods: [
+			"Network.getCookies",
+			"Network.getAllCookies",
+			"Storage.getCookies",
+		],
+	},
+	cookieWrite: {
+		key: "cookieWrite",
+		label: "Cookie 書き込み / 削除",
+		description:
+			"Cookie の設定・削除を許可します。MCP でセッションを差し替えたい場合のみ。",
+		methods: [
+			"Network.setCookie",
+			"Network.setCookies",
+			"Network.clearBrowserCookies",
+			"Storage.setCookie",
+			"Storage.setCookies",
+			"Storage.clearCookies",
+		],
+	},
+	storageWrite: {
+		key: "storageWrite",
+		label: "Storage 変更",
+		description:
+			"localStorage / IndexedDB / origin-scoped storage の書き換え・削除を許可します。",
+		methods: [
+			"Storage.clearDataForOrigin",
+			"Storage.clearDataForStorageKey",
+			"DOMStorage.clear",
+			"DOMStorage.setDOMStorageItem",
+			"DOMStorage.removeDOMStorageItem",
+			"DOMStorage.getDOMStorageItems",
+		],
+	},
+	permissions: {
+		key: "permissions",
+		label: "ブラウザ権限付与",
+		description:
+			"通知 / 位置情報 / カメラ等のブラウザ権限を MCP から操作することを許可します。全ペイン共有なので要注意。",
+		methods: [
+			"Browser.grantPermissions",
+			"Browser.resetPermissions",
+			"Browser.setPermission",
+		],
+	},
+	privilegedSchemes: {
+		key: "privilegedSchemes",
+		label: "特権スキーム navigate",
+		description:
+			"file:// / chrome:// / devtools:// / javascript: への createTarget を許可します。通常は http(s) のみ。",
+		methods: ["Target.createTarget (url scheme)"],
+	},
+	downloadOverride: {
+		key: "downloadOverride",
+		label: "ダウンロード先上書き",
+		description:
+			"Browser.setDownloadBehavior で任意パスへのダウンロードを許可します。任意パス書き込みの起点になるので注意。",
+		methods: ["Browser.setDownloadBehavior"],
+	},
+	uaOverride: {
+		key: "uaOverride",
+		label: "User-Agent 上書き",
+		description:
+			"Network.setUserAgentOverride を許可。partition-wide なので他ペインにも影響します。",
+		methods: ["Network.setUserAgentOverride"],
+	},
+	debugger: {
+		key: "debugger",
+		label: "Debugger ドメイン",
+		description:
+			"JS デバッガー操作を許可。Runtime.evaluate と同等の実行権限を持ちます。",
+		methods: ["Debugger.*"],
+	},
+	networkIntercept: {
+		key: "networkIntercept",
+		label: "Fetch / Network 書き換え",
+		description:
+			"Fetch.enable 系でリクエスト/レスポンスの MITM 的改ざんを許可します。",
+		methods: [
+			"Fetch.enable",
+			"Fetch.continueRequest",
+			"Fetch.fulfillRequest",
+			"Fetch.failRequest",
+		],
+	},
+};
+
+export type PermissionToggles = Partial<Record<PermissionToggleKey, boolean>>;
+
+export interface PermissionPreset {
+	id: string;
+	name: string;
+	/** Built-in presets cannot be renamed or deleted. */
+	builtin?: boolean;
+	toggles: PermissionToggles;
+}
+
+export interface PermissionConfig {
+	presets: PermissionPreset[];
+	activePresetId: string;
+}
+
+const BUILTIN_SECURE: PermissionPreset = {
+	id: "builtin-secure",
+	name: "Secure (default)",
+	builtin: true,
+	toggles: {
+		cookieRead: false,
+		cookieWrite: false,
+		storageWrite: false,
+		permissions: false,
+		privilegedSchemes: false,
+		downloadOverride: false,
+		uaOverride: false,
+		debugger: false,
+		networkIntercept: false,
+	},
+};
+
+const BUILTIN_FRONTEND_DEV: PermissionPreset = {
+	id: "builtin-frontend-dev",
+	name: "Frontend Dev",
+	builtin: true,
+	toggles: {
+		cookieRead: true,
+		cookieWrite: false,
+		storageWrite: true,
+		permissions: false,
+		privilegedSchemes: false,
+		downloadOverride: false,
+		uaOverride: true,
+		debugger: true,
+		networkIntercept: true,
+	},
+};
+
+const BUILTIN_PERMISSIVE: PermissionPreset = {
+	id: "builtin-permissive",
+	name: "Permissive",
+	builtin: true,
+	toggles: {
+		cookieRead: true,
+		cookieWrite: true,
+		storageWrite: true,
+		permissions: true,
+		privilegedSchemes: true,
+		downloadOverride: true,
+		uaOverride: true,
+		debugger: true,
+		networkIntercept: true,
+	},
+};
+
+export const BUILTIN_PRESETS: PermissionPreset[] = [
+	BUILTIN_SECURE,
+	BUILTIN_FRONTEND_DEV,
+	BUILTIN_PERMISSIVE,
+];
+
+const CONFIG_PATH = join(SUPERSET_HOME_DIR, "browser-mcp-permissions.json");
+
+interface StoreEvents {
+	change: [config: PermissionConfig];
+	activeChanged: [presetId: string];
+}
+
+class PermissionStore extends EventEmitter<StoreEvents> {
+	private config: PermissionConfig = {
+		presets: BUILTIN_PRESETS.map((p) => ({
+			...p,
+			toggles: { ...p.toggles },
+		})),
+		activePresetId: BUILTIN_SECURE.id,
+	};
+
+	constructor() {
+		super();
+		this.load();
+	}
+
+	private load(): void {
+		if (!existsSync(CONFIG_PATH)) return;
+		try {
+			const raw = readFileSync(CONFIG_PATH, "utf-8");
+			const parsed = JSON.parse(raw) as Partial<PermissionConfig>;
+			const userPresets = Array.isArray(parsed.presets)
+				? parsed.presets.filter(
+						(p): p is PermissionPreset =>
+							!!p && typeof p.id === "string" && typeof p.name === "string",
+					)
+				: [];
+			// Merge builtin + user. Builtins always come first and
+			// override any stored copy (so we can update defaults
+			// without the user's file sticking on stale values).
+			const byId = new Map<string, PermissionPreset>();
+			for (const p of BUILTIN_PRESETS) {
+				byId.set(p.id, { ...p, toggles: { ...p.toggles } });
+			}
+			for (const p of userPresets) {
+				if (byId.has(p.id) && byId.get(p.id)?.builtin) continue;
+				byId.set(p.id, {
+					...p,
+					builtin: false,
+					toggles: { ...p.toggles },
+				});
+			}
+			const active =
+				typeof parsed.activePresetId === "string" &&
+				byId.has(parsed.activePresetId)
+					? parsed.activePresetId
+					: BUILTIN_SECURE.id;
+			this.config = {
+				presets: Array.from(byId.values()),
+				activePresetId: active,
+			};
+		} catch (error) {
+			console.warn("[permissions] failed to load config:", error);
+		}
+	}
+
+	private persist(): void {
+		try {
+			mkdirSync(dirname(CONFIG_PATH), { recursive: true });
+			writeFileSync(CONFIG_PATH, JSON.stringify(this.config, null, 2), {
+				mode: 0o600,
+			});
+			try {
+				chmodSync(CONFIG_PATH, 0o600);
+			} catch {
+				/* best effort */
+			}
+		} catch (error) {
+			console.warn("[permissions] failed to persist config:", error);
+		}
+	}
+
+	getConfig(): PermissionConfig {
+		return {
+			presets: this.config.presets.map((p) => ({
+				...p,
+				toggles: { ...p.toggles },
+			})),
+			activePresetId: this.config.activePresetId,
+		};
+	}
+
+	getActive(): PermissionPreset {
+		const found = this.config.presets.find(
+			(p) => p.id === this.config.activePresetId,
+		);
+		return found ?? BUILTIN_SECURE;
+	}
+
+	getActiveToggles(): PermissionToggles {
+		return this.getActive().toggles;
+	}
+
+	setActive(presetId: string): void {
+		if (!this.config.presets.some((p) => p.id === presetId)) {
+			throw new Error(`Unknown preset id: ${presetId}`);
+		}
+		if (this.config.activePresetId === presetId) return;
+		this.config.activePresetId = presetId;
+		this.persist();
+		this.emit("activeChanged", presetId);
+		this.emit("change", this.getConfig());
+	}
+
+	savePreset(input: {
+		id?: string;
+		name: string;
+		toggles: PermissionToggles;
+	}): PermissionPreset {
+		const id = input.id ?? `user-${Date.now().toString(36)}`;
+		const existing = this.config.presets.find((p) => p.id === id);
+		if (existing?.builtin) {
+			throw new Error(`Cannot modify built-in preset: ${id}`);
+		}
+		const next: PermissionPreset = {
+			id,
+			name: input.name,
+			builtin: false,
+			toggles: { ...input.toggles },
+		};
+		if (existing) {
+			this.config.presets = this.config.presets.map((p) =>
+				p.id === id ? next : p,
+			);
+		} else {
+			this.config.presets = [...this.config.presets, next];
+		}
+		this.persist();
+		this.emit("change", this.getConfig());
+		// If the edited preset is the active one, notify filter to
+		// re-close connections so the MCP picks up new toggles.
+		if (this.config.activePresetId === id) {
+			this.emit("activeChanged", id);
+		}
+		return next;
+	}
+
+	deletePreset(id: string): void {
+		const existing = this.config.presets.find((p) => p.id === id);
+		if (!existing) return;
+		if (existing.builtin) {
+			throw new Error(`Cannot delete built-in preset: ${id}`);
+		}
+		this.config.presets = this.config.presets.filter((p) => p.id !== id);
+		if (this.config.activePresetId === id) {
+			this.config.activePresetId = BUILTIN_SECURE.id;
+			this.emit("activeChanged", this.config.activePresetId);
+		}
+		this.persist();
+		this.emit("change", this.getConfig());
+	}
+}
+
+export const permissionStore = new PermissionStore();
+
+/**
+ * Classify a CDP method into (a) always-denied, (b) toggle-gated,
+ * or (c) always-allowed.
+ *
+ * The filter proxy calls this before forwarding any message and
+ * consults the current active preset's toggles. Returning
+ * {allowed:false} causes the filter to reply with -32000.
+ */
+export interface PermissionCheckResult {
+	allowed: boolean;
+	reason?: string;
+	/**
+	 * When false, indicates the method is gated by a toggle that is
+	 * currently OFF. UI surfaces this so the user can flip the
+	 * relevant preset toggle.
+	 */
+	togglesKey?: PermissionToggleKey;
+}
+
+const ALWAYS_DENIED = new Set<string>([
+	"Target.createBrowserContext",
+	"Target.disposeBrowserContext",
+	// Target.getBrowserContexts is READ-ONLY and required by
+	// puppeteer.connect() bootstrap — NOT denied.
+	"Target.setRemoteLocations",
+	"Target.exposeDevToolsProtocol",
+	"Browser.close",
+	"Browser.crash",
+	"Browser.crashGpuProcess",
+	"Page.setWebLifecycleState",
+	"Page.close",
+]);
+
+const TOGGLE_BY_METHOD: Record<string, PermissionToggleKey> = {
+	// cookieRead
+	"Network.getCookies": "cookieRead",
+	"Network.getAllCookies": "cookieRead",
+	"Storage.getCookies": "cookieRead",
+	// cookieWrite
+	"Network.setCookie": "cookieWrite",
+	"Network.setCookies": "cookieWrite",
+	"Network.clearBrowserCookies": "cookieWrite",
+	"Storage.setCookie": "cookieWrite",
+	"Storage.setCookies": "cookieWrite",
+	"Storage.clearCookies": "cookieWrite",
+	// storageWrite
+	"Storage.clearDataForOrigin": "storageWrite",
+	"Storage.clearDataForStorageKey": "storageWrite",
+	"DOMStorage.clear": "storageWrite",
+	"DOMStorage.setDOMStorageItem": "storageWrite",
+	"DOMStorage.removeDOMStorageItem": "storageWrite",
+	"DOMStorage.getDOMStorageItems": "storageWrite",
+	// permissions
+	"Browser.grantPermissions": "permissions",
+	"Browser.resetPermissions": "permissions",
+	"Browser.setPermission": "permissions",
+	// downloadOverride
+	"Browser.setDownloadBehavior": "downloadOverride",
+	// uaOverride
+	"Network.setUserAgentOverride": "uaOverride",
+	// networkIntercept
+	"Fetch.enable": "networkIntercept",
+	"Fetch.continueRequest": "networkIntercept",
+	"Fetch.fulfillRequest": "networkIntercept",
+	"Fetch.failRequest": "networkIntercept",
+	"Fetch.continueResponse": "networkIntercept",
+	"Fetch.continueWithAuth": "networkIntercept",
+};
+
+export function checkMethodPermitted(
+	method: string,
+	toggles: PermissionToggles,
+): PermissionCheckResult {
+	if (ALWAYS_DENIED.has(method)) {
+		return {
+			allowed: false,
+			reason: `${method} is always denied by the Superset CDP filter (pane lifecycle / scope escape).`,
+		};
+	}
+	if (method.startsWith("Debugger.")) {
+		if (!toggles.debugger) {
+			return {
+				allowed: false,
+				reason: `${method} requires the Debugger permission toggle.`,
+				togglesKey: "debugger",
+			};
+		}
+		return { allowed: true };
+	}
+	const tog = TOGGLE_BY_METHOD[method];
+	if (!tog) return { allowed: true };
+	if (!toggles[tog]) {
+		return {
+			allowed: false,
+			reason: `${method} requires the "${PERMISSION_TOGGLE_META[tog].label}" permission toggle.`,
+			togglesKey: tog,
+		};
+	}
+	return { allowed: true };
+}
+
+/**
+ * Scheme check for Target.createTarget url param. Returns true when
+ * the current toggles allow privileged schemes (file:, chrome:,
+ * devtools:, javascript:, data:). http(s) and about:blank are always
+ * allowed.
+ */
+export function isPrivilegedSchemeAllowed(toggles: PermissionToggles): boolean {
+	return toggles.privilegedSchemes === true;
+}

--- a/apps/desktop/src/main/lib/browser-mcp-bridge/server.ts
+++ b/apps/desktop/src/main/lib/browser-mcp-bridge/server.ts
@@ -87,19 +87,19 @@ function readPersistedPort(): number | null {
 }
 
 async function listenPreferringStablePort(server: Server): Promise<number> {
-	// 1. Try the port used last run (so external MCP registrations stay
-	//    valid across restarts).
+	// The gateway URL is now always http://127.0.0.1:47834, so prefer
+	// that first even if an older build persisted a different port in
+	// browser-mcp.json (e.g. 49939 from the per-session port era). Only
+	// fall back to the persisted value if 47834 is taken, then to a
+	// kernel-assigned port.
 	const previous = readPersistedPort();
-	const candidates = [previous, PREFERRED_BRIDGE_PORT].filter(
-		(p): p is number => typeof p === "number",
+	const candidates = [PREFERRED_BRIDGE_PORT, previous].filter(
+		(p, i, arr): p is number => typeof p === "number" && arr.indexOf(p) === i,
 	);
 	for (const candidate of candidates) {
 		const bound = await tryListen(server, candidate);
 		if (bound) return bound;
 	}
-	// 2. Fall back to a kernel-assigned port. The user will have to
-	//    re-register external MCPs with the new URL, but the app still
-	//    comes up cleanly instead of hanging on a conflict.
 	const bound = await tryListen(server, 0);
 	if (bound) return bound;
 	throw new Error("browser-mcp-bridge: could not bind any loopback port");

--- a/apps/desktop/src/main/lib/browser/browser-manager.ts
+++ b/apps/desktop/src/main/lib/browser/browser-manager.ts
@@ -140,9 +140,16 @@ class BrowserManager extends EventEmitter {
 		this.paneTargetIds.delete(paneId);
 		const wc = webContents.fromId(webContentsId);
 		if (wc) {
-			// Keep throttling enabled so parked/offscreen persistent webviews don't
-			// run at full speed in the background.
-			wc.setBackgroundThrottling(true);
+			// External CDP MCPs (chrome-devtools-mcp, browser-use) may
+			// drive this primary webview while its BrowserPane is
+			// off-screen, the parent BrowserWindow is minimised, or
+			// the pane is obscured. Chromium's LifecycleWatcher and
+			// many sites gate work on document.hidden /
+			// requestAnimationFrame / IntersectionObserver, all of
+			// which freeze under background throttling. Keep throttling
+			// off so automation stays responsive; the perf cost of an
+			// idle pane is negligible.
+			wc.setBackgroundThrottling(false);
 			wc.setWindowOpenHandler(({ url, disposition }) => {
 				if (!url || url === "about:blank") {
 					return { action: "deny" as const };

--- a/apps/desktop/src/main/lib/browser/browser-manager.ts
+++ b/apps/desktop/src/main/lib/browser/browser-manager.ts
@@ -386,6 +386,15 @@ class BrowserManager extends EventEmitter {
 	): Promise<void> {
 		const wc = webContents.fromId(webContentsId);
 		if (!wc || wc.isDestroyed()) return;
+		// Tabs are routinely off-screen while another tab is active.
+		// External CDP MCPs (browser-use, chrome-devtools-mcp) need
+		// the inactive tab's webContents to keep timers / network /
+		// JS running so navigation doesn't stall waiting for visibility.
+		try {
+			wc.setBackgroundThrottling(false);
+		} catch {
+			/* best-effort */
+		}
 		this.paneTabWebContents.set(this.tabKey(paneId, tabId), webContentsId);
 		let attached = false;
 		try {

--- a/apps/desktop/src/main/lib/browser/browser-manager.ts
+++ b/apps/desktop/src/main/lib/browser/browser-manager.ts
@@ -177,9 +177,15 @@ class BrowserManager extends EventEmitter {
 					};
 				}
 
-				// Regular target="_blank" links — open as a new browser tab
-				this.emit(`new-window:${paneId}`, url);
-				this.emit("new-window", { paneId, url });
+				// Regular target="_blank" / window.open() — open as a
+				// new secondary tab in the same pane so it stays within
+				// the MCP's bound scope (the pane's CDP session sees it
+				// via paneTabTargetIds and the user can drive it with
+				// the same binding). This matches Chrome's default
+				// target="_blank" UX (new tab, not new window). The old
+				// split-pane / workspace-tab behaviours are still
+				// reachable via the "Open in Split" context menu.
+				this.emit(`create-tab-requested:${paneId}`, { url });
 				return { action: "deny" as const };
 			});
 			this.setupPopupWindowHandler(paneId, wc);

--- a/apps/desktop/src/main/lib/browser/browser-manager.ts
+++ b/apps/desktop/src/main/lib/browser/browser-manager.ts
@@ -209,7 +209,17 @@ class BrowserManager extends EventEmitter {
 		}
 		this.paneWebContentsIds.delete(paneId);
 		this.paneTargetIds.delete(paneId);
+		this.paneTabTargetIds.delete(paneId);
+		// Sweep per-tab maps keyed by paneId::tabId.
+		const tabPrefix = `${paneId}::`;
+		for (const key of [...this.paneTabTargetIdByKey.keys()]) {
+			if (key.startsWith(tabPrefix)) this.paneTabTargetIdByKey.delete(key);
+		}
+		for (const key of [...this.paneTabWebContents.keys()]) {
+			if (key.startsWith(tabPrefix)) this.paneTabWebContents.delete(key);
+		}
 		this.consoleLogs.delete(paneId);
+		this.emit(`pane-target-set-changed:${paneId}`, { action: "clear" });
 	}
 
 	unregisterAll(): void {
@@ -270,11 +280,16 @@ class BrowserManager extends EventEmitter {
 		);
 		// Notify any in-flight Target.createTarget waiters in the gateway.
 		this.emit(`tab-target-added:${paneId}`, targetId);
+		this.emit(`pane-target-set-changed:${paneId}`, { action: "add", targetId });
 	}
 
 	removePaneTabTarget(paneId: string, targetId: string): void {
 		this.paneTabTargetIds.get(paneId)?.delete(targetId);
 		console.log("[browser-manager] removePaneTabTarget", paneId, targetId);
+		this.emit(`pane-target-set-changed:${paneId}`, {
+			action: "remove",
+			targetId,
+		});
 	}
 
 	listPanesWithCdpTargets(): Array<{ paneId: string; targetId: string }> {
@@ -355,6 +370,12 @@ class BrowserManager extends EventEmitter {
 					"previous",
 					previous,
 				);
+				if (previous !== targetId) {
+					this.emit(`pane-target-set-changed:${paneId}`, {
+						action: "primary",
+						targetId,
+					});
+				}
 			} else {
 				console.log(
 					"[browser-manager] discarded captured targetId pane",
@@ -441,6 +462,41 @@ class BrowserManager extends EventEmitter {
 		if (targetId) this.removePaneTabTarget(paneId, targetId);
 		this.paneTabTargetIdByKey.delete(key);
 		this.paneTabWebContents.delete(key);
+	}
+
+	/**
+	 * Correlate a renderer-side tab spawn (result of a
+	 * create-tab-requested event) with its Chromium CDP targetId for
+	 * the gateway's Target.createTarget waiter. Requires registerTab
+	 * to have already captured the targetId; if it hasn't yet,
+	 * listen for the next addPaneTabTarget on the pane and use that.
+	 */
+	acknowledgeTabCreated(
+		paneId: string,
+		requestId: string,
+		tabId: string,
+	): void {
+		const key = this.tabKey(paneId, tabId);
+		const existing = this.paneTabTargetIdByKey.get(key);
+		if (existing) {
+			this.emit(`tab-target-added-for:${paneId}`, {
+				requestId,
+				targetId: existing,
+			});
+			return;
+		}
+		const handler = (addedTargetId: string) => {
+			const current = this.paneTabTargetIdByKey.get(key);
+			if (current !== addedTargetId) return;
+			this.off(`tab-target-added:${paneId}`, handler);
+			this.emit(`tab-target-added-for:${paneId}`, {
+				requestId,
+				targetId: addedTargetId,
+			});
+		};
+		this.on(`tab-target-added:${paneId}`, handler);
+		// Safety: drop the listener after 10s so it can't leak.
+		setTimeout(() => this.off(`tab-target-added:${paneId}`, handler), 10_000);
 	}
 
 	private tabKey(paneId: string, tabId: string): string {

--- a/apps/desktop/src/main/lib/browser/browser-manager.ts
+++ b/apps/desktop/src/main/lib/browser/browser-manager.ts
@@ -254,10 +254,18 @@ class BrowserManager extends EventEmitter {
 			this.paneTabTargetIds.set(paneId, set);
 		}
 		set.add(targetId);
+		console.log(
+			"[browser-manager] addPaneTabTarget",
+			paneId,
+			targetId,
+			"now",
+			Array.from(set),
+		);
 	}
 
 	removePaneTabTarget(paneId: string, targetId: string): void {
 		this.paneTabTargetIds.get(paneId)?.delete(targetId);
+		console.log("[browser-manager] removePaneTabTarget", paneId, targetId);
 	}
 
 	listPanesWithCdpTargets(): Array<{ paneId: string; targetId: string }> {
@@ -326,7 +334,29 @@ class BrowserManager extends EventEmitter {
 				targetId.length > 0 &&
 				currentId === expectedWebContentsId
 			) {
+				const previous = this.paneTargetIds.get(paneId);
 				this.paneTargetIds.set(paneId, targetId);
+				console.log(
+					"[browser-manager] captured primary targetId pane",
+					paneId,
+					"wc",
+					expectedWebContentsId,
+					"targetId",
+					targetId,
+					"previous",
+					previous,
+				);
+			} else {
+				console.log(
+					"[browser-manager] discarded captured targetId pane",
+					paneId,
+					"expectedWc",
+					expectedWebContentsId,
+					"currentWc",
+					currentId,
+					"targetId",
+					targetId,
+				);
 			}
 		} catch (error) {
 			console.warn(

--- a/apps/desktop/src/main/lib/browser/browser-manager.ts
+++ b/apps/desktop/src/main/lib/browser/browser-manager.ts
@@ -489,6 +489,16 @@ class BrowserManager extends EventEmitter {
 	): void {
 		const key = this.tabKey(paneId, tabId);
 		const existing = this.paneTabTargetIdByKey.get(key);
+		console.log(
+			"[tab-diag] acknowledgeTabCreated pane=",
+			paneId,
+			"tab=",
+			tabId,
+			"req=",
+			requestId,
+			"existingTarget=",
+			existing ?? "(waiting)",
+		);
 		if (existing) {
 			this.emit(`tab-target-added-for:${paneId}`, {
 				requestId,

--- a/apps/desktop/src/main/lib/browser/browser-manager.ts
+++ b/apps/desktop/src/main/lib/browser/browser-manager.ts
@@ -1,7 +1,10 @@
 import { EventEmitter } from "node:events";
+import { basename, join } from "node:path";
 import {
+	app,
 	type BrowserWindow,
 	clipboard,
+	dialog,
 	Menu,
 	nativeTheme,
 	shell,
@@ -185,6 +188,8 @@ class BrowserManager extends EventEmitter {
 			this.setupContextMenu(paneId, wc);
 			this.setupFindInPage(paneId, wc);
 			this.setupPaneIdMarker(paneId, wc);
+			this.setupJsDialogHandler(paneId, wc);
+			this.setupDownloadHandler(paneId, wc);
 			void this.captureCdpTargetId(paneId, wc);
 		}
 	}
@@ -503,6 +508,56 @@ class BrowserManager extends EventEmitter {
 		return `${paneId}::${tabId}`;
 	}
 
+	/**
+	 * Inverse of registerTab: given a CDP targetId and a paneId,
+	 * return the tabId the pane registered against that target.
+	 * Returns null for the pane's primary (host-level webContents)
+	 * target — callers typically treat that as "already the active
+	 * tab" and no-op.
+	 */
+	getTabIdForTarget(paneId: string, targetId: string): string | null {
+		const prefix = `${paneId}::`;
+		for (const [key, tid] of this.paneTabTargetIdByKey) {
+			if (tid === targetId && key.startsWith(prefix)) {
+				return key.slice(prefix.length);
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Find which pane (if any) a given CDP targetId belongs to. Used
+	 * by the CDP filter to route Target.activateTarget /
+	 * Page.bringToFront back to the renderer so the tab bar UI
+	 * follows MCP-driven tab switches (matches Chrome's behaviour).
+	 */
+	getPaneIdForTarget(targetId: string): string | null {
+		for (const [paneId, primary] of this.paneTargetIds) {
+			if (primary === targetId) return paneId;
+		}
+		for (const [key, tid] of this.paneTabTargetIdByKey) {
+			if (tid === targetId) {
+				const sep = key.indexOf("::");
+				if (sep > 0) return key.slice(0, sep);
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Emit an activate-tab event for the given pane so subscribers
+	 * (the BrowserPane renderer) can flip their tab-bar UI. Called
+	 * by the CDP filter when MCP sends Target.activateTarget /
+	 * Page.bringToFront for a tab we know about.
+	 *
+	 * When tabId is null the pane's primary is meant (i.e. the
+	 * non-secondary tab driven by usePersistentWebview); the
+	 * renderer uses that to reveal the primary and hide secondaries.
+	 */
+	requestTabActivation(paneId: string, tabId: string | null): void {
+		this.emit(`activate-tab-requested:${paneId}`, { tabId });
+	}
+
 	getPaneIdForWebContents(webContentsId: number): string | null {
 		for (const [paneId, registeredWebContentsId] of this.paneWebContentsIds) {
 			if (registeredWebContentsId === webContentsId) {
@@ -545,6 +600,22 @@ class BrowserManager extends EventEmitter {
 		const wc = this.getWebContents(paneId);
 		if (!wc) return;
 		wc.openDevTools({ mode: "detach" });
+	}
+
+	/**
+	 * Surface the native Electron print dialog for the pane. Called
+	 * from the renderer when the user hits Cmd+P, and also
+	 * indirectly via window.print() (Chromium routes that through
+	 * the webContents print event which Electron handles).
+	 */
+	print(paneId: string): void {
+		const wc = this.getWebContents(paneId);
+		if (!wc) return;
+		try {
+			wc.print({ silent: false, printBackground: true });
+		} catch (error) {
+			console.warn("[browser-manager] print failed:", error);
+		}
 	}
 
 	findInPage(
@@ -686,6 +757,164 @@ class BrowserManager extends EventEmitter {
 				// webContents may be destroyed
 			}
 		});
+	}
+
+	/**
+	 * Surface JavaScript dialogs (alert / confirm / prompt /
+	 * beforeunload) as native Electron dialogs so the user can see
+	 * and respond to them. Without this Electron auto-dismisses
+	 * dialogs in webview-hosted content, which silently breaks sites
+	 * that use confirm/prompt for destructive actions and makes
+	 * beforeunload unloads invisible to the user.
+	 */
+	private setupJsDialogHandler(paneId: string, wc: Electron.WebContents): void {
+		// beforeunload: Electron only emits will-prevent-unload when
+		// the page asked for the confirmation; preventDefault tells
+		// Chromium to block the unload.
+		const handleBeforeUnload = (event: Electron.Event) => {
+			const owner = this.getOwnerWindow(paneId);
+			const choice = owner
+				? dialog.showMessageBoxSync(owner, {
+						type: "question",
+						buttons: ["Leave", "Stay"],
+						defaultId: 0,
+						cancelId: 1,
+						title: "Leave site?",
+						message: "Changes you made may not be saved.",
+					})
+				: 1;
+			if (choice === 1) event.preventDefault();
+		};
+		wc.on("will-prevent-unload", handleBeforeUnload);
+
+		// alert/confirm/prompt are surfaced through the internal
+		// `-run-dialog` event in recent Electron versions. The event
+		// signature is still undocumented, so we cast defensively.
+		type RunDialogArgs = [
+			event: Electron.Event & {
+				sender?: unknown;
+				preventDefault: () => void;
+			},
+			dialogType: "alert" | "confirm" | "prompt",
+			messageText: string,
+			defaultPromptText: string,
+			reply: (shouldContinue: boolean, userInput: string) => void,
+		];
+		const handleRunDialog = (...args: unknown[]) => {
+			const [event, dialogType, messageText, defaultPromptText, reply] =
+				args as RunDialogArgs;
+			event.preventDefault();
+			const owner = this.getOwnerWindow(paneId);
+			if (!owner) {
+				reply(false, "");
+				return;
+			}
+			if (dialogType === "alert") {
+				dialog
+					.showMessageBox(owner, {
+						type: "info",
+						buttons: ["OK"],
+						message: messageText || "",
+					})
+					.then(() => reply(true, ""))
+					.catch(() => reply(false, ""));
+			} else if (dialogType === "confirm") {
+				dialog
+					.showMessageBox(owner, {
+						type: "question",
+						buttons: ["OK", "Cancel"],
+						defaultId: 0,
+						cancelId: 1,
+						message: messageText || "",
+					})
+					.then(({ response }) => reply(response === 0, ""))
+					.catch(() => reply(false, ""));
+			} else {
+				// prompt: Electron doesn't have a first-class prompt
+				// dialog, so we approximate with showMessageBox +
+				// inputs aren't natively supported — best we can do is
+				// accept the default text on OK and empty on Cancel
+				// until a custom modal is wired up.
+				dialog
+					.showMessageBox(owner, {
+						type: "question",
+						buttons: ["OK", "Cancel"],
+						defaultId: 0,
+						cancelId: 1,
+						message: messageText || "",
+						detail: defaultPromptText
+							? `Default: ${defaultPromptText}`
+							: undefined,
+					})
+					.then(({ response }) =>
+						reply(response === 0, response === 0 ? defaultPromptText : ""),
+					)
+					.catch(() => reply(false, ""));
+			}
+		};
+		(wc as unknown as NodeJS.EventEmitter).on("-run-dialog", handleRunDialog);
+	}
+
+	private getOwnerWindow(paneId: string): BrowserWindow | null {
+		const wc = this.getWebContents(paneId);
+		if (!wc) return null;
+		const { BrowserWindow } = require("electron") as typeof import("electron");
+		return (
+			BrowserWindow.fromWebContents(wc) ?? BrowserWindow.getFocusedWindow()
+		);
+	}
+
+	/**
+	 * Handle webContents download events. Save to ~/Downloads with
+	 * the suggested filename (de-duplicated) and emit a toast-style
+	 * event so the renderer can surface the completion to the user.
+	 * Chrome shows a persistent download bar; for now a toast per
+	 * completion is the MVP.
+	 */
+	private setupDownloadHandler(paneId: string, wc: Electron.WebContents): void {
+		const session = wc.session;
+		const handler = (_event: Electron.Event, item: Electron.DownloadItem) => {
+			const downloadsDir = app.getPath("downloads");
+			const suggested = item.getFilename() || "download";
+			let target = join(downloadsDir, suggested);
+			// Best-effort de-dupe: append a timestamp when the target
+			// already exists. Synchronous fs.existsSync keeps the
+			// handler race-free against concurrent downloads.
+			try {
+				const fs = require("node:fs") as typeof import("node:fs");
+				if (fs.existsSync(target)) {
+					const ext = suggested.includes(".")
+						? suggested.slice(suggested.lastIndexOf("."))
+						: "";
+					const stem = ext
+						? suggested.slice(0, suggested.length - ext.length)
+						: suggested;
+					target = join(downloadsDir, `${stem}-${Date.now()}${ext}`);
+				}
+			} catch {
+				/* best effort */
+			}
+			item.setSavePath(target);
+			this.emit(`download-started:${paneId}`, {
+				filename: basename(target),
+				targetPath: target,
+				url: item.getURL(),
+			});
+			item.on("done", (_e, state) => {
+				this.emit(`download-finished:${paneId}`, {
+					filename: basename(target),
+					targetPath: target,
+					state,
+				});
+			});
+		};
+		session.on("will-download", handler);
+		// No teardown: the session is shared across panes
+		// (persist:superset). Attaching the same handler for multiple
+		// panes is idempotent-enough because every pane's webContents
+		// routes the download through the same session; we emit per
+		// paneId using the event's frame owner. In the common case
+		// where only one pane is downloading at a time this is fine.
 	}
 
 	private setupContextMenu(paneId: string, wc: Electron.WebContents): void {

--- a/apps/desktop/src/main/lib/browser/browser-manager.ts
+++ b/apps/desktop/src/main/lib/browser/browser-manager.ts
@@ -521,6 +521,21 @@ class BrowserManager extends EventEmitter {
 	 * target — callers typically treat that as "already the active
 	 * tab" and no-op.
 	 */
+	/**
+	 * Return the webContents id registered for a given (paneId, tabId)
+	 * tuple or the pane's primary if tabId is null. Used by the CDP
+	 * filter to force-focus the right webContents before dispatching
+	 * session-scoped Input.* events — Electron otherwise sometimes
+	 * routes synthetic key events to whichever widget has OS focus
+	 * (including the Superset terminal pane).
+	 */
+	getWebContentsIdForTab(paneId: string, tabId: string | null): number | null {
+		if (tabId === null) {
+			return this.paneWebContentsIds.get(paneId) ?? null;
+		}
+		return this.paneTabWebContents.get(this.tabKey(paneId, tabId)) ?? null;
+	}
+
 	getTabIdForTarget(paneId: string, targetId: string): string | null {
 		const prefix = `${paneId}::`;
 		for (const [key, tid] of this.paneTabTargetIdByKey) {

--- a/apps/desktop/src/main/lib/browser/browser-manager.ts
+++ b/apps/desktop/src/main/lib/browser/browser-manager.ts
@@ -261,6 +261,8 @@ class BrowserManager extends EventEmitter {
 			"now",
 			Array.from(set),
 		);
+		// Notify any in-flight Target.createTarget waiters in the gateway.
+		this.emit(`tab-target-added:${paneId}`, targetId);
 	}
 
 	removePaneTabTarget(paneId: string, targetId: string): void {

--- a/apps/desktop/src/main/lib/browser/browser-site-permission-manager.ts
+++ b/apps/desktop/src/main/lib/browser/browser-site-permission-manager.ts
@@ -53,6 +53,20 @@ function mediaTypeToPermissionKind(
 	return null;
 }
 
+/**
+ * Electron's `permission` string for non-media requests. We route a
+ * subset through the same user-consent flow so sites don't silently
+ * get (or fail to get) geolocation / notifications / clipboard-read.
+ */
+function electronPermissionToKind(
+	permission: string,
+): SitePermissionKind | null {
+	if (permission === "geolocation") return "geolocation";
+	if (permission === "notifications") return "notifications";
+	if (permission === "clipboard-read") return "clipboard-read";
+	return null;
+}
+
 class BrowserSitePermissionManager extends EventEmitter {
 	private initialized = false;
 	private lastRequestNotificationAt = new Map<string, number>();
@@ -68,45 +82,72 @@ class BrowserSitePermissionManager extends EventEmitter {
 
 		browserSession.setPermissionCheckHandler(
 			(webContents, permission, requestingOrigin, details) => {
-				if (permission !== "media") {
-					return false;
-				}
-
 				const origin =
 					normalizeOrigin(
 						(details as { securityOrigin?: string }).securityOrigin ?? "",
 					) ??
 					normalizeOrigin(requestingOrigin) ??
 					normalizeOrigin(webContents?.getURL() ?? "");
+				if (!origin) return false;
 
-				if (!origin) {
-					return false;
+				if (permission === "media") {
+					const permissionKind = mediaTypeToPermissionKind(
+						details.mediaType ?? "unknown",
+					);
+					if (!permissionKind) return false;
+					return this.getPermission(origin, permissionKind) === "allow";
 				}
-
-				const permissionKind = mediaTypeToPermissionKind(
-					details.mediaType ?? "unknown",
-				);
-				if (!permissionKind) {
-					return false;
-				}
-
-				return this.getPermission(origin, permissionKind) === "allow";
+				const kind = electronPermissionToKind(permission);
+				if (!kind) return false;
+				return this.getPermission(origin, kind) === "allow";
 			},
 		);
 
 		browserSession.setPermissionRequestHandler(
 			(webContents, permission, callback, details) => {
-				if (permission !== "media") {
-					callback(true);
-					return;
-				}
-
 				const origin =
 					normalizeOrigin(
 						(details as { securityOrigin?: string }).securityOrigin ?? "",
 					) ??
 					normalizeOrigin(details.requestingUrl ?? "") ??
 					normalizeOrigin(webContents.getURL());
+
+				if (permission !== "media") {
+					// Route non-media permissions (geolocation /
+					// notifications / clipboard-read) through the same
+					// user-consent flow as media. Permissions we don't
+					// recognise keep the previous permissive default so
+					// we don't regress sites that depend on them (e.g.
+					// midi, background-sync).
+					const kind = electronPermissionToKind(permission);
+					if (!kind) {
+						callback(true);
+						return;
+					}
+					if (!origin) {
+						callback(false);
+						return;
+					}
+					const stored = this.getPermission(origin, kind);
+					if (stored === "allow") {
+						callback(true);
+						return;
+					}
+					if (stored === "block") {
+						callback(false);
+						return;
+					}
+					const paneId = browserManager.getPaneIdForWebContents(webContents.id);
+					if (paneId) {
+						this.emitPermissionRequested({
+							paneId,
+							origin,
+							permissions: [kind],
+						});
+					}
+					callback(false);
+					return;
+				}
 
 				if (!origin) {
 					callback(false);

--- a/apps/desktop/src/main/lib/vscode-shim/api/commands.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/api/commands.ts
@@ -4,9 +4,41 @@
 
 import { shimLog, shimWarn } from "./debug-log";
 import { Disposable } from "./event-emitter";
-import { fireOpenDiff } from "./window";
+import { fireOpenDiff, fireOpenFile } from "./window";
+import { Uri } from "./uri";
+import { resolveTextDocumentContent } from "./workspace";
 
 const UNHANDLED = Symbol("unhandled");
+
+function toUri(
+	value:
+		| Uri
+		| {
+				scheme?: string;
+				authority?: string;
+				path?: string;
+				query?: string;
+				fragment?: string;
+		  }
+		| undefined,
+): Uri | undefined {
+	if (!value) {
+		return undefined;
+	}
+	if (value instanceof Uri) {
+		return value;
+	}
+	if (value.scheme) {
+		return Uri.from({
+			scheme: value.scheme,
+			authority: value.authority,
+			path: value.path,
+			query: value.query,
+			fragment: value.fragment,
+		});
+	}
+	return undefined;
+}
 
 /**
  * Handle VS Code built-in commands that extensions expect to work.
@@ -20,7 +52,15 @@ function handleBuiltinCommand(
 		// Diff view (Claude Code / Codex uses this for file diffs)
 		case "vscode.diff": {
 			const leftUri = args[0] as
-				| { fsPath?: string; toString?(): string }
+				| {
+						fsPath?: string;
+						toString?(): string;
+						scheme?: string;
+						authority?: string;
+						path?: string;
+						query?: string;
+						fragment?: string;
+				  }
 				| undefined;
 			const rightUri = args[1] as
 				| { fsPath?: string; toString?(): string }
@@ -29,17 +69,37 @@ function handleBuiltinCommand(
 			const left = leftUri?.fsPath ?? leftUri?.toString?.() ?? "";
 			const right = rightUri?.fsPath ?? rightUri?.toString?.() ?? "";
 			shimLog(`[vscode-shim] vscode.diff called: ${left} → ${right}`);
-			if (left && right) {
-				fireOpenDiff(left, right, title);
+			if (!left || !right) {
+				return undefined;
 			}
-			return undefined;
+
+			const resolvedLeftUri = toUri(leftUri);
+			if (!resolvedLeftUri || resolvedLeftUri.scheme === "file") {
+				fireOpenDiff(left, right, title);
+				return undefined;
+			}
+
+			return resolveTextDocumentContent(resolvedLeftUri).then((leftContent) => {
+				fireOpenDiff(left, right, title, leftContent);
+				return undefined;
+			});
 		}
 
 		// Open file
 		case "vscode.open": {
-			shimLog(`[vscode-shim] vscode.open called with`, args[0]);
+			const uri = args[0] as
+				| { fsPath?: string; scheme?: string; toString?(): string }
+				| undefined;
+			shimLog(`[vscode-shim] vscode.open called with`, uri);
+			if (uri?.scheme === "file" && uri.fsPath) {
+				fireOpenFile(uri.fsPath);
+			}
 			return undefined;
 		}
+
+		case "vscode.openFolder":
+		case "kimi.webview.focus":
+			return undefined;
 
 		// Reveal file in OS file manager
 		case "revealFileInOS":

--- a/apps/desktop/src/main/lib/vscode-shim/api/extension-context.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/api/extension-context.ts
@@ -189,6 +189,9 @@ export interface VscodeExtensionContext {
 	globalState: Memento;
 	workspaceState: Memento;
 	secrets: SecretStorage;
+	storageUri: Uri | undefined;
+	globalStorageUri: Uri;
+	logUri: Uri;
 	storagePath: string | undefined;
 	globalStoragePath: string;
 	logPath: string;
@@ -223,6 +226,9 @@ export function createExtensionContext(
 		globalState: new Memento(path.join(globalStoragePath, "state.json")),
 		workspaceState: new Memento(path.join(storagePath, "state.json")),
 		secrets: new SecretStorage(path.join(globalStoragePath, "secrets.json")),
+		storageUri: Uri.file(storagePath),
+		globalStorageUri: Uri.file(globalStoragePath),
+		logUri: Uri.file(logPath),
 		storagePath,
 		globalStoragePath,
 		logPath,

--- a/apps/desktop/src/main/lib/vscode-shim/api/window.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/api/window.ts
@@ -20,6 +20,7 @@ import {
 	type WebviewOptions,
 	type WebviewPanel,
 } from "./webview";
+import { setActiveWorkspaceTextDocument } from "./workspace";
 
 interface TextEditor {
 	readonly document: {
@@ -27,6 +28,8 @@ interface TextEditor {
 		fileName: string;
 		getText(range?: unknown): string;
 		languageId: string;
+		isDirty?: boolean;
+		isUntitled?: boolean;
 	};
 	readonly selection: {
 		readonly start: { line: number; character: number };
@@ -36,6 +39,14 @@ interface TextEditor {
 	};
 	readonly selections: Array<unknown>;
 	readonly viewColumn: number | undefined;
+	edit(
+		callback: (builder: {
+			insert(
+				position: { line: number; character: number },
+				value: string,
+			): void;
+		}) => void,
+	): Promise<boolean>;
 }
 
 interface Terminal {
@@ -65,20 +76,25 @@ const _openFileEmitter = new EventEmitter<{
 	line?: number;
 }>();
 export const onOpenFile = _openFileEmitter.event;
+export function fireOpenFile(filePath: string, line?: number): void {
+	_openFileEmitter.fire({ filePath, line });
+}
 
 // Emits when vscode.diff is called - renderer listens to open diff viewer
 const _openDiffEmitter = new EventEmitter<{
 	leftUri: string;
 	rightUri: string;
 	title?: string;
+	leftContent?: string;
 }>();
 export const onOpenDiff = _openDiffEmitter.event;
 export function fireOpenDiff(
 	leftUri: string,
 	rightUri: string,
 	title?: string,
+	leftContent?: string,
 ): void {
-	_openDiffEmitter.fire({ leftUri, rightUri, title });
+	_openDiffEmitter.fire({ leftUri, rightUri, title, leftContent });
 }
 
 // IPC send function — injected from worker process so dialog calls go via main
@@ -132,6 +148,7 @@ export function setActiveTextEditor(
 
 	if (!filePath) {
 		_activeTextEditor = undefined;
+		setActiveWorkspaceTextDocument(null);
 	} else {
 		const uri = Uri.file(filePath);
 		_activeTextEditor = {
@@ -146,6 +163,8 @@ export function setActiveTextEditor(
 					}
 				},
 				languageId: languageId ?? "plaintext",
+				isDirty: false,
+				isUntitled: false,
 			},
 			selection: {
 				start: { line: 0, character: 0 },
@@ -155,7 +174,48 @@ export function setActiveTextEditor(
 			},
 			selections: [],
 			viewColumn: 1,
+			async edit(callback) {
+				const inserts: Array<{
+					position: { line: number; character: number };
+					value: string;
+				}> = [];
+				callback({
+					insert(position, value) {
+						inserts.push({ position, value });
+					},
+				});
+				if (inserts.length === 0) {
+					return true;
+				}
+
+				try {
+					const fs = require("node:fs") as typeof import("node:fs");
+					const content = fs.readFileSync(filePath, "utf-8");
+					const lines = content.split("\n");
+					const sortedInserts = [...inserts].sort((left, right) => {
+						const lineDelta = right.position.line - left.position.line;
+						return lineDelta !== 0
+							? lineDelta
+							: right.position.character - left.position.character;
+					});
+
+					for (const insert of sortedInserts) {
+						const line = lines[insert.position.line] ?? "";
+						lines[insert.position.line] =
+							line.slice(0, insert.position.character) +
+							insert.value +
+							line.slice(insert.position.character);
+					}
+
+					fs.writeFileSync(filePath, lines.join("\n"), "utf-8");
+					return true;
+				} catch (error) {
+					shimWarn("[vscode-shim] TextEditor.edit failed:", error);
+					return false;
+				}
+			},
 		};
+		setActiveWorkspaceTextDocument(filePath, languageId);
 		// Update visible editors
 		_visibleTextEditors.length = 0;
 		_visibleTextEditors.push(_activeTextEditor);
@@ -274,16 +334,30 @@ export const window = {
 	async showQuickPick(
 		items:
 			| string[]
-			| Array<{ label: string; description?: string; detail?: string }>
+			| Array<{
+					label: string;
+					description?: string;
+					detail?: string;
+					kind?: number;
+			  }>
 			| Promise<
 					| string[]
-					| Array<{ label: string; description?: string; detail?: string }>
+					| Array<{
+							label: string;
+							description?: string;
+							detail?: string;
+							kind?: number;
+					  }>
 			  >,
 		options?: { placeHolder?: string; canPickMany?: boolean },
 	): Promise<string | { label: string } | undefined> {
 		const resolved = await items;
 		if (!resolved || resolved.length === 0) return undefined;
-		const labels = resolved.map((item) =>
+		const selectableItems = resolved.filter((item) => {
+			return typeof item === "string" || item.kind !== -1;
+		});
+		if (selectableItems.length === 0) return undefined;
+		const labels = selectableItems.map((item) =>
 			typeof item === "string" ? item : item.label,
 		);
 		if (!_sendToMain) {
@@ -301,7 +375,7 @@ export const window = {
 			});
 		});
 		if (selectedIndex < 0) return undefined;
-		return resolved[selectedIndex];
+		return selectableItems[selectedIndex];
 	},
 
 	async showInputBox(_options?: {
@@ -361,11 +435,11 @@ export const window = {
 
 		// Notify renderer to open the file in file viewer
 		if (uri.scheme === "file" && uri.fsPath) {
-			_openFileEmitter.fire({
-				filePath: uri.fsPath,
-				line: (_options as { selection?: { start?: { line?: number } } })
-					?.selection?.start?.line,
-			});
+			fireOpenFile(
+				uri.fsPath,
+				(_options as { selection?: { start?: { line?: number } } })?.selection
+					?.start?.line,
+			);
 		}
 
 		// Return a minimal editor stub
@@ -377,6 +451,8 @@ export const window = {
 					return "";
 				},
 				languageId: "plaintext",
+				isDirty: false,
+				isUntitled: false,
 			},
 			selection: {
 				start: { line: 0, character: 0 },
@@ -386,6 +462,9 @@ export const window = {
 			},
 			selections: [],
 			viewColumn: 1,
+			async edit(_callback) {
+				return false;
+			},
 		};
 	},
 

--- a/apps/desktop/src/main/lib/vscode-shim/api/workspace.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/api/workspace.ts
@@ -21,6 +21,8 @@ interface TextDocument {
 	readonly languageId: string;
 	readonly version: number;
 	readonly lineCount: number;
+	readonly isDirty: boolean;
+	readonly isUntitled: boolean;
 	getText(range?: unknown): string;
 	save(): Promise<boolean>;
 }
@@ -51,9 +53,128 @@ const _onDidChangeTextDocument = new EventEmitter<unknown>();
 const _onDidOpenTextDocument = new EventEmitter<TextDocument>();
 const _onDidCloseTextDocument = new EventEmitter<TextDocument>();
 const _onWillSaveTextDocument = new EventEmitter<unknown>();
+const _textDocuments: TextDocument[] = [];
 
 const fileSystemProviders = new Map<string, unknown>();
 const textDocumentContentProviders = new Map<string, unknown>();
+
+function normalizeGlobPath(value: string): string {
+	return value.split(path.sep).join("/");
+}
+
+function escapeRegexLiteral(value: string): string {
+	return value.replace(/[|\\{}()[\]^$+?.]/g, "\\$&");
+}
+
+function globToRegExp(glob: string): RegExp {
+	let source = "^";
+
+	for (let index = 0; index < glob.length; index += 1) {
+		const char = glob[index];
+
+		if (char === "\\") {
+			const next = glob[index + 1];
+			if (next) {
+				source += escapeRegexLiteral(next);
+				index += 1;
+			} else {
+				source += "\\\\";
+			}
+			continue;
+		}
+
+		if (char === "*") {
+			if (glob[index + 1] === "*") {
+				while (glob[index + 1] === "*") {
+					index += 1;
+				}
+				if (glob[index + 1] === "/") {
+					source += "(?:.*/)?";
+					index += 1;
+				} else {
+					source += ".*";
+				}
+			} else {
+				source += "[^/]*";
+			}
+			continue;
+		}
+
+		if (char === "?") {
+			source += "[^/]";
+			continue;
+		}
+
+		if (char === "[") {
+			const closingIndex = glob.indexOf("]", index + 1);
+			if (closingIndex === -1) {
+				source += "\\[";
+			} else {
+				source += glob.slice(index, closingIndex + 1);
+				index = closingIndex;
+			}
+			continue;
+		}
+
+		source += escapeRegexLiteral(char);
+	}
+
+	source += "$";
+	return new RegExp(source);
+}
+
+function compileGlobMatchers(pattern: string | null | undefined): RegExp[] {
+	if (!pattern) {
+		return [];
+	}
+
+	const normalized = pattern.trim();
+	if (!normalized) {
+		return [];
+	}
+
+	const patterns =
+		normalized.startsWith("{") && normalized.endsWith("}")
+			? normalized
+					.slice(1, -1)
+					.split(",")
+					.map((entry) => entry.trim())
+					.filter(Boolean)
+			: [normalized];
+
+	return patterns.map((entry) => globToRegExp(normalizeGlobPath(entry)));
+}
+
+function matchesAnyGlob(matchers: RegExp[], targetPath: string): boolean {
+	if (matchers.length === 0) {
+		return false;
+	}
+
+	const normalizedTarget = normalizeGlobPath(targetPath);
+	return matchers.some((matcher) => matcher.test(normalizedTarget));
+}
+
+export async function resolveTextDocumentContent(
+	uri: Uri,
+): Promise<string | undefined> {
+	if (uri.scheme === "file") {
+		try {
+			return await fs.promises.readFile(uri.fsPath, "utf-8");
+		} catch {
+			return undefined;
+		}
+	}
+
+	const provider = textDocumentContentProviders.get(uri.scheme) as
+		| { provideTextDocumentContent?(uri: Uri): string | Promise<string> }
+		| undefined;
+	if (!provider?.provideTextDocumentContent) {
+		return undefined;
+	}
+
+	const content = await provider.provideTextDocumentContent(uri);
+	return typeof content === "string" ? content : "";
+}
 
 export function setWorkspacePath(folderPath: string): void {
 	const oldPath = workspaceFolderPath;
@@ -77,6 +198,43 @@ export function setWorkspacePath(folderPath: string): void {
 	}
 }
 
+export function setActiveWorkspaceTextDocument(
+	filePath: string | null,
+	languageId?: string,
+): void {
+	_textDocuments.length = 0;
+	if (!filePath) {
+		return;
+	}
+
+	const readContent = () => {
+		try {
+			return fs.readFileSync(filePath, "utf-8");
+		} catch {
+			return "";
+		}
+	};
+
+	const content = readContent();
+	const doc: TextDocument = {
+		uri: Uri.file(filePath),
+		fileName: filePath,
+		languageId:
+			languageId ?? (path.extname(filePath).slice(1) || "plaintext"),
+		version: 1,
+		lineCount: content.split("\n").length,
+		isDirty: false,
+		isUntitled: false,
+		getText() {
+			return readContent();
+		},
+		async save() {
+			return true;
+		},
+	};
+	_textDocuments.push(doc);
+}
+
 export const workspace = {
 	get workspaceFolders(): WorkspaceFolder[] | undefined {
 		if (!workspaceFolderPath) return undefined;
@@ -98,7 +256,7 @@ export const workspace = {
 	},
 
 	get textDocuments(): TextDocument[] {
-		return [];
+		return [..._textDocuments];
 	},
 
 	get name(): string | undefined {
@@ -138,20 +296,21 @@ export const workspace = {
 	},
 
 	async openTextDocument(uriOrPath: Uri | string): Promise<TextDocument> {
-		const filePath =
-			typeof uriOrPath === "string" ? uriOrPath : uriOrPath.fsPath;
-		const content = fs.existsSync(filePath)
-			? fs.readFileSync(filePath, "utf-8")
-			: "";
+		const uri =
+			typeof uriOrPath === "string" ? Uri.file(uriOrPath) : uriOrPath;
+		const filePath = uri.scheme === "file" ? uri.fsPath : uri.path;
+		const content = (await resolveTextDocumentContent(uri)) ?? "";
 		const lines = content.split("\n");
 		const ext = path.extname(filePath).slice(1);
 
 		return {
-			uri: Uri.file(filePath),
+			uri,
 			fileName: filePath,
 			languageId: ext || "plaintext",
 			version: 1,
 			lineCount: lines.length,
+			isDirty: false,
+			isUntitled: false,
 			getText(_range?: unknown) {
 				return content;
 			},
@@ -170,7 +329,8 @@ export const workspace = {
 		if (!workspaceFolderPath) return [];
 		try {
 			const results: string[] = [];
-			const ignorePatterns = exclude ? [exclude] : ["node_modules", ".git"];
+			const includeMatchers = compileGlobMatchers(include);
+			const excludeMatchers = compileGlobMatchers(exclude);
 
 			function walkDir(dir: string, depth: number): void {
 				if (depth > 15 || (maxResults && results.length >= maxResults)) return;
@@ -181,14 +341,25 @@ export const workspace = {
 					return;
 				}
 				for (const entry of entries) {
-					if (ignorePatterns.some((p) => entry.name.includes(p))) continue;
 					const fullPath = path.join(dir, entry.name);
+					const relativePath = normalizeGlobPath(
+						path.relative(workspaceFolderPath, fullPath),
+					);
+					if (
+						relativePath &&
+						(matchesAnyGlob(excludeMatchers, relativePath) ||
+							(entry.isDirectory() &&
+								matchesAnyGlob(excludeMatchers, `${relativePath}/`)))
+					) {
+						continue;
+					}
 					if (entry.isDirectory()) {
 						walkDir(fullPath, depth + 1);
 					} else if (entry.isFile()) {
-						// Simple extension matching from include pattern (e.g., "**/*.ts")
-						const ext = include.match(/\*(\.\w+)$/)?.[1];
-						if (!ext || entry.name.endsWith(ext)) {
+						if (
+							includeMatchers.length === 0 ||
+							matchesAnyGlob(includeMatchers, relativePath)
+						) {
 							results.push(fullPath);
 						}
 					}
@@ -260,11 +431,126 @@ export const workspace = {
 		const _onCreate = new EventEmitter<Uri>();
 		const _onChange = new EventEmitter<Uri>();
 		const _onDelete = new EventEmitter<Uri>();
+		const rootPath = workspaceFolderPath;
+		const includeMatchers = compileGlobMatchers(_globPattern);
+		const dirWatchers = new Map<string, fs.FSWatcher>();
+
+		const matchesWatcherPath = (fullPath: string): boolean => {
+			if (!rootPath) {
+				return false;
+			}
+			const relativePath = normalizeGlobPath(path.relative(rootPath, fullPath));
+			if (!relativePath || relativePath.startsWith("..")) {
+				return false;
+			}
+			return (
+				includeMatchers.length === 0 ||
+				matchesAnyGlob(includeMatchers, relativePath) ||
+				matchesAnyGlob(includeMatchers, `${relativePath}/`)
+			);
+		};
+
+		const closeDescendantWatchers = (targetPath: string) => {
+			const watchedDirs = [...dirWatchers.keys()];
+			for (const watchedDir of watchedDirs) {
+				if (
+					watchedDir === targetPath ||
+					watchedDir.startsWith(`${targetPath}${path.sep}`)
+				) {
+					const watcher = dirWatchers.get(watchedDir);
+					if (!watcher) {
+						continue;
+					}
+					watcher.close();
+					dirWatchers.delete(watchedDir);
+				}
+			}
+		};
+
+		const addDirectoryWatcher = (directoryPath: string) => {
+			if (dirWatchers.has(directoryPath)) {
+				return;
+			}
+
+			try {
+				const watcher = fs.watch(directoryPath, (eventType, filename) => {
+					if (!filename) {
+						return;
+					}
+
+					const fullPath = path.join(directoryPath, filename.toString());
+					const exists = fs.existsSync(fullPath);
+
+					if (exists) {
+						try {
+							if (fs.statSync(fullPath).isDirectory()) {
+								addDirectoryWatcher(fullPath);
+							}
+						} catch {}
+					} else {
+						closeDescendantWatchers(fullPath);
+					}
+
+					if (!matchesWatcherPath(fullPath)) {
+						return;
+					}
+
+					const uri = Uri.file(fullPath);
+					if (!exists) {
+						if (!_ignoreDeleteEvents) {
+							_onDelete.fire(uri);
+						}
+						return;
+					}
+
+					if (eventType === "change") {
+						if (!_ignoreChangeEvents) {
+							_onChange.fire(uri);
+						}
+						return;
+					}
+
+					if (!_ignoreCreateEvents) {
+						_onCreate.fire(uri);
+					}
+				});
+				dirWatchers.set(directoryPath, watcher);
+			} catch (error) {
+				shimWarn(
+					`[vscode-shim] createFileSystemWatcher failed for ${directoryPath}:`,
+					error,
+				);
+				return;
+			}
+
+			let entries: fs.Dirent[];
+			try {
+				entries = fs.readdirSync(directoryPath, { withFileTypes: true });
+			} catch {
+				return;
+			}
+
+			for (const entry of entries) {
+				if (!entry.isDirectory()) {
+					continue;
+				}
+				addDirectoryWatcher(path.join(directoryPath, entry.name));
+			}
+		};
+
+		if (rootPath) {
+			addDirectoryWatcher(rootPath);
+		}
+
 		return {
 			onDidCreate: _onCreate.event,
 			onDidChange: _onChange.event,
 			onDidDelete: _onDelete.event,
 			dispose() {
+				for (const watcher of dirWatchers.values()) {
+					watcher.close();
+				}
+				dirWatchers.clear();
 				_onCreate.dispose();
 				_onChange.dispose();
 				_onDelete.dispose();
@@ -370,6 +656,28 @@ export const workspace = {
 			_options?: { overwrite?: boolean },
 		): Promise<void> {
 			await fs.promises.copyFile(source.fsPath, target.fsPath);
+		},
+		async readDirectory(uri: Uri): Promise<[string, number][]> {
+			if (uri.scheme !== "file") {
+				const provider = fileSystemProviders.get(uri.scheme) as
+					| { readDirectory?(uri: Uri): Promise<[string, number][]> }
+					| undefined;
+				if (provider?.readDirectory) {
+					return provider.readDirectory(uri);
+				}
+				throw new Error(`No file system provider for scheme: ${uri.scheme}`);
+			}
+			const entries = await fs.promises.readdir(uri.fsPath, {
+				withFileTypes: true,
+			});
+			return entries.map((entry) => [
+				entry.name,
+				entry.isDirectory()
+					? 2
+					: entry.isSymbolicLink()
+						? 64
+						: 1,
+			]);
 		},
 		isWritableFileSystem(scheme: string): boolean | undefined {
 			return scheme === "file" ? true : undefined;

--- a/apps/desktop/src/main/lib/vscode-shim/ipc-types.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/ipc-types.ts
@@ -40,7 +40,13 @@ export type WorkerToMainMessage =
 			html: string | null;
 	  }
 	| { type: "open-file"; filePath: string; line?: number }
-	| { type: "open-diff"; leftUri: string; rightUri: string; title?: string }
+	| {
+			type: "open-diff";
+			leftUri: string;
+			rightUri: string;
+			title?: string;
+			leftContent?: string;
+	  }
 	| {
 			type: "show-dialog";
 			requestId: string;

--- a/apps/desktop/src/main/lib/vscode-shim/vscode-api.ts
+++ b/apps/desktop/src/main/lib/vscode-shim/vscode-api.ts
@@ -140,6 +140,10 @@ const CompletionItemKind = {
 	TypeParameter: 24,
 } as const;
 const TextDocumentChangeReason = { Undo: 1, Redo: 2 } as const;
+const QuickPickItemKind = {
+	Default: 0,
+	Separator: -1,
+} as const;
 
 // Stub classes
 class Position {
@@ -733,6 +737,7 @@ export function createVscodeApi(): Record<string, unknown> {
 		SymbolKind,
 		CompletionItemKind,
 		TextDocumentChangeReason,
+		QuickPickItemKind,
 	};
 
 	// Proxy logger: log access to unimplemented APIs

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/BrowserPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/BrowserPane.tsx
@@ -59,11 +59,34 @@ export function BrowserPane({ ctx }: BrowserPaneProps) {
 			{ paneId },
 			{
 				onData: (evt) => {
-					const tabId = browserRuntimeRegistry.createTab(paneId, evt.url);
+					const tabId = browserRuntimeRegistry.createTab(paneId, evt.url, {
+						background: evt.background === true,
+					});
 					if (tabId && evt.requestId) {
 						electronTrpcClient.browser.acknowledgeTabCreated
 							.mutate({ paneId, requestId: evt.requestId, tabId })
 							.catch(() => {});
+					}
+				},
+				onError: () => {
+					/* subscription errors surface in console */
+				},
+			},
+		);
+		return () => sub.unsubscribe();
+	}, [paneId]);
+
+	// Mirror MCP-driven tab activation (Target.activateTarget /
+	// Page.bringToFront) onto the pane's tab bar.
+	useEffect(() => {
+		const sub = electronTrpcClient.browser.onActivateTabRequested.subscribe(
+			{ paneId },
+			{
+				onData: (evt) => {
+					if (evt.tabId === null) {
+						browserRuntimeRegistry.showPrimary?.(paneId);
+					} else {
+						browserRuntimeRegistry.activateTab?.(paneId, evt.tabId);
 					}
 				},
 				onError: () => {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/BrowserPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/BrowserPane.tsx
@@ -59,7 +59,12 @@ export function BrowserPane({ ctx }: BrowserPaneProps) {
 			{ paneId },
 			{
 				onData: (evt) => {
-					browserRuntimeRegistry.createTab(paneId, evt.url);
+					const tabId = browserRuntimeRegistry.createTab(paneId, evt.url);
+					if (tabId && evt.requestId) {
+						electronTrpcClient.browser.acknowledgeTabCreated
+							.mutate({ paneId, requestId: evt.requestId, tabId })
+							.catch(() => {});
+					}
 				},
 				onError: () => {
 					/* subscription errors surface in console */

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/browserRuntimeRegistry.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/browserRuntimeRegistry.ts
@@ -578,7 +578,11 @@ class BrowserRuntimeRegistryImpl {
 		return () => set.delete(listener);
 	}
 
-	createTab(paneId: string, url?: string): string | null {
+	createTab(
+		paneId: string,
+		url?: string,
+		options?: { background?: boolean },
+	): string | null {
 		const root = this.ensureRootContainer();
 		const group = this.groups.get(paneId);
 		if (!group) return null;
@@ -591,11 +595,22 @@ class BrowserRuntimeRegistryImpl {
 		);
 		group.tabs.push(entry);
 		root.appendChild(entry.webview);
-		group.activeTabId = tabId;
+		if (!options?.background) {
+			group.activeTabId = tabId;
+		}
 		this.applyLayout(group);
 		this.notifyState(paneId);
 		this.notifyTabs(paneId);
 		return tabId;
+	}
+
+	/**
+	 * Activate the pane's primary tab (the one created during
+	 * register() with tabId "primary"). Used when the MCP flips
+	 * focus back to the primary via Target.activateTarget.
+	 */
+	showPrimary(paneId: string): void {
+		this.activateTab(paneId, "primary");
 	}
 
 	closeTab(paneId: string, tabId: string): void {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/browserRuntimeRegistry.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/browserRuntimeRegistry.ts
@@ -149,25 +149,25 @@ class BrowserRuntimeRegistryImpl {
 		for (const tab of group.tabs) {
 			const w = tab.webview;
 			const isActive = tab.tabId === group.activeTabId;
-			// Inactive tabs are pushed off-screen rather than
-			// `visibility:hidden` so Chromium does not flip the
-			// underlying webContents into the page-lifecycle "hidden"
-			// state. External CDP MCPs (browser-use, chrome-devtools-
-			// mcp) drive sites that frequently pause work while hidden
-			// (IntersectionObserver, requestAnimationFrame, deferred
-			// load), which presents to the user as the MCP hanging.
+			// All tabs share the same rect. Active/inactive is expressed
+			// via opacity + z-index + pointer-events. We avoid
+			// visibility:hidden (triggers page-lifecycle "hidden"
+			// state → CDP MCPs hang) AND avoid moving inactive tabs
+			// off-screen (Electron's <webview> tag does not always
+			// re-position its native GuestView compositor on CSS
+			// top/left changes, leaving the GuestView rendering at
+			// whichever tab painted first regardless of which the
+			// tab bar currently flags active).
+			w.style.top = `${rect.top}px`;
+			w.style.left = `${rect.left}px`;
+			w.style.width = `${rect.width}px`;
+			w.style.height = `${rect.height}px`;
 			if (group.visible && isActive) {
-				w.style.top = `${rect.top}px`;
-				w.style.left = `${rect.left}px`;
-				w.style.width = `${rect.width}px`;
-				w.style.height = `${rect.height}px`;
+				w.style.opacity = "1";
 				w.style.zIndex = "100";
 				w.style.pointerEvents = "auto";
 			} else {
-				w.style.top = "-100000px";
-				w.style.left = "-100000px";
-				w.style.width = `${rect.width}px`;
-				w.style.height = `${rect.height}px`;
+				w.style.opacity = "0";
 				w.style.zIndex = "0";
 				w.style.pointerEvents = "none";
 			}
@@ -274,8 +274,9 @@ class BrowserRuntimeRegistryImpl {
 		webview.style.margin = "0";
 		webview.style.padding = "0";
 		webview.style.border = "none";
-		webview.style.visibility = "hidden";
-		webview.style.pointerEvents = "auto";
+		webview.style.visibility = "visible";
+		webview.style.opacity = "0";
+		webview.style.pointerEvents = "none";
 		const sanitized = sanitizeUrl(initialUrl);
 		console.log(
 			"[tab-diag v2] createTabEntry pane=",
@@ -530,12 +531,11 @@ class BrowserRuntimeRegistryImpl {
 		group.resizeObserver?.disconnect();
 		group.resizeObserver = null;
 		group.visible = false;
-		// Keep tabs Chromium-visible (just off-screen) so CDP MCPs
+		// Keep tabs Chromium-visible (opacity:0 only) so CDP MCPs
 		// that drive them through pane detach don't stall on
 		// document.hidden.
 		for (const t of group.tabs) {
-			t.webview.style.top = "-100000px";
-			t.webview.style.left = "-100000px";
+			t.webview.style.opacity = "0";
 			t.webview.style.pointerEvents = "none";
 			t.webview.style.visibility = "visible";
 		}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/browserRuntimeRegistry.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/browserRuntimeRegistry.ts
@@ -148,13 +148,30 @@ class BrowserRuntimeRegistryImpl {
 		const rect = group.placeholder.getBoundingClientRect();
 		for (const tab of group.tabs) {
 			const w = tab.webview;
-			w.style.top = `${rect.top}px`;
-			w.style.left = `${rect.left}px`;
-			w.style.width = `${rect.width}px`;
-			w.style.height = `${rect.height}px`;
 			const isActive = tab.tabId === group.activeTabId;
-			w.style.visibility = group.visible && isActive ? "visible" : "hidden";
-			w.style.pointerEvents = isActive ? "auto" : "none";
+			// Inactive tabs are pushed off-screen rather than
+			// `visibility:hidden` so Chromium does not flip the
+			// underlying webContents into the page-lifecycle "hidden"
+			// state. External CDP MCPs (browser-use, chrome-devtools-
+			// mcp) drive sites that frequently pause work while hidden
+			// (IntersectionObserver, requestAnimationFrame, deferred
+			// load), which presents to the user as the MCP hanging.
+			if (group.visible && isActive) {
+				w.style.top = `${rect.top}px`;
+				w.style.left = `${rect.left}px`;
+				w.style.width = `${rect.width}px`;
+				w.style.height = `${rect.height}px`;
+				w.style.zIndex = "100";
+				w.style.pointerEvents = "auto";
+			} else {
+				w.style.top = "-100000px";
+				w.style.left = "-100000px";
+				w.style.width = `${rect.width}px`;
+				w.style.height = `${rect.height}px`;
+				w.style.zIndex = "0";
+				w.style.pointerEvents = "none";
+			}
+			w.style.visibility = "visible";
 		}
 	}
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/browserRuntimeRegistry.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/browserRuntimeRegistry.ts
@@ -276,7 +276,20 @@ class BrowserRuntimeRegistryImpl {
 		webview.style.border = "none";
 		webview.style.visibility = "hidden";
 		webview.style.pointerEvents = "auto";
-		webview.src = sanitizeUrl(initialUrl);
+		const sanitized = sanitizeUrl(initialUrl);
+		console.log(
+			"[tab-diag v2] createTabEntry pane=",
+			paneId,
+			"tab=",
+			tabId,
+			"isPrimary=",
+			isPrimary,
+			"incomingUrl=",
+			initialUrl,
+			"sanitized=",
+			sanitized,
+		);
+		webview.src = sanitized;
 
 		const entry: TabEntry = {
 			tabId,
@@ -332,6 +345,14 @@ class BrowserRuntimeRegistryImpl {
 		};
 
 		const handleDidNavigate = (e: Electron.DidNavigateEvent) => {
+			console.log(
+				"[tab-diag v2] did-navigate pane=",
+				paneId,
+				"tab=",
+				tabId,
+				"url=",
+				e.url,
+			);
 			const url = e.url ?? "";
 			const title = webview.getTitle() ?? "";
 			this.setTabState(paneId, tabId, {
@@ -372,6 +393,18 @@ class BrowserRuntimeRegistryImpl {
 		};
 
 		const handleDidFailLoad = (e: Electron.DidFailLoadEvent) => {
+			console.warn(
+				"[tab-diag v2] did-fail-load pane=",
+				paneId,
+				"tab=",
+				tabId,
+				"url=",
+				e.validatedURL,
+				"errorCode=",
+				e.errorCode,
+				"errorDesc=",
+				e.errorDescription,
+			);
 			if (e.errorCode === -3) return; // ERR_ABORTED
 			this.setTabState(paneId, tabId, {
 				isLoading: false,

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/browserRuntimeRegistry.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/browserRuntimeRegistry.ts
@@ -489,7 +489,15 @@ class BrowserRuntimeRegistryImpl {
 		group.resizeObserver?.disconnect();
 		group.resizeObserver = null;
 		group.visible = false;
-		for (const t of group.tabs) t.webview.style.visibility = "hidden";
+		// Keep tabs Chromium-visible (just off-screen) so CDP MCPs
+		// that drive them through pane detach don't stall on
+		// document.hidden.
+		for (const t of group.tabs) {
+			t.webview.style.top = "-100000px";
+			t.webview.style.left = "-100000px";
+			t.webview.style.pointerEvents = "none";
+			t.webview.style.visibility = "visible";
+		}
 	}
 
 	destroy(paneId: string): void {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/browserRuntimeRegistry.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/browserRuntimeRegistry.ts
@@ -407,7 +407,15 @@ class BrowserRuntimeRegistryImpl {
 			handleDidFailLoad as EventListener,
 		);
 
+		// Close tab when the guest page closes itself or Chromium
+		// destroys the webContents (MCP Target.closeTarget etc.).
+		const handleClose = () => {
+			this.closeTab(paneId, tabId);
+		};
+		webview.addEventListener("close", handleClose);
+
 		entry.detachHandlers = () => {
+			webview.removeEventListener("close", handleClose);
 			webview.removeEventListener("dom-ready", handleDomReady);
 			webview.removeEventListener("did-start-loading", handleDidStartLoading);
 			webview.removeEventListener("did-stop-loading", handleDidStopLoading);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/browserRuntimeRegistry.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/browserRuntimeRegistry.ts
@@ -149,24 +149,26 @@ class BrowserRuntimeRegistryImpl {
 		for (const tab of group.tabs) {
 			const w = tab.webview;
 			const isActive = tab.tabId === group.activeTabId;
-			// All tabs share the same rect. Active/inactive is expressed
-			// via opacity + z-index + pointer-events. We avoid
-			// visibility:hidden (triggers page-lifecycle "hidden"
-			// state → CDP MCPs hang) AND avoid moving inactive tabs
-			// off-screen (Electron's <webview> tag does not always
-			// re-position its native GuestView compositor on CSS
-			// top/left changes, leaving the GuestView rendering at
-			// whichever tab painted first regardless of which the
-			// tab bar currently flags active).
-			w.style.top = `${rect.top}px`;
-			w.style.left = `${rect.left}px`;
-			w.style.width = `${rect.width}px`;
-			w.style.height = `${rect.height}px`;
+			// Inactive tabs must leave the viewport entirely:
+			// opacity:0 / pointer-events:none is not enough because
+			// Electron <webview>'s native GuestView compositor still
+			// captures wheel / right-click / focus, blocking scroll /
+			// context menu / interactions on whatever's supposed to
+			// be below. visibility stays "visible" so Chromium does
+			// not flip page-lifecycle to hidden.
 			if (group.visible && isActive) {
+				w.style.top = `${rect.top}px`;
+				w.style.left = `${rect.left}px`;
+				w.style.width = `${rect.width}px`;
+				w.style.height = `${rect.height}px`;
 				w.style.opacity = "1";
 				w.style.zIndex = "100";
 				w.style.pointerEvents = "auto";
 			} else {
+				w.style.top = "-100000px";
+				w.style.left = "-100000px";
+				w.style.width = `${rect.width}px`;
+				w.style.height = `${rect.height}px`;
 				w.style.opacity = "0";
 				w.style.zIndex = "0";
 				w.style.pointerEvents = "none";
@@ -531,10 +533,11 @@ class BrowserRuntimeRegistryImpl {
 		group.resizeObserver?.disconnect();
 		group.resizeObserver = null;
 		group.visible = false;
-		// Keep tabs Chromium-visible (opacity:0 only) so CDP MCPs
-		// that drive them through pane detach don't stall on
-		// document.hidden.
+		// Off-screen + opacity:0 so GuestView stops intercepting
+		// events but page-lifecycle stays "visible" for CDP MCPs.
 		for (const t of group.tabs) {
+			t.webview.style.top = "-100000px";
+			t.webview.style.left = "-100000px";
 			t.webview.style.opacity = "0";
 			t.webview.style.pointerEvents = "none";
 			t.webview.style.visibility = "visible";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/browserRuntimeRegistry.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/browserRuntimeRegistry.ts
@@ -66,6 +66,11 @@ class BrowserRuntimeRegistryImpl {
 	private groups = new Map<string, PaneGroup>();
 	private stateListenersByPaneId = new Map<string, Set<() => void>>();
 	private tabsListenersByPaneId = new Map<string, Set<() => void>>();
+	// Snapshot caches so useSyncExternalStore returns stable references
+	// until something actually changes — without this the array
+	// identity flips every render and React aborts the BrowserPane
+	// with "Maximum update depth exceeded".
+	private tabsSnapshots = new Map<string, BrowserTabSummary[]>();
 	private rootContainer: HTMLDivElement | null = null;
 	private globalListenersInstalled = false;
 
@@ -160,6 +165,7 @@ class BrowserRuntimeRegistryImpl {
 	}
 
 	private notifyTabs(paneId: string) {
+		this.tabsSnapshots.delete(paneId);
 		const set = this.tabsListenersByPaneId.get(paneId);
 		if (!set) return;
 		for (const l of set) l();
@@ -519,17 +525,26 @@ class BrowserRuntimeRegistryImpl {
 		return () => set.delete(listener);
 	}
 
+	private static EMPTY_TABS: BrowserTabSummary[] = Object.freeze(
+		[] as BrowserTabSummary[],
+	) as BrowserTabSummary[];
+
 	listTabs(paneId: string): BrowserTabSummary[] {
+		const cached = this.tabsSnapshots.get(paneId);
+		if (cached) return cached;
 		const group = this.groups.get(paneId);
-		if (!group) return [];
-		return group.tabs.map((t) => ({
-			tabId: t.tabId,
-			url: t.state.currentUrl,
-			title: t.state.pageTitle,
-			faviconUrl: t.state.faviconUrl,
-			isLoading: t.state.isLoading,
-			isActive: t.tabId === group.activeTabId,
-		}));
+		const next = group
+			? group.tabs.map((t) => ({
+					tabId: t.tabId,
+					url: t.state.currentUrl,
+					title: t.state.pageTitle,
+					faviconUrl: t.state.faviconUrl,
+					isLoading: t.state.isLoading,
+					isActive: t.tabId === group.activeTabId,
+				}))
+			: BrowserRuntimeRegistryImpl.EMPTY_TABS;
+		this.tabsSnapshots.set(paneId, next);
+		return next;
 	}
 
 	onTabsChange(paneId: string, listener: () => void): () => void {

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/utils/settings-search/settings-search.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/utils/settings-search/settings-search.ts
@@ -1231,7 +1231,7 @@ export const SETTINGS_ITEMS: SettingsItem[] = [
 		section: "vscodeExtensions",
 		title: "VS Code Extensions",
 		description:
-			"Manage VS Code extensions like Claude Code and ChatGPT running inside Superset",
+			"Manage VS Code extensions like Claude Code, ChatGPT, and Kimi Code running inside Superset",
 		keywords: [
 			"vscode",
 			"vs code",
@@ -1239,6 +1239,7 @@ export const SETTINGS_ITEMS: SettingsItem[] = [
 			"claude",
 			"chatgpt",
 			"codex",
+			"kimi",
 			"ai",
 			"install",
 			"manage",

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/vscode-extensions/components/VscodeExtensionsSettings/VscodeExtensionsSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/vscode-extensions/components/VscodeExtensionsSettings/VscodeExtensionsSettings.tsx
@@ -13,6 +13,7 @@ import {
 	LuSparkles,
 	LuTrash2,
 } from "react-icons/lu";
+import { SiOpenai } from "react-icons/si";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { INDENT_RAINBOW_DEFAULT_COLORS } from "renderer/screens/main/components/WorkspaceView/components/CodeEditor/createIndentRainbowPlugin";
 import { TRAILING_SPACES_DEFAULT_COLOR } from "renderer/screens/main/components/WorkspaceView/components/CodeEditor/createTrailingSpacesPlugin";
@@ -32,7 +33,8 @@ const EXTENSION_ICONS: Record<
 	React.ComponentType<{ className?: string }>
 > = {
 	"anthropic.claude-code": LuBot,
-	"openai.chatgpt": LuSparkles,
+	"openai.chatgpt": SiOpenai,
+	"moonshot-ai.kimi-code": LuSparkles,
 };
 
 const HEX6_COLOR_RE = /^#[0-9a-f]{6}$/i;

--- a/apps/desktop/src/renderer/screens/main/components/VscodeExtensionButtons/VscodeExtensionButtons.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/VscodeExtensionButtons/VscodeExtensionButtons.tsx
@@ -13,6 +13,7 @@ import {
 	LuSparkles,
 	LuSquareArrowOutUpRight,
 } from "react-icons/lu";
+import { SiOpenai } from "react-icons/si";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { useWorkspaceId } from "renderer/screens/main/components/WorkspaceView/WorkspaceIdContext";
 import {
@@ -132,10 +133,19 @@ export function VscodeExtensionButtons() {
 			{installed.some((e) => e.id === "openai.chatgpt") && (
 				<ExtensionButton
 					tab={RightSidebarTab.Codex}
-					icon={LuSparkles}
+					icon={SiOpenai}
 					label="Codex"
 					viewType="chatgpt.sidebarView"
 					extensionId="openai.chatgpt"
+				/>
+			)}
+			{installed.some((e) => e.id === "moonshot-ai.kimi-code") && (
+				<ExtensionButton
+					tab={RightSidebarTab.Kimi}
+					icon={LuSparkles}
+					label="Kimi"
+					viewType="kimi.webview"
+					extensionId="moonshot-ai.kimi-code"
 				/>
 			)}
 		</div>

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/BrowserPane.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/BrowserPane.tsx
@@ -287,7 +287,17 @@ export function BrowserPane({
 		{ paneId },
 		{
 			onData: (evt) => {
+				console.log(
+					"[BrowserPane v1] create-tab-requested url=",
+					evt.url,
+					"pane=",
+					paneId,
+				);
 				const tabId = secondaryTabRegistry.createTab(paneId, evt.url);
+				console.log(
+					"[BrowserPane v1] secondaryTabRegistry.createTab returned tabId=",
+					tabId,
+				);
 				if (tabId) setActiveTabId(tabId);
 			},
 		},

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/BrowserPane.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/BrowserPane.tsx
@@ -1,6 +1,13 @@
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { GlobeIcon } from "lucide-react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+	useCallback,
+	useEffect,
+	useMemo,
+	useRef,
+	useState,
+	useSyncExternalStore,
+} from "react";
 import { LuMinus, LuPlus } from "react-icons/lu";
 import { TbDeviceDesktop } from "react-icons/tb";
 import type { MosaicBranch } from "react-mosaic-component";
@@ -255,6 +262,21 @@ export function BrowserPane({
 	const [activeTabId, setActiveTabId] = useState("primary");
 	const secondaryContainerRef = useRef<HTMLDivElement | null>(null);
 
+	// Subscribe to the secondary tab registry so the toolbar's URL
+	// bar / loading spinner / nav buttons can reflect whichever tab
+	// is currently active (primary vs one of the secondaries).
+	const secondaryTabs = useSyncExternalStore(
+		useCallback(
+			(cb) => secondaryTabRegistry.onTabsChange(paneId, cb),
+			[paneId],
+		),
+		useCallback(() => secondaryTabRegistry.listTabs(paneId), [paneId]),
+	);
+	const activeSecondary =
+		activeTabId === "primary"
+			? null
+			: (secondaryTabs.find((t) => t.tabId === activeTabId) ?? null);
+
 	useEffect(() => {
 		const el = secondaryContainerRef.current;
 		if (!el) return;
@@ -393,17 +415,45 @@ export function BrowserPane({
 				<div className="flex h-full w-full items-center justify-between min-w-0">
 					<BrowserToolbar
 						paneId={paneId}
-						currentUrl={currentUrl}
-						pageTitle={pageTitle}
-						isLoading={isLoading}
-						hasPage={!isBlankPage}
-						isBookmarked={Boolean(currentBookmark)}
-						canGoBack={canGoBack}
-						canGoForward={canGoForward}
-						onGoBack={goBack}
-						onGoForward={goForward}
-						onReload={reload}
-						onNavigate={navigateTo}
+						currentUrl={activeSecondary ? activeSecondary.url : currentUrl}
+						pageTitle={activeSecondary ? activeSecondary.title : pageTitle}
+						isLoading={
+							activeSecondary ? activeSecondary.isLoading : isLoading
+						}
+						hasPage={
+							activeSecondary
+								? Boolean(
+										activeSecondary.url &&
+											activeSecondary.url !== "about:blank",
+									)
+								: !isBlankPage
+						}
+						isBookmarked={
+							activeSecondary ? false : Boolean(currentBookmark)
+						}
+						canGoBack={activeSecondary ? true : canGoBack}
+						canGoForward={activeSecondary ? true : canGoForward}
+						onGoBack={
+							activeSecondary
+								? () => secondaryTabRegistry.goBackActive(paneId)
+								: goBack
+						}
+						onGoForward={
+							activeSecondary
+								? () => secondaryTabRegistry.goForwardActive(paneId)
+								: goForward
+						}
+						onReload={
+							activeSecondary
+								? () => secondaryTabRegistry.reloadActive(paneId)
+								: reload
+						}
+						onNavigate={
+							activeSecondary
+								? (url: string) =>
+										secondaryTabRegistry.navigateActive(paneId, url)
+								: navigateTo
+						}
 						onToggleBookmark={handleToggleBookmark}
 						onEditingChange={setIsEditingUrl}
 					/>

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/BrowserPane.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/BrowserPane.tsx
@@ -28,6 +28,7 @@ import { ExtensionToolbar } from "./components/ExtensionToolbar";
 import { SessionConnectModal } from "./components/SessionConnectModal";
 import { DEFAULT_BROWSER_URL } from "./constants";
 import { usePersistentWebview } from "./hooks/usePersistentWebview";
+import { getPersistentWrapper } from "./hooks/usePersistentWebview/runtime";
 import { secondaryTabRegistry } from "./hooks/useSecondaryTabs";
 
 interface BrowserPaneProps {
@@ -266,17 +267,33 @@ export function BrowserPane({
 	}, [paneId]);
 
 	useEffect(() => {
-		// We never CSS-hide the primary — that would put its
-		// underlying webContents into Chromium's page-lifecycle
-		// "hidden" state, which causes external CDP MCPs to appear to
-		// hang on sites that pause work while hidden. The active
-		// secondary tab simply z-index-overlays the primary; when
-		// activeTabId === "primary" we just hide all secondaries.
+		// Electron's <webview> tag uses a native BrowserPlugin
+		// compositor that does NOT reliably respect CSS z-index when
+		// two webview elements overlap (the primary managed by
+		// usePersistentWebview lives in a different DOM parent from
+		// the secondary-tab registry's webviews). The primary ends
+		// up painting on top regardless of z-index, so we can't hide
+		// it with stacking alone.
+		//
+		// Instead, fade the primary's wrapper to opacity:0 while a
+		// secondary tab is active. opacity:0 does NOT trigger
+		// Chromium's page-lifecycle "hidden" state (only display:none
+		// / visibility:hidden do), so external CDP MCPs driving the
+		// primary keep working in the background.
+		const primaryWrapper = getPersistentWrapper(paneId);
 		if (activeTabId === "primary") {
 			secondaryTabRegistry.setVisible(paneId, false);
+			if (primaryWrapper) {
+				primaryWrapper.style.opacity = "1";
+				primaryWrapper.style.pointerEvents = "auto";
+			}
 		} else {
 			secondaryTabRegistry.activateTab(paneId, activeTabId);
 			secondaryTabRegistry.setVisible(paneId, true);
+			if (primaryWrapper) {
+				primaryWrapper.style.opacity = "0";
+				primaryWrapper.style.pointerEvents = "none";
+			}
 		}
 	}, [activeTabId, paneId]);
 

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/BrowserPane.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/BrowserPane.tsx
@@ -283,6 +283,9 @@ export function BrowserPane({
 	// External CDP MCPs issue Target.createTarget → bridge emits
 	// create-tab-requested on the pane. Spawn a real secondary tab so
 	// the gateway's bound-set picks up the new targetId.
+	const { mutate: ackTabCreated } =
+		electronTrpc.browser.acknowledgeTabCreated.useMutation();
+
 	electronTrpc.browser.onCreateTabRequested.useSubscription(
 		{ paneId },
 		{
@@ -292,13 +295,20 @@ export function BrowserPane({
 					evt.url,
 					"pane=",
 					paneId,
+					"req=",
+					evt.requestId,
 				);
 				const tabId = secondaryTabRegistry.createTab(paneId, evt.url);
 				console.log(
 					"[BrowserPane v1] secondaryTabRegistry.createTab returned tabId=",
 					tabId,
 				);
-				if (tabId) setActiveTabId(tabId);
+				if (tabId) {
+					setActiveTabId(tabId);
+					if (evt.requestId) {
+						ackTabCreated({ paneId, requestId: evt.requestId, tabId });
+					}
+				}
 			},
 		},
 	);

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/BrowserPane.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/BrowserPane.tsx
@@ -28,7 +28,6 @@ import { ExtensionToolbar } from "./components/ExtensionToolbar";
 import { SessionConnectModal } from "./components/SessionConnectModal";
 import { DEFAULT_BROWSER_URL } from "./constants";
 import { usePersistentWebview } from "./hooks/usePersistentWebview";
-import { getPersistentWebview } from "./hooks/usePersistentWebview/runtime";
 import { secondaryTabRegistry } from "./hooks/useSecondaryTabs";
 
 interface BrowserPaneProps {
@@ -266,27 +265,20 @@ export function BrowserPane({
 		return () => secondaryTabRegistry.destroy(paneId);
 	}, [paneId]);
 
-	const setPrimaryWebviewVisible = useCallback(
-		(visible: boolean) => {
-			const primary = getPersistentWebview(paneId);
-			if (primary) {
-				primary.style.visibility = visible ? "visible" : "hidden";
-				primary.style.pointerEvents = visible ? "auto" : "none";
-			}
-		},
-		[paneId],
-	);
-
 	useEffect(() => {
+		// We never CSS-hide the primary — that would put its
+		// underlying webContents into Chromium's page-lifecycle
+		// "hidden" state, which causes external CDP MCPs to appear to
+		// hang on sites that pause work while hidden. The active
+		// secondary tab simply z-index-overlays the primary; when
+		// activeTabId === "primary" we just hide all secondaries.
 		if (activeTabId === "primary") {
 			secondaryTabRegistry.setVisible(paneId, false);
-			setPrimaryWebviewVisible(true);
 		} else {
-			setPrimaryWebviewVisible(false);
 			secondaryTabRegistry.activateTab(paneId, activeTabId);
 			secondaryTabRegistry.setVisible(paneId, true);
 		}
-	}, [activeTabId, paneId, setPrimaryWebviewVisible]);
+	}, [activeTabId, paneId]);
 
 	// External CDP MCPs issue Target.createTarget → bridge emits
 	// create-tab-requested on the pane. Spawn a real secondary tab so

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/BrowserPane.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/BrowserPane.tsx
@@ -297,17 +297,39 @@ export function BrowserPane({
 					paneId,
 					"req=",
 					evt.requestId,
+					"bg=",
+					evt.background,
 				);
-				const tabId = secondaryTabRegistry.createTab(paneId, evt.url);
+				const tabId = secondaryTabRegistry.createTab(paneId, evt.url, {
+					background: evt.background === true,
+				});
 				console.log(
 					"[BrowserPane v1] secondaryTabRegistry.createTab returned tabId=",
 					tabId,
 				);
 				if (tabId) {
-					setActiveTabId(tabId);
+					if (!evt.background) setActiveTabId(tabId);
 					if (evt.requestId) {
 						ackTabCreated({ paneId, requestId: evt.requestId, tabId });
 					}
+				}
+			},
+		},
+	);
+
+	// MCP may flip tabs via Target.activateTarget / Page.bringToFront.
+	// Mirror that into the BrowserPane's tab bar so what the MCP drives
+	// matches what the user sees (Chrome's tab strip follows CDP).
+	electronTrpc.browser.onActivateTabRequested.useSubscription(
+		{ paneId },
+		{
+			onData: (evt) => {
+				if (evt.tabId === null) {
+					secondaryTabRegistry.showPrimary(paneId);
+					setActiveTabId(null);
+				} else {
+					secondaryTabRegistry.activateTab(paneId, evt.tabId);
+					setActiveTabId(evt.tabId);
 				}
 			},
 		},

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/BrowserPane.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/BrowserPane.tsx
@@ -20,6 +20,7 @@ import {
 	BrowserFindOverlay,
 	type BrowserFindOverlayHandle,
 } from "./components/BrowserFindOverlay";
+import { BrowserTabBar } from "./components/BrowserTabBar";
 import { BrowserToolbar } from "./components/BrowserToolbar";
 import { BrowserOverflowMenu } from "./components/BrowserToolbar/components/BrowserOverflowMenu";
 import { ConnectButton } from "./components/ConnectButton";
@@ -27,6 +28,8 @@ import { ExtensionToolbar } from "./components/ExtensionToolbar";
 import { SessionConnectModal } from "./components/SessionConnectModal";
 import { DEFAULT_BROWSER_URL } from "./constants";
 import { usePersistentWebview } from "./hooks/usePersistentWebview";
+import { getPersistentWebview } from "./hooks/usePersistentWebview/runtime";
+import { secondaryTabRegistry } from "./hooks/useSecondaryTabs";
 
 interface BrowserPaneProps {
 	paneId: string;
@@ -240,6 +243,64 @@ export function BrowserPane({
 		openDevTools({ paneId });
 	}, [openDevTools, paneId]);
 
+	// -- Secondary tabs -----------------------------------------------------
+	//
+	// v1's primary webview lives in usePersistentWebview + tabs-store. This
+	// BrowserPane also hosts a secondary tab registry for anything beyond
+	// the primary (user-opened via the overflow menu, or CDP-opened via an
+	// external MCP's Target.createTarget). When a secondary tab is active,
+	// we hide the primary webview via CSS and the secondary registry
+	// overlays its own webview atop the same placeholder (containerRef).
+
+	const [activeTabId, setActiveTabId] = useState("primary");
+	const secondaryContainerRef = useRef<HTMLDivElement | null>(null);
+
+	useEffect(() => {
+		const el = secondaryContainerRef.current;
+		if (!el) return;
+		secondaryTabRegistry.attach(paneId, el);
+		return () => secondaryTabRegistry.detach(paneId);
+	}, [paneId]);
+
+	useEffect(() => {
+		return () => secondaryTabRegistry.destroy(paneId);
+	}, [paneId]);
+
+	const setPrimaryWebviewVisible = useCallback(
+		(visible: boolean) => {
+			const primary = getPersistentWebview(paneId);
+			if (primary) {
+				primary.style.visibility = visible ? "visible" : "hidden";
+				primary.style.pointerEvents = visible ? "auto" : "none";
+			}
+		},
+		[paneId],
+	);
+
+	useEffect(() => {
+		if (activeTabId === "primary") {
+			secondaryTabRegistry.setVisible(paneId, false);
+			setPrimaryWebviewVisible(true);
+		} else {
+			setPrimaryWebviewVisible(false);
+			secondaryTabRegistry.activateTab(paneId, activeTabId);
+			secondaryTabRegistry.setVisible(paneId, true);
+		}
+	}, [activeTabId, paneId, setPrimaryWebviewVisible]);
+
+	// External CDP MCPs issue Target.createTarget → bridge emits
+	// create-tab-requested on the pane. Spawn a real secondary tab so
+	// the gateway's bound-set picks up the new targetId.
+	electronTrpc.browser.onCreateTabRequested.useSubscription(
+		{ paneId },
+		{
+			onData: (evt) => {
+				const tabId = secondaryTabRegistry.createTab(paneId, evt.url);
+				if (tabId) setActiveTabId(tabId);
+			},
+		},
+	);
+
 	const [isEditingUrl, setIsEditingUrl] = useState(false);
 
 	useEffect(() => {
@@ -397,11 +458,24 @@ export function BrowserPane({
 				{!isFullscreen && (
 					<BookmarkBar currentUrl={currentUrl} onNavigate={navigateTo} />
 				)}
+				<BrowserTabBar
+					paneId={paneId}
+					primaryUrl={currentUrl}
+					primaryTitle={pageTitle}
+					primaryFaviconUrl={currentFaviconUrl ?? null}
+					primaryIsLoading={isLoading}
+					activeTabId={activeTabId}
+					onActivate={setActiveTabId}
+				/>
 				<div className="relative flex flex-1 min-h-0">
 					<div
 						ref={containerRef}
 						className="h-full w-full"
 						style={{ flex: 1 }}
+					/>
+					<div
+						ref={secondaryContainerRef}
+						className="absolute inset-0 pointer-events-none"
 					/>
 					<BrowserFindOverlay
 						ref={findOverlayRef}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/components/BrowserTabBar/BrowserTabBar.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/components/BrowserTabBar/BrowserTabBar.tsx
@@ -1,0 +1,137 @@
+import { cn } from "@superset/ui/utils";
+import { useCallback, useSyncExternalStore } from "react";
+import { LuPlus, LuX } from "react-icons/lu";
+import {
+	type SecondaryTabState,
+	secondaryTabRegistry,
+} from "../../hooks/useSecondaryTabs";
+
+interface BrowserTabBarProps {
+	paneId: string;
+	/** URL of the primary tab as surfaced by tabs-store / persistent webview. */
+	primaryUrl: string;
+	primaryTitle: string;
+	primaryFaviconUrl: string | null;
+	primaryIsLoading: boolean;
+	/** Which tab should be active. "primary" or a secondary tabId. */
+	activeTabId: string;
+	/** Called when the user picks a tab. Pass "primary" for the primary. */
+	onActivate: (tabId: string) => void;
+}
+
+interface DisplayTab {
+	tabId: string;
+	url: string;
+	title: string;
+	faviconUrl: string | null;
+	isLoading: boolean;
+	isActive: boolean;
+	isPrimary: boolean;
+}
+
+export function BrowserTabBar({
+	paneId,
+	primaryUrl,
+	primaryTitle,
+	primaryFaviconUrl,
+	primaryIsLoading,
+	activeTabId,
+	onActivate,
+}: BrowserTabBarProps) {
+	const secondary = useSyncExternalStore<SecondaryTabState[]>(
+		useCallback(
+			(cb) => secondaryTabRegistry.onTabsChange(paneId, cb),
+			[paneId],
+		),
+		useCallback(() => secondaryTabRegistry.listTabs(paneId), [paneId]),
+	);
+
+	const handleClose = useCallback(
+		(tabId: string, e: React.MouseEvent) => {
+			e.stopPropagation();
+			secondaryTabRegistry.closeTab(paneId, tabId);
+			if (activeTabId === tabId) onActivate("primary");
+		},
+		[paneId, activeTabId, onActivate],
+	);
+
+	const handleNew = useCallback(() => {
+		const tabId = secondaryTabRegistry.createTab(paneId, "about:blank");
+		if (tabId) onActivate(tabId);
+	}, [paneId, onActivate]);
+
+	// Hide the bar entirely when there's no secondary tab. Manual "New
+	// Tab" lives in the overflow menu so single-tab panes stay clean.
+	if (secondary.length === 0) return null;
+
+	const tabs: DisplayTab[] = [
+		{
+			tabId: "primary",
+			url: primaryUrl,
+			title: primaryTitle,
+			faviconUrl: primaryFaviconUrl,
+			isLoading: primaryIsLoading,
+			isActive: activeTabId === "primary",
+			isPrimary: true,
+		},
+		...secondary.map((s) => ({
+			tabId: s.tabId,
+			url: s.url,
+			title: s.title,
+			faviconUrl: s.faviconUrl,
+			isLoading: s.isLoading,
+			isActive: activeTabId === s.tabId,
+			isPrimary: false,
+		})),
+	];
+
+	return (
+		<div className="flex h-7 items-center gap-0.5 border-b bg-muted/40 px-1 shrink-0 overflow-x-auto">
+			{tabs.map((t) => (
+				<div
+					key={t.tabId}
+					className={cn(
+						"group flex items-center gap-1.5 h-5 max-w-[180px] rounded px-1.5 text-[11px] shrink-0",
+						t.isActive
+							? "bg-background text-foreground"
+							: "text-muted-foreground hover:bg-muted/80",
+					)}
+					title={t.title || t.url}
+				>
+					<button
+						type="button"
+						onClick={() => onActivate(t.tabId)}
+						className="flex flex-1 min-w-0 items-center gap-1.5 text-left"
+					>
+						{t.faviconUrl ? (
+							<img src={t.faviconUrl} alt="" className="size-3 shrink-0" />
+						) : (
+							<div className="size-3 shrink-0 rounded-sm bg-muted-foreground/20" />
+						)}
+						<span className="truncate">
+							{t.title || t.url || (t.isPrimary ? "Tab" : "New tab")}
+						</span>
+					</button>
+					{!t.isPrimary && (
+						<button
+							type="button"
+							onClick={(e) => handleClose(t.tabId, e)}
+							className="ml-0.5 opacity-60 hover:opacity-100"
+							aria-label="Close tab"
+						>
+							<LuX className="size-3" />
+						</button>
+					)}
+				</div>
+			))}
+			<button
+				type="button"
+				onClick={handleNew}
+				className="flex items-center justify-center size-5 rounded text-muted-foreground hover:bg-muted/80"
+				title="New tab"
+			>
+				<LuPlus className="size-3" />
+			</button>
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/components/BrowserTabBar/index.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/components/BrowserTabBar/index.ts
@@ -1,0 +1,1 @@
+export { BrowserTabBar } from "./BrowserTabBar";

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/components/BrowserToolbar/components/BrowserOverflowMenu/BrowserOverflowMenu.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/components/BrowserToolbar/components/BrowserOverflowMenu/BrowserOverflowMenu.tsx
@@ -14,6 +14,7 @@ import {
 	TbDots,
 	TbDownload,
 	TbFolderPlus,
+	TbPlus,
 	TbReload,
 	TbTrash,
 	TbUpload,
@@ -26,6 +27,7 @@ import {
 	importBrowserBookmarksFromHtml,
 } from "renderer/stores/browser-bookmarks-html";
 import { useTabsStore } from "renderer/stores/tabs/store";
+import { secondaryTabRegistry } from "../../../../hooks/useSecondaryTabs";
 import { BookmarkFolderDialog } from "../../../BookmarkFolderDialog";
 
 interface BrowserOverflowMenuProps {
@@ -178,6 +180,16 @@ export function BrowserOverflowMenu({
 						scheduleNewFolderDialogOpen();
 					}}
 				>
+					<DropdownMenuItem
+						onClick={() =>
+							secondaryTabRegistry.createTab(paneId, "about:blank")
+						}
+						className="gap-2"
+					>
+						<TbPlus className="size-4" />
+						New Tab
+					</DropdownMenuItem>
+					<DropdownMenuSeparator />
 					<DropdownMenuItem
 						onClick={handleScreenshot}
 						disabled={!hasPage}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/components/SessionConnectModal/SessionConnectModal.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/components/SessionConnectModal/SessionConnectModal.tsx
@@ -9,8 +9,8 @@ import {
 } from "@superset/ui/dialog";
 import { toast } from "@superset/ui/sonner";
 import { cn } from "@superset/ui/utils";
-import { useEffect, useMemo } from "react";
-import { LuList } from "react-icons/lu";
+import { useEffect, useMemo, useState } from "react";
+import { LuList, LuShield } from "react-icons/lu";
 import { useBrowserAutomationData } from "renderer/hooks/useBrowserAutomationData";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import {
@@ -22,6 +22,7 @@ import {
 import { useTabsStore } from "renderer/stores/tabs/store";
 import { CdpEndpointCard } from "./components/CdpEndpointCard";
 import { McpInstallPanel } from "./components/McpInstallPanel";
+import { PermissionsTab } from "./components/PermissionsTab";
 
 interface SessionConnectModalProps {
 	open: boolean;
@@ -32,6 +33,9 @@ export function SessionConnectModal({
 	open,
 	onOpenChange,
 }: SessionConnectModalProps) {
+	const [activeTab, setActiveTab] = useState<"sessions" | "permissions">(
+		"sessions",
+	);
 	const paneId = useBrowserAutomationStore((s) => s.connectModal.paneId);
 	const selectedSessionId = useBrowserAutomationStore(
 		(s) => s.connectModal.selectedSessionId,
@@ -170,149 +174,198 @@ export function SessionConnectModal({
 					<DialogDescription className="text-xs">
 						Choose which running LLM session should control this browser pane.
 					</DialogDescription>
+					<div className="mt-3 flex items-center gap-1 border-b -mb-4 pb-0">
+						<TabButton
+							active={activeTab === "sessions"}
+							onClick={() => setActiveTab("sessions")}
+						>
+							<LuList className="size-3.5" />
+							Sessions
+						</TabButton>
+						<TabButton
+							active={activeTab === "permissions"}
+							onClick={() => setActiveTab("permissions")}
+						>
+							<LuShield className="size-3.5" />
+							Permissions
+						</TabButton>
+					</div>
 				</DialogHeader>
 
-				<div className="grid grid-cols-[minmax(320px,1fr)_minmax(280px,0.9fr)] min-h-[min(570px,70vh)] max-h-[min(840px,85vh)]">
-					<div className="overflow-y-auto p-4 border-r">
-						<div className="flex items-center gap-3 rounded-lg bg-muted/40 px-3 py-2.5 mb-3">
-							<div className="flex size-7 items-center justify-center rounded-md bg-brand/15 text-brand text-sm font-bold">
-								◎
-							</div>
-							<div className="min-w-0">
-								<div className="text-xs font-semibold truncate">{paneName}</div>
-								<div className="text-[11px] text-muted-foreground truncate">
-									{paneUrl}
+				{activeTab === "permissions" ? (
+					<PermissionsTab />
+				) : (
+					<div className="grid grid-cols-[minmax(320px,1fr)_minmax(280px,0.9fr)] min-h-[min(570px,70vh)] max-h-[min(840px,85vh)]">
+						<div className="overflow-y-auto p-4 border-r">
+							<div className="flex items-center gap-3 rounded-lg bg-muted/40 px-3 py-2.5 mb-3">
+								<div className="flex size-7 items-center justify-center rounded-md bg-brand/15 text-brand text-sm font-bold">
+									◎
 								</div>
+								<div className="min-w-0">
+									<div className="text-xs font-semibold truncate">
+										{paneName}
+									</div>
+									<div className="text-[11px] text-muted-foreground truncate">
+										{paneUrl}
+									</div>
+								</div>
+								<button
+									type="button"
+									onClick={() => {
+										// Close this dialog first so focus traps don't stack.
+										onOpenChange(false);
+										setListViewOpen(true);
+									}}
+									className="ml-auto inline-flex items-center gap-1 rounded-md border bg-background/60 px-2 py-1 text-[11px] text-muted-foreground hover:text-foreground"
+								>
+									<LuList className="size-3" />
+									All panes
+								</button>
 							</div>
-							<button
-								type="button"
-								onClick={() => {
-									// Close this dialog first so focus traps don't stack.
-									onOpenChange(false);
-									setListViewOpen(true);
-								}}
-								className="ml-auto inline-flex items-center gap-1 rounded-md border bg-background/60 px-2 py-1 text-[11px] text-muted-foreground hover:text-foreground"
-							>
-								<LuList className="size-3" />
-								All panes
-							</button>
-						</div>
 
-						<div className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/70 px-1 mb-2">
-							Running sessions
-						</div>
-
-						{sessions.length === 0 ? (
-							<div className="rounded-xl border border-dashed p-6 text-center text-xs text-muted-foreground">
-								No running LLM sessions found. Start a TODO-Agent session or run
-								`claude` / `codex` in any terminal pane, then return here.
+							<div className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/70 px-1 mb-2">
+								Running sessions
 							</div>
-						) : (
-							<div className="flex flex-col gap-2">
-								{sessions.map((s) => {
-									const otherPaneId = Object.entries(bindingsByPane).find(
-										([pid, sid]) => sid === s.id && pid !== paneId,
-									)?.[0];
-									const otherPaneName = otherPaneId
-										? (panes[otherPaneId]?.name ?? null)
-										: null;
-									return (
-										<SessionCard
-											key={s.id}
-											session={s}
-											isSelected={s.id === selectedSessionId}
-											attachedToThisPane={s.id === currentBinding}
-											assignedElsewherePaneName={otherPaneName}
-											onSelect={() => setSelectedSession(s.id)}
-										/>
-									);
-								})}
-							</div>
-						)}
-					</div>
 
-					<div className="overflow-y-auto p-4 bg-muted/20">
-						{session ? (
-							session.mcpStatus === "ready" ? (
-								<ReadyPanel
-									session={session}
-									paneName={paneName}
-									reassigning={Boolean(assignedPaneIdForSelected)}
-									previousPaneName={
-										assignedPaneIdForSelected
-											? (panes[assignedPaneIdForSelected]?.name ?? null)
-											: null
-									}
-									attachedToThisPane={session.id === currentBinding}
-								/>
+							{sessions.length === 0 ? (
+								<div className="rounded-xl border border-dashed p-6 text-center text-xs text-muted-foreground">
+									No running LLM sessions found. Start a TODO-Agent session or
+									run `claude` / `codex` in any terminal pane, then return here.
+								</div>
 							) : (
-								<SetupPanel
-									session={session}
-									mcpConfigPath={
-										session.provider === "Codex"
-											? (mcpStatus?.codexConfigPath ?? null)
-											: (mcpStatus?.claudeConfigPath ?? null)
-									}
-									serverCommand={serverCommand}
-									onCopy={handleCopySnippet}
-								/>
-							)
-						) : (
-							<div className="text-xs text-muted-foreground">
-								Select a session to see details.
-							</div>
-						)}
-					</div>
-				</div>
+								<div className="flex flex-col gap-2">
+									{sessions.map((s) => {
+										const otherPaneId = Object.entries(bindingsByPane).find(
+											([pid, sid]) => sid === s.id && pid !== paneId,
+										)?.[0];
+										const otherPaneName = otherPaneId
+											? (panes[otherPaneId]?.name ?? null)
+											: null;
+										return (
+											<SessionCard
+												key={s.id}
+												session={s}
+												isSelected={s.id === selectedSessionId}
+												attachedToThisPane={s.id === currentBinding}
+												assignedElsewherePaneName={otherPaneName}
+												onSelect={() => setSelectedSession(s.id)}
+											/>
+										);
+									})}
+								</div>
+							)}
+						</div>
 
-				<DialogFooter className="px-5 py-3 border-t gap-2 flex !justify-between">
-					<div className="text-[11px] text-muted-foreground">
-						{session?.mcpStatus === "ready"
-							? assignedPaneIdForSelected
-								? `Connecting will reassign ${session.displayName} from ${panes[assignedPaneIdForSelected]?.name ?? "another pane"} to ${paneName}.`
-								: "Connecting binds this browser pane to the selected session only."
-							: session
-								? "Add the MCP entry first, then reopen or restart this session."
-								: sessions.length === 0
-									? "Start an LLM session, then pick it here."
-									: "Select a session from the left."}
+						<div className="overflow-y-auto p-4 bg-muted/20">
+							{session ? (
+								session.mcpStatus === "ready" ? (
+									<ReadyPanel
+										session={session}
+										paneName={paneName}
+										reassigning={Boolean(assignedPaneIdForSelected)}
+										previousPaneName={
+											assignedPaneIdForSelected
+												? (panes[assignedPaneIdForSelected]?.name ?? null)
+												: null
+										}
+										attachedToThisPane={session.id === currentBinding}
+									/>
+								) : (
+									<SetupPanel
+										session={session}
+										mcpConfigPath={
+											session.provider === "Codex"
+												? (mcpStatus?.codexConfigPath ?? null)
+												: (mcpStatus?.claudeConfigPath ?? null)
+										}
+										serverCommand={serverCommand}
+										onCopy={handleCopySnippet}
+									/>
+								)
+							) : (
+								<div className="text-xs text-muted-foreground">
+									Select a session to see details.
+								</div>
+							)}
+						</div>
 					</div>
-					<div className="flex items-center gap-2">
-						{currentBinding && (
+				)}
+
+				{activeTab === "sessions" && (
+					<DialogFooter className="px-5 py-3 border-t gap-2 flex !justify-between">
+						<div className="text-[11px] text-muted-foreground">
+							{session?.mcpStatus === "ready"
+								? assignedPaneIdForSelected
+									? `Connecting will reassign ${session.displayName} from ${panes[assignedPaneIdForSelected]?.name ?? "another pane"} to ${paneName}.`
+									: "Connecting binds this browser pane to the selected session only."
+								: session
+									? "Add the MCP entry first, then reopen or restart this session."
+									: sessions.length === 0
+										? "Start an LLM session, then pick it here."
+										: "Select a session from the left."}
+						</div>
+						<div className="flex items-center gap-2">
+							{currentBinding && (
+								<Button
+									variant="outline"
+									size="sm"
+									onClick={handleDisconnect}
+									disabled={removeBinding.isPending}
+								>
+									Disconnect
+									{currentSession ? ` ${currentSession.displayName}` : ""}
+								</Button>
+							)}
 							<Button
 								variant="outline"
 								size="sm"
-								onClick={handleDisconnect}
-								disabled={removeBinding.isPending}
+								onClick={() => onOpenChange(false)}
 							>
-								Disconnect
-								{currentSession ? ` ${currentSession.displayName}` : ""}
+								Cancel
 							</Button>
-						)}
-						<Button
-							variant="outline"
-							size="sm"
-							onClick={() => onOpenChange(false)}
-						>
-							Cancel
-						</Button>
-						<Button
-							size="sm"
-							disabled={
-								!session ||
-								session.mcpStatus !== "ready" ||
-								setBinding.isPending
-							}
-							onClick={handleConnect}
-						>
-							{session?.mcpStatus === "ready"
-								? "Connect session"
-								: "Connect blocked"}
-						</Button>
-					</div>
-				</DialogFooter>
+							<Button
+								size="sm"
+								disabled={
+									!session ||
+									session.mcpStatus !== "ready" ||
+									setBinding.isPending
+								}
+								onClick={handleConnect}
+							>
+								{session?.mcpStatus === "ready"
+									? "Connect session"
+									: "Connect blocked"}
+							</Button>
+						</div>
+					</DialogFooter>
+				)}
 			</DialogContent>
 		</Dialog>
+	);
+}
+
+function TabButton({
+	active,
+	onClick,
+	children,
+}: {
+	active: boolean;
+	onClick: () => void;
+	children: React.ReactNode;
+}) {
+	return (
+		<button
+			type="button"
+			onClick={onClick}
+			className={cn(
+				"inline-flex items-center gap-1.5 px-3 py-2 text-[12px] font-medium border-b-2 transition-colors",
+				active
+					? "border-brand text-foreground"
+					: "border-transparent text-muted-foreground hover:text-foreground",
+			)}
+		>
+			{children}
+		</button>
 	);
 }
 

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/components/SessionConnectModal/components/PermissionsTab/PermissionsTab.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/components/SessionConnectModal/components/PermissionsTab/PermissionsTab.tsx
@@ -1,0 +1,336 @@
+import { Button } from "@superset/ui/button";
+import { Input } from "@superset/ui/input";
+import { Label } from "@superset/ui/label";
+import { toast } from "@superset/ui/sonner";
+import { Switch } from "@superset/ui/switch";
+import { cn } from "@superset/ui/utils";
+import { useEffect, useMemo, useState } from "react";
+import { LuCheck, LuCopy, LuPlus, LuTrash2 } from "react-icons/lu";
+import { electronTrpc } from "renderer/lib/electron-trpc";
+
+type PermissionToggleKey =
+	| "cookieRead"
+	| "cookieWrite"
+	| "storageWrite"
+	| "permissions"
+	| "privilegedSchemes"
+	| "downloadOverride"
+	| "uaOverride"
+	| "debugger"
+	| "networkIntercept";
+
+type PermissionToggles = Partial<Record<PermissionToggleKey, boolean>>;
+
+interface PermissionPreset {
+	id: string;
+	name: string;
+	builtin?: boolean;
+	toggles: PermissionToggles;
+}
+
+export function PermissionsTab() {
+	const configQuery = electronTrpc.browserPermissions.getConfig.useQuery();
+	const metaQuery = electronTrpc.browserPermissions.getToggleMeta.useQuery();
+	const setActive = electronTrpc.browserPermissions.setActive.useMutation();
+	const savePreset = electronTrpc.browserPermissions.savePreset.useMutation();
+	const deletePreset =
+		electronTrpc.browserPermissions.deletePreset.useMutation();
+	const utils = electronTrpc.useUtils();
+
+	const config = configQuery.data;
+	const meta = metaQuery.data;
+
+	const [selectedId, setSelectedId] = useState<string | null>(null);
+	const selected = useMemo<PermissionPreset | null>(() => {
+		if (!config) return null;
+		const id = selectedId ?? config.activePresetId;
+		return config.presets.find((p) => p.id === id) ?? null;
+	}, [config, selectedId]);
+
+	// Local editing buffer so toggles feel snappy and so renaming
+	// doesn't commit on every keystroke.
+	const [draftName, setDraftName] = useState("");
+	const [draftToggles, setDraftToggles] = useState<PermissionToggles>({});
+	const [dirty, setDirty] = useState(false);
+
+	useEffect(() => {
+		if (!selected) return;
+		setDraftName(selected.name);
+		setDraftToggles({ ...selected.toggles });
+		setDirty(false);
+	}, [selected]);
+
+	if (!config || !meta) {
+		return (
+			<div className="p-4 text-xs text-muted-foreground">
+				Loading permissions…
+			</div>
+		);
+	}
+
+	const toggleKeys = Object.keys(meta) as PermissionToggleKey[];
+
+	const isActive = selected?.id === config.activePresetId;
+	const isBuiltin = selected?.builtin === true;
+
+	const handleToggle = (key: PermissionToggleKey, value: boolean) => {
+		setDraftToggles((prev) => ({ ...prev, [key]: value }));
+		setDirty(true);
+	};
+
+	const handleSave = async () => {
+		if (!selected) return;
+		if (isBuiltin) {
+			toast.error("Built-in presets can't be edited. Duplicate first.");
+			return;
+		}
+		try {
+			await savePreset.mutateAsync({
+				id: selected.id,
+				name: draftName.trim() || selected.name,
+				toggles: draftToggles,
+			});
+			await utils.browserPermissions.getConfig.invalidate();
+			toast.success("Preset saved");
+			setDirty(false);
+		} catch (error) {
+			toast.error(
+				`Save failed: ${error instanceof Error ? error.message : String(error)}`,
+			);
+		}
+	};
+
+	const handleDuplicate = async () => {
+		if (!selected) return;
+		try {
+			const suggested = `${selected.name} (copy)`;
+			const newPreset = await savePreset.mutateAsync({
+				name: suggested,
+				toggles: draftToggles,
+			});
+			await utils.browserPermissions.getConfig.invalidate();
+			setSelectedId(newPreset.id);
+			toast.success(`Duplicated as "${newPreset.name}"`);
+		} catch (error) {
+			toast.error(
+				`Duplicate failed: ${error instanceof Error ? error.message : String(error)}`,
+			);
+		}
+	};
+
+	const handleCreate = async () => {
+		try {
+			const newPreset = await savePreset.mutateAsync({
+				name: "Untitled preset",
+				toggles: {},
+			});
+			await utils.browserPermissions.getConfig.invalidate();
+			setSelectedId(newPreset.id);
+			toast.success("Preset created");
+		} catch (error) {
+			toast.error(
+				`Create failed: ${error instanceof Error ? error.message : String(error)}`,
+			);
+		}
+	};
+
+	const handleDelete = async () => {
+		if (!selected || isBuiltin) return;
+		try {
+			await deletePreset.mutateAsync({ id: selected.id });
+			await utils.browserPermissions.getConfig.invalidate();
+			setSelectedId(null);
+			toast.info(`Deleted preset "${selected.name}"`);
+		} catch (error) {
+			toast.error(
+				`Delete failed: ${error instanceof Error ? error.message : String(error)}`,
+			);
+		}
+	};
+
+	const handleSetActive = async () => {
+		if (!selected) return;
+		if (dirty) {
+			toast.error("Save pending changes before activating.");
+			return;
+		}
+		try {
+			await setActive.mutateAsync({ presetId: selected.id });
+			await utils.browserPermissions.getConfig.invalidate();
+			toast.success(`"${selected.name}" is now active`);
+		} catch (error) {
+			toast.error(
+				`Activate failed: ${error instanceof Error ? error.message : String(error)}`,
+			);
+		}
+	};
+
+	return (
+		<div className="grid grid-cols-[240px_1fr] min-h-[min(570px,70vh)] max-h-[min(840px,85vh)]">
+			<div className="overflow-y-auto p-3 border-r">
+				<div className="flex items-center justify-between mb-2">
+					<div className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/70">
+						Presets
+					</div>
+					<button
+						type="button"
+						onClick={handleCreate}
+						className="inline-flex items-center gap-1 rounded-md border bg-background/60 px-2 py-1 text-[11px] text-muted-foreground hover:text-foreground"
+						title="New preset"
+					>
+						<LuPlus className="size-3" />
+						New
+					</button>
+				</div>
+				<div className="flex flex-col gap-1.5">
+					{config.presets.map((p) => {
+						const selectedHere = p.id === selected?.id;
+						const active = p.id === config.activePresetId;
+						return (
+							<button
+								key={p.id}
+								type="button"
+								onClick={() => setSelectedId(p.id)}
+								className={cn(
+									"text-left rounded-md border p-2 transition-colors",
+									selectedHere
+										? "border-brand/40 bg-brand/10"
+										: "border-border bg-card hover:bg-muted/40",
+								)}
+							>
+								<div className="flex items-center justify-between gap-2">
+									<span className="text-[13px] font-medium truncate">
+										{p.name}
+									</span>
+									{active && (
+										<span className="shrink-0 inline-flex items-center gap-0.5 rounded-full bg-emerald-500/15 text-emerald-300 px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wider">
+											<LuCheck className="size-2.5" />
+											Active
+										</span>
+									)}
+								</div>
+								<div className="mt-0.5 text-[10px] text-muted-foreground">
+									{p.builtin ? "Built-in" : "Custom"}
+								</div>
+							</button>
+						);
+					})}
+				</div>
+			</div>
+
+			<div className="overflow-y-auto p-4">
+				{!selected ? (
+					<div className="text-xs text-muted-foreground">
+						Select a preset on the left.
+					</div>
+				) : (
+					<div className="flex flex-col gap-4">
+						<div className="flex items-end gap-2">
+							<div className="flex-1">
+								<Label className="text-[11px] text-muted-foreground">
+									Preset name
+								</Label>
+								<Input
+									value={draftName}
+									disabled={isBuiltin}
+									onChange={(e) => {
+										setDraftName(e.target.value);
+										setDirty(true);
+									}}
+									className="mt-1 h-8 text-[13px]"
+								/>
+							</div>
+							<Button
+								type="button"
+								variant="outline"
+								size="sm"
+								onClick={handleDuplicate}
+								disabled={savePreset.isPending}
+							>
+								<LuCopy className="size-3.5 mr-1" />
+								Duplicate
+							</Button>
+							{!isBuiltin && (
+								<Button
+									type="button"
+									variant="outline"
+									size="sm"
+									onClick={handleDelete}
+									disabled={deletePreset.isPending || isActive}
+									title={
+										isActive
+											? "Activate a different preset first to delete this one"
+											: undefined
+									}
+								>
+									<LuTrash2 className="size-3.5 mr-1" />
+									Delete
+								</Button>
+							)}
+						</div>
+
+						{isBuiltin && (
+							<div className="rounded-md border border-amber-500/30 bg-amber-500/10 p-2 text-[11px] text-amber-200">
+								Built-in preset. Duplicate to customize.
+							</div>
+						)}
+
+						<div className="flex flex-col divide-y border rounded-md">
+							{toggleKeys.map((key) => {
+								const m = meta[key];
+								const value = draftToggles[key] === true;
+								return (
+									<div key={key} className="flex items-start gap-3 p-3">
+										<div className="flex-1 min-w-0">
+											<div className="text-[12px] font-medium">{m.label}</div>
+											<div className="mt-0.5 text-[11px] text-muted-foreground leading-snug">
+												{m.description}
+											</div>
+											<div className="mt-1 text-[10px] font-mono text-muted-foreground/70 truncate">
+												{m.methods.join(", ")}
+											</div>
+										</div>
+										<Switch
+											checked={value}
+											disabled={isBuiltin}
+											onCheckedChange={(v: boolean) => handleToggle(key, v)}
+										/>
+									</div>
+								);
+							})}
+						</div>
+
+						<div className="flex items-center justify-between pt-2">
+							<div className="text-[11px] text-muted-foreground">
+								{isActive
+									? "This preset is currently active. Changes to toggles apply to all live MCP sessions after save (connections are force-reconnected)."
+									: "Save, then click Activate to apply to MCP sessions."}
+							</div>
+							<div className="flex items-center gap-2">
+								{!isBuiltin && (
+									<Button
+										type="button"
+										size="sm"
+										variant="outline"
+										disabled={!dirty || savePreset.isPending}
+										onClick={handleSave}
+									>
+										Save
+									</Button>
+								)}
+								<Button
+									type="button"
+									size="sm"
+									disabled={isActive || setActive.isPending}
+									onClick={handleSetActive}
+								>
+									{isActive ? "Active" : "Activate"}
+								</Button>
+							</div>
+						</div>
+					</div>
+				)}
+			</div>
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/components/SessionConnectModal/components/PermissionsTab/index.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/components/SessionConnectModal/components/PermissionsTab/index.ts
@@ -1,0 +1,1 @@
+export { PermissionsTab } from "./PermissionsTab";

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/hooks/useSecondaryTabs/index.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/hooks/useSecondaryTabs/index.ts
@@ -1,0 +1,4 @@
+export {
+	type SecondaryTabState,
+	secondaryTabRegistry,
+} from "./registry";

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/hooks/useSecondaryTabs/registry.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/hooks/useSecondaryTabs/registry.ts
@@ -1,0 +1,420 @@
+import { electronTrpcClient } from "renderer/lib/trpc-client";
+import { sanitizeUrl } from "../usePersistentWebview/runtime";
+
+/**
+ * Secondary-tab registry for the v1 BrowserPane.
+ *
+ * v1's persistent webview machinery (usePersistentWebview + tabs-store
+ * `browser`) is designed around a single primary webview per pane and
+ * is deeply integrated with bookmarks, history, find-in-page, zoom,
+ * etc. Rather than untangle that singleton assumption, this sidecar
+ * runs alongside it: it owns *additional* webviews that share the
+ * pane's placeholder. The primary stays in usePersistentWebview; when
+ * the user (or an external CDP MCP via Target.createTarget) opens a
+ * secondary tab, we spawn another <webview> and overlay it atop the
+ * same placeholder.
+ *
+ * The pane's PaneTabBar decides which tab is active and tells this
+ * registry to show/hide accordingly; the primary is hidden from the
+ * outside by flipping the primary webview's CSS visibility.
+ */
+
+export interface SecondaryTabState {
+	tabId: string;
+	url: string;
+	title: string;
+	faviconUrl: string | null;
+	isLoading: boolean;
+}
+
+interface TabEntry {
+	tabId: string;
+	webview: Electron.WebviewTag;
+	state: SecondaryTabState;
+	webContentsId: number | null;
+	detachHandlers: () => void;
+}
+
+interface PaneGroup {
+	tabs: TabEntry[];
+	activeTabId: string | null;
+	placeholder: HTMLElement | null;
+	resizeObserver: ResizeObserver | null;
+	visible: boolean;
+}
+
+const ROOT_ID = "browser-secondary-tab-root";
+
+let tabIdSeq = 0;
+function nextTabId(): string {
+	tabIdSeq += 1;
+	return `tab-${Date.now().toString(36)}-${tabIdSeq.toString(36)}`;
+}
+
+class SecondaryTabRegistry {
+	private groups = new Map<string, PaneGroup>();
+	private listenersByPaneId = new Map<string, Set<() => void>>();
+	private root: HTMLDivElement | null = null;
+	private globalListenersInstalled = false;
+
+	private ensureRoot(): HTMLDivElement {
+		if (this.root?.isConnected) return this.root;
+		const existing = document.getElementById(ROOT_ID) as HTMLDivElement | null;
+		if (existing) {
+			this.root = existing;
+			return existing;
+		}
+		const el = document.createElement("div");
+		el.id = ROOT_ID;
+		el.style.position = "fixed";
+		el.style.top = "0";
+		el.style.left = "0";
+		el.style.width = "0";
+		el.style.height = "0";
+		el.style.pointerEvents = "none";
+		el.style.zIndex = "0";
+		document.body.appendChild(el);
+		this.root = el;
+		this.installGlobal();
+		return el;
+	}
+
+	private installGlobal(): void {
+		if (this.globalListenersInstalled) return;
+		this.globalListenersInstalled = true;
+		window.addEventListener("resize", () => {
+			for (const g of this.groups.values()) {
+				if (g.placeholder) this.layout(g);
+			}
+		});
+	}
+
+	private notify(paneId: string): void {
+		const set = this.listenersByPaneId.get(paneId);
+		if (!set) return;
+		for (const l of set) l();
+	}
+
+	private getListeners(paneId: string): Set<() => void> {
+		let set = this.listenersByPaneId.get(paneId);
+		if (!set) {
+			set = new Set();
+			this.listenersByPaneId.set(paneId, set);
+		}
+		return set;
+	}
+
+	private layout(group: PaneGroup): void {
+		if (!group.placeholder) return;
+		const rect = group.placeholder.getBoundingClientRect();
+		for (const tab of group.tabs) {
+			const w = tab.webview;
+			w.style.top = `${rect.top}px`;
+			w.style.left = `${rect.left}px`;
+			w.style.width = `${rect.width}px`;
+			w.style.height = `${rect.height}px`;
+			const isActive = group.visible && tab.tabId === group.activeTabId;
+			w.style.visibility = isActive ? "visible" : "hidden";
+			w.style.pointerEvents = isActive ? "auto" : "none";
+		}
+	}
+
+	private patchState(
+		paneId: string,
+		tabId: string,
+		patch: Partial<SecondaryTabState>,
+	): void {
+		const group = this.groups.get(paneId);
+		const tab = group?.tabs.find((t) => t.tabId === tabId);
+		if (!tab) return;
+		let changed = false;
+		for (const key in patch) {
+			const k = key as keyof SecondaryTabState;
+			if (tab.state[k] !== patch[k]) {
+				changed = true;
+				break;
+			}
+		}
+		if (!changed) return;
+		tab.state = { ...tab.state, ...patch };
+		this.notify(paneId);
+	}
+
+	private spawnTab(paneId: string, url: string, tabId: string): TabEntry {
+		const webview = document.createElement("webview") as Electron.WebviewTag;
+		webview.setAttribute("partition", "persist:superset");
+		webview.setAttribute("allowpopups", "");
+		webview.setAttribute("webpreferences", "transparent=no");
+		webview.style.position = "fixed";
+		webview.style.top = "0";
+		webview.style.left = "0";
+		webview.style.width = "0";
+		webview.style.height = "0";
+		webview.style.margin = "0";
+		webview.style.padding = "0";
+		webview.style.border = "none";
+		webview.style.visibility = "hidden";
+		webview.style.pointerEvents = "auto";
+		webview.src = sanitizeUrl(url);
+
+		const entry: TabEntry = {
+			tabId,
+			webview,
+			state: {
+				tabId,
+				url,
+				title: "",
+				faviconUrl: null,
+				isLoading: false,
+			},
+			webContentsId: null,
+			detachHandlers: () => {},
+		};
+
+		const handleDomReady = () => {
+			const id = webview.getWebContentsId();
+			if (entry.webContentsId !== id) {
+				entry.webContentsId = id;
+				electronTrpcClient.browser.registerTab
+					.mutate({ paneId, tabId, webContentsId: id })
+					.catch((err) =>
+						console.error("[v1 secondary-tabs] registerTab failed:", err),
+					);
+			}
+		};
+		const handleDidStartLoading = () => {
+			this.patchState(paneId, tabId, { isLoading: true });
+		};
+		const handleDidStopLoading = () => {
+			const u = webview.getURL() ?? "";
+			const t = webview.getTitle() ?? "";
+			this.patchState(paneId, tabId, { isLoading: false, url: u, title: t });
+		};
+		const handleDidNav = (e: Electron.DidNavigateEvent) => {
+			this.patchState(paneId, tabId, {
+				url: e.url ?? "",
+				title: webview.getTitle() ?? "",
+				isLoading: false,
+			});
+		};
+		const handleDidNavInPage = (e: Electron.DidNavigateInPageEvent) => {
+			this.patchState(paneId, tabId, {
+				url: e.url ?? "",
+				title: webview.getTitle() ?? "",
+			});
+		};
+		const handleTitle = (e: Electron.PageTitleUpdatedEvent) => {
+			this.patchState(paneId, tabId, { title: e.title ?? "" });
+		};
+		const handleFavicon = (e: Electron.PageFaviconUpdatedEvent) => {
+			const favicon = e.favicons?.[0] ?? null;
+			if (favicon !== entry.state.faviconUrl) {
+				this.patchState(paneId, tabId, { faviconUrl: favicon });
+			}
+		};
+
+		webview.addEventListener("dom-ready", handleDomReady);
+		webview.addEventListener("did-start-loading", handleDidStartLoading);
+		webview.addEventListener("did-stop-loading", handleDidStopLoading);
+		webview.addEventListener("did-navigate", handleDidNav as EventListener);
+		webview.addEventListener(
+			"did-navigate-in-page",
+			handleDidNavInPage as EventListener,
+		);
+		webview.addEventListener(
+			"page-title-updated",
+			handleTitle as EventListener,
+		);
+		webview.addEventListener(
+			"page-favicon-updated",
+			handleFavicon as EventListener,
+		);
+
+		entry.detachHandlers = () => {
+			webview.removeEventListener("dom-ready", handleDomReady);
+			webview.removeEventListener("did-start-loading", handleDidStartLoading);
+			webview.removeEventListener("did-stop-loading", handleDidStopLoading);
+			webview.removeEventListener(
+				"did-navigate",
+				handleDidNav as EventListener,
+			);
+			webview.removeEventListener(
+				"did-navigate-in-page",
+				handleDidNavInPage as EventListener,
+			);
+			webview.removeEventListener(
+				"page-title-updated",
+				handleTitle as EventListener,
+			);
+			webview.removeEventListener(
+				"page-favicon-updated",
+				handleFavicon as EventListener,
+			);
+		};
+
+		return entry;
+	}
+
+	attach(paneId: string, placeholder: HTMLElement): void {
+		const root = this.ensureRoot();
+		let group = this.groups.get(paneId);
+		if (!group) {
+			group = {
+				tabs: [],
+				activeTabId: null,
+				placeholder,
+				resizeObserver: null,
+				visible: false,
+			};
+			this.groups.set(paneId, group);
+		} else {
+			group.placeholder = placeholder;
+		}
+		for (const tab of group.tabs) {
+			if (!tab.webview.isConnected) root.appendChild(tab.webview);
+		}
+		group.resizeObserver?.disconnect();
+		const ref = group;
+		const observer = new ResizeObserver(() => this.layout(ref));
+		observer.observe(placeholder);
+		group.resizeObserver = observer;
+		this.layout(group);
+	}
+
+	detach(paneId: string): void {
+		const group = this.groups.get(paneId);
+		if (!group) return;
+		group.resizeObserver?.disconnect();
+		group.resizeObserver = null;
+		group.placeholder = null;
+		group.visible = false;
+		for (const tab of group.tabs) {
+			tab.webview.style.visibility = "hidden";
+		}
+	}
+
+	destroy(paneId: string): void {
+		const group = this.groups.get(paneId);
+		if (!group) return;
+		group.resizeObserver?.disconnect();
+		for (const tab of group.tabs) {
+			tab.detachHandlers();
+			tab.webview.remove();
+			electronTrpcClient.browser.unregisterTab
+				.mutate({ paneId, tabId: tab.tabId })
+				.catch(() => {});
+		}
+		this.groups.delete(paneId);
+		this.listenersByPaneId.delete(paneId);
+	}
+
+	setVisible(paneId: string, visible: boolean): void {
+		const group = this.groups.get(paneId);
+		if (!group) return;
+		group.visible = visible;
+		this.layout(group);
+	}
+
+	createTab(paneId: string, url: string): string | null {
+		this.ensureRoot();
+		let group = this.groups.get(paneId);
+		if (!group) {
+			group = {
+				tabs: [],
+				activeTabId: null,
+				placeholder: null,
+				resizeObserver: null,
+				visible: false,
+			};
+			this.groups.set(paneId, group);
+		}
+		const tabId = nextTabId();
+		const entry = this.spawnTab(paneId, url, tabId);
+		group.tabs.push(entry);
+		if (this.root) this.root.appendChild(entry.webview);
+		group.activeTabId = tabId;
+		group.visible = true;
+		this.layout(group);
+		this.notify(paneId);
+		return tabId;
+	}
+
+	closeTab(paneId: string, tabId: string): void {
+		const group = this.groups.get(paneId);
+		if (!group) return;
+		const idx = group.tabs.findIndex((t) => t.tabId === tabId);
+		if (idx < 0) return;
+		const [removed] = group.tabs.splice(idx, 1);
+		removed.detachHandlers();
+		removed.webview.remove();
+		electronTrpcClient.browser.unregisterTab
+			.mutate({ paneId, tabId: removed.tabId })
+			.catch(() => {});
+		if (group.activeTabId === tabId) {
+			group.activeTabId =
+				group.tabs[Math.min(idx, group.tabs.length - 1)]?.tabId ?? null;
+		}
+		this.layout(group);
+		this.notify(paneId);
+	}
+
+	activateTab(paneId: string, tabId: string): void {
+		const group = this.groups.get(paneId);
+		if (!group) return;
+		if (!group.tabs.some((t) => t.tabId === tabId)) return;
+		if (group.activeTabId === tabId) return;
+		group.activeTabId = tabId;
+		group.visible = true;
+		this.layout(group);
+		this.notify(paneId);
+	}
+
+	listTabs(paneId: string): SecondaryTabState[] {
+		const group = this.groups.get(paneId);
+		if (!group) return [];
+		return group.tabs.map((t) => ({ ...t.state }));
+	}
+
+	getActiveTabId(paneId: string): string | null {
+		return this.groups.get(paneId)?.activeTabId ?? null;
+	}
+
+	onTabsChange(paneId: string, listener: () => void): () => void {
+		const set = this.getListeners(paneId);
+		set.add(listener);
+		return () => set.delete(listener);
+	}
+
+	navigateActive(paneId: string, url: string): void {
+		const group = this.groups.get(paneId);
+		const tab = group?.tabs.find((t) => t.tabId === group.activeTabId);
+		if (!tab) return;
+		tab.webview.loadURL(sanitizeUrl(url)).catch(() => {});
+	}
+
+	goBackActive(paneId: string): void {
+		const group = this.groups.get(paneId);
+		const tab = group?.tabs.find((t) => t.tabId === group.activeTabId);
+		if (tab?.webview.canGoBack()) tab.webview.goBack();
+	}
+
+	goForwardActive(paneId: string): void {
+		const group = this.groups.get(paneId);
+		const tab = group?.tabs.find((t) => t.tabId === group.activeTabId);
+		if (tab?.webview.canGoForward()) tab.webview.goForward();
+	}
+
+	reloadActive(paneId: string): void {
+		const group = this.groups.get(paneId);
+		const tab = group?.tabs.find((t) => t.tabId === group.activeTabId);
+		tab?.webview.reload();
+	}
+}
+
+export const secondaryTabRegistry: SecondaryTabRegistry =
+	(import.meta.hot?.data?.v1SecondaryTabRegistry as
+		| SecondaryTabRegistry
+		| undefined) ?? new SecondaryTabRegistry();
+if (import.meta.hot) {
+	import.meta.hot.data.v1SecondaryTabRegistry = secondaryTabRegistry;
+}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/hooks/useSecondaryTabs/registry.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/hooks/useSecondaryTabs/registry.ts
@@ -362,7 +362,11 @@ class SecondaryTabRegistry {
 		this.layout(group);
 	}
 
-	createTab(paneId: string, url: string): string | null {
+	createTab(
+		paneId: string,
+		url: string,
+		options?: { background?: boolean },
+	): string | null {
 		this.ensureRoot();
 		let group = this.groups.get(paneId);
 		if (!group) {
@@ -379,8 +383,14 @@ class SecondaryTabRegistry {
 		const entry = this.spawnTab(paneId, url, tabId);
 		group.tabs.push(entry);
 		if (this.root) this.root.appendChild(entry.webview);
-		group.activeTabId = tabId;
-		group.visible = true;
+		// Honour the CDP createTarget `background` flag: when set,
+		// the new tab is spawned but the active tab stays put. When
+		// unset (Chrome default for createTarget when called by MCP)
+		// the new tab takes focus.
+		if (!options?.background) {
+			group.activeTabId = tabId;
+			group.visible = true;
+		}
 		this.layout(group);
 		this.notify(paneId);
 		return tabId;
@@ -412,6 +422,21 @@ class SecondaryTabRegistry {
 		if (group.activeTabId === tabId) return;
 		group.activeTabId = tabId;
 		group.visible = true;
+		this.layout(group);
+		this.notify(paneId);
+	}
+
+	/**
+	 * Hide any secondary tabs for this pane so the pane's primary
+	 * (managed by usePersistentWebview) becomes visible. Used when
+	 * MCP activates the primary target via Target.activateTarget.
+	 */
+	showPrimary(paneId: string): void {
+		const group = this.groups.get(paneId);
+		if (!group) return;
+		if (group.activeTabId === null && !group.visible) return;
+		group.activeTabId = null;
+		group.visible = false;
 		this.layout(group);
 		this.notify(paneId);
 	}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/hooks/useSecondaryTabs/registry.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/hooks/useSecondaryTabs/registry.ts
@@ -116,27 +116,34 @@ class SecondaryTabRegistry {
 		for (const tab of group.tabs) {
 			const w = tab.webview;
 			const isActive = group.visible && tab.tabId === group.activeTabId;
-			// Inactive tabs are pushed far off-screen rather than
-			// `visibility:hidden`. Hiding via CSS triggers Chromium's
-			// page-lifecycle "hidden" state on the underlying
-			// webContents, which makes external CDP MCPs (browser-use
-			// etc.) appear to hang while the page they're driving is
-			// throttled by the site itself (IntersectionObserver,
-			// requestAnimationFrame pauses, "wait until visible" load
-			// patterns, …). Keeping the webview at its real size but
-			// offscreen avoids that without showing it to the user.
+			// All tabs share the same rect; active/inactive is expressed
+			// via opacity + z-index + pointer-events. We deliberately
+			// avoid:
+			//   - visibility:hidden / display:none — these trigger
+			//     Chromium's page-lifecycle "hidden" state, which makes
+			//     CDP MCPs (browser-use / chrome-devtools-mcp) appear
+			//     to hang while sites throttle work on
+			//     IntersectionObserver / requestAnimationFrame / "wait
+			//     until visible" load paths.
+			//   - moving inactive tabs off-screen — Electron's
+			//     <webview> tag does not reliably re-position the
+			//     native GuestView compositor when only CSS top/left
+			//     change, so the inactive tab's GuestView would stay
+			//     compositing at the active rect and the user would
+			//     see whichever tab happened to paint first regardless
+			//     of which one the tab-bar flagged "active".
+			// opacity:0 pauses neither the renderer nor the page
+			// lifecycle and reliably hides the widget.
+			w.style.top = `${rect.top}px`;
+			w.style.left = `${rect.left}px`;
+			w.style.width = `${rect.width}px`;
+			w.style.height = `${rect.height}px`;
 			if (isActive) {
-				w.style.top = `${rect.top}px`;
-				w.style.left = `${rect.left}px`;
-				w.style.width = `${rect.width}px`;
-				w.style.height = `${rect.height}px`;
+				w.style.opacity = "1";
 				w.style.zIndex = "100";
 				w.style.pointerEvents = "auto";
 			} else {
-				w.style.top = "-100000px";
-				w.style.left = "-100000px";
-				w.style.width = `${rect.width}px`;
-				w.style.height = `${rect.height}px`;
+				w.style.opacity = "0";
 				w.style.zIndex = "0";
 				w.style.pointerEvents = "none";
 			}
@@ -178,8 +185,9 @@ class SecondaryTabRegistry {
 		webview.style.margin = "0";
 		webview.style.padding = "0";
 		webview.style.border = "none";
-		webview.style.visibility = "hidden";
-		webview.style.pointerEvents = "auto";
+		webview.style.visibility = "visible";
+		webview.style.opacity = "0";
+		webview.style.pointerEvents = "none";
 		const sanitized = sanitizeUrl(url);
 		console.log(
 			"[tab-diag v1] spawnTab pane=",
@@ -399,12 +407,11 @@ class SecondaryTabRegistry {
 		group.resizeObserver = null;
 		group.placeholder = null;
 		group.visible = false;
-		// Stay off-screen rather than visibility:hidden to keep
+		// Hide via opacity rather than visibility:hidden to keep
 		// Chromium's page-lifecycle state "visible" so external CDP
 		// MCPs driving these tabs don't stall when the pane detaches.
 		for (const tab of group.tabs) {
-			tab.webview.style.top = "-100000px";
-			tab.webview.style.left = "-100000px";
+			tab.webview.style.opacity = "0";
 			tab.webview.style.pointerEvents = "none";
 			tab.webview.style.visibility = "visible";
 		}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/hooks/useSecondaryTabs/registry.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/hooks/useSecondaryTabs/registry.ts
@@ -180,7 +180,18 @@ class SecondaryTabRegistry {
 		webview.style.border = "none";
 		webview.style.visibility = "hidden";
 		webview.style.pointerEvents = "auto";
-		webview.src = sanitizeUrl(url);
+		const sanitized = sanitizeUrl(url);
+		console.log(
+			"[tab-diag v1] spawnTab pane=",
+			paneId,
+			"tab=",
+			tabId,
+			"incomingUrl=",
+			url,
+			"sanitized=",
+			sanitized,
+		);
+		webview.src = sanitized;
 
 		const entry: TabEntry = {
 			tabId,
@@ -224,14 +235,56 @@ class SecondaryTabRegistry {
 			}
 		};
 		const handleDidStartLoading = () => {
+			console.log(
+				"[tab-diag v1] did-start-loading pane=",
+				paneId,
+				"tab=",
+				tabId,
+				"url=",
+				webview.getURL?.(),
+			);
 			this.patchState(paneId, tabId, { isLoading: true });
 		};
 		const handleDidStopLoading = () => {
 			const u = webview.getURL() ?? "";
 			const t = webview.getTitle() ?? "";
+			console.log(
+				"[tab-diag v1] did-stop-loading pane=",
+				paneId,
+				"tab=",
+				tabId,
+				"url=",
+				u,
+				"title=",
+				t,
+			);
 			this.patchState(paneId, tabId, { isLoading: false, url: u, title: t });
 		};
+		const handleDidFailLoad = (
+			e: Electron.DidFailLoadEvent & { validatedURL?: string },
+		) => {
+			console.warn(
+				"[tab-diag v1] did-fail-load pane=",
+				paneId,
+				"tab=",
+				tabId,
+				"url=",
+				e.validatedURL ?? webview.getURL?.(),
+				"errorCode=",
+				e.errorCode,
+				"errorDesc=",
+				e.errorDescription,
+			);
+		};
 		const handleDidNav = (e: Electron.DidNavigateEvent) => {
+			console.log(
+				"[tab-diag v1] did-navigate pane=",
+				paneId,
+				"tab=",
+				tabId,
+				"url=",
+				e.url,
+			);
 			this.patchState(paneId, tabId, {
 				url: e.url ?? "",
 				title: webview.getTitle() ?? "",
@@ -257,6 +310,7 @@ class SecondaryTabRegistry {
 		webview.addEventListener("dom-ready", handleDomReady);
 		webview.addEventListener("did-start-loading", handleDidStartLoading);
 		webview.addEventListener("did-stop-loading", handleDidStopLoading);
+		webview.addEventListener("did-fail-load", handleDidFailLoad as EventListener);
 		webview.addEventListener("did-navigate", handleDidNav as EventListener);
 		webview.addEventListener(
 			"did-navigate-in-page",
@@ -287,6 +341,10 @@ class SecondaryTabRegistry {
 			webview.removeEventListener("dom-ready", handleDomReady);
 			webview.removeEventListener("did-start-loading", handleDidStartLoading);
 			webview.removeEventListener("did-stop-loading", handleDidStopLoading);
+			webview.removeEventListener(
+				"did-fail-load",
+				handleDidFailLoad as EventListener,
+			);
 			webview.removeEventListener(
 				"did-navigate",
 				handleDidNav as EventListener,

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/hooks/useSecondaryTabs/registry.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/hooks/useSecondaryTabs/registry.ts
@@ -271,7 +271,19 @@ class SecondaryTabRegistry {
 			handleFavicon as EventListener,
 		);
 
+		// Fires when the guest page attempts to close itself OR when
+		// Chromium destroys the underlying webContents (e.g. MCP sends
+		// Target.closeTarget for this tab's targetId). Without this
+		// listener the tab's webview element would stay dead in the
+		// DOM and the registry would still list it as alive, while the
+		// CDP filter has already pruned its targetId.
+		const handleClose = () => {
+			this.closeTab(paneId, tabId);
+		};
+		webview.addEventListener("close", handleClose);
+
 		entry.detachHandlers = () => {
+			webview.removeEventListener("close", handleClose);
 			webview.removeEventListener("dom-ready", handleDomReady);
 			webview.removeEventListener("did-start-loading", handleDidStartLoading);
 			webview.removeEventListener("did-stop-loading", handleDidStopLoading);

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/hooks/useSecondaryTabs/registry.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/hooks/useSecondaryTabs/registry.ts
@@ -198,10 +198,26 @@ class SecondaryTabRegistry {
 
 		const handleDomReady = () => {
 			const id = webview.getWebContentsId();
+			console.log(
+				"[v1 secondary-tabs] dom-ready pane=",
+				paneId,
+				"tab=",
+				tabId,
+				"webContentsId=",
+				id,
+			);
 			if (entry.webContentsId !== id) {
 				entry.webContentsId = id;
 				electronTrpcClient.browser.registerTab
 					.mutate({ paneId, tabId, webContentsId: id })
+					.then(() =>
+						console.log(
+							"[v1 secondary-tabs] registerTab OK pane=",
+							paneId,
+							"tab=",
+							tabId,
+						),
+					)
 					.catch((err) =>
 						console.error("[v1 secondary-tabs] registerTab failed:", err),
 					);

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/hooks/useSecondaryTabs/registry.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/hooks/useSecondaryTabs/registry.ts
@@ -329,8 +329,14 @@ class SecondaryTabRegistry {
 		group.resizeObserver = null;
 		group.placeholder = null;
 		group.visible = false;
+		// Stay off-screen rather than visibility:hidden to keep
+		// Chromium's page-lifecycle state "visible" so external CDP
+		// MCPs driving these tabs don't stall when the pane detaches.
 		for (const tab of group.tabs) {
-			tab.webview.style.visibility = "hidden";
+			tab.webview.style.top = "-100000px";
+			tab.webview.style.left = "-100000px";
+			tab.webview.style.pointerEvents = "none";
+			tab.webview.style.visibility = "visible";
 		}
 	}
 

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/hooks/useSecondaryTabs/registry.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/hooks/useSecondaryTabs/registry.ts
@@ -115,13 +115,32 @@ class SecondaryTabRegistry {
 		const rect = group.placeholder.getBoundingClientRect();
 		for (const tab of group.tabs) {
 			const w = tab.webview;
-			w.style.top = `${rect.top}px`;
-			w.style.left = `${rect.left}px`;
-			w.style.width = `${rect.width}px`;
-			w.style.height = `${rect.height}px`;
 			const isActive = group.visible && tab.tabId === group.activeTabId;
-			w.style.visibility = isActive ? "visible" : "hidden";
-			w.style.pointerEvents = isActive ? "auto" : "none";
+			// Inactive tabs are pushed far off-screen rather than
+			// `visibility:hidden`. Hiding via CSS triggers Chromium's
+			// page-lifecycle "hidden" state on the underlying
+			// webContents, which makes external CDP MCPs (browser-use
+			// etc.) appear to hang while the page they're driving is
+			// throttled by the site itself (IntersectionObserver,
+			// requestAnimationFrame pauses, "wait until visible" load
+			// patterns, …). Keeping the webview at its real size but
+			// offscreen avoids that without showing it to the user.
+			if (isActive) {
+				w.style.top = `${rect.top}px`;
+				w.style.left = `${rect.left}px`;
+				w.style.width = `${rect.width}px`;
+				w.style.height = `${rect.height}px`;
+				w.style.zIndex = "100";
+				w.style.pointerEvents = "auto";
+			} else {
+				w.style.top = "-100000px";
+				w.style.left = "-100000px";
+				w.style.width = `${rect.width}px`;
+				w.style.height = `${rect.height}px`;
+				w.style.zIndex = "0";
+				w.style.pointerEvents = "none";
+			}
+			w.style.visibility = "visible";
 		}
 	}
 

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/hooks/useSecondaryTabs/registry.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/hooks/useSecondaryTabs/registry.ts
@@ -116,33 +116,28 @@ class SecondaryTabRegistry {
 		for (const tab of group.tabs) {
 			const w = tab.webview;
 			const isActive = group.visible && tab.tabId === group.activeTabId;
-			// All tabs share the same rect; active/inactive is expressed
-			// via opacity + z-index + pointer-events. We deliberately
-			// avoid:
-			//   - visibility:hidden / display:none — these trigger
-			//     Chromium's page-lifecycle "hidden" state, which makes
-			//     CDP MCPs (browser-use / chrome-devtools-mcp) appear
-			//     to hang while sites throttle work on
-			//     IntersectionObserver / requestAnimationFrame / "wait
-			//     until visible" load paths.
-			//   - moving inactive tabs off-screen — Electron's
-			//     <webview> tag does not reliably re-position the
-			//     native GuestView compositor when only CSS top/left
-			//     change, so the inactive tab's GuestView would stay
-			//     compositing at the active rect and the user would
-			//     see whichever tab happened to paint first regardless
-			//     of which one the tab-bar flagged "active".
-			// opacity:0 pauses neither the renderer nor the page
-			// lifecycle and reliably hides the widget.
-			w.style.top = `${rect.top}px`;
-			w.style.left = `${rect.left}px`;
-			w.style.width = `${rect.width}px`;
-			w.style.height = `${rect.height}px`;
+			// Inactive tabs must leave the viewport entirely. Keeping
+			// them at rect with opacity:0 / pointer-events:none does
+			// NOT work: Electron's <webview> native GuestView
+			// compositor intercepts wheel / right-click / keyboard
+			// focus regardless of CSS pointer-events, which would
+			// break scroll / context menu / URL bar suggestions on
+			// whatever should be below. Push them off-screen.
+			// visibility stays "visible" so page-lifecycle stays
+			// "visible" for background CDP automation.
 			if (isActive) {
+				w.style.top = `${rect.top}px`;
+				w.style.left = `${rect.left}px`;
+				w.style.width = `${rect.width}px`;
+				w.style.height = `${rect.height}px`;
 				w.style.opacity = "1";
 				w.style.zIndex = "100";
 				w.style.pointerEvents = "auto";
 			} else {
+				w.style.top = "-100000px";
+				w.style.left = "-100000px";
+				w.style.width = `${rect.width}px`;
+				w.style.height = `${rect.height}px`;
 				w.style.opacity = "0";
 				w.style.zIndex = "0";
 				w.style.pointerEvents = "none";
@@ -407,10 +402,12 @@ class SecondaryTabRegistry {
 		group.resizeObserver = null;
 		group.placeholder = null;
 		group.visible = false;
-		// Hide via opacity rather than visibility:hidden to keep
-		// Chromium's page-lifecycle state "visible" so external CDP
-		// MCPs driving these tabs don't stall when the pane detaches.
+		// Push off-screen so the GuestView stops intercepting events
+		// but stays Chromium-visible so page-lifecycle remains
+		// "visible" (CDP MCPs keep working).
 		for (const tab of group.tabs) {
+			tab.webview.style.top = "-100000px";
+			tab.webview.style.left = "-100000px";
 			tab.webview.style.opacity = "0";
 			tab.webview.style.pointerEvents = "none";
 			tab.webview.style.visibility = "visible";

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/hooks/useSecondaryTabs/registry.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/hooks/useSecondaryTabs/registry.ts
@@ -54,6 +54,11 @@ function nextTabId(): string {
 class SecondaryTabRegistry {
 	private groups = new Map<string, PaneGroup>();
 	private listenersByPaneId = new Map<string, Set<() => void>>();
+	// Snapshot cache so useSyncExternalStore's getSnapshot returns the
+	// same array reference until something actually changes — without
+	// this, every render schedules another render and React aborts with
+	// "Maximum update depth exceeded".
+	private snapshots = new Map<string, SecondaryTabState[]>();
 	private root: HTMLDivElement | null = null;
 	private globalListenersInstalled = false;
 
@@ -90,6 +95,7 @@ class SecondaryTabRegistry {
 	}
 
 	private notify(paneId: string): void {
+		this.snapshots.delete(paneId);
 		const set = this.listenersByPaneId.get(paneId);
 		if (!set) return;
 		for (const l of set) l();
@@ -369,10 +375,19 @@ class SecondaryTabRegistry {
 		this.notify(paneId);
 	}
 
+	private static EMPTY: SecondaryTabState[] = Object.freeze(
+		[] as SecondaryTabState[],
+	) as SecondaryTabState[];
+
 	listTabs(paneId: string): SecondaryTabState[] {
+		const cached = this.snapshots.get(paneId);
+		if (cached) return cached;
 		const group = this.groups.get(paneId);
-		if (!group) return [];
-		return group.tabs.map((t) => ({ ...t.state }));
+		const next = group
+			? group.tabs.map((t) => ({ ...t.state }))
+			: SecondaryTabRegistry.EMPTY;
+		this.snapshots.set(paneId, next);
+		return next;
 	}
 
 	getActiveTabId(paneId: string): string | null {

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/FileViewerPane.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/FileViewerPane.tsx
@@ -185,6 +185,8 @@ export function FileViewerPane({
 	const diffCategory = fileViewer?.diffCategory;
 	const commitHash = fileViewer?.commitHash;
 	const oldPath = fileViewer?.oldPath;
+	const inlineOriginalContent = fileViewer?.inlineOriginalContent;
+	const inlineOriginalContentKey = fileViewer?.inlineOriginalContentKey;
 	const initialLine = fileViewer?.initialLine;
 	const initialColumn = fileViewer?.initialColumn;
 
@@ -213,8 +215,16 @@ export function FileViewerPane({
 				diffCategory,
 				commitHash,
 				oldPath,
+				inlineOriginalContentKey,
 			}),
-		[normalizedWorkspaceId, filePath, diffCategory, commitHash, oldPath],
+		[
+			normalizedWorkspaceId,
+			filePath,
+			diffCategory,
+			commitHash,
+			oldPath,
+			inlineOriginalContentKey,
+		],
 	);
 	const documentState = useEditorDocumentsStore(
 		(state) => state.documents[documentKey],
@@ -272,6 +282,7 @@ export function FileViewerPane({
 		diffCategory,
 		commitHash,
 		oldPath,
+		inlineOriginalContent,
 	});
 
 	useEffect(() => {
@@ -292,6 +303,7 @@ export function FileViewerPane({
 				diffCategory,
 				commitHash,
 				oldPath,
+				inlineOriginalContentKey,
 			},
 			{
 				preserveDocumentState,
@@ -310,6 +322,7 @@ export function FileViewerPane({
 		diffCategory,
 		commitHash,
 		oldPath,
+		inlineOriginalContentKey,
 	]);
 
 	const { handleSaveFile, isSaving } = useFileSave({

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/hooks/useFileContent/useFileContent.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/hooks/useFileContent/useFileContent.ts
@@ -23,6 +23,7 @@ interface UseFileContentParams {
 	diffCategory?: ChangeCategory;
 	commitHash?: string;
 	oldPath?: string;
+	inlineOriginalContent?: string;
 }
 
 function isBinaryText(content: string): boolean {
@@ -43,6 +44,7 @@ export function useFileContent({
 	diffCategory,
 	commitHash,
 	oldPath,
+	inlineOriginalContent,
 }: UseFileContentParams) {
 	// For remote URLs (e.g. Vercel Blob), skip all IPC queries
 	const isRemote =
@@ -181,7 +183,12 @@ export function useFileContent({
 				oldAbsolutePath: oldPath,
 			},
 			{
-				enabled: !isRemote && isUnstagedDiff && !!filePath && !!worktreePath,
+				enabled:
+					!isRemote &&
+					isUnstagedDiff &&
+					inlineOriginalContent === undefined &&
+					!!filePath &&
+					!!worktreePath,
 			},
 		);
 
@@ -200,7 +207,7 @@ export function useFileContent({
 
 	const diffData = useMemo(() => {
 		if (isGitDiff) return gitDiffData;
-		if (isUnstagedDiff && gitOriginal) {
+		if (isUnstagedDiff && (inlineOriginalContent !== undefined || gitOriginal)) {
 			let modifiedContent = "";
 			if (workingCopy) {
 				if (workingCopy.exceededLimit) {
@@ -210,7 +217,7 @@ export function useFileContent({
 				}
 			}
 			return {
-				original: gitOriginal.content,
+				original: inlineOriginalContent ?? gitOriginal?.content ?? "",
 				modified: modifiedContent,
 				language: detectLanguage(filePath),
 			};
@@ -221,6 +228,7 @@ export function useFileContent({
 		isUnstagedDiff,
 		gitDiffData,
 		gitOriginal,
+		inlineOriginalContent,
 		workingCopy,
 		filePath,
 	]);
@@ -228,7 +236,8 @@ export function useFileContent({
 	const isLoadingDiff = isGitDiff
 		? isLoadingGitDiff
 		: isUnstagedDiff
-			? isLoadingGitOriginal || isLoadingWorkingCopy
+			? (inlineOriginalContent === undefined && isLoadingGitOriginal) ||
+				isLoadingWorkingCopy
 			: false;
 
 	return {

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/index.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/index.tsx
@@ -44,6 +44,7 @@ import {
 	LuSparkles,
 	LuX,
 } from "react-icons/lu";
+import { SiOpenai } from "react-icons/si";
 import { HotkeyLabel } from "renderer/hotkeys";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { useWorkspaceId } from "renderer/screens/main/components/WorkspaceView/WorkspaceIdContext";
@@ -107,6 +108,10 @@ const RIGHT_SIDEBAR_TAB_METADATA: Record<
 	},
 	[RightSidebarTab.Codex]: {
 		label: "Codex",
+		icon: SiOpenai,
+	},
+	[RightSidebarTab.Kimi]: {
+		label: "Kimi",
 		icon: LuSparkles,
 	},
 };
@@ -300,6 +305,7 @@ export function RightSidebar({ isActive = true }: { isActive?: boolean }) {
 	);
 	const showClaudeCodeTab = installedExtensionIds.has("anthropic.claude-code");
 	const showCodexTab = installedExtensionIds.has("openai.chatgpt");
+	const showKimiTab = installedExtensionIds.has("moonshot-ai.kimi-code");
 	const hasProblemErrors = (workspaceDiagnostics?.summary.errorCount ?? 0) > 0;
 	const dockerComposeFiles = dockerComposeFilesQuery.data;
 	const isResolvingDockerVisibility =
@@ -334,6 +340,9 @@ export function RightSidebar({ isActive = true }: { isActive?: boolean }) {
 				if (tabId === RightSidebarTab.Codex) {
 					return showCodexTab;
 				}
+				if (tabId === RightSidebarTab.Kimi) {
+					return showKimiTab;
+				}
 				return true;
 			})
 			.map((tabId) => ({
@@ -349,6 +358,7 @@ export function RightSidebar({ isActive = true }: { isActive?: boolean }) {
 		showDockerTab,
 		showClaudeCodeTab,
 		showCodexTab,
+		showKimiTab,
 	]);
 
 	useEffect(() => {
@@ -848,6 +858,24 @@ export function RightSidebar({ isActive = true }: { isActive?: boolean }) {
 						isActive={rightSidebarTab === RightSidebarTab.Codex}
 						persistenceId={createVscodeExtensionSidebarPersistenceId(
 							"chatgpt.sidebarView",
+						)}
+					/>
+				</div>
+			)}
+			{showKimiTab && (
+				<div
+					className={
+						rightSidebarTab === RightSidebarTab.Kimi
+							? "flex-1 min-h-0 flex flex-col overflow-hidden"
+							: "hidden"
+					}
+				>
+					<VscodeExtensionView
+						viewType="kimi.webview"
+						extensionId="moonshot-ai.kimi-code"
+						isActive={rightSidebarTab === RightSidebarTab.Kimi}
+						persistenceId={createVscodeExtensionSidebarPersistenceId(
+							"kimi.webview",
 						)}
 					/>
 				</div>

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/hooks/useVscodeDiffSync.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/hooks/useVscodeDiffSync.ts
@@ -26,6 +26,10 @@ export function useVscodeDiffSync() {
 					viewMode: "diff",
 					diffCategory: "unstaged",
 					useRightSidebarOpenViewWidth: true,
+					inlineOriginalContent: data.leftContent,
+					inlineOriginalContentKey: data.leftContent !== undefined
+						? data.leftUri
+						: undefined,
 					...(isRename ? { oldPath: data.leftUri } : {}),
 				});
 			},

--- a/apps/desktop/src/renderer/stores/editor-state/editorCoordinator.ts
+++ b/apps/desktop/src/renderer/stores/editor-state/editorCoordinator.ts
@@ -93,6 +93,8 @@ function applyFileViewerReplacement(
 					diffCategory: options.diffCategory,
 					commitHash: options.commitHash,
 					oldPath: options.oldPath,
+					inlineOriginalContent: options.inlineOriginalContent,
+					inlineOriginalContentKey: options.inlineOriginalContentKey,
 					initialLine: options.line,
 					initialColumn: options.column,
 					displayName: options.displayName,

--- a/apps/desktop/src/renderer/stores/editor-state/types.ts
+++ b/apps/desktop/src/renderer/stores/editor-state/types.ts
@@ -61,6 +61,7 @@ export interface FileViewerDocumentIdentity {
 	diffCategory?: ChangeCategory;
 	commitHash?: string;
 	oldPath?: string;
+	inlineOriginalContentKey?: string;
 }
 
 export function resolveEditorDocumentScope(
@@ -102,6 +103,7 @@ export function buildEditorDocumentKey({
 	diffCategory,
 	commitHash,
 	oldPath,
+	inlineOriginalContentKey,
 }: FileViewerDocumentIdentity): string {
 	const scope = resolveEditorDocumentScope(diffCategory);
 
@@ -110,6 +112,7 @@ export function buildEditorDocumentKey({
 			encodeDocumentKeyPart(workspaceId),
 			encodeDocumentKeyPart(scope),
 			encodeDocumentKeyPart(filePath),
+			encodeDocumentKeyPart(inlineOriginalContentKey),
 		].join("::");
 	}
 

--- a/apps/desktop/src/renderer/stores/sidebar-state.ts
+++ b/apps/desktop/src/renderer/stores/sidebar-state.ts
@@ -15,6 +15,7 @@ export enum RightSidebarTab {
 	Databases = "databases",
 	ClaudeCode = "claude-code",
 	Codex = "codex",
+	Kimi = "kimi",
 }
 
 export const DEFAULT_RIGHT_SIDEBAR_TAB_ORDER = [
@@ -26,6 +27,7 @@ export const DEFAULT_RIGHT_SIDEBAR_TAB_ORDER = [
 	RightSidebarTab.Databases,
 	RightSidebarTab.ClaudeCode,
 	RightSidebarTab.Codex,
+	RightSidebarTab.Kimi,
 ] as const satisfies RightSidebarTab[];
 
 export const DEFAULT_SIDEBAR_WIDTH = 250;

--- a/apps/desktop/src/renderer/stores/tabs/store.ts
+++ b/apps/desktop/src/renderer/stores/tabs/store.ts
@@ -960,7 +960,9 @@ export const useTabsStore = create<TabsStore>()(
 						const isSameFile =
 							pathsMatch(existingFileViewer.filePath, options.filePath) &&
 							existingFileViewer.diffCategory === options.diffCategory &&
-							existingFileViewer.commitHash === options.commitHash;
+							existingFileViewer.commitHash === options.commitHash &&
+							existingFileViewer.inlineOriginalContentKey ===
+								options.inlineOriginalContentKey;
 
 						if (paneDocument?.dirty && !isSameFile) {
 							set({
@@ -1052,6 +1054,10 @@ export const useTabsStore = create<TabsStore>()(
 										diffCategory: options.diffCategory,
 										commitHash: options.commitHash,
 										oldPath: options.oldPath,
+										inlineOriginalContent:
+											options.inlineOriginalContent,
+										inlineOriginalContentKey:
+											options.inlineOriginalContentKey,
 										initialLine: options.line,
 										initialColumn: options.column,
 										displayName: options.displayName,

--- a/apps/desktop/src/renderer/stores/tabs/types.ts
+++ b/apps/desktop/src/renderer/stores/tabs/types.ts
@@ -82,6 +82,8 @@ export interface AddFileViewerPaneOptions {
 	commitHash?: string;
 	/** Canonical absolute original path for renamed files */
 	oldPath?: string;
+	inlineOriginalContent?: string;
+	inlineOriginalContentKey?: string;
 	/** Line to scroll to (raw mode only) */
 	line?: number;
 	/** Column to scroll to (raw mode only) */

--- a/apps/desktop/src/renderer/stores/tabs/utils.ts
+++ b/apps/desktop/src/renderer/stores/tabs/utils.ts
@@ -204,6 +204,8 @@ export interface CreateFileViewerPaneOptions {
 	fileStatus?: FileStatus;
 	commitHash?: string;
 	oldPath?: string;
+	inlineOriginalContent?: string;
+	inlineOriginalContentKey?: string;
 	/** Line to scroll to (raw mode only) */
 	line?: number;
 	/** Column to scroll to (raw mode only) */
@@ -234,6 +236,8 @@ export const createFileViewerPane = (
 		diffCategory: options.diffCategory,
 		commitHash: options.commitHash,
 		oldPath: options.oldPath,
+		inlineOriginalContent: options.inlineOriginalContent,
+		inlineOriginalContentKey: options.inlineOriginalContentKey,
 		initialLine: options.line,
 		initialColumn: options.column,
 		displayName: options.displayName,
@@ -845,11 +849,14 @@ export const updateHistoryStack = (
 
 export const fileViewerTargetsMatch = (
 	fileViewer:
-		| Pick<FileViewerState, "filePath" | "diffCategory" | "commitHash">
+		| Pick<
+				FileViewerState,
+				"filePath" | "diffCategory" | "commitHash" | "inlineOriginalContentKey"
+		  >
 		| undefined,
 	options: Pick<
 		AddFileViewerPaneOptions,
-		"filePath" | "diffCategory" | "commitHash"
+		"filePath" | "diffCategory" | "commitHash" | "inlineOriginalContentKey"
 	>,
 ): boolean => {
 	if (!fileViewer) {
@@ -870,7 +877,8 @@ export const fileViewerTargetsMatch = (
 	return (
 		filePathsMatch &&
 		fileViewer.diffCategory === options.diffCategory &&
-		fileViewer.commitHash === options.commitHash
+		fileViewer.commitHash === options.commitHash &&
+		fileViewer.inlineOriginalContentKey === options.inlineOriginalContentKey
 	);
 };
 
@@ -995,6 +1003,11 @@ export const applyFileViewerOpenOptionsToPane = (
 		viewMode: options.viewMode ?? fallbackViewMode,
 		isPinned: pane.fileViewer.isPinned || (options.isPinned ?? false),
 		oldPath: options.oldPath ?? pane.fileViewer.oldPath,
+		inlineOriginalContent:
+			options.inlineOriginalContent ?? pane.fileViewer.inlineOriginalContent,
+		inlineOriginalContentKey:
+			options.inlineOriginalContentKey ??
+			pane.fileViewer.inlineOriginalContentKey,
 		initialLine: options.line ?? pane.fileViewer.initialLine,
 		initialColumn: options.column ?? pane.fileViewer.initialColumn,
 		displayName: options.displayName ?? pane.fileViewer.displayName,
@@ -1009,6 +1022,10 @@ export const applyFileViewerOpenOptionsToPane = (
 		nextFileViewer.viewMode === pane.fileViewer.viewMode &&
 		nextFileViewer.isPinned === pane.fileViewer.isPinned &&
 		nextFileViewer.oldPath === pane.fileViewer.oldPath &&
+		nextFileViewer.inlineOriginalContent ===
+			pane.fileViewer.inlineOriginalContent &&
+		nextFileViewer.inlineOriginalContentKey ===
+			pane.fileViewer.inlineOriginalContentKey &&
 		nextFileViewer.initialLine === pane.fileViewer.initialLine &&
 		nextFileViewer.initialColumn === pane.fileViewer.initialColumn &&
 		nextFileViewer.displayName === pane.fileViewer.displayName

--- a/apps/desktop/src/shared/tabs-types.ts
+++ b/apps/desktop/src/shared/tabs-types.ts
@@ -120,6 +120,10 @@ export interface FileViewerState {
 	commitHash?: string;
 	/** Canonical absolute original path for renamed files */
 	oldPath?: string;
+	/** Optional inline baseline/original content for extension-driven diffs */
+	inlineOriginalContent?: string;
+	/** Stable identity for inlineOriginalContent so pane reuse/document keys stay correct */
+	inlineOriginalContentKey?: string;
 	/** Initial line to scroll to (raw mode only, transient - applied once) */
 	initialLine?: number;
 	/** Initial column to scroll to (raw mode only, transient - applied once) */

--- a/packages/local-db/src/schema/zod.ts
+++ b/packages/local-db/src/schema/zod.ts
@@ -273,7 +273,13 @@ export const POST_COMMIT_COMMANDS = ["none", "push", "sync"] as const;
 
 export type PostCommitCommand = (typeof POST_COMMIT_COMMANDS)[number];
 
-export const SITE_PERMISSION_KINDS = ["microphone", "camera"] as const;
+export const SITE_PERMISSION_KINDS = [
+	"microphone",
+	"camera",
+	"geolocation",
+	"notifications",
+	"clipboard-read",
+] as const;
 
 export type SitePermissionKind = (typeof SITE_PERMISSION_KINDS)[number];
 


### PR DESCRIPTION
## Summary
- apps/desktop の VS Code extensions に Kimi Code (`moonshot-ai.kimi-code`) を追加
- 右サイドバーと Settings から Kimi を表示・起動できるように調整
- Kimi 拡張が実際に使う VS Code shim を補強し、baseline diff 表示まで Superset 側で受けられるように対応

## Details
- `kimi.webview` / `moonshot-ai.kimi-code` を既知拡張として登録
- `ExtensionContext` の URI 群、`workspace.fs.readDirectory`、`workspace.findFiles`、`createFileSystemWatcher`、`showQuickPick`、`TextEditor.edit` などを Kimi の利用実態に合わせて実装
- `vscode.diff` で `kimi-baseline:` の content provider を解決し、inline baseline content を renderer に渡すよう変更
- file viewer 側に inline original content を持てるようにして、Kimi の baseline diff を Git 由来でない差分でも表示できるようにした

## Validation
- `git diff --check`

## Notes
- このワークツリー単体では `bun` 型定義と `@superset/typescript/electron.json` の解決が不足しており、`tsc --noEmit -p apps/desktop/tsconfig.json` は環境依存エラーで完走していません
- `vscode.openFolder` / settings 画面遷移は現状 no-op ベースのままで、Superset 側の画面遷移導線までは未接続です
