### PR TITLE
feat(desktop): Connect browser automation モーダルのUX改善

### DIFF
--- a/apps/desktop/src/lib/errors.ts
+++ b/apps/desktop/src/lib/errors.ts
@@ -1,0 +1,6 @@
+export class SessionDisposedError extends Error {
+	constructor() {
+		super("TypeScript session disposed");
+		this.name = "SessionDisposedError";
+	}
+}

--- a/apps/desktop/src/lib/trpc/index.ts
+++ b/apps/desktop/src/lib/trpc/index.ts
@@ -2,6 +2,7 @@ import { createTRPCReact } from "@trpc/react-query";
 import { initTRPC } from "@trpc/server";
 import superjson from "superjson";
 import type { AppRouter } from "./routers";
+import { SessionDisposedError } from "../errors";
 import { NotGitRepoError } from "./routers/workspaces/utils/git";
 import { WorktreePathMissingError } from "./routers/workspaces/utils/git-client";
 
@@ -40,8 +41,10 @@ const sentryMiddleware = t.middleware(async ({ next, path, type }) => {
 			if (
 				originalError instanceof NotGitRepoError ||
 				originalError instanceof WorktreePathMissingError ||
+				originalError instanceof SessionDisposedError ||
 				errorName === "NotGitRepoError" ||
-				errorName === "WorktreePathMissingError"
+				errorName === "WorktreePathMissingError" ||
+				errorName === "SessionDisposedError"
 			) {
 				return result;
 			}

--- a/apps/desktop/src/lib/trpc/index.ts
+++ b/apps/desktop/src/lib/trpc/index.ts
@@ -1,8 +1,8 @@
 import { createTRPCReact } from "@trpc/react-query";
 import { initTRPC } from "@trpc/server";
 import superjson from "superjson";
-import type { AppRouter } from "./routers";
 import { SessionDisposedError } from "../errors";
+import type { AppRouter } from "./routers";
 import { NotGitRepoError } from "./routers/workspaces/utils/git";
 import { WorktreePathMissingError } from "./routers/workspaces/utils/git-client";
 

--- a/apps/desktop/src/main/lib/language-services/providers/typescript/TypeScriptLanguageProvider.ts
+++ b/apps/desktop/src/main/lib/language-services/providers/typescript/TypeScriptLanguageProvider.ts
@@ -2,6 +2,7 @@ import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
 import fs from "node:fs";
 import { createRequire } from "node:module";
 import path from "node:path";
+import { SessionDisposedError } from "lib/errors";
 import { resolveShikiLanguageFromFilePath } from "shared/language-registry";
 import { languageDiagnosticsStore } from "../../diagnostics-store";
 import type {
@@ -531,7 +532,7 @@ export class TypeScriptLanguageProvider implements LanguageServiceProvider {
 		}
 
 		for (const request of session.requestResolvers.values()) {
-			request.reject(new Error("TypeScript session disposed"));
+			request.reject(new SessionDisposedError());
 		}
 		session.requestResolvers.clear();
 

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/components/BrowserAutomationList/BrowserAutomationList.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/components/BrowserAutomationList/BrowserAutomationList.tsx
@@ -8,6 +8,7 @@ import {
 } from "@superset/ui/dialog";
 import { cn } from "@superset/ui/utils";
 import { useMemo } from "react";
+import { LuArrowLeft } from "react-icons/lu";
 import { useBrowserAutomationData } from "renderer/hooks/useBrowserAutomationData";
 import { useBrowserAutomationStore } from "renderer/stores/browser-automation";
 import { useTabsStore } from "renderer/stores/tabs/store";
@@ -41,81 +42,112 @@ export function BrowserAutomationList({
 		);
 	}, [panes, tabs, workspaceId]);
 
-	// A binding only counts as "connected" if the bound session is still in
-	// the live session list. Stale bindings render as `Unassigned` in the
-	// row below, so summing raw bindings would show a misleading higher
-	// count.
+	// Stale bindings (bound session no longer live) count as Unassigned.
 	const liveSessionIds = new Set(sessions.map((s) => s.id));
 	const connectedCount = browserPanes.filter((p) => {
 		const sid = bindingsByPane[p.id];
 		return sid && liveSessionIds.has(sid);
 	}).length;
+	const unassignedCount = browserPanes.length - connectedCount;
 	const needsSetupCount = sessions.filter(
 		(s) => s.mcpStatus === "missing",
 	).length;
 
 	return (
 		<Dialog open={open} onOpenChange={onOpenChange}>
-			<DialogContent className="!max-w-[640px] sm:!max-w-[640px] p-0 gap-0 overflow-hidden">
+			<DialogContent className="!max-w-[720px] sm:!max-w-[720px] p-0 gap-0 overflow-hidden">
 				<DialogHeader className="px-5 py-4 border-b">
-					<DialogTitle className="text-sm">Browser Automation</DialogTitle>
+					<DialogTitle className="text-sm">
+						Browser Automation — workspace overview
+					</DialogTitle>
 					<DialogDescription className="text-xs">
-						All browser panes in this workspace and their bound sessions.
+						Every browser pane and which LLM session is driving it.
 					</DialogDescription>
 				</DialogHeader>
 
-				<div className="p-4 grid grid-cols-3 gap-2 border-b">
-					<Metric label="Browser panes" value={browserPanes.length} />
-					<Metric label="Connected" value={connectedCount} />
-					<Metric label="Needs setup" value={needsSetupCount} />
+				<div className="px-4 py-3 border-b flex items-center gap-4 text-[11px]">
+					<span>
+						<b className="text-base tabular-nums">{browserPanes.length}</b>{" "}
+						panes
+					</span>
+					<span className="text-emerald-300">
+						<b className="text-base tabular-nums">{connectedCount}</b> connected
+					</span>
+					<span className="text-muted-foreground">
+						<b className="text-base tabular-nums">{unassignedCount}</b>{" "}
+						unassigned
+					</span>
+					{needsSetupCount > 0 && (
+						<span className="text-amber-400">
+							<b className="text-base tabular-nums">{needsSetupCount}</b> needs
+							setup
+						</span>
+					)}
 				</div>
 
-				<div className="max-h-[420px] overflow-y-auto p-3 flex flex-col gap-2">
+				<div className="max-h-[460px] overflow-y-auto">
 					{browserPanes.length === 0 && (
 						<div className="text-xs text-muted-foreground text-center py-8">
 							No browser panes in this workspace.
 						</div>
 					)}
-					{browserPanes.map((pane) => {
+					{browserPanes.map((pane, index) => {
 						const sessionId = bindingsByPane[pane.id];
 						const session = sessionId
 							? (sessions.find((s) => s.id === sessionId) ?? null)
 							: null;
 						const url = pane.browser?.currentUrl ?? pane.url ?? "about:blank";
+						const isConnected = session !== null;
 						return (
 							<div
 								key={pane.id}
 								className={cn(
-									"rounded-xl border p-3 bg-card/60",
-									session && "border-brand/30 bg-brand/5",
+									"flex items-center gap-3 px-4 py-3 hover:bg-muted/20",
+									index !== browserPanes.length - 1 && "border-b",
 								)}
 							>
-								<div className="flex items-start justify-between gap-3">
-									<div className="min-w-0">
-										<div className="text-xs font-semibold truncate">
-											{pane.userTitle || pane.name}
-										</div>
-										<div className="text-[11px] text-muted-foreground truncate">
-											{url}
-										</div>
+								<span
+									className={cn(
+										"size-2 rounded-full shrink-0",
+										isConnected ? "bg-emerald-400" : "bg-muted-foreground/40",
+									)}
+								/>
+								<div className="min-w-0 flex-1">
+									<div className="text-xs font-semibold truncate">
+										{pane.userTitle || pane.name}
 									</div>
-									<span
-										className={cn(
-											"shrink-0 inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider",
-											session
-												? "bg-emerald-500/15 text-emerald-300"
-												: "bg-muted text-muted-foreground",
-										)}
-									>
-										{session ? "Connected" : "Unassigned"}
-									</span>
+									<div className="text-[11px] text-muted-foreground truncate">
+										{url}
+									</div>
 								</div>
-								<div className="mt-2 text-[11px] text-muted-foreground">
-									{session
-										? `${session.displayName} · ${session.provider} · ${session.mcpStatus === "ready" ? "MCP ready" : "MCP missing"}`
-										: "Pick any running LLM session"}
+								<LuArrowLeft
+									className={cn(
+										"size-3 shrink-0",
+										isConnected
+											? "text-muted-foreground"
+											: "text-muted-foreground/30",
+									)}
+								/>
+								<div className="min-w-0 flex-1">
+									{session ? (
+										<>
+											<div className="text-xs font-medium truncate">
+												{session.displayName}
+											</div>
+											<div className="text-[10px] text-muted-foreground truncate">
+												{session.provider} ·{" "}
+												{session.mcpStatus === "ready"
+													? "MCP ready"
+													: "MCP missing"}
+											</div>
+										</>
+									) : (
+										<div className="text-[11px] text-muted-foreground italic truncate">
+											Unassigned — pick any running LLM session
+										</div>
+									)}
 								</div>
-								<div className="mt-3 flex gap-2">
+								<div className="flex gap-1 shrink-0">
 									<Button
 										size="sm"
 										variant="outline"
@@ -129,20 +161,18 @@ export function BrowserAutomationList({
 									</Button>
 									<Button
 										size="sm"
+										variant={isConnected ? "outline" : "default"}
 										onClick={() => {
-											// SessionConnectModal is rendered inside each
-											// BrowserPane (gated by isConnectOpenForThisPane), so
-											// it only mounts when the owning tab/pane is active.
-											// Activate the target before opening the modal, or the
-											// dialog never appears if the pane lives on another
-											// tab.
+											// SessionConnectModal lives inside BrowserPane and only
+											// mounts for the active pane; activate the target pane
+											// before opening the modal.
 											setActiveTab(workspaceId, pane.tabId);
 											setFocusedPane(pane.tabId, pane.id);
 											openConnectModal(pane.id, sessionId);
 											onOpenChange(false);
 										}}
 									>
-										{session ? "Change" : "Connect"}
+										{isConnected ? "Change" : "Connect"}
 									</Button>
 								</div>
 							</div>
@@ -151,16 +181,5 @@ export function BrowserAutomationList({
 				</div>
 			</DialogContent>
 		</Dialog>
-	);
-}
-
-function Metric({ label, value }: { label: string; value: number }) {
-	return (
-		<div className="rounded-lg bg-muted/40 p-3">
-			<div className="text-xl font-bold tabular-nums">{value}</div>
-			<div className="mt-1 text-[10px] uppercase tracking-wider text-muted-foreground">
-				{label}
-			</div>
-		</div>
 	);
 }

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/components/SessionConnectModal/SessionConnectModal.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/components/SessionConnectModal/SessionConnectModal.tsx
@@ -448,11 +448,15 @@ function WorkspaceBindingsSummary({
 		});
 	}, [panes, tabs, workspaceId]);
 
-	const connected = browserPanes.filter((p) => {
+	let connected = 0;
+	let stale = 0;
+	for (const p of browserPanes) {
 		const sid = bindingsByPane[p.id];
-		return sid && liveSessionIds.has(sid);
-	}).length;
-	const unassigned = browserPanes.length - connected;
+		if (!sid) continue;
+		if (liveSessionIds.has(sid)) connected++;
+		else stale++;
+	}
+	const unassigned = browserPanes.length - connected - stale;
 	const needsSetup = sessions.filter((s) => s.mcpStatus === "missing").length;
 
 	return (
@@ -468,6 +472,12 @@ function WorkspaceBindingsSummary({
 				<span className="size-1.5 rounded-full bg-muted-foreground/50" />
 				{unassigned} unassigned
 			</span>
+			{stale > 0 && (
+				<span className="flex items-center gap-1.5 text-amber-300">
+					<span className="size-1.5 rounded-full bg-amber-400" />
+					{stale} stale
+				</span>
+			)}
 			{needsSetup > 0 && (
 				<span className="flex items-center gap-1.5 text-amber-400">
 					<span className="size-1.5 rounded-full bg-amber-400" />
@@ -633,7 +643,16 @@ function WorkspacePanesTab({
 						? (sessions.find((s) => s.id === sessionId) ?? null)
 						: null;
 					const url = pane.browser?.currentUrl ?? pane.url ?? "about:blank";
+					// Three-state status, matching PaneIdentityCard:
+					// connected (live session), stale (binding exists but session
+					// dropped out of the live set), unassigned (no binding).
 					const isConnected = session !== null;
+					const isStale = sessionId != null && session === null;
+					const dotClass = isConnected
+						? "bg-emerald-400"
+						: isStale
+							? "bg-amber-400"
+							: "bg-muted-foreground/40";
 					const paneDisplay = pane.userTitle || pane.name;
 					return (
 						<div
@@ -643,12 +662,7 @@ function WorkspacePanesTab({
 								index !== browserPanes.length - 1 && "border-b",
 							)}
 						>
-							<span
-								className={cn(
-									"size-2 rounded-full shrink-0",
-									isConnected ? "bg-emerald-400" : "bg-muted-foreground/40",
-								)}
-							/>
+							<span className={cn("size-2 rounded-full shrink-0", dotClass)} />
 							<div className="min-w-0 flex-1">
 								<div
 									className="text-xs font-semibold truncate"
@@ -684,6 +698,10 @@ function WorkspacePanesTab({
 												: "MCP missing"}
 										</div>
 									</>
+								) : isStale ? (
+									<div className="text-[11px] text-amber-300/90 italic truncate">
+										Session ended — rebind or disconnect
+									</div>
 								) : (
 									<div className="text-[11px] text-muted-foreground italic truncate">
 										Unassigned — pick any running LLM session
@@ -716,7 +734,7 @@ function WorkspacePanesTab({
 										onSwitchToSessions();
 									}}
 								>
-									{isConnected ? "Change" : "Connect"}
+									{isConnected ? "Change" : isStale ? "Rebind" : "Connect"}
 								</Button>
 							</div>
 						</div>

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/components/SessionConnectModal/SessionConnectModal.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/components/SessionConnectModal/SessionConnectModal.tsx
@@ -56,6 +56,11 @@ export function SessionConnectModal({
 
 	const pane = useTabsStore((s) => (paneId ? s.panes[paneId] : null));
 	const panes = useTabsStore((s) => s.panes);
+	const tabs = useTabsStore((s) => s.tabs);
+	const workspaceId = useMemo(() => {
+		if (!pane) return null;
+		return tabs.find((t) => t.id === pane.tabId)?.workspaceId ?? null;
+	}, [pane, tabs]);
 
 	const session = selectedSessionId
 		? (sessions.find((s) => s.id === selectedSessionId) ?? null)
@@ -199,6 +204,7 @@ export function SessionConnectModal({
 						<WorkspaceBindingsSummary
 							sessions={sessions}
 							bindingsByPane={bindingsByPane}
+							workspaceId={workspaceId}
 							onOpenAllPanes={() => {
 								onOpenChange(false);
 								setListViewOpen(true);
@@ -210,6 +216,7 @@ export function SessionConnectModal({
 									paneName={paneName}
 									paneUrl={paneUrl}
 									currentSession={currentSession}
+									hasBinding={Boolean(currentBinding)}
 									onDisconnect={currentBinding ? handleDisconnect : undefined}
 									disconnectPending={removeBinding.isPending}
 								/>
@@ -354,23 +361,32 @@ function TabButton({
 function WorkspaceBindingsSummary({
 	sessions,
 	bindingsByPane,
+	workspaceId,
 	onOpenAllPanes,
 }: {
 	sessions: AutomationSession[];
 	bindingsByPane: Record<string, string>;
+	workspaceId: string | null;
 	onOpenAllPanes: () => void;
 }) {
 	const panes = useTabsStore((s) => s.panes);
 	const tabs = useTabsStore((s) => s.tabs);
 	const liveSessionIds = new Set(sessions.map((s) => s.id));
+	// Scope to the current pane's workspace so the summary stays in sync
+	// with BrowserAutomationList (which is already workspace-scoped).
+	// Falling back to the full set when workspaceId is null keeps the
+	// counts non-empty during transient states, but the expected path is
+	// always to filter.
 	const browserPanes = useMemo(() => {
 		const tabById = new Map(tabs.map((t) => [t.id, t]));
 		return Object.values(panes).filter((p) => {
 			if (p.type !== "webview") return false;
 			const tab = tabById.get(p.tabId);
-			return Boolean(tab);
+			if (!tab) return false;
+			if (workspaceId && tab.workspaceId !== workspaceId) return false;
+			return true;
 		});
-	}, [panes, tabs]);
+	}, [panes, tabs, workspaceId]);
 
 	const connected = browserPanes.filter((p) => {
 		const sid = bindingsByPane[p.id];
@@ -414,23 +430,42 @@ function PaneIdentityCard({
 	paneName,
 	paneUrl,
 	currentSession,
+	hasBinding,
 	onDisconnect,
 	disconnectPending,
 }: {
 	paneName: string;
 	paneUrl: string;
 	currentSession: AutomationSession | null;
+	hasBinding: boolean;
 	onDisconnect?: () => void;
 	disconnectPending?: boolean;
 }) {
 	const isConnected = currentSession !== null;
+	// Stale binding: binding record exists but the target session is no
+	// longer in the live set (e.g. the claude/codex process exited).
+	// Surface this explicitly and keep Disconnect available so the user
+	// can clear it without first rebinding to another session.
+	const isStale = hasBinding && !isConnected;
+	const statusLabel = isConnected
+		? "Connected"
+		: isStale
+			? "Session ended"
+			: "Unassigned";
+	const statusClass = isConnected
+		? "bg-emerald-500/15 text-emerald-300"
+		: isStale
+			? "bg-amber-500/15 text-amber-300"
+			: "bg-muted text-muted-foreground";
 	return (
 		<div
 			className={cn(
 				"rounded-xl border p-3 mb-3",
 				isConnected
 					? "border-brand/30 bg-brand/5"
-					: "border-border bg-muted/40",
+					: isStale
+						? "border-amber-500/30 bg-amber-500/5"
+						: "border-border bg-muted/40",
 			)}
 		>
 			<div className="flex items-start gap-3">
@@ -443,12 +478,10 @@ function PaneIdentityCard({
 						<span
 							className={cn(
 								"shrink-0 inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider",
-								isConnected
-									? "bg-emerald-500/15 text-emerald-300"
-									: "bg-muted text-muted-foreground",
+								statusClass,
 							)}
 						>
-							{isConnected ? "Connected" : "Unassigned"}
+							{statusLabel}
 						</span>
 					</div>
 					<div className="text-[11px] text-muted-foreground truncate">
@@ -465,6 +498,11 @@ function PaneIdentityCard({
 									({currentSession.provider})
 								</span>
 							</>
+						) : isStale ? (
+							<span className="text-amber-300/80">
+								Previous session has ended — disconnect to clear, or pick a new
+								one below.
+							</span>
 						) : (
 							<span className="text-muted-foreground">
 								No session is driving this pane yet.
@@ -472,7 +510,7 @@ function PaneIdentityCard({
 						)}
 					</div>
 				</div>
-				{isConnected && onDisconnect && (
+				{hasBinding && onDisconnect && (
 					<button
 						type="button"
 						onClick={onDisconnect}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/components/SessionConnectModal/SessionConnectModal.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/components/SessionConnectModal/SessionConnectModal.tsx
@@ -197,8 +197,8 @@ export function SessionConnectModal({
 
 	return (
 		<Dialog open={open} onOpenChange={onOpenChange}>
-			<DialogContent className="!max-w-[min(1640px,95vw)] sm:!max-w-[min(1640px,95vw)] p-0 gap-0 overflow-hidden">
-				<DialogHeader className="px-5 py-4 border-b">
+			<DialogContent className="!max-w-[min(1640px,95vw)] sm:!max-w-[min(1640px,95vw)] h-[min(840px,85vh)] p-0 gap-0 overflow-hidden flex flex-col">
+				<DialogHeader className="px-5 py-4 border-b shrink-0">
 					<DialogTitle className="text-sm">
 						Connect browser automation
 					</DialogTitle>
@@ -230,111 +230,106 @@ export function SessionConnectModal({
 					</div>
 				</DialogHeader>
 
+				{activeTab !== "permissions" && (
+					<WorkspaceBindingsSummary
+						sessions={sessions}
+						bindingsByPane={bindingsByPane}
+						workspaceId={workspaceId}
+						onOpenAllPanes={() => setActiveTab("workspace")}
+						activeTab={activeTab}
+					/>
+				)}
+
 				{activeTab === "permissions" ? (
-					<PermissionsTab />
+					<div className="flex-1 min-h-0">
+						<PermissionsTab />
+					</div>
 				) : activeTab === "workspace" ? (
-					<>
-						<WorkspaceBindingsSummary
-							sessions={sessions}
-							bindingsByPane={bindingsByPane}
-							workspaceId={workspaceId}
-							onOpenAllPanes={() => setActiveTab("workspace")}
-							activeTab={activeTab}
-						/>
+					<div className="flex-1 min-h-0">
 						<WorkspacePanesTab
 							workspaceId={workspaceId}
 							onClose={() => onOpenChange(false)}
 							onSwitchToSessions={() => setActiveTab("sessions")}
 						/>
-					</>
+					</div>
 				) : (
-					<>
-						<WorkspaceBindingsSummary
-							sessions={sessions}
-							bindingsByPane={bindingsByPane}
-							workspaceId={workspaceId}
-							onOpenAllPanes={() => setActiveTab("workspace")}
-							activeTab={activeTab}
-						/>
-						<div className="grid grid-cols-[minmax(320px,1fr)_minmax(280px,0.9fr)] min-h-[min(570px,70vh)] max-h-[min(840px,85vh)]">
-							<div className="overflow-y-auto p-4 border-r">
-								<PaneIdentityCard
-									paneName={paneName}
-									paneUrl={paneUrl}
-									currentSession={currentSession}
-									hasBinding={Boolean(currentBinding)}
-									onDisconnect={currentBinding ? handleDisconnect : undefined}
-									disconnectPending={removeBinding.isPending}
-								/>
+					<div className="flex-1 min-h-0 grid grid-cols-[minmax(320px,1fr)_minmax(280px,0.9fr)]">
+						<div className="overflow-y-auto p-4 border-r">
+							<PaneIdentityCard
+								paneName={paneName}
+								paneUrl={paneUrl}
+								currentSession={currentSession}
+								hasBinding={Boolean(currentBinding)}
+								onDisconnect={currentBinding ? handleDisconnect : undefined}
+								disconnectPending={removeBinding.isPending}
+							/>
 
-								<div className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/70 px-1 mb-2">
-									Running sessions
+							<div className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/70 px-1 mb-2">
+								Running sessions
+							</div>
+
+							{sessions.length === 0 ? (
+								<div className="rounded-xl border border-dashed p-6 text-center text-xs text-muted-foreground">
+									No running LLM sessions found. Start a TODO-Agent session or
+									run `claude` / `codex` in any terminal pane, then return here.
 								</div>
-
-								{sessions.length === 0 ? (
-									<div className="rounded-xl border border-dashed p-6 text-center text-xs text-muted-foreground">
-										No running LLM sessions found. Start a TODO-Agent session or
-										run `claude` / `codex` in any terminal pane, then return
-										here.
-									</div>
-								) : (
-									<div className="flex flex-col gap-2">
-										{sessions.map((s) => {
-											const otherPaneId = Object.entries(bindingsByPane).find(
-												([pid, sid]) => sid === s.id && pid !== paneId,
-											)?.[0];
-											const otherPaneName = otherPaneId
-												? (panes[otherPaneId]?.name ?? null)
-												: null;
-											return (
-												<SessionCard
-													key={s.id}
-													session={s}
-													isSelected={s.id === selectedSessionId}
-													attachedToThisPane={s.id === currentBinding}
-													assignedElsewherePaneName={otherPaneName}
-													onSelect={() => setSelectedSession(s.id)}
-												/>
-											);
-										})}
-									</div>
-								)}
-							</div>
-
-							<div className="overflow-y-auto p-4 bg-muted/20">
-								{session ? (
-									session.mcpStatus === "ready" ? (
-										<ReadyPanel
-											session={session}
-											paneName={paneName}
-											reassigning={Boolean(assignedPaneIdForSelected)}
-											previousPaneName={
-												assignedPaneIdForSelected
-													? (panes[assignedPaneIdForSelected]?.name ?? null)
-													: null
-											}
-											attachedToThisPane={session.id === currentBinding}
-										/>
-									) : (
-										<SetupPanel
-											session={session}
-											mcpConfigPath={
-												session.provider === "Codex"
-													? (mcpStatus?.codexConfigPath ?? null)
-													: (mcpStatus?.claudeConfigPath ?? null)
-											}
-											serverCommand={serverCommand}
-											onCopy={handleCopySnippet}
-										/>
-									)
-								) : (
-									<div className="text-xs text-muted-foreground">
-										Select a session to see details.
-									</div>
-								)}
-							</div>
+							) : (
+								<div className="flex flex-col gap-2">
+									{sessions.map((s) => {
+										const otherPaneId = Object.entries(bindingsByPane).find(
+											([pid, sid]) => sid === s.id && pid !== paneId,
+										)?.[0];
+										const otherPaneName = otherPaneId
+											? (panes[otherPaneId]?.name ?? null)
+											: null;
+										return (
+											<SessionCard
+												key={s.id}
+												session={s}
+												isSelected={s.id === selectedSessionId}
+												attachedToThisPane={s.id === currentBinding}
+												assignedElsewherePaneName={otherPaneName}
+												onSelect={() => setSelectedSession(s.id)}
+											/>
+										);
+									})}
+								</div>
+							)}
 						</div>
-					</>
+
+						<div className="overflow-y-auto p-4 bg-muted/20">
+							{session ? (
+								session.mcpStatus === "ready" ? (
+									<ReadyPanel
+										session={session}
+										paneName={paneName}
+										reassigning={Boolean(assignedPaneIdForSelected)}
+										previousPaneName={
+											assignedPaneIdForSelected
+												? (panes[assignedPaneIdForSelected]?.name ?? null)
+												: null
+										}
+										attachedToThisPane={session.id === currentBinding}
+									/>
+								) : (
+									<SetupPanel
+										session={session}
+										mcpConfigPath={
+											session.provider === "Codex"
+												? (mcpStatus?.codexConfigPath ?? null)
+												: (mcpStatus?.claudeConfigPath ?? null)
+										}
+										serverCommand={serverCommand}
+										onCopy={handleCopySnippet}
+									/>
+								)
+							) : (
+								<div className="text-xs text-muted-foreground">
+									Select a session to see details.
+								</div>
+							)}
+						</div>
+					</div>
 				)}
 
 				{activeTab === "sessions" && (

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/components/SessionConnectModal/SessionConnectModal.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/components/SessionConnectModal/SessionConnectModal.tsx
@@ -10,7 +10,13 @@ import {
 import { toast } from "@superset/ui/sonner";
 import { cn } from "@superset/ui/utils";
 import { useEffect, useMemo, useState } from "react";
-import { LuList, LuPlug, LuShield } from "react-icons/lu";
+import {
+	LuArrowLeft,
+	LuLayoutGrid,
+	LuList,
+	LuPlug,
+	LuShield,
+} from "react-icons/lu";
 import { useBrowserAutomationData } from "renderer/hooks/useBrowserAutomationData";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import {
@@ -24,6 +30,27 @@ import { CdpEndpointCard } from "./components/CdpEndpointCard";
 import { McpInstallPanel } from "./components/McpInstallPanel";
 import { PermissionsTab } from "./components/PermissionsTab";
 
+/**
+ * pane.name / userTitle は長大な URL (特に Google 検索結果の query
+ * 付き) になることがあり、pill / DetailItem / footer 文言にそのまま流すと
+ * モーダルからはみ出す。URL は host + 先頭パスだけに縮め、それ以外は
+ * 40 文字でカットしてツールチップに全文を出すための補助。
+ */
+function shortenPaneLabel(raw: string, max = 40): string {
+	if (!raw) return raw;
+	try {
+		if (raw.startsWith("http://") || raw.startsWith("https://")) {
+			const url = new URL(raw);
+			const tail = `${url.pathname}${url.search ? "?…" : ""}`;
+			const short = `${url.host}${tail}`;
+			return short.length > max ? `${short.slice(0, max - 1)}…` : short;
+		}
+	} catch {
+		// fall through to generic truncation
+	}
+	return raw.length > max ? `${raw.slice(0, max - 1)}…` : raw;
+}
+
 interface SessionConnectModalProps {
 	open: boolean;
 	onOpenChange: (open: boolean) => void;
@@ -33,9 +60,9 @@ export function SessionConnectModal({
 	open,
 	onOpenChange,
 }: SessionConnectModalProps) {
-	const [activeTab, setActiveTab] = useState<"sessions" | "permissions">(
-		"sessions",
-	);
+	const [activeTab, setActiveTab] = useState<
+		"sessions" | "workspace" | "permissions"
+	>("sessions");
 	const paneId = useBrowserAutomationStore((s) => s.connectModal.paneId);
 	const selectedSessionId = useBrowserAutomationStore(
 		(s) => s.connectModal.selectedSessionId,
@@ -43,7 +70,6 @@ export function SessionConnectModal({
 	const setSelectedSession = useBrowserAutomationStore(
 		(s) => s.setSelectedSession,
 	);
-	const setListViewOpen = useBrowserAutomationStore((s) => s.setListViewOpen);
 
 	const { sessions, bindingsByPane, mcpStatus } = useBrowserAutomationData({
 		enabled: open,
@@ -188,6 +214,13 @@ export function SessionConnectModal({
 							Sessions
 						</TabButton>
 						<TabButton
+							active={activeTab === "workspace"}
+							onClick={() => setActiveTab("workspace")}
+						>
+							<LuLayoutGrid className="size-3.5" />
+							Workspace
+						</TabButton>
+						<TabButton
 							active={activeTab === "permissions"}
 							onClick={() => setActiveTab("permissions")}
 						>
@@ -199,16 +232,29 @@ export function SessionConnectModal({
 
 				{activeTab === "permissions" ? (
 					<PermissionsTab />
+				) : activeTab === "workspace" ? (
+					<>
+						<WorkspaceBindingsSummary
+							sessions={sessions}
+							bindingsByPane={bindingsByPane}
+							workspaceId={workspaceId}
+							onOpenAllPanes={() => setActiveTab("workspace")}
+							activeTab={activeTab}
+						/>
+						<WorkspacePanesTab
+							workspaceId={workspaceId}
+							onClose={() => onOpenChange(false)}
+							onSwitchToSessions={() => setActiveTab("sessions")}
+						/>
+					</>
 				) : (
 					<>
 						<WorkspaceBindingsSummary
 							sessions={sessions}
 							bindingsByPane={bindingsByPane}
 							workspaceId={workspaceId}
-							onOpenAllPanes={() => {
-								onOpenChange(false);
-								setListViewOpen(true);
-							}}
+							onOpenAllPanes={() => setActiveTab("workspace")}
+							activeTab={activeTab}
 						/>
 						<div className="grid grid-cols-[minmax(320px,1fr)_minmax(280px,0.9fr)] min-h-[min(570px,70vh)] max-h-[min(840px,85vh)]">
 							<div className="overflow-y-auto p-4 border-r">
@@ -293,10 +339,13 @@ export function SessionConnectModal({
 
 				{activeTab === "sessions" && (
 					<DialogFooter className="px-5 py-3 border-t gap-2 flex !justify-between">
-						<div className="text-[11px] text-muted-foreground">
+						<div className="text-[11px] text-muted-foreground min-w-0 flex-1 line-clamp-2 break-words">
 							{session?.mcpStatus === "ready"
 								? assignedPaneIdForSelected
-									? `Connecting will reassign ${session.displayName} from ${panes[assignedPaneIdForSelected]?.name ?? "another pane"} to ${paneName}.`
+									? `Connecting will reassign ${session.displayName} from "${shortenPaneLabel(
+											panes[assignedPaneIdForSelected]?.name ?? "another pane",
+											32,
+										)}" to "${shortenPaneLabel(paneName, 32)}".`
 									: "Connecting binds this browser pane to the selected session only."
 								: session
 									? "Add the MCP entry first, then reopen or restart this session."
@@ -363,11 +412,13 @@ function WorkspaceBindingsSummary({
 	bindingsByPane,
 	workspaceId,
 	onOpenAllPanes,
+	activeTab,
 }: {
 	sessions: AutomationSession[];
 	bindingsByPane: Record<string, string>;
 	workspaceId: string | null;
 	onOpenAllPanes: () => void;
+	activeTab: "sessions" | "workspace" | "permissions";
 }) {
 	const panes = useTabsStore((s) => s.panes);
 	const tabs = useTabsStore((s) => s.tabs);
@@ -414,14 +465,16 @@ function WorkspaceBindingsSummary({
 					{needsSetup} needs setup
 				</span>
 			)}
-			<button
-				type="button"
-				onClick={onOpenAllPanes}
-				className="ml-auto inline-flex items-center gap-1 text-brand hover:underline"
-			>
-				<LuList className="size-3" />
-				Open all panes view →
-			</button>
+			{activeTab !== "workspace" && (
+				<button
+					type="button"
+					onClick={onOpenAllPanes}
+					className="ml-auto inline-flex items-center gap-1 text-brand hover:underline"
+				>
+					<LuLayoutGrid className="size-3" />
+					Switch to Workspace view →
+				</button>
+			)}
 		</div>
 	);
 }
@@ -474,7 +527,12 @@ function PaneIdentityCard({
 				</div>
 				<div className="min-w-0 flex-1">
 					<div className="flex items-center gap-2">
-						<div className="text-[13px] font-semibold truncate">{paneName}</div>
+						<div
+							className="text-[13px] font-semibold truncate"
+							title={paneName}
+						>
+							{shortenPaneLabel(paneName, 50)}
+						</div>
 						<span
 							className={cn(
 								"shrink-0 inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider",
@@ -525,6 +583,142 @@ function PaneIdentityCard({
 	);
 }
 
+function WorkspacePanesTab({
+	workspaceId,
+	onClose,
+	onSwitchToSessions,
+}: {
+	workspaceId: string | null;
+	onClose: () => void;
+	onSwitchToSessions: () => void;
+}) {
+	const panes = useTabsStore((s) => s.panes);
+	const tabs = useTabsStore((s) => s.tabs);
+	const setFocusedPane = useTabsStore((s) => s.setFocusedPane);
+	const setActiveTabInStore = useTabsStore((s) => s.setActiveTab);
+	const openConnectModal = useBrowserAutomationStore((s) => s.openConnectModal);
+	const { sessions, bindingsByPane } = useBrowserAutomationData({
+		enabled: true,
+	});
+
+	const browserPanes = useMemo(() => {
+		const tabById = new Map(tabs.map((t) => [t.id, t]));
+		return Object.values(panes).filter((p) => {
+			if (p.type !== "webview") return false;
+			const tab = tabById.get(p.tabId);
+			if (!tab) return false;
+			if (workspaceId && tab.workspaceId !== workspaceId) return false;
+			return true;
+		});
+	}, [panes, tabs, workspaceId]);
+
+	return (
+		<div className="min-h-[min(570px,70vh)] max-h-[min(840px,85vh)] overflow-y-auto">
+			{browserPanes.length === 0 ? (
+				<div className="text-xs text-muted-foreground text-center py-10">
+					No browser panes in this workspace.
+				</div>
+			) : (
+				browserPanes.map((pane, index) => {
+					const sessionId = bindingsByPane[pane.id];
+					const session = sessionId
+						? (sessions.find((s) => s.id === sessionId) ?? null)
+						: null;
+					const url = pane.browser?.currentUrl ?? pane.url ?? "about:blank";
+					const isConnected = session !== null;
+					const paneDisplay = pane.userTitle || pane.name;
+					return (
+						<div
+							key={pane.id}
+							className={cn(
+								"flex items-center gap-3 px-5 py-3 hover:bg-muted/20",
+								index !== browserPanes.length - 1 && "border-b",
+							)}
+						>
+							<span
+								className={cn(
+									"size-2 rounded-full shrink-0",
+									isConnected ? "bg-emerald-400" : "bg-muted-foreground/40",
+								)}
+							/>
+							<div className="min-w-0 flex-1">
+								<div
+									className="text-xs font-semibold truncate"
+									title={paneDisplay}
+								>
+									{shortenPaneLabel(paneDisplay, 50)}
+								</div>
+								<div
+									className="text-[11px] text-muted-foreground truncate"
+									title={url}
+								>
+									{url}
+								</div>
+							</div>
+							<LuArrowLeft
+								className={cn(
+									"size-3 shrink-0",
+									isConnected
+										? "text-muted-foreground"
+										: "text-muted-foreground/30",
+								)}
+							/>
+							<div className="min-w-0 flex-1">
+								{session ? (
+									<>
+										<div className="text-xs font-medium truncate">
+											{session.displayName}
+										</div>
+										<div className="text-[10px] text-muted-foreground truncate">
+											{session.provider} ·{" "}
+											{session.mcpStatus === "ready"
+												? "MCP ready"
+												: "MCP missing"}
+										</div>
+									</>
+								) : (
+									<div className="text-[11px] text-muted-foreground italic truncate">
+										Unassigned — pick any running LLM session
+									</div>
+								)}
+							</div>
+							<div className="flex gap-1 shrink-0">
+								<Button
+									size="sm"
+									variant="outline"
+									onClick={() => {
+										if (workspaceId) {
+											setActiveTabInStore(workspaceId, pane.tabId);
+										}
+										setFocusedPane(pane.tabId, pane.id);
+										onClose();
+									}}
+								>
+									Focus
+								</Button>
+								<Button
+									size="sm"
+									variant={isConnected ? "outline" : "default"}
+									onClick={() => {
+										if (workspaceId) {
+											setActiveTabInStore(workspaceId, pane.tabId);
+										}
+										setFocusedPane(pane.tabId, pane.id);
+										openConnectModal(pane.id, sessionId);
+										onSwitchToSessions();
+									}}
+								>
+									{isConnected ? "Change" : "Connect"}
+								</Button>
+							</div>
+						</div>
+					);
+				})
+			)}
+		</div>
+	);
+}
+
 function SessionCard({
 	session,
 	isSelected,
@@ -552,19 +746,23 @@ function SessionCard({
 				: session.mcpStatus === "missing"
 					? "bg-amber-500/15 text-amber-300"
 					: "bg-muted text-muted-foreground";
+	const shortOtherPane = assignedElsewherePaneName
+		? shortenPaneLabel(assignedElsewherePaneName, 28)
+		: null;
 	const pillLabel = attachedToThisPane
 		? "● Driving this pane"
-		: assignedElsewherePaneName
-			? `Driving: ${assignedElsewherePaneName}`
+		: shortOtherPane
+			? `Driving: ${shortOtherPane}`
 			: session.mcpStatus === "ready"
 				? "Ready · Free"
 				: session.mcpStatus === "missing"
 					? "Needs MCP"
 					: "Unknown";
+	const pillTooltip = assignedElsewherePaneName ?? pillLabel;
 	const note = attachedToThisPane
 		? null
 		: assignedElsewherePaneName
-			? `Connecting here will move ownership from "${assignedElsewherePaneName}".`
+			? `Connecting here will move ownership from "${shortenPaneLabel(assignedElsewherePaneName, 60)}".`
 			: session.mcpStatus === "missing"
 				? "This session does not currently expose the required browser automation MCP entry."
 				: session.mcpStatus === "unknown"
@@ -594,10 +792,10 @@ function SessionCard({
 				</div>
 				<span
 					className={cn(
-						"shrink-0 inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider max-w-[55%] truncate",
+						"shrink-0 max-w-[50%] rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider overflow-hidden whitespace-nowrap text-ellipsis",
 						pillClass,
 					)}
-					title={pillLabel}
+					title={pillTooltip}
 				>
 					{pillLabel}
 				</span>
@@ -605,7 +803,7 @@ function SessionCard({
 			{note && (
 				<div
 					className={cn(
-						"mt-2 text-[11px] leading-snug",
+						"mt-2 text-[11px] leading-snug break-words",
 						assignedElsewherePaneName
 							? "text-amber-300/80"
 							: "text-muted-foreground",
@@ -649,10 +847,12 @@ function ReadyPanel({
 						{session.displayName} / {session.provider}
 					</DetailItem>
 					<DetailItem label="Binding mode">Exclusive control</DetailItem>
-					<DetailItem label="Pane">{paneName}</DetailItem>
+					<DetailItem label="Pane" title={paneName}>
+						{shortenPaneLabel(paneName, 60)}
+					</DetailItem>
 					<DetailItem label="Expected">
 						{reassigning
-							? `Moves from ${previousPaneName ?? "another pane"}`
+							? `Moves from ${shortenPaneLabel(previousPaneName ?? "another pane", 32)}`
 							: "Toolbar badge updates instantly"}
 					</DetailItem>
 				</div>
@@ -665,16 +865,21 @@ function ReadyPanel({
 function DetailItem({
 	label,
 	children,
+	title,
 }: {
 	label: string;
 	children: React.ReactNode;
+	title?: string;
 }) {
 	return (
-		<div className="rounded-md bg-muted/40 p-2">
+		<div className="rounded-md bg-muted/40 p-2 min-w-0">
 			<span className="block text-[10px] uppercase tracking-wider text-muted-foreground/70">
 				{label}
 			</span>
-			<strong className="block mt-0.5 text-[12px] font-medium">
+			<strong
+				className="block mt-0.5 text-[12px] font-medium break-words"
+				title={title}
+			>
 				{children}
 			</strong>
 		</div>

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/components/SessionConnectModal/SessionConnectModal.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/components/SessionConnectModal/SessionConnectModal.tsx
@@ -27,7 +27,10 @@ import {
 	useBrowserAutomationStore,
 } from "renderer/stores/browser-automation";
 import { useTabsStore } from "renderer/stores/tabs/store";
-import { CdpEndpointCard } from "./components/CdpEndpointCard";
+import {
+	CdpEndpointCard,
+	PlaceholderSetupCommandsCard,
+} from "./components/CdpEndpointCard";
 import { McpInstallPanel } from "./components/McpInstallPanel";
 import { PermissionsTab } from "./components/PermissionsTab";
 
@@ -304,7 +307,13 @@ export function SessionConnectModal({
 							)}
 						</div>
 
-						<div className="overflow-y-auto p-4 bg-muted/20">
+						<div className="overflow-y-auto p-4 bg-muted/20 flex flex-col gap-3">
+							{setupRevealToken > 0 && session?.id !== currentBinding && (
+								<PlaceholderSetupCommandsCard
+									revealToken={setupRevealToken}
+									onDismiss={() => setSetupRevealToken(0)}
+								/>
+							)}
 							{session ? (
 								session.mcpStatus === "ready" ? (
 									<ReadyPanel

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/components/SessionConnectModal/SessionConnectModal.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/components/SessionConnectModal/SessionConnectModal.tsx
@@ -10,7 +10,7 @@ import {
 import { toast } from "@superset/ui/sonner";
 import { cn } from "@superset/ui/utils";
 import { useEffect, useMemo, useState } from "react";
-import { LuList, LuShield } from "react-icons/lu";
+import { LuList, LuPlug, LuShield } from "react-icons/lu";
 import { useBrowserAutomationData } from "renderer/hooks/useBrowserAutomationData";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import {
@@ -195,100 +195,93 @@ export function SessionConnectModal({
 				{activeTab === "permissions" ? (
 					<PermissionsTab />
 				) : (
-					<div className="grid grid-cols-[minmax(320px,1fr)_minmax(280px,0.9fr)] min-h-[min(570px,70vh)] max-h-[min(840px,85vh)]">
-						<div className="overflow-y-auto p-4 border-r">
-							<div className="flex items-center gap-3 rounded-lg bg-muted/40 px-3 py-2.5 mb-3">
-								<div className="flex size-7 items-center justify-center rounded-md bg-brand/15 text-brand text-sm font-bold">
-									◎
+					<>
+						<WorkspaceBindingsSummary
+							sessions={sessions}
+							bindingsByPane={bindingsByPane}
+							onOpenAllPanes={() => {
+								onOpenChange(false);
+								setListViewOpen(true);
+							}}
+						/>
+						<div className="grid grid-cols-[minmax(320px,1fr)_minmax(280px,0.9fr)] min-h-[min(570px,70vh)] max-h-[min(840px,85vh)]">
+							<div className="overflow-y-auto p-4 border-r">
+								<PaneIdentityCard
+									paneName={paneName}
+									paneUrl={paneUrl}
+									currentSession={currentSession}
+									onDisconnect={currentBinding ? handleDisconnect : undefined}
+									disconnectPending={removeBinding.isPending}
+								/>
+
+								<div className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/70 px-1 mb-2">
+									Running sessions
 								</div>
-								<div className="min-w-0">
-									<div className="text-xs font-semibold truncate">
-										{paneName}
+
+								{sessions.length === 0 ? (
+									<div className="rounded-xl border border-dashed p-6 text-center text-xs text-muted-foreground">
+										No running LLM sessions found. Start a TODO-Agent session or
+										run `claude` / `codex` in any terminal pane, then return
+										here.
 									</div>
-									<div className="text-[11px] text-muted-foreground truncate">
-										{paneUrl}
-									</div>
-								</div>
-								<button
-									type="button"
-									onClick={() => {
-										// Close this dialog first so focus traps don't stack.
-										onOpenChange(false);
-										setListViewOpen(true);
-									}}
-									className="ml-auto inline-flex items-center gap-1 rounded-md border bg-background/60 px-2 py-1 text-[11px] text-muted-foreground hover:text-foreground"
-								>
-									<LuList className="size-3" />
-									All panes
-								</button>
-							</div>
-
-							<div className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/70 px-1 mb-2">
-								Running sessions
-							</div>
-
-							{sessions.length === 0 ? (
-								<div className="rounded-xl border border-dashed p-6 text-center text-xs text-muted-foreground">
-									No running LLM sessions found. Start a TODO-Agent session or
-									run `claude` / `codex` in any terminal pane, then return here.
-								</div>
-							) : (
-								<div className="flex flex-col gap-2">
-									{sessions.map((s) => {
-										const otherPaneId = Object.entries(bindingsByPane).find(
-											([pid, sid]) => sid === s.id && pid !== paneId,
-										)?.[0];
-										const otherPaneName = otherPaneId
-											? (panes[otherPaneId]?.name ?? null)
-											: null;
-										return (
-											<SessionCard
-												key={s.id}
-												session={s}
-												isSelected={s.id === selectedSessionId}
-												attachedToThisPane={s.id === currentBinding}
-												assignedElsewherePaneName={otherPaneName}
-												onSelect={() => setSelectedSession(s.id)}
-											/>
-										);
-									})}
-								</div>
-							)}
-						</div>
-
-						<div className="overflow-y-auto p-4 bg-muted/20">
-							{session ? (
-								session.mcpStatus === "ready" ? (
-									<ReadyPanel
-										session={session}
-										paneName={paneName}
-										reassigning={Boolean(assignedPaneIdForSelected)}
-										previousPaneName={
-											assignedPaneIdForSelected
-												? (panes[assignedPaneIdForSelected]?.name ?? null)
-												: null
-										}
-										attachedToThisPane={session.id === currentBinding}
-									/>
 								) : (
-									<SetupPanel
-										session={session}
-										mcpConfigPath={
-											session.provider === "Codex"
-												? (mcpStatus?.codexConfigPath ?? null)
-												: (mcpStatus?.claudeConfigPath ?? null)
-										}
-										serverCommand={serverCommand}
-										onCopy={handleCopySnippet}
-									/>
-								)
-							) : (
-								<div className="text-xs text-muted-foreground">
-									Select a session to see details.
-								</div>
-							)}
+									<div className="flex flex-col gap-2">
+										{sessions.map((s) => {
+											const otherPaneId = Object.entries(bindingsByPane).find(
+												([pid, sid]) => sid === s.id && pid !== paneId,
+											)?.[0];
+											const otherPaneName = otherPaneId
+												? (panes[otherPaneId]?.name ?? null)
+												: null;
+											return (
+												<SessionCard
+													key={s.id}
+													session={s}
+													isSelected={s.id === selectedSessionId}
+													attachedToThisPane={s.id === currentBinding}
+													assignedElsewherePaneName={otherPaneName}
+													onSelect={() => setSelectedSession(s.id)}
+												/>
+											);
+										})}
+									</div>
+								)}
+							</div>
+
+							<div className="overflow-y-auto p-4 bg-muted/20">
+								{session ? (
+									session.mcpStatus === "ready" ? (
+										<ReadyPanel
+											session={session}
+											paneName={paneName}
+											reassigning={Boolean(assignedPaneIdForSelected)}
+											previousPaneName={
+												assignedPaneIdForSelected
+													? (panes[assignedPaneIdForSelected]?.name ?? null)
+													: null
+											}
+											attachedToThisPane={session.id === currentBinding}
+										/>
+									) : (
+										<SetupPanel
+											session={session}
+											mcpConfigPath={
+												session.provider === "Codex"
+													? (mcpStatus?.codexConfigPath ?? null)
+													: (mcpStatus?.claudeConfigPath ?? null)
+											}
+											serverCommand={serverCommand}
+											onCopy={handleCopySnippet}
+										/>
+									)
+								) : (
+									<div className="text-xs text-muted-foreground">
+										Select a session to see details.
+									</div>
+								)}
+							</div>
 						</div>
-					</div>
+					</>
 				)}
 
 				{activeTab === "sessions" && (
@@ -305,17 +298,6 @@ export function SessionConnectModal({
 										: "Select a session from the left."}
 						</div>
 						<div className="flex items-center gap-2">
-							{currentBinding && (
-								<Button
-									variant="outline"
-									size="sm"
-									onClick={handleDisconnect}
-									disabled={removeBinding.isPending}
-								>
-									Disconnect
-									{currentSession ? ` ${currentSession.displayName}` : ""}
-								</Button>
-							)}
 							<Button
 								variant="outline"
 								size="sm"
@@ -369,6 +351,142 @@ function TabButton({
 	);
 }
 
+function WorkspaceBindingsSummary({
+	sessions,
+	bindingsByPane,
+	onOpenAllPanes,
+}: {
+	sessions: AutomationSession[];
+	bindingsByPane: Record<string, string>;
+	onOpenAllPanes: () => void;
+}) {
+	const panes = useTabsStore((s) => s.panes);
+	const tabs = useTabsStore((s) => s.tabs);
+	const liveSessionIds = new Set(sessions.map((s) => s.id));
+	const browserPanes = useMemo(() => {
+		const tabById = new Map(tabs.map((t) => [t.id, t]));
+		return Object.values(panes).filter((p) => {
+			if (p.type !== "webview") return false;
+			const tab = tabById.get(p.tabId);
+			return Boolean(tab);
+		});
+	}, [panes, tabs]);
+
+	const connected = browserPanes.filter((p) => {
+		const sid = bindingsByPane[p.id];
+		return sid && liveSessionIds.has(sid);
+	}).length;
+	const unassigned = browserPanes.length - connected;
+	const needsSetup = sessions.filter((s) => s.mcpStatus === "missing").length;
+
+	return (
+		<div className="px-5 py-2 border-b flex items-center gap-3 text-[11px] bg-muted/20">
+			<span className="text-muted-foreground uppercase tracking-wider text-[10px] font-semibold">
+				Workspace bindings
+			</span>
+			<span className="flex items-center gap-1.5">
+				<span className="size-1.5 rounded-full bg-emerald-400" />
+				{connected} connected
+			</span>
+			<span className="flex items-center gap-1.5 text-muted-foreground">
+				<span className="size-1.5 rounded-full bg-muted-foreground/50" />
+				{unassigned} unassigned
+			</span>
+			{needsSetup > 0 && (
+				<span className="flex items-center gap-1.5 text-amber-400">
+					<span className="size-1.5 rounded-full bg-amber-400" />
+					{needsSetup} needs setup
+				</span>
+			)}
+			<button
+				type="button"
+				onClick={onOpenAllPanes}
+				className="ml-auto inline-flex items-center gap-1 text-brand hover:underline"
+			>
+				<LuList className="size-3" />
+				Open all panes view →
+			</button>
+		</div>
+	);
+}
+
+function PaneIdentityCard({
+	paneName,
+	paneUrl,
+	currentSession,
+	onDisconnect,
+	disconnectPending,
+}: {
+	paneName: string;
+	paneUrl: string;
+	currentSession: AutomationSession | null;
+	onDisconnect?: () => void;
+	disconnectPending?: boolean;
+}) {
+	const isConnected = currentSession !== null;
+	return (
+		<div
+			className={cn(
+				"rounded-xl border p-3 mb-3",
+				isConnected
+					? "border-brand/30 bg-brand/5"
+					: "border-border bg-muted/40",
+			)}
+		>
+			<div className="flex items-start gap-3">
+				<div className="flex size-9 items-center justify-center rounded-lg bg-brand/15 text-brand text-base font-bold shrink-0">
+					<LuPlug className="size-4" />
+				</div>
+				<div className="min-w-0 flex-1">
+					<div className="flex items-center gap-2">
+						<div className="text-[13px] font-semibold truncate">{paneName}</div>
+						<span
+							className={cn(
+								"shrink-0 inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider",
+								isConnected
+									? "bg-emerald-500/15 text-emerald-300"
+									: "bg-muted text-muted-foreground",
+							)}
+						>
+							{isConnected ? "Connected" : "Unassigned"}
+						</span>
+					</div>
+					<div className="text-[11px] text-muted-foreground truncate">
+						{paneUrl}
+					</div>
+					<div className="mt-1.5 text-[11px] flex items-center gap-1.5 flex-wrap">
+						{isConnected ? (
+							<>
+								<span className="text-muted-foreground">Driven by:</span>
+								<span className="font-medium">
+									{currentSession.displayName}
+								</span>
+								<span className="text-muted-foreground">
+									({currentSession.provider})
+								</span>
+							</>
+						) : (
+							<span className="text-muted-foreground">
+								No session is driving this pane yet.
+							</span>
+						)}
+					</div>
+				</div>
+				{isConnected && onDisconnect && (
+					<button
+						type="button"
+						onClick={onDisconnect}
+						disabled={disconnectPending}
+						className="h-7 px-2 rounded-md border text-[11px] shrink-0 hover:bg-muted/40 disabled:opacity-50"
+					>
+						Disconnect
+					</button>
+				)}
+			</div>
+		</div>
+	);
+}
+
 function SessionCard({
 	session,
 	isSelected,
@@ -397,23 +515,23 @@ function SessionCard({
 					? "bg-amber-500/15 text-amber-300"
 					: "bg-muted text-muted-foreground";
 	const pillLabel = attachedToThisPane
-		? "Attached"
+		? "● Driving this pane"
 		: assignedElsewherePaneName
-			? "Reassign"
+			? `Driving: ${assignedElsewherePaneName}`
 			: session.mcpStatus === "ready"
-				? "Ready"
+				? "Ready · Free"
 				: session.mcpStatus === "missing"
 					? "Needs MCP"
 					: "Unknown";
 	const note = attachedToThisPane
-		? "This session is currently driving this browser pane."
+		? null
 		: assignedElsewherePaneName
-			? `${session.displayName} is currently controlling ${assignedElsewherePaneName}. Connecting here moves ownership.`
-			: session.mcpStatus === "ready"
-				? "Browser MCP is configured. Connect will be immediate."
-				: session.mcpStatus === "missing"
-					? "This session does not currently expose the required browser automation MCP entry."
-					: "Could not verify MCP status for this session.";
+			? `Connecting here will move ownership from "${assignedElsewherePaneName}".`
+			: session.mcpStatus === "missing"
+				? "This session does not currently expose the required browser automation MCP entry."
+				: session.mcpStatus === "unknown"
+					? "Could not verify MCP status for this session."
+					: null;
 
 	return (
 		<button
@@ -432,35 +550,33 @@ function SessionCard({
 						{session.displayName}
 					</div>
 					<div className="text-[11px] text-muted-foreground truncate">
-						{session.provider} · {session.branchOrContextLabel}
+						{session.provider} · {session.kind} · {session.branchOrContextLabel}{" "}
+						· Last active {session.lastActiveAt}
 					</div>
 				</div>
 				<span
 					className={cn(
-						"shrink-0 inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider",
+						"shrink-0 inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider max-w-[55%] truncate",
 						pillClass,
 					)}
+					title={pillLabel}
 				>
 					{pillLabel}
 				</span>
 			</div>
-			<div className="mt-2 flex flex-wrap gap-1.5">
-				<Tag>{session.kind}</Tag>
-				<Tag>{session.branchOrContextLabel}</Tag>
-				<Tag>Last active {session.lastActiveAt}</Tag>
-			</div>
-			<div className="mt-2 text-[11px] leading-snug text-muted-foreground">
-				{note}
-			</div>
+			{note && (
+				<div
+					className={cn(
+						"mt-2 text-[11px] leading-snug",
+						assignedElsewherePaneName
+							? "text-amber-300/80"
+							: "text-muted-foreground",
+					)}
+				>
+					{note}
+				</div>
+			)}
 		</button>
-	);
-}
-
-function Tag({ children }: { children: React.ReactNode }) {
-	return (
-		<span className="inline-flex items-center rounded-full bg-muted/60 px-2 py-0.5 text-[10px] uppercase tracking-wider text-muted-foreground">
-			{children}
-		</span>
 	);
 }
 

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/components/SessionConnectModal/SessionConnectModal.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/components/SessionConnectModal/SessionConnectModal.tsx
@@ -247,7 +247,6 @@ export function SessionConnectModal({
 						setActiveTab("sessions");
 						setSetupRevealToken((n) => n + 1);
 					}}
-					activeTab={activeTab}
 				/>
 
 				{activeTab === "permissions" ? (
@@ -424,13 +423,11 @@ function WorkspaceBindingsSummary({
 	bindingsByPane,
 	workspaceId,
 	onShowSetup,
-	activeTab,
 }: {
 	sessions: AutomationSession[];
 	bindingsByPane: Record<string, string>;
 	workspaceId: string | null;
 	onShowSetup: () => void;
-	activeTab: "sessions" | "workspace" | "permissions";
 }) {
 	const panes = useTabsStore((s) => s.panes);
 	const tabs = useTabsStore((s) => s.tabs);

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/components/SessionConnectModal/SessionConnectModal.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/components/SessionConnectModal/SessionConnectModal.tsx
@@ -234,18 +234,18 @@ export function SessionConnectModal({
 					</div>
 				</DialogHeader>
 
-				{activeTab !== "permissions" && (
-					<WorkspaceBindingsSummary
-						sessions={sessions}
-						bindingsByPane={bindingsByPane}
-						workspaceId={workspaceId}
-						onShowSetup={() => {
-							setActiveTab("sessions");
-							setSetupRevealToken((n) => n + 1);
-						}}
-						activeTab={activeTab}
-					/>
-				)}
+				{/* Always render the summary bar so the right-side "Show setup
+				    commands" button stays in a fixed position across tabs. */}
+				<WorkspaceBindingsSummary
+					sessions={sessions}
+					bindingsByPane={bindingsByPane}
+					workspaceId={workspaceId}
+					onShowSetup={() => {
+						setActiveTab("sessions");
+						setSetupRevealToken((n) => n + 1);
+					}}
+					activeTab={activeTab}
+				/>
 
 				{activeTab === "permissions" ? (
 					<div className="flex-1 min-h-0">
@@ -615,7 +615,7 @@ function WorkspacePanesTab({
 	}, [panes, tabs, workspaceId]);
 
 	return (
-		<div className="min-h-[min(570px,70vh)] max-h-[min(840px,85vh)] overflow-y-auto">
+		<div className="h-full overflow-y-auto">
 			{browserPanes.length === 0 ? (
 				<div className="text-xs text-muted-foreground text-center py-10">
 					No browser panes in this workspace.

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/components/SessionConnectModal/SessionConnectModal.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/components/SessionConnectModal/SessionConnectModal.tsx
@@ -16,6 +16,7 @@ import {
 	LuList,
 	LuPlug,
 	LuShield,
+	LuTerminal,
 } from "react-icons/lu";
 import { useBrowserAutomationData } from "renderer/hooks/useBrowserAutomationData";
 import { electronTrpc } from "renderer/lib/electron-trpc";
@@ -63,6 +64,9 @@ export function SessionConnectModal({
 	const [activeTab, setActiveTab] = useState<
 		"sessions" | "workspace" | "permissions"
 	>("sessions");
+	// Incremented each time the user asks for setup commands from the
+	// summary bar; CdpEndpointCard listens and expands its section.
+	const [setupRevealToken, setSetupRevealToken] = useState(0);
 	const paneId = useBrowserAutomationStore((s) => s.connectModal.paneId);
 	const selectedSessionId = useBrowserAutomationStore(
 		(s) => s.connectModal.selectedSessionId,
@@ -235,7 +239,10 @@ export function SessionConnectModal({
 						sessions={sessions}
 						bindingsByPane={bindingsByPane}
 						workspaceId={workspaceId}
-						onOpenAllPanes={() => setActiveTab("workspace")}
+						onShowSetup={() => {
+							setActiveTab("sessions");
+							setSetupRevealToken((n) => n + 1);
+						}}
 						activeTab={activeTab}
 					/>
 				)}
@@ -310,6 +317,7 @@ export function SessionConnectModal({
 												: null
 										}
 										attachedToThisPane={session.id === currentBinding}
+										revealSetupToken={setupRevealToken}
 									/>
 								) : (
 									<SetupPanel
@@ -406,13 +414,13 @@ function WorkspaceBindingsSummary({
 	sessions,
 	bindingsByPane,
 	workspaceId,
-	onOpenAllPanes,
+	onShowSetup,
 	activeTab,
 }: {
 	sessions: AutomationSession[];
 	bindingsByPane: Record<string, string>;
 	workspaceId: string | null;
-	onOpenAllPanes: () => void;
+	onShowSetup: () => void;
 	activeTab: "sessions" | "workspace" | "permissions";
 }) {
 	const panes = useTabsStore((s) => s.panes);
@@ -460,16 +468,15 @@ function WorkspaceBindingsSummary({
 					{needsSetup} needs setup
 				</span>
 			)}
-			{activeTab !== "workspace" && (
-				<button
-					type="button"
-					onClick={onOpenAllPanes}
-					className="ml-auto inline-flex items-center gap-1 text-brand hover:underline"
-				>
-					<LuLayoutGrid className="size-3" />
-					Switch to Workspace view →
-				</button>
-			)}
+			<button
+				type="button"
+				onClick={onShowSetup}
+				className="ml-auto inline-flex items-center gap-1 text-brand hover:underline"
+				title="Show MCP setup commands (claude/codex mcp add …)"
+			>
+				<LuTerminal className="size-3" />
+				Show setup commands
+			</button>
 		</div>
 	);
 }
@@ -817,12 +824,14 @@ function ReadyPanel({
 	reassigning,
 	previousPaneName,
 	attachedToThisPane,
+	revealSetupToken,
 }: {
 	session: AutomationSession;
 	paneName: string;
 	reassigning: boolean;
 	previousPaneName: string | null;
 	attachedToThisPane: boolean;
+	revealSetupToken?: number;
 }) {
 	return (
 		<div className="flex flex-col gap-3">
@@ -852,7 +861,12 @@ function ReadyPanel({
 					</DetailItem>
 				</div>
 			</div>
-			{attachedToThisPane && <CdpEndpointCard sessionId={session.id} />}
+			{attachedToThisPane && (
+				<CdpEndpointCard
+					sessionId={session.id}
+					revealSetupToken={revealSetupToken}
+				/>
+			)}
 		</div>
 	);
 }

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/components/SessionConnectModal/components/CdpEndpointCard/CdpEndpointCard.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/components/SessionConnectModal/components/CdpEndpointCard/CdpEndpointCard.tsx
@@ -9,6 +9,16 @@ import {
 } from "react-icons/lu";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 
+/**
+ * POSIX shell single-quote a value so copy-pasted commands survive
+ * arbitrary characters (spaces in `~/Library/Application Support/…`,
+ * `'`, `$`, etc). We single-quote the whole string and break out for
+ * embedded single quotes via the canonical `'\''` trick.
+ */
+function shellQuote(value: string): string {
+	return `'${value.replace(/'/g, "'\\''")}'`;
+}
+
 interface CdpEndpointCardProps {
 	sessionId: string;
 	/**
@@ -84,8 +94,10 @@ export function CdpEndpointCard({
 		);
 	}
 
-	const chromeDevtoolsCmdClaude = `claude mcp add chrome-devtools-mcp -s user -- npx -y chrome-devtools-mcp --browser-url ${data.httpBase}`;
-	const chromeDevtoolsCmdCodex = `codex mcp add chrome-devtools-mcp -- npx -y chrome-devtools-mcp --browser-url ${data.httpBase}`;
+	const httpBaseArg = shellQuote(data.httpBase);
+	const configPathArg = shellQuote(data.browserUseConfigPath);
+	const chromeDevtoolsCmdClaude = `claude mcp add chrome-devtools-mcp -s user -- npx -y chrome-devtools-mcp --browser-url ${httpBaseArg}`;
+	const chromeDevtoolsCmdCodex = `codex mcp add chrome-devtools-mcp -- npx -y chrome-devtools-mcp --browser-url ${httpBaseArg}`;
 	// browser-use's `--mcp` branch intentionally ignores `--cdp-url`
 	// (skill_cli/main.py ~2280 routes straight to the MCP main without
 	// forwarding the flag). The only officially supported injection
@@ -93,8 +105,8 @@ export function CdpEndpointCard({
 	// (see browser_use/config.py and mcp/server.py). The desktop app
 	// writes that file per session at `data.browserUseConfigPath` and
 	// we point browser-use at it here.
-	const browserUseCmdClaude = `claude mcp add browser-use -s user -e BROWSER_USE_CONFIG_PATH=${data.browserUseConfigPath} -- uvx --from "browser-use[cli]" browser-use --mcp`;
-	const browserUseCmdCodex = `codex mcp add browser-use --env BROWSER_USE_CONFIG_PATH=${data.browserUseConfigPath} -- uvx --from "browser-use[cli]" browser-use --mcp`;
+	const browserUseCmdClaude = `claude mcp add browser-use -s user -e BROWSER_USE_CONFIG_PATH=${configPathArg} -- uvx --from 'browser-use[cli]' browser-use --mcp`;
+	const browserUseCmdCodex = `codex mcp add browser-use --env BROWSER_USE_CONFIG_PATH=${configPathArg} -- uvx --from 'browser-use[cli]' browser-use --mcp`;
 
 	return (
 		<div className="rounded-xl border p-3 bg-card/60 flex flex-col gap-3">

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/components/SessionConnectModal/components/CdpEndpointCard/CdpEndpointCard.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/components/SessionConnectModal/components/CdpEndpointCard/CdpEndpointCard.tsx
@@ -189,6 +189,110 @@ export function CdpEndpointCard({
 	);
 }
 
+/**
+ * Standalone version of the "Example setup" section that works even
+ * when no session is bound yet — the WebSocket/HTTP base are not
+ * known until a binding exists, so the commands are rendered with
+ * placeholder tokens that the user substitutes after binding.
+ * Intended use: the "Show setup commands" button in the summary bar
+ * wants to reveal setup instructions even before the user has bound
+ * a session.
+ */
+export function PlaceholderSetupCommandsCard({
+	revealToken,
+	onDismiss,
+}: {
+	revealToken?: number;
+	onDismiss?: () => void;
+}) {
+	const [open, setOpen] = useState(true);
+	useEffect(() => {
+		if (revealToken !== undefined && revealToken > 0) setOpen(true);
+	}, [revealToken]);
+
+	const copy = async (value: string, label: string): Promise<void> => {
+		try {
+			await navigator.clipboard.writeText(value);
+			toast.success(`${label} copied`);
+		} catch {
+			toast.error(`Failed to copy ${label.toLowerCase()}`);
+		}
+	};
+
+	const HTTP = "http://127.0.0.1:<port>";
+	const CFG = "<BROWSER_USE_CONFIG_PATH>";
+	const chromeClaude = `claude mcp add chrome-devtools-mcp -s user -- npx -y chrome-devtools-mcp --browser-url ${HTTP}`;
+	const chromeCodex = `codex mcp add chrome-devtools-mcp -- npx -y chrome-devtools-mcp --browser-url ${HTTP}`;
+	const useClaude = `claude mcp add browser-use -s user -e BROWSER_USE_CONFIG_PATH=${CFG} -- uvx --from "browser-use[cli]" browser-use --mcp`;
+	const useCodex = `codex mcp add browser-use --env BROWSER_USE_CONFIG_PATH=${CFG} -- uvx --from "browser-use[cli]" browser-use --mcp`;
+
+	return (
+		<div className="rounded-xl border border-dashed p-3 bg-card/40 flex flex-col gap-3">
+			<div className="flex items-start gap-2">
+				<div className="flex-1 min-w-0">
+					<div className="text-xs font-semibold">Setup commands (template)</div>
+					<div className="mt-1 text-[11px] text-muted-foreground leading-relaxed">
+						外部ブラウザ MCP (chrome-devtools-mcp / browser-use) を登録する
+						ためのテンプレートです。プレースホルダ部分 (
+						<code className="rounded bg-muted px-1">{HTTP}</code> /{" "}
+						<code className="rounded bg-muted px-1">{CFG}</code>)
+						は、セッションを bind すると実際の値に置き換わって CDP endpoint
+						カードに表示されます。
+					</div>
+				</div>
+				{onDismiss && (
+					<button
+						type="button"
+						onClick={onDismiss}
+						className="shrink-0 text-[11px] text-muted-foreground hover:text-foreground px-1.5 py-0.5 rounded hover:bg-muted/40"
+					>
+						×
+					</button>
+				)}
+			</div>
+
+			<button
+				type="button"
+				onClick={() => setOpen((v) => !v)}
+				className="flex w-full items-center gap-1.5 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/70 hover:text-foreground"
+			>
+				{open ? (
+					<LuChevronUp className="size-3" />
+				) : (
+					<LuChevronDown className="size-3" />
+				)}
+				Example setup
+			</button>
+			{open && (
+				<div>
+					<CommandBlock
+						title="chrome-devtools-mcp (Claude Code)"
+						cmd={chromeClaude}
+						onCopy={() => copy(chromeClaude, "chrome-devtools-mcp command")}
+					/>
+					<CommandBlock
+						title="chrome-devtools-mcp (Codex)"
+						cmd={chromeCodex}
+						onCopy={() =>
+							copy(chromeCodex, "chrome-devtools-mcp (codex) command")
+						}
+					/>
+					<CommandBlock
+						title="browser-use (Claude Code)"
+						cmd={useClaude}
+						onCopy={() => copy(useClaude, "browser-use command")}
+					/>
+					<CommandBlock
+						title="browser-use (Codex)"
+						cmd={useCodex}
+						onCopy={() => copy(useCodex, "browser-use (codex) command")}
+					/>
+				</div>
+			)}
+		</div>
+	);
+}
+
 function UrlRow({
 	label,
 	value,

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/components/SessionConnectModal/components/CdpEndpointCard/CdpEndpointCard.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/components/SessionConnectModal/components/CdpEndpointCard/CdpEndpointCard.tsx
@@ -57,7 +57,8 @@ export function CdpEndpointCard({ sessionId }: CdpEndpointCardProps) {
 		);
 	}
 
-	const chromeDevtoolsCmd = `claude mcp add chrome-devtools-mcp -s user -- npx -y chrome-devtools-mcp --browser-url ${data.httpBase}`;
+	const chromeDevtoolsCmdClaude = `claude mcp add chrome-devtools-mcp -s user -- npx -y chrome-devtools-mcp --browser-url ${data.httpBase}`;
+	const chromeDevtoolsCmdCodex = `codex mcp add chrome-devtools-mcp -- npx -y chrome-devtools-mcp --browser-url ${data.httpBase}`;
 	// browser-use's `--mcp` branch intentionally ignores `--cdp-url`
 	// (skill_cli/main.py ~2280 routes straight to the MCP main without
 	// forwarding the flag). The only officially supported injection
@@ -65,7 +66,8 @@ export function CdpEndpointCard({ sessionId }: CdpEndpointCardProps) {
 	// (see browser_use/config.py and mcp/server.py). The desktop app
 	// writes that file per session at `data.browserUseConfigPath` and
 	// we point browser-use at it here.
-	const browserUseCmd = `claude mcp add browser-use -s user -e BROWSER_USE_CONFIG_PATH=${data.browserUseConfigPath} -- uvx --from "browser-use[cli]" browser-use --mcp`;
+	const browserUseCmdClaude = `claude mcp add browser-use -s user -e BROWSER_USE_CONFIG_PATH=${data.browserUseConfigPath} -- uvx --from "browser-use[cli]" browser-use --mcp`;
+	const browserUseCmdCodex = `codex mcp add browser-use --env BROWSER_USE_CONFIG_PATH=${data.browserUseConfigPath} -- uvx --from "browser-use[cli]" browser-use --mcp`;
 
 	return (
 		<div className="rounded-xl border p-3 bg-card/60 flex flex-col gap-3">
@@ -102,13 +104,27 @@ export function CdpEndpointCard({ sessionId }: CdpEndpointCardProps) {
 				</div>
 				<CommandBlock
 					title="chrome-devtools-mcp (Claude Code)"
-					cmd={chromeDevtoolsCmd}
-					onCopy={() => copy(chromeDevtoolsCmd, "chrome-devtools-mcp command")}
+					cmd={chromeDevtoolsCmdClaude}
+					onCopy={() =>
+						copy(chromeDevtoolsCmdClaude, "chrome-devtools-mcp command")
+					}
 				/>
 				<CommandBlock
-					title="browser-use"
-					cmd={browserUseCmd}
-					onCopy={() => copy(browserUseCmd, "browser-use command")}
+					title="chrome-devtools-mcp (Codex)"
+					cmd={chromeDevtoolsCmdCodex}
+					onCopy={() =>
+						copy(chromeDevtoolsCmdCodex, "chrome-devtools-mcp (codex) command")
+					}
+				/>
+				<CommandBlock
+					title="browser-use (Claude Code)"
+					cmd={browserUseCmdClaude}
+					onCopy={() => copy(browserUseCmdClaude, "browser-use command")}
+				/>
+				<CommandBlock
+					title="browser-use (Codex)"
+					cmd={browserUseCmdCodex}
+					onCopy={() => copy(browserUseCmdCodex, "browser-use (codex) command")}
 				/>
 			</div>
 

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/components/SessionConnectModal/components/CdpEndpointCard/CdpEndpointCard.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/components/SessionConnectModal/components/CdpEndpointCard/CdpEndpointCard.tsx
@@ -1,10 +1,24 @@
 import { Button } from "@superset/ui/button";
 import { toast } from "@superset/ui/sonner";
-import { LuCopy, LuExternalLink } from "react-icons/lu";
+import { useEffect, useState } from "react";
+import {
+	LuChevronDown,
+	LuChevronUp,
+	LuCopy,
+	LuExternalLink,
+} from "react-icons/lu";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 
 interface CdpEndpointCardProps {
 	sessionId: string;
+	/**
+	 * Increment to force the Example setup section open from outside
+	 * (e.g., the summary-bar "Show setup commands" button). The card
+	 * defaults to collapsed because once a session is bound the MCP
+	 * registration is a one-shot task; keeping four command blocks
+	 * permanently visible drowns out the actual status info.
+	 */
+	revealSetupToken?: number;
 }
 
 /**
@@ -15,12 +29,25 @@ interface CdpEndpointCardProps {
  * delegate actual browser control to those tools, so this is the
  * primary success-state UI once a pane is attached.
  */
-export function CdpEndpointCard({ sessionId }: CdpEndpointCardProps) {
+export function CdpEndpointCard({
+	sessionId,
+	revealSetupToken,
+}: CdpEndpointCardProps) {
 	const { data, isLoading } =
 		electronTrpc.browserAutomation.getCdpEndpointForSession.useQuery(
 			{ sessionId },
 			{ refetchInterval: 5_000 },
 		);
+
+	// Setup commands stay hidden by default. They re-appear when the
+	// user explicitly asks via the summary-bar button (revealSetupToken
+	// bumps) or the inline toggle.
+	const [setupOpen, setSetupOpen] = useState(false);
+	useEffect(() => {
+		if (revealSetupToken !== undefined && revealSetupToken > 0) {
+			setSetupOpen(true);
+		}
+	}, [revealSetupToken]);
 
 	const copy = async (value: string, label: string): Promise<void> => {
 		try {
@@ -99,33 +126,56 @@ export function CdpEndpointCard({ sessionId }: CdpEndpointCardProps) {
 			/>
 
 			<div className="mt-1">
-				<div className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/70 mb-1">
+				<button
+					type="button"
+					onClick={() => setSetupOpen((v) => !v)}
+					className="flex w-full items-center gap-1.5 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/70 hover:text-foreground"
+				>
+					{setupOpen ? (
+						<LuChevronUp className="size-3" />
+					) : (
+						<LuChevronDown className="size-3" />
+					)}
 					Example setup
-				</div>
-				<CommandBlock
-					title="chrome-devtools-mcp (Claude Code)"
-					cmd={chromeDevtoolsCmdClaude}
-					onCopy={() =>
-						copy(chromeDevtoolsCmdClaude, "chrome-devtools-mcp command")
-					}
-				/>
-				<CommandBlock
-					title="chrome-devtools-mcp (Codex)"
-					cmd={chromeDevtoolsCmdCodex}
-					onCopy={() =>
-						copy(chromeDevtoolsCmdCodex, "chrome-devtools-mcp (codex) command")
-					}
-				/>
-				<CommandBlock
-					title="browser-use (Claude Code)"
-					cmd={browserUseCmdClaude}
-					onCopy={() => copy(browserUseCmdClaude, "browser-use command")}
-				/>
-				<CommandBlock
-					title="browser-use (Codex)"
-					cmd={browserUseCmdCodex}
-					onCopy={() => copy(browserUseCmdCodex, "browser-use (codex) command")}
-				/>
+					{!setupOpen && (
+						<span className="ml-1 normal-case tracking-normal font-normal text-muted-foreground/60">
+							(一度だけ実行すれば OK — 必要なら開いて参照)
+						</span>
+					)}
+				</button>
+				{setupOpen && (
+					<div className="mt-1">
+						<CommandBlock
+							title="chrome-devtools-mcp (Claude Code)"
+							cmd={chromeDevtoolsCmdClaude}
+							onCopy={() =>
+								copy(chromeDevtoolsCmdClaude, "chrome-devtools-mcp command")
+							}
+						/>
+						<CommandBlock
+							title="chrome-devtools-mcp (Codex)"
+							cmd={chromeDevtoolsCmdCodex}
+							onCopy={() =>
+								copy(
+									chromeDevtoolsCmdCodex,
+									"chrome-devtools-mcp (codex) command",
+								)
+							}
+						/>
+						<CommandBlock
+							title="browser-use (Claude Code)"
+							cmd={browserUseCmdClaude}
+							onCopy={() => copy(browserUseCmdClaude, "browser-use command")}
+						/>
+						<CommandBlock
+							title="browser-use (Codex)"
+							cmd={browserUseCmdCodex}
+							onCopy={() =>
+								copy(browserUseCmdCodex, "browser-use (codex) command")
+							}
+						/>
+					</div>
+				)}
 			</div>
 
 			<div className="text-[10px] text-muted-foreground flex items-start gap-1">

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/components/SessionConnectModal/components/CdpEndpointCard/index.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/components/SessionConnectModal/components/CdpEndpointCard/index.ts
@@ -1,1 +1,4 @@
-export { CdpEndpointCard } from "./CdpEndpointCard";
+export {
+	CdpEndpointCard,
+	PlaceholderSetupCommandsCard,
+} from "./CdpEndpointCard";

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/components/SessionConnectModal/components/McpInstallPanel/McpInstallPanel.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/components/SessionConnectModal/components/McpInstallPanel/McpInstallPanel.tsx
@@ -2,7 +2,7 @@ import { Button } from "@superset/ui/button";
 import { Checkbox } from "@superset/ui/checkbox";
 import { toast } from "@superset/ui/sonner";
 import { useState } from "react";
-import { LuInfo } from "react-icons/lu";
+import { LuCheck, LuChevronDown, LuInfo } from "react-icons/lu";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import type { ServerCommand } from "renderer/stores/browser-automation";
 
@@ -32,6 +32,23 @@ export function McpInstallPanel({ serverCommand }: McpInstallPanelProps) {
 
 	const [claudeChecked, setClaudeChecked] = useState(true);
 	const [codexChecked, setCodexChecked] = useState(false);
+	const [expanded, setExpanded] = useState(false);
+
+	// Collapse to a single "all good" banner when every CLI-found runtime is
+	// already installed with a matching command. Showing the full install UI
+	// in that case reads as "something is wrong" even though nothing is.
+	const claudeReady =
+		!state?.claude.cliFound ||
+		(state.claude.installed && state.claude.matchesExpected);
+	const codexReady =
+		!state?.codex.cliFound ||
+		(state.codex.installed && state.codex.matchesExpected);
+	const anyCliFound = canInstallClaude || canInstallCodex;
+	const allInstalled = anyCliFound && claudeReady && codexReady;
+	const readyLabels = [
+		canInstallClaude ? "Claude Code" : null,
+		canInstallCodex ? "Codex" : null,
+	].filter((v): v is string => v !== null);
 
 	if (serverCommand && !serverCommand.available) {
 		return (
@@ -79,6 +96,34 @@ export function McpInstallPanel({ serverCommand }: McpInstallPanelProps) {
 			);
 		}
 	};
+
+	if (allInstalled && !expanded) {
+		return (
+			<div className="flex flex-col gap-3">
+				<div className="rounded-lg border border-emerald-500/30 bg-emerald-500/5 px-3 py-2 flex items-center gap-2">
+					<LuCheck className="size-4 text-emerald-300 shrink-0" />
+					<div className="flex-1 min-w-0">
+						<div className="text-[12px] font-medium text-emerald-300">
+							Browser MCP is installed — ready to connect
+						</div>
+						{readyLabels.length > 0 && (
+							<div className="text-[10px] text-muted-foreground">
+								{readyLabels.join(" · ")}
+							</div>
+						)}
+					</div>
+					<button
+						type="button"
+						onClick={() => setExpanded(true)}
+						className="inline-flex items-center gap-0.5 text-[11px] text-muted-foreground hover:text-foreground"
+					>
+						Manage
+						<LuChevronDown className="size-3" />
+					</button>
+				</div>
+			</div>
+		);
+	}
 
 	return (
 		<div className="flex flex-col gap-3">

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/components/SessionConnectModal/components/PermissionsTab/PermissionsTab.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/components/SessionConnectModal/components/PermissionsTab/PermissionsTab.tsx
@@ -229,10 +229,14 @@ export function PermissionsTab() {
 						<div className="shrink-0 p-4 pb-3 border-b bg-background">
 							<div className="flex items-end gap-2">
 								<div className="flex-1">
-									<Label className="text-[11px] text-muted-foreground">
+									<Label
+										htmlFor="permission-preset-name"
+										className="text-[11px] text-muted-foreground"
+									>
 										Preset name
 									</Label>
 									<Input
+										id="permission-preset-name"
 										value={draftName}
 										disabled={isBuiltin}
 										onChange={(e) => {
@@ -297,6 +301,7 @@ export function PermissionsTab() {
 												</div>
 											</div>
 											<Switch
+												aria-label={`${m.label} permission`}
 												checked={value}
 												disabled={isBuiltin}
 												onCheckedChange={(v: boolean) => handleToggle(key, v)}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/components/SessionConnectModal/components/PermissionsTab/PermissionsTab.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/components/SessionConnectModal/components/PermissionsTab/PermissionsTab.tsx
@@ -166,7 +166,7 @@ export function PermissionsTab() {
 	};
 
 	return (
-		<div className="grid grid-cols-[240px_1fr] min-h-[min(570px,70vh)] max-h-[min(840px,85vh)]">
+		<div className="grid grid-cols-[240px_1fr] h-full min-h-0">
 			<div className="overflow-y-auto p-3 border-r">
 				<div className="flex items-center justify-between mb-2">
 					<div className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/70">

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/components/SessionConnectModal/components/PermissionsTab/PermissionsTab.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/components/SessionConnectModal/components/PermissionsTab/PermissionsTab.tsx
@@ -218,95 +218,103 @@ export function PermissionsTab() {
 				</div>
 			</div>
 
-			<div className="overflow-y-auto p-4">
+			<div className="flex flex-col min-h-0">
 				{!selected ? (
-					<div className="text-xs text-muted-foreground">
+					<div className="p-4 text-xs text-muted-foreground">
 						Select a preset on the left.
 					</div>
 				) : (
-					<div className="flex flex-col gap-4">
-						<div className="flex items-end gap-2">
-							<div className="flex-1">
-								<Label className="text-[11px] text-muted-foreground">
-									Preset name
-								</Label>
-								<Input
-									value={draftName}
-									disabled={isBuiltin}
-									onChange={(e) => {
-										setDraftName(e.target.value);
-										setDirty(true);
-									}}
-									className="mt-1 h-8 text-[13px]"
-								/>
-							</div>
-							<Button
-								type="button"
-								variant="outline"
-								size="sm"
-								onClick={handleDuplicate}
-								disabled={savePreset.isPending}
-							>
-								<LuCopy className="size-3.5 mr-1" />
-								Duplicate
-							</Button>
-							{!isBuiltin && (
+					<>
+						{/* Sticky header: name input + duplicate/delete stay visible. */}
+						<div className="shrink-0 p-4 pb-3 border-b bg-background">
+							<div className="flex items-end gap-2">
+								<div className="flex-1">
+									<Label className="text-[11px] text-muted-foreground">
+										Preset name
+									</Label>
+									<Input
+										value={draftName}
+										disabled={isBuiltin}
+										onChange={(e) => {
+											setDraftName(e.target.value);
+											setDirty(true);
+										}}
+										className="mt-1 h-8 text-[13px]"
+									/>
+								</div>
 								<Button
 									type="button"
 									variant="outline"
 									size="sm"
-									onClick={handleDelete}
-									disabled={deletePreset.isPending || isActive}
-									title={
-										isActive
-											? "Activate a different preset first to delete this one"
-											: undefined
-									}
+									onClick={handleDuplicate}
+									disabled={savePreset.isPending}
 								>
-									<LuTrash2 className="size-3.5 mr-1" />
-									Delete
+									<LuCopy className="size-3.5 mr-1" />
+									Duplicate
 								</Button>
+								{!isBuiltin && (
+									<Button
+										type="button"
+										variant="outline"
+										size="sm"
+										onClick={handleDelete}
+										disabled={deletePreset.isPending || isActive}
+										title={
+											isActive
+												? "Activate a different preset first to delete this one"
+												: undefined
+										}
+									>
+										<LuTrash2 className="size-3.5 mr-1" />
+										Delete
+									</Button>
+								)}
+							</div>
+							{isBuiltin && (
+								<div className="mt-3 rounded-md border border-amber-500/30 bg-amber-500/10 p-2 text-[11px] text-amber-200">
+									Built-in preset. Duplicate to customize.
+								</div>
 							)}
 						</div>
 
-						{isBuiltin && (
-							<div className="rounded-md border border-amber-500/30 bg-amber-500/10 p-2 text-[11px] text-amber-200">
-								Built-in preset. Duplicate to customize.
-							</div>
-						)}
-
-						<div className="flex flex-col divide-y border rounded-md">
-							{toggleKeys.map((key) => {
-								const m = meta[key];
-								const value = draftToggles[key] === true;
-								return (
-									<div key={key} className="flex items-start gap-3 p-3">
-										<div className="flex-1 min-w-0">
-											<div className="text-[12px] font-medium">{m.label}</div>
-											<div className="mt-0.5 text-[11px] text-muted-foreground leading-snug">
-												{m.description}
+						{/* Scrollable toggle list — only this region scrolls so the
+						    header and the Save/Activate action bar stay on screen
+						    even with many toggle rows. */}
+						<div className="flex-1 min-h-0 overflow-y-auto p-4">
+							<div className="flex flex-col divide-y border rounded-md">
+								{toggleKeys.map((key) => {
+									const m = meta[key];
+									const value = draftToggles[key] === true;
+									return (
+										<div key={key} className="flex items-start gap-3 p-3">
+											<div className="flex-1 min-w-0">
+												<div className="text-[12px] font-medium">{m.label}</div>
+												<div className="mt-0.5 text-[11px] text-muted-foreground leading-snug">
+													{m.description}
+												</div>
+												<div className="mt-1 text-[10px] font-mono text-muted-foreground/70 truncate">
+													{m.methods.join(", ")}
+												</div>
 											</div>
-											<div className="mt-1 text-[10px] font-mono text-muted-foreground/70 truncate">
-												{m.methods.join(", ")}
-											</div>
+											<Switch
+												checked={value}
+												disabled={isBuiltin}
+												onCheckedChange={(v: boolean) => handleToggle(key, v)}
+											/>
 										</div>
-										<Switch
-											checked={value}
-											disabled={isBuiltin}
-											onCheckedChange={(v: boolean) => handleToggle(key, v)}
-										/>
-									</div>
-								);
-							})}
+									);
+								})}
+							</div>
 						</div>
 
-						<div className="flex items-center justify-between pt-2">
-							<div className="text-[11px] text-muted-foreground">
+						{/* Sticky action bar. */}
+						<div className="shrink-0 flex items-center justify-between gap-3 px-4 py-3 border-t bg-background">
+							<div className="text-[11px] text-muted-foreground min-w-0 flex-1 line-clamp-2">
 								{isActive
-									? "This preset is currently active. Changes to toggles apply to all live MCP sessions after save (connections are force-reconnected)."
+									? "Active preset. Changes apply to all live MCP sessions after save."
 									: "Save, then click Activate to apply to MCP sessions."}
 							</div>
-							<div className="flex items-center gap-2">
+							<div className="flex items-center gap-2 shrink-0">
 								{!isBuiltin && (
 									<Button
 										type="button"
@@ -328,7 +336,7 @@ export function PermissionsTab() {
 								</Button>
 							</div>
 						</div>
-					</div>
+					</>
 				)}
 			</div>
 		</div>

--- a/mock.html
+++ b/mock.html
@@ -1,0 +1,753 @@
+<!doctype html>
+<html lang="ja">
+<head>
+<meta charset="utf-8" />
+<title>Connect Browser Automation — current UI mock</title>
+<script src="https://cdn.tailwindcss.com"></script>
+<style>
+    :root {
+        --background: #0b0b0f;
+        --card: #121218;
+        --muted: #1a1a22;
+        --muted-foreground: #8a8aa0;
+        --foreground: #e7e7ee;
+        --border: #26262f;
+        --brand: #7c5cff;
+    }
+    html, body { background: var(--background); color: var(--foreground); font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif; }
+    .bg-background { background: var(--background); }
+    .bg-card { background: var(--card); }
+    .bg-card\/60 { background: color-mix(in srgb, var(--card) 60%, transparent); }
+    .bg-muted { background: var(--muted); }
+    .bg-muted\/20 { background: color-mix(in srgb, var(--muted) 20%, transparent); }
+    .bg-muted\/40 { background: color-mix(in srgb, var(--muted) 40%, transparent); }
+    .bg-muted\/60 { background: color-mix(in srgb, var(--muted) 60%, transparent); }
+    .text-foreground { color: var(--foreground); }
+    .text-muted-foreground { color: var(--muted-foreground); }
+    .text-muted-foreground\/70 { color: color-mix(in srgb, var(--muted-foreground) 70%, transparent); }
+    .text-brand { color: var(--brand); }
+    .bg-brand { background: var(--brand); }
+    .bg-brand\/5 { background: color-mix(in srgb, var(--brand) 5%, transparent); }
+    .bg-brand\/10 { background: color-mix(in srgb, var(--brand) 10%, transparent); }
+    .bg-brand\/15 { background: color-mix(in srgb, var(--brand) 15%, transparent); }
+    .border-brand\/30 { border-color: color-mix(in srgb, var(--brand) 30%, transparent); }
+    .border-brand\/40 { border-color: color-mix(in srgb, var(--brand) 40%, transparent); }
+    .border-brand { border-color: var(--brand); }
+    .border-border, .border { border-color: var(--border); }
+    .text-amber-300 { color: #fcd34d; }
+    .bg-amber-500\/15 { background: rgba(245,158,11,0.15); }
+    .text-emerald-300 { color: #6ee7b7; }
+    .bg-emerald-500\/15 { background: rgba(16,185,129,0.15); }
+    .dialog {
+        box-shadow: 0 20px 60px rgba(0,0,0,0.5);
+        border: 1px solid var(--border);
+        border-radius: 12px;
+    }
+    code { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 11px; }
+    button { cursor: pointer; }
+    .tag { display: inline-flex; align-items: center; border-radius: 9999px; padding: 2px 8px; font-size: 10px; letter-spacing: 0.08em; text-transform: uppercase; }
+    .pill { display: inline-flex; align-items: center; border-radius: 9999px; padding: 2px 8px; font-size: 10px; font-weight: 600; letter-spacing: 0.08em; text-transform: uppercase; }
+    hr.sep { border: none; border-top: 1px solid var(--border); }
+</style>
+</head>
+<body class="p-8">
+<div class="max-w-[1760px] mx-auto space-y-12">
+
+    <!-- ===================================================================
+         1) Connect browser automation modal (Sessions tab) — current UI
+         =================================================================== -->
+    <section>
+        <h2 class="text-sm font-semibold mb-3 text-muted-foreground">① Connect browser automation — Sessions タブ (現状)</h2>
+        <div class="dialog bg-background overflow-hidden" style="max-width: min(1640px, 95vw);">
+            <!-- Header -->
+            <div class="px-5 py-4 border-b">
+                <div class="text-sm font-semibold">Connect browser automation</div>
+                <div class="text-xs text-muted-foreground mt-0.5">Choose which running LLM session should control this browser pane.</div>
+                <div class="mt-3 flex items-center gap-1 border-b -mb-4 pb-0">
+                    <button class="inline-flex items-center gap-1.5 px-3 py-2 text-[12px] font-medium border-b-2 border-brand text-foreground">
+                        <span>☰</span> Sessions
+                    </button>
+                    <button class="inline-flex items-center gap-1.5 px-3 py-2 text-[12px] font-medium border-b-2 border-transparent text-muted-foreground">
+                        <span>🛡</span> Permissions
+                    </button>
+                </div>
+            </div>
+
+            <!-- Body: 2-col grid -->
+            <div class="grid" style="grid-template-columns: minmax(320px,1fr) minmax(280px,0.9fr); min-height: min(570px,70vh); max-height: min(840px,85vh);">
+                <!-- Left: pane header + session list -->
+                <div class="overflow-y-auto p-4 border-r">
+                    <!-- Pane identity + All panes -->
+                    <div class="flex items-center gap-3 rounded-lg bg-muted/40 px-3 py-2.5 mb-3">
+                        <div class="flex w-7 h-7 items-center justify-center rounded-md bg-brand/15 text-brand text-sm font-bold">◎</div>
+                        <div class="min-w-0">
+                            <div class="text-xs font-semibold truncate">Browser · GitHub</div>
+                            <div class="text-[11px] text-muted-foreground truncate">https://github.com/MocA-Love/superset/pull/371</div>
+                        </div>
+                        <button class="ml-auto inline-flex items-center gap-1 rounded-md border bg-background/60 px-2 py-1 text-[11px] text-muted-foreground hover:text-foreground">
+                            <span>☰</span> All panes
+                        </button>
+                    </div>
+
+                    <div class="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/70 px-1 mb-2">Running sessions</div>
+
+                    <div class="flex flex-col gap-2">
+                        <!-- Selected + attached to this pane -->
+                        <button class="text-left rounded-xl border border-brand/40 bg-brand/10 p-3">
+                            <div class="flex items-start justify-between gap-3">
+                                <div class="min-w-0">
+                                    <div class="text-[13px] font-semibold truncate">claude · feature/browser-mcp-target-filter</div>
+                                    <div class="text-[11px] text-muted-foreground truncate">Claude · feature/browser-mcp-target-filter</div>
+                                </div>
+                                <span class="pill bg-brand/15 text-brand shrink-0">Attached</span>
+                            </div>
+                            <div class="mt-2 flex flex-wrap gap-1.5">
+                                <span class="tag bg-muted/60 text-muted-foreground">terminal</span>
+                                <span class="tag bg-muted/60 text-muted-foreground">feature/browser-mcp-target-filter</span>
+                                <span class="tag bg-muted/60 text-muted-foreground">Last active 2m ago</span>
+                            </div>
+                            <div class="mt-2 text-[11px] leading-snug text-muted-foreground">This session is currently driving this browser pane.</div>
+                        </button>
+
+                        <!-- Ready, not attached -->
+                        <button class="text-left rounded-xl border bg-card hover:bg-muted/40 p-3">
+                            <div class="flex items-start justify-between gap-3">
+                                <div class="min-w-0">
+                                    <div class="text-[13px] font-semibold truncate">codex · main</div>
+                                    <div class="text-[11px] text-muted-foreground truncate">Codex · main</div>
+                                </div>
+                                <span class="pill bg-emerald-500/15 text-emerald-300 shrink-0">Ready</span>
+                            </div>
+                            <div class="mt-2 flex flex-wrap gap-1.5">
+                                <span class="tag bg-muted/60 text-muted-foreground">terminal</span>
+                                <span class="tag bg-muted/60 text-muted-foreground">main</span>
+                                <span class="tag bg-muted/60 text-muted-foreground">Last active 10m ago</span>
+                            </div>
+                            <div class="mt-2 text-[11px] leading-snug text-muted-foreground">Browser MCP is configured. Connect will be immediate.</div>
+                        </button>
+
+                        <!-- Reassign (bound to other pane) -->
+                        <button class="text-left rounded-xl border bg-card hover:bg-muted/40 p-3">
+                            <div class="flex items-start justify-between gap-3">
+                                <div class="min-w-0">
+                                    <div class="text-[13px] font-semibold truncate">claude · issue-377</div>
+                                    <div class="text-[11px] text-muted-foreground truncate">Claude · issue-377</div>
+                                </div>
+                                <span class="pill bg-amber-500/15 text-amber-300 shrink-0">Reassign</span>
+                            </div>
+                            <div class="mt-2 flex flex-wrap gap-1.5">
+                                <span class="tag bg-muted/60 text-muted-foreground">terminal</span>
+                                <span class="tag bg-muted/60 text-muted-foreground">issue-377</span>
+                                <span class="tag bg-muted/60 text-muted-foreground">Last active 1h ago</span>
+                            </div>
+                            <div class="mt-2 text-[11px] leading-snug text-muted-foreground">claude · issue-377 is currently controlling Browser · Docs. Connecting here moves ownership.</div>
+                        </button>
+
+                        <!-- Needs MCP -->
+                        <button class="text-left rounded-xl border bg-card hover:bg-muted/40 p-3">
+                            <div class="flex items-start justify-between gap-3">
+                                <div class="min-w-0">
+                                    <div class="text-[13px] font-semibold truncate">todo-agent · default</div>
+                                    <div class="text-[11px] text-muted-foreground truncate">TODO-Agent · default</div>
+                                </div>
+                                <span class="pill bg-amber-500/15 text-amber-300 shrink-0">Needs MCP</span>
+                            </div>
+                            <div class="mt-2 flex flex-wrap gap-1.5">
+                                <span class="tag bg-muted/60 text-muted-foreground">todo-agent</span>
+                                <span class="tag bg-muted/60 text-muted-foreground">default</span>
+                                <span class="tag bg-muted/60 text-muted-foreground">Last active 5m ago</span>
+                            </div>
+                            <div class="mt-2 text-[11px] leading-snug text-muted-foreground">This session does not currently expose the required browser automation MCP entry.</div>
+                        </button>
+                    </div>
+                </div>
+
+                <!-- Right: detail panel (Ready + attached → shows CDP endpoint) -->
+                <div class="overflow-y-auto p-4 bg-muted/20">
+                    <div class="flex flex-col gap-3">
+                        <div class="rounded-xl border p-3 bg-card/60">
+                            <div class="text-xs font-semibold">Session is attached to this pane</div>
+                            <div class="mt-1 text-[11px] text-muted-foreground leading-relaxed">
+                                Drive the pane from this session by pointing an external browser MCP at the CDP endpoint below.
+                            </div>
+                            <div class="mt-3 grid grid-cols-2 gap-2">
+                                <div class="rounded-md bg-muted/40 p-2">
+                                    <span class="block text-[10px] uppercase tracking-wider text-muted-foreground/70">Owner</span>
+                                    <strong class="block mt-0.5 text-[12px] font-medium">claude · feature/browser-mcp-target-filter / Claude</strong>
+                                </div>
+                                <div class="rounded-md bg-muted/40 p-2">
+                                    <span class="block text-[10px] uppercase tracking-wider text-muted-foreground/70">Binding mode</span>
+                                    <strong class="block mt-0.5 text-[12px] font-medium">Exclusive control</strong>
+                                </div>
+                                <div class="rounded-md bg-muted/40 p-2">
+                                    <span class="block text-[10px] uppercase tracking-wider text-muted-foreground/70">Pane</span>
+                                    <strong class="block mt-0.5 text-[12px] font-medium">Browser · GitHub</strong>
+                                </div>
+                                <div class="rounded-md bg-muted/40 p-2">
+                                    <span class="block text-[10px] uppercase tracking-wider text-muted-foreground/70">Expected</span>
+                                    <strong class="block mt-0.5 text-[12px] font-medium">Toolbar badge updates instantly</strong>
+                                </div>
+                            </div>
+                        </div>
+
+                        <!-- CDP endpoint card (shown when attachedToThisPane) -->
+                        <div class="rounded-xl border p-3 bg-card/60">
+                            <div class="flex items-center justify-between">
+                                <div class="text-xs font-semibold">CDP endpoint</div>
+                                <span class="pill bg-emerald-500/15 text-emerald-300">Ready</span>
+                            </div>
+                            <div class="mt-2 text-[11px] text-muted-foreground">Point an external MCP / puppeteer at this URL.</div>
+                            <div class="mt-2 flex items-center gap-2 rounded-md bg-muted/40 px-2 py-1.5">
+                                <code class="text-[11px] truncate">ws://127.0.0.1:47891/devtools/browser/abc123-filtered</code>
+                                <button class="ml-auto shrink-0 text-[11px] text-brand">Copy</button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Footer -->
+            <div class="px-5 py-3 border-t flex items-center justify-between gap-2">
+                <div class="text-[11px] text-muted-foreground">Connecting binds this browser pane to the selected session only.</div>
+                <div class="flex items-center gap-2">
+                    <button class="h-8 px-3 rounded-md border text-xs">Disconnect claude · feature/browser-mcp-target-filter</button>
+                    <button class="h-8 px-3 rounded-md border text-xs">Cancel</button>
+                    <button class="h-8 px-3 rounded-md text-xs font-medium" style="background: var(--brand); color: white;">Connect session</button>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- ===================================================================
+         2) Connect browser automation — session has Needs MCP (shows install panel)
+         =================================================================== -->
+    <section>
+        <h2 class="text-sm font-semibold mb-3 text-muted-foreground">② Connect browser automation — 選択セッションが Needs MCP (現状 / McpInstallPanel)</h2>
+        <div class="dialog bg-background overflow-hidden" style="max-width: min(1640px, 95vw);">
+            <div class="px-5 py-4 border-b">
+                <div class="text-sm font-semibold">Connect browser automation</div>
+                <div class="text-xs text-muted-foreground mt-0.5">Choose which running LLM session should control this browser pane.</div>
+            </div>
+
+            <div class="grid" style="grid-template-columns: minmax(320px,1fr) minmax(280px,0.9fr); min-height: min(570px,70vh);">
+                <div class="overflow-y-auto p-4 border-r">
+                    <div class="flex items-center gap-3 rounded-lg bg-muted/40 px-3 py-2.5 mb-3">
+                        <div class="flex w-7 h-7 items-center justify-center rounded-md bg-brand/15 text-brand text-sm font-bold">◎</div>
+                        <div class="min-w-0">
+                            <div class="text-xs font-semibold truncate">Browser · localhost</div>
+                            <div class="text-[11px] text-muted-foreground truncate">http://localhost:3000</div>
+                        </div>
+                        <button class="ml-auto inline-flex items-center gap-1 rounded-md border bg-background/60 px-2 py-1 text-[11px] text-muted-foreground">☰ All panes</button>
+                    </div>
+                    <div class="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/70 px-1 mb-2">Running sessions</div>
+                    <button class="w-full text-left rounded-xl border border-brand/40 bg-brand/10 p-3 mb-2">
+                        <div class="flex items-start justify-between gap-3">
+                            <div>
+                                <div class="text-[13px] font-semibold">todo-agent · default</div>
+                                <div class="text-[11px] text-muted-foreground">TODO-Agent · default</div>
+                            </div>
+                            <span class="pill bg-amber-500/15 text-amber-300">Needs MCP</span>
+                        </div>
+                        <div class="mt-2 text-[11px] text-muted-foreground">This session does not currently expose the required browser automation MCP entry.</div>
+                    </button>
+                </div>
+
+                <div class="overflow-y-auto p-4 bg-muted/20">
+                    <!-- McpInstallPanel -->
+                    <div class="rounded-xl border p-3 bg-card/60">
+                        <div class="text-xs font-semibold">Install Superset Browser MCP</div>
+                        <div class="mt-1 text-[11px] text-muted-foreground leading-relaxed">
+                            Pick which LLM runtime(s) should be able to drive the browser pane.
+                            Installing is a one-shot operation; after this you just bind panes
+                            from the Connect dialog. Already-installed runtimes are kept
+                            idempotent — re-installing corrects stale paths.
+                        </div>
+                        <div class="mt-3 flex flex-col gap-2">
+                            <div class="flex items-start gap-2 rounded-md border p-2">
+                                <input type="checkbox" checked class="mt-0.5" />
+                                <span class="flex flex-col gap-0.5">
+                                    <span class="text-xs font-medium">Claude Code</span>
+                                    <span class="text-[11px] text-muted-foreground">✓ installed and up to date</span>
+                                </span>
+                            </div>
+                            <div class="flex items-start gap-2 rounded-md border p-2">
+                                <input type="checkbox" class="mt-0.5" />
+                                <span class="flex flex-col gap-0.5">
+                                    <span class="text-xs font-medium">Codex</span>
+                                    <span class="text-[11px] text-muted-foreground">codex CLI found, not yet installed</span>
+                                </span>
+                            </div>
+                        </div>
+                        <div class="mt-3 flex gap-2">
+                            <button class="h-8 px-3 rounded-md text-xs font-medium" style="background: var(--brand); color: white;">Install</button>
+                        </div>
+                        <div class="mt-3 text-[10px] text-muted-foreground">
+                            ⓘ Will register the command <code class="rounded bg-muted px-1">/Applications/Superset.app/Contents/Resources/app.asar.unpacked/resources/superset-browser-mcp</code>.
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="px-5 py-3 border-t flex items-center justify-between gap-2">
+                <div class="text-[11px] text-muted-foreground">Add the MCP entry first, then reopen or restart this session.</div>
+                <div class="flex items-center gap-2">
+                    <button class="h-8 px-3 rounded-md border text-xs">Cancel</button>
+                    <button class="h-8 px-3 rounded-md text-xs font-medium opacity-50" style="background: var(--brand); color: white;" disabled>Connect blocked</button>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- ===================================================================
+         3) All panes (BrowserAutomationList) — current UI
+         =================================================================== -->
+    <section>
+        <h2 class="text-sm font-semibold mb-3 text-muted-foreground">③ All panes ボタン押下時 (BrowserAutomationList / 現状)</h2>
+        <div class="dialog bg-background overflow-hidden" style="max-width: 640px;">
+            <div class="px-5 py-4 border-b">
+                <div class="text-sm font-semibold">Browser Automation</div>
+                <div class="text-xs text-muted-foreground mt-0.5">All browser panes in this workspace and their bound sessions.</div>
+            </div>
+
+            <div class="p-4 grid grid-cols-3 gap-2 border-b">
+                <div class="rounded-lg bg-muted/40 p-3">
+                    <div class="text-xl font-bold tabular-nums">4</div>
+                    <div class="mt-1 text-[10px] uppercase tracking-wider text-muted-foreground">Browser panes</div>
+                </div>
+                <div class="rounded-lg bg-muted/40 p-3">
+                    <div class="text-xl font-bold tabular-nums">2</div>
+                    <div class="mt-1 text-[10px] uppercase tracking-wider text-muted-foreground">Connected</div>
+                </div>
+                <div class="rounded-lg bg-muted/40 p-3">
+                    <div class="text-xl font-bold tabular-nums">1</div>
+                    <div class="mt-1 text-[10px] uppercase tracking-wider text-muted-foreground">Needs setup</div>
+                </div>
+            </div>
+
+            <div class="max-h-[420px] overflow-y-auto p-3 flex flex-col gap-2">
+                <div class="rounded-xl border border-brand/30 bg-brand/5 p-3">
+                    <div class="flex items-start justify-between gap-3">
+                        <div class="min-w-0">
+                            <div class="text-xs font-semibold truncate">Browser · GitHub</div>
+                            <div class="text-[11px] text-muted-foreground truncate">https://github.com/MocA-Love/superset/pull/371</div>
+                        </div>
+                        <span class="pill bg-emerald-500/15 text-emerald-300 shrink-0">Connected</span>
+                    </div>
+                    <div class="mt-2 text-[11px] text-muted-foreground">claude · feature/browser-mcp-target-filter · Claude · MCP ready</div>
+                    <div class="mt-3 flex gap-2">
+                        <button class="h-8 px-3 rounded-md border text-xs">Focus</button>
+                        <button class="h-8 px-3 rounded-md text-xs font-medium" style="background: var(--brand); color: white;">Change</button>
+                    </div>
+                </div>
+
+                <div class="rounded-xl border p-3 bg-card/60">
+                    <div class="flex items-start justify-between gap-3">
+                        <div class="min-w-0">
+                            <div class="text-xs font-semibold truncate">Browser · Docs</div>
+                            <div class="text-[11px] text-muted-foreground truncate">https://docs.superset.sh/</div>
+                        </div>
+                        <span class="pill bg-muted text-muted-foreground shrink-0">Unassigned</span>
+                    </div>
+                    <div class="mt-2 text-[11px] text-muted-foreground">Pick any running LLM session</div>
+                    <div class="mt-3 flex gap-2">
+                        <button class="h-8 px-3 rounded-md border text-xs">Focus</button>
+                        <button class="h-8 px-3 rounded-md text-xs font-medium" style="background: var(--brand); color: white;">Connect</button>
+                    </div>
+                </div>
+
+                <div class="rounded-xl border border-brand/30 bg-brand/5 p-3">
+                    <div class="flex items-start justify-between gap-3">
+                        <div class="min-w-0">
+                            <div class="text-xs font-semibold truncate">Browser · localhost</div>
+                            <div class="text-[11px] text-muted-foreground truncate">http://localhost:3000</div>
+                        </div>
+                        <span class="pill bg-emerald-500/15 text-emerald-300 shrink-0">Connected</span>
+                    </div>
+                    <div class="mt-2 text-[11px] text-muted-foreground">codex · main · Codex · MCP ready</div>
+                    <div class="mt-3 flex gap-2">
+                        <button class="h-8 px-3 rounded-md border text-xs">Focus</button>
+                        <button class="h-8 px-3 rounded-md text-xs font-medium" style="background: var(--brand); color: white;">Change</button>
+                    </div>
+                </div>
+
+                <div class="rounded-xl border p-3 bg-card/60">
+                    <div class="flex items-start justify-between gap-3">
+                        <div class="min-w-0">
+                            <div class="text-xs font-semibold truncate">Browser · Jira</div>
+                            <div class="text-[11px] text-muted-foreground truncate">about:blank</div>
+                        </div>
+                        <span class="pill bg-muted text-muted-foreground shrink-0">Unassigned</span>
+                    </div>
+                    <div class="mt-2 text-[11px] text-muted-foreground">Pick any running LLM session</div>
+                    <div class="mt-3 flex gap-2">
+                        <button class="h-8 px-3 rounded-md border text-xs">Focus</button>
+                        <button class="h-8 px-3 rounded-md text-xs font-medium" style="background: var(--brand); color: white;">Connect</button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- ===================================================================
+         Pain point annotation (ユーザーの声)
+         =================================================================== -->
+    <section class="rounded-xl border p-4 bg-card/60">
+        <h2 class="text-sm font-semibold mb-2">ユーザーが感じている問題点</h2>
+        <ul class="text-xs text-muted-foreground space-y-1.5 list-disc ml-5">
+            <li><b>どれがどのタブに繋がっているかわかりづらい:</b> Session 側は「Attached / Reassign」で自 pane / 他 pane を示すが、右カラムの detail は 1 件ずつしか見えない。"All panes" を開くまで全体像が掴めない。</li>
+            <li><b>すでに紐づいているものがどれかわかりづらい:</b> pane header に現在 bound なセッション名が直接表示されていない (<code>◎</code> + pane 名 + URL のみ)。Session カードの pill で初めて分かる。</li>
+            <li><b>MCP 追加済みなのに毎回インストール用スニペット/パネルが見える:</b> Needs MCP セッションを選ぶたびに <code>McpInstallPanel</code> が右カラム全域を占有。全 runtime が ✓ 済みでも "Install Superset Browser MCP" の見出しが残り、未設定かと勘違いする。</li>
+        </ul>
+    </section>
+
+    <hr class="sep my-8" />
+
+    <div class="rounded-xl p-4" style="background: linear-gradient(180deg, rgba(124,92,255,0.08), transparent);">
+        <h1 class="text-base font-semibold">改善案 (Proposed)</h1>
+        <p class="text-xs text-muted-foreground mt-1">上の3つの Pain Point を解消する方針。元の情報構造はできるだけ保ちつつ、"いま何が繋がっているか" をモーダルを開いた瞬間に一目で伝える。</p>
+        <ul class="text-xs text-muted-foreground mt-3 space-y-1 list-disc ml-5">
+            <li><b>Pain 1/2 を解消:</b> 左ペイン上部に「この pane の現在の binding」を専用カードで常時固定表示 + 全 session カードに "→ どの pane を駆動しているか" を明記。"All panes" のミニサマリもヘッダー直下に inline 展開 (開かずに全 pane の状態が見える)。</li>
+            <li><b>Pain 3 を解消:</b> MCP が「全 runtime ✓ 済み」の場合は右カラムをグリーンの 1 行バナー ("Browser MCP is installed — ready to connect") に畳む。"Manage installations" リンクを添えて必要時だけ詳細展開。未インストール runtime がある場合のみ現状の Install パネルを表示。</li>
+            <li><b>ついでの改善:</b> Session カードの pill に"pane 名"を添える (例: "Driving: Browser · Docs")。detail 右カラムは "Switch / Disconnect / Copy CDP" の3アクションに整理し情報密度を下げる。</li>
+        </ul>
+    </div>
+
+    <!-- ===================================================================
+         A) Improved Connect browser automation — Sessions tab
+         =================================================================== -->
+    <section>
+        <h2 class="text-sm font-semibold mb-3 text-muted-foreground">④ 改善案: Connect browser automation — Sessions タブ</h2>
+        <div class="dialog bg-background overflow-hidden" style="max-width: min(1640px, 95vw);">
+            <!-- Header -->
+            <div class="px-5 py-4 border-b">
+                <div class="text-sm font-semibold">Connect browser automation</div>
+                <div class="text-xs text-muted-foreground mt-0.5">Choose which running LLM session should control this browser pane.</div>
+                <div class="mt-3 flex items-center gap-1 border-b -mb-4 pb-0">
+                    <button class="inline-flex items-center gap-1.5 px-3 py-2 text-[12px] font-medium border-b-2 border-brand text-foreground">☰ Sessions</button>
+                    <button class="inline-flex items-center gap-1.5 px-3 py-2 text-[12px] font-medium border-b-2 border-transparent text-muted-foreground">🛡 Permissions</button>
+                </div>
+            </div>
+
+            <!-- NEW: workspace-wide binding summary bar (inline "All panes") -->
+            <div class="px-5 py-2.5 border-b flex items-center gap-3 text-[11px] bg-muted/20">
+                <span class="text-muted-foreground uppercase tracking-wider text-[10px] font-semibold">Workspace bindings</span>
+                <span class="flex items-center gap-1.5"><span class="w-1.5 h-1.5 rounded-full bg-emerald-300"></span>2 connected</span>
+                <span class="flex items-center gap-1.5 text-muted-foreground"><span class="w-1.5 h-1.5 rounded-full bg-muted-foreground/50"></span>2 unassigned</span>
+                <span class="flex items-center gap-1.5 text-amber-300"><span class="w-1.5 h-1.5 rounded-full bg-amber-300"></span>1 needs setup</span>
+                <button class="ml-auto text-brand hover:underline">Open all panes view →</button>
+            </div>
+
+            <!-- Body -->
+            <div class="grid" style="grid-template-columns: minmax(360px,1fr) minmax(280px,0.9fr); min-height: min(570px,70vh); max-height: min(840px,85vh);">
+                <!-- Left -->
+                <div class="overflow-y-auto p-4 border-r">
+                    <!-- Pane identity now foregrounds the CURRENT binding -->
+                    <div class="rounded-xl border border-brand/30 bg-brand/5 p-3 mb-3">
+                        <div class="flex items-start gap-3">
+                            <div class="flex w-9 h-9 items-center justify-center rounded-lg bg-brand/15 text-brand text-base font-bold shrink-0">◎</div>
+                            <div class="min-w-0 flex-1">
+                                <div class="flex items-center gap-2">
+                                    <div class="text-[13px] font-semibold truncate">Browser · GitHub</div>
+                                    <span class="pill bg-emerald-500/15 text-emerald-300">Connected</span>
+                                </div>
+                                <div class="text-[11px] text-muted-foreground truncate">https://github.com/MocA-Love/superset/pull/371</div>
+                                <div class="mt-1.5 text-[11px] flex items-center gap-1.5">
+                                    <span class="text-muted-foreground">Driven by:</span>
+                                    <span class="font-medium">claude · feature/browser-mcp-target-filter</span>
+                                    <span class="text-muted-foreground">(Claude)</span>
+                                </div>
+                            </div>
+                            <button class="h-7 px-2 rounded-md border text-[11px] shrink-0">Disconnect</button>
+                        </div>
+                    </div>
+
+                    <div class="flex items-center justify-between px-1 mb-2">
+                        <div class="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/70">Running sessions (4)</div>
+                        <div class="flex items-center gap-1 text-[10px]">
+                            <button class="px-1.5 py-0.5 rounded bg-muted text-foreground">All</button>
+                            <button class="px-1.5 py-0.5 rounded text-muted-foreground">Ready</button>
+                            <button class="px-1.5 py-0.5 rounded text-muted-foreground">Unbound</button>
+                        </div>
+                    </div>
+
+                    <div class="flex flex-col gap-2">
+                        <!-- Attached to THIS pane -->
+                        <button class="text-left rounded-xl border border-brand/40 bg-brand/10 p-3">
+                            <div class="flex items-start justify-between gap-3">
+                                <div class="min-w-0">
+                                    <div class="text-[13px] font-semibold truncate">claude · feature/browser-mcp-target-filter</div>
+                                    <div class="text-[11px] text-muted-foreground truncate">Claude · terminal · Last active 2m ago</div>
+                                </div>
+                                <span class="pill bg-brand/15 text-brand shrink-0">● Driving this pane</span>
+                            </div>
+                        </button>
+
+                        <!-- Ready + free -->
+                        <button class="text-left rounded-xl border bg-card hover:bg-muted/40 p-3">
+                            <div class="flex items-start justify-between gap-3">
+                                <div class="min-w-0">
+                                    <div class="text-[13px] font-semibold truncate">codex · main</div>
+                                    <div class="text-[11px] text-muted-foreground truncate">Codex · terminal · Last active 10m ago</div>
+                                </div>
+                                <span class="pill bg-emerald-500/15 text-emerald-300 shrink-0">Ready · Free</span>
+                            </div>
+                        </button>
+
+                        <!-- Reassign -->
+                        <button class="text-left rounded-xl border bg-card hover:bg-muted/40 p-3">
+                            <div class="flex items-start justify-between gap-3">
+                                <div class="min-w-0">
+                                    <div class="text-[13px] font-semibold truncate">claude · issue-377</div>
+                                    <div class="text-[11px] text-muted-foreground truncate">Claude · terminal · Last active 1h ago</div>
+                                </div>
+                                <span class="pill bg-amber-500/15 text-amber-300 shrink-0">Driving: Browser · Docs</span>
+                            </div>
+                            <div class="mt-1.5 text-[11px] leading-snug text-amber-300/80">Connecting here will move ownership from "Browser · Docs".</div>
+                        </button>
+
+                        <!-- Needs MCP -->
+                        <button class="text-left rounded-xl border bg-card hover:bg-muted/40 p-3">
+                            <div class="flex items-start justify-between gap-3">
+                                <div class="min-w-0">
+                                    <div class="text-[13px] font-semibold truncate">todo-agent · default</div>
+                                    <div class="text-[11px] text-muted-foreground truncate">TODO-Agent · Last active 5m ago</div>
+                                </div>
+                                <span class="pill bg-amber-500/15 text-amber-300 shrink-0">Needs MCP</span>
+                            </div>
+                        </button>
+                    </div>
+                </div>
+
+                <!-- Right -->
+                <div class="overflow-y-auto p-4 bg-muted/20">
+                    <!-- NEW: collapsed MCP status banner when everything is installed -->
+                    <div class="rounded-lg border border-emerald-500/30 bg-emerald-500/5 px-3 py-2 mb-3 flex items-center gap-2">
+                        <span class="text-emerald-300 text-sm">✓</span>
+                        <div class="flex-1 min-w-0">
+                            <div class="text-[12px] font-medium text-emerald-300">Browser MCP is installed — ready to connect</div>
+                            <div class="text-[10px] text-muted-foreground">Claude Code · Codex</div>
+                        </div>
+                        <button class="text-[11px] text-muted-foreground hover:text-foreground">Manage ▾</button>
+                    </div>
+
+                    <div class="flex flex-col gap-3">
+                        <div class="rounded-xl border p-3 bg-card/60">
+                            <div class="flex items-center justify-between">
+                                <div class="text-xs font-semibold">claude · feature/browser-mcp-target-filter</div>
+                                <span class="pill bg-brand/15 text-brand">Driving this pane</span>
+                            </div>
+                            <div class="mt-1 text-[11px] text-muted-foreground">Already bound. Use the CDP endpoint below for external tools.</div>
+                            <div class="mt-3 flex items-center gap-2 rounded-md bg-muted/40 px-2 py-1.5">
+                                <code class="text-[11px] truncate">ws://127.0.0.1:47891/devtools/browser/abc123-filtered</code>
+                                <button class="ml-auto shrink-0 text-[11px] text-brand">Copy</button>
+                            </div>
+                            <div class="mt-3 flex gap-2">
+                                <button class="h-7 px-2 rounded-md border text-[11px]">Disconnect</button>
+                                <button class="h-7 px-2 rounded-md border text-[11px]">Move to another pane…</button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="px-5 py-3 border-t flex items-center justify-between gap-2">
+                <div class="text-[11px] text-muted-foreground">This session is already driving this pane. Pick a different one to reassign.</div>
+                <div class="flex items-center gap-2">
+                    <button class="h-8 px-3 rounded-md border text-xs">Close</button>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- ===================================================================
+         B) Improved Connect — Needs MCP (full install panel only when needed)
+         =================================================================== -->
+    <section>
+        <h2 class="text-sm font-semibold mb-3 text-muted-foreground">⑤ 改善案: Needs MCP セッション選択時 (全 runtime インストール済みならバナー、未済み runtime のみ展開)</h2>
+        <div class="dialog bg-background overflow-hidden" style="max-width: min(1640px, 95vw);">
+            <div class="px-5 py-4 border-b">
+                <div class="text-sm font-semibold">Connect browser automation</div>
+                <div class="text-xs text-muted-foreground mt-0.5">Choose which running LLM session should control this browser pane.</div>
+            </div>
+            <div class="grid" style="grid-template-columns: minmax(360px,1fr) minmax(280px,0.9fr); min-height: min(460px,60vh);">
+                <div class="overflow-y-auto p-4 border-r">
+                    <div class="rounded-xl border bg-muted/40 p-3 mb-3">
+                        <div class="text-[13px] font-semibold">Browser · localhost</div>
+                        <div class="text-[11px] text-muted-foreground truncate">http://localhost:3000</div>
+                        <div class="mt-1.5 text-[11px] text-muted-foreground">No session is driving this pane yet.</div>
+                    </div>
+                    <button class="w-full text-left rounded-xl border border-brand/40 bg-brand/10 p-3">
+                        <div class="flex items-start justify-between gap-3">
+                            <div>
+                                <div class="text-[13px] font-semibold">todo-agent · default</div>
+                                <div class="text-[11px] text-muted-foreground">TODO-Agent · Last active 5m ago</div>
+                            </div>
+                            <span class="pill bg-amber-500/15 text-amber-300">Needs MCP</span>
+                        </div>
+                    </button>
+                </div>
+                <div class="overflow-y-auto p-4 bg-muted/20">
+                    <!-- Scoped: only TODO-Agent is missing; Claude/Codex banner stays collapsed -->
+                    <div class="rounded-lg border border-emerald-500/30 bg-emerald-500/5 px-3 py-2 mb-3 flex items-center gap-2">
+                        <span class="text-emerald-300 text-sm">✓</span>
+                        <div class="flex-1 text-[12px] font-medium text-emerald-300">Claude Code / Codex: MCP ready</div>
+                        <button class="text-[11px] text-muted-foreground">Manage ▾</button>
+                    </div>
+
+                    <div class="rounded-xl border border-amber-500/30 p-3 bg-amber-500/5">
+                        <div class="flex items-center gap-2">
+                            <span class="pill bg-amber-500/15 text-amber-300">1 missing</span>
+                            <div class="text-xs font-semibold">TODO-Agent is missing the Browser MCP entry</div>
+                        </div>
+                        <div class="mt-1 text-[11px] text-muted-foreground leading-relaxed">This session type does not auto-install. Register it once, then restart the agent.</div>
+                        <div class="mt-3 flex gap-2">
+                            <button class="h-8 px-3 rounded-md text-xs font-medium" style="background: var(--brand); color: white;">Install for TODO-Agent</button>
+                            <button class="h-8 px-3 rounded-md border text-xs">Copy snippet</button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="px-5 py-3 border-t flex items-center justify-between gap-2">
+                <div class="text-[11px] text-muted-foreground">Install the MCP entry, then reopen this session.</div>
+                <div class="flex items-center gap-2">
+                    <button class="h-8 px-3 rounded-md border text-xs">Cancel</button>
+                    <button class="h-8 px-3 rounded-md text-xs font-medium opacity-50" style="background: var(--brand); color: white;" disabled>Connect blocked</button>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- ===================================================================
+         C) Improved All panes (BrowserAutomationList)
+         =================================================================== -->
+    <section>
+        <h2 class="text-sm font-semibold mb-3 text-muted-foreground">⑥ 改善案: All panes</h2>
+        <div class="dialog bg-background overflow-hidden" style="max-width: 720px;">
+            <div class="px-5 py-4 border-b">
+                <div class="text-sm font-semibold">Browser Automation — workspace overview</div>
+                <div class="text-xs text-muted-foreground mt-0.5">Every browser pane and which LLM session is driving it.</div>
+            </div>
+
+            <!-- Same 3 metrics but tighter + one-row status bar -->
+            <div class="px-4 py-3 border-b flex items-center gap-4 text-[11px]">
+                <span><b class="text-base tabular-nums">4</b> panes</span>
+                <span class="text-emerald-300"><b class="text-base tabular-nums">2</b> connected</span>
+                <span class="text-muted-foreground"><b class="text-base tabular-nums">2</b> unassigned</span>
+                <span class="text-amber-300"><b class="text-base tabular-nums">1</b> needs setup</span>
+                <button class="ml-auto text-[11px] px-2 py-1 rounded-md border">Install MCP…</button>
+            </div>
+
+            <!-- Table-ish row layout so pane ↔ session is obvious at a glance -->
+            <div class="max-h-[460px] overflow-y-auto">
+                <!-- Row: connected -->
+                <div class="flex items-center gap-3 px-4 py-3 border-b hover:bg-muted/20">
+                    <div class="w-2 h-2 rounded-full bg-emerald-400 shrink-0"></div>
+                    <div class="min-w-0 flex-1">
+                        <div class="text-xs font-semibold truncate">Browser · GitHub</div>
+                        <div class="text-[11px] text-muted-foreground truncate">https://github.com/MocA-Love/superset/pull/371</div>
+                    </div>
+                    <div class="text-[11px] text-muted-foreground shrink-0">←</div>
+                    <div class="min-w-0 flex-1">
+                        <div class="text-xs font-medium truncate">claude · feature/browser-mcp-target-filter</div>
+                        <div class="text-[10px] text-muted-foreground">Claude · MCP ready</div>
+                    </div>
+                    <div class="flex gap-1 shrink-0">
+                        <button class="h-7 px-2 rounded-md border text-[11px]">Focus</button>
+                        <button class="h-7 px-2 rounded-md border text-[11px]">Change</button>
+                        <button class="h-7 px-2 rounded-md border text-[11px] text-muted-foreground">⋯</button>
+                    </div>
+                </div>
+
+                <div class="flex items-center gap-3 px-4 py-3 border-b hover:bg-muted/20">
+                    <div class="w-2 h-2 rounded-full bg-emerald-400 shrink-0"></div>
+                    <div class="min-w-0 flex-1">
+                        <div class="text-xs font-semibold truncate">Browser · localhost</div>
+                        <div class="text-[11px] text-muted-foreground truncate">http://localhost:3000</div>
+                    </div>
+                    <div class="text-[11px] text-muted-foreground shrink-0">←</div>
+                    <div class="min-w-0 flex-1">
+                        <div class="text-xs font-medium truncate">codex · main</div>
+                        <div class="text-[10px] text-muted-foreground">Codex · MCP ready</div>
+                    </div>
+                    <div class="flex gap-1 shrink-0">
+                        <button class="h-7 px-2 rounded-md border text-[11px]">Focus</button>
+                        <button class="h-7 px-2 rounded-md border text-[11px]">Change</button>
+                        <button class="h-7 px-2 rounded-md border text-[11px] text-muted-foreground">⋯</button>
+                    </div>
+                </div>
+
+                <!-- Row: unassigned -->
+                <div class="flex items-center gap-3 px-4 py-3 border-b hover:bg-muted/20">
+                    <div class="w-2 h-2 rounded-full bg-muted-foreground/40 shrink-0"></div>
+                    <div class="min-w-0 flex-1">
+                        <div class="text-xs font-semibold truncate">Browser · Docs</div>
+                        <div class="text-[11px] text-muted-foreground truncate">https://docs.superset.sh/</div>
+                    </div>
+                    <div class="text-[11px] text-muted-foreground shrink-0">—</div>
+                    <div class="min-w-0 flex-1">
+                        <div class="text-[11px] text-muted-foreground italic">Unassigned — pick any running LLM session</div>
+                    </div>
+                    <div class="flex gap-1 shrink-0">
+                        <button class="h-7 px-2 rounded-md border text-[11px]">Focus</button>
+                        <button class="h-7 px-2 rounded-md text-[11px] font-medium" style="background: var(--brand); color: white;">Connect</button>
+                    </div>
+                </div>
+
+                <div class="flex items-center gap-3 px-4 py-3 hover:bg-muted/20">
+                    <div class="w-2 h-2 rounded-full bg-muted-foreground/40 shrink-0"></div>
+                    <div class="min-w-0 flex-1">
+                        <div class="text-xs font-semibold truncate">Browser · Jira</div>
+                        <div class="text-[11px] text-muted-foreground truncate">about:blank</div>
+                    </div>
+                    <div class="text-[11px] text-muted-foreground shrink-0">—</div>
+                    <div class="min-w-0 flex-1">
+                        <div class="text-[11px] text-muted-foreground italic">Unassigned</div>
+                    </div>
+                    <div class="flex gap-1 shrink-0">
+                        <button class="h-7 px-2 rounded-md border text-[11px]">Focus</button>
+                        <button class="h-7 px-2 rounded-md text-[11px] font-medium" style="background: var(--brand); color: white;">Connect</button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <section class="rounded-xl border p-4 bg-card/60">
+        <h2 class="text-sm font-semibold mb-2">改善ポイントまとめ (現状 ⇄ 改善後)</h2>
+        <div class="grid grid-cols-2 gap-4 text-xs">
+            <div>
+                <div class="font-semibold text-muted-foreground mb-1">Pain 1/2: 「どれがどのタブに繋がっているか」</div>
+                <ul class="list-disc ml-4 space-y-1 text-muted-foreground">
+                    <li>pane header を "Driven by: claude · …" 明示表示に変更 + Connected pill</li>
+                    <li>Reassign カードに "Driving: Browser · Docs" を pill で同居</li>
+                    <li>ヘッダー直下に workspace 全体の bindings サマリーバーを常駐 (2 connected / 2 unassigned / 1 needs setup)</li>
+                </ul>
+            </div>
+            <div>
+                <div class="font-semibold text-muted-foreground mb-1">Pain 3: 「MCP 追加済みなのに毎回スニペット」</div>
+                <ul class="list-disc ml-4 space-y-1 text-muted-foreground">
+                    <li>全 runtime ✓ なら 1 行のグリーンバナーに折り畳み</li>
+                    <li>"Manage ▾" で従来の Install パネルに展開可能</li>
+                    <li>欠けている runtime がある場合のみ、その runtime 名入りの amber パネルを表示</li>
+                </ul>
+            </div>
+            <div>
+                <div class="font-semibold text-muted-foreground mb-1">All panes の可読性</div>
+                <ul class="list-disc ml-4 space-y-1 text-muted-foreground">
+                    <li>カード羅列 → テーブル風の 1 行レイアウト (pane ← session を矢印で示す)</li>
+                    <li>ステータスドット (emerald / muted / amber) で一目判別</li>
+                </ul>
+            </div>
+            <div>
+                <div class="font-semibold text-muted-foreground mb-1">情報密度の最適化</div>
+                <ul class="list-disc ml-4 space-y-1 text-muted-foreground">
+                    <li>Session カードの 3 Tag 行 (kind / branch / last active) を sub-line 1 行に統合</li>
+                    <li>右カラム detail は Copy CDP / Disconnect / Move to another pane の3アクションに絞る</li>
+                </ul>
+            </div>
+        </div>
+    </section>
+
+</div>
+</body>
+</html>


### PR DESCRIPTION
## 背景 / 動機

ユーザーから以下の声がありました:

1. どれがどのタブに繋がっているかわかりづらい
2. すでに紐づいているものがどれかわかりづらい
3. すでに MCP を追加しているのに毎回追加用スニペットが出て、「設定できてないのかな?」と思ってしまう

`mock.html` で現状 UI を再現し改善案を作成、本 PR で実装に落とし込みました。

## 変更点

### SessionConnectModal
- pane identity カードを刷新: **Connected / Unassigned pill** + `Driven by: <session名>` を明示。disconnect ボタンもカード右端に同居
- ヘッダー直下に **Workspace bindings サマリバー** (connected / unassigned / needs setup) を常駐。"Open all panes view →" から `BrowserAutomationList` にジャンプ
- SessionCard の pill を状況別に刷新:
  - 自 pane に bind されているセッション → `● Driving this pane`
  - 他 pane に bind されているセッション → `Driving: <pane名>`
  - 未 bind で ready → `Ready · Free`
- 3 タグ行 (kind / branch / last active) を 1 行 sub-line に統合し情報密度を下げた
- footer の重複 Disconnect ボタンを削除 (pane identity カード側に統合)

### McpInstallPanel
- 全 runtime が installed + matchesExpected なら **emerald 1 行バナー** ("Browser MCP is installed — ready to connect") に畳む
- "Manage ▾" で従来のインストールパネルへ展開可能
- 未インストール runtime がある場合のみ従来通り展開表示

### BrowserAutomationList (All panes)
- カード羅列 → **status dot + pane ← session 矢印 + actions** の 1 行テーブル風レイアウト
- メトリクスを 3 カード → 1 行のインライン表示に圧縮

## 参考

- UI 比較は `mock.html` に現状 ①②③ / 改善案 ④⑤⑥ を並べて確認できます

## Test plan

- [ ] ブラウザ pane を開き Connect モーダルで pane identity カードに "Driven by: …" が出る
- [ ] 他 pane に bind 済みのセッションを選ぶと "Driving: <pane名>" pill が表示される
- [ ] 全 runtime インストール済みなら右カラムが 1 行バナーに畳まれる
- [ ] Manage ▾ で従来のインストールパネルが展開される
- [ ] All panes モーダルが 1 行レイアウトで表示される

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * セッション接続モーダルに「Workspace」タブを追加し、ワークスペース単位のペーン一覧と操作を追加。
  * 新しい視覚モックを追加し、接続フローと各種状態をサンプル表示。

* **UI改善**
  * ブラウザ自動化一覧をテーブル風に再設計し、合計/接続/未割当/要設定を一行で要約表示。
  * モーダルや行レイアウトを整理、名称短縮・トゥールチップ・分割コマンド表示を導入。
* **改善**
  * MCPインストール表示を凝縮バナーで簡潔化。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->