### PR TITLE
fix(desktop): Codex 重さ調査ログ改善・xterm rAFバッファ・JSONL タイムアウト延長 (#293)

### DIFF
--- a/apps/desktop/src/main/todo-daemon/pty-turn-runner.ts
+++ b/apps/desktop/src/main/todo-daemon/pty-turn-runner.ts
@@ -78,7 +78,7 @@ const CLAUDE_BIN =
 const CLAUDE_PROJECTS_ROOT = path.join(os.homedir(), ".claude", "projects");
 
 /** How long we wait after spawn for the JSONL file to appear. */
-const JSONL_DISCOVERY_TIMEOUT_MS = 15_000;
+const JSONL_DISCOVERY_TIMEOUT_MS = 30_000;
 
 /** How often we poll the JSONL file for appended lines. */
 const JSONL_POLL_INTERVAL_MS = 250;
@@ -330,14 +330,19 @@ export async function runClaudeTurnPty(
 
 		if (!state.jsonlPath) {
 			const runtimeSid = hookSink.readRuntimeSessionId();
+			const foundJsonls = listJsonl(projectDir);
+			const foundStr =
+				foundJsonls.length > 0
+					? `projectDir に存在するファイル: ${foundJsonls.slice(0, 5).join(", ")}${foundJsonls.length > 5 ? ` 他${foundJsonls.length - 5}件` : ""}`
+					: "projectDir に .jsonl ファイルが見つかりません";
 			return {
 				result: null,
 				sessionId: state.claudeSessionId,
 				costUsd: null,
 				numTurns: null,
 				error: runtimeSid
-					? `Claude Code のセッション JSONL (${runtimeSid}.jsonl) が発見できませんでした`
-					: "SessionStart hook が発火しなかったため JSONL を同定できませんでした (PTY 起動は成功)",
+					? `Claude Code のセッション JSONL (${runtimeSid}.jsonl) が発見できませんでした — ${foundStr}`
+					: `SessionStart hook が発火しなかったため JSONL を同定できませんでした (PTY 起動は成功) — ${foundStr}`,
 				interrupted: false,
 				scheduledWakeup: null,
 			};

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalStream.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalStream.ts
@@ -5,6 +5,7 @@ import { useTabsStore } from "renderer/stores/tabs/store";
 import { setPaneWorkspaceRunState } from "renderer/stores/tabs/workspace-run";
 import { DEBUG_TERMINAL } from "../config";
 import { logTerminalWrite, terminalRendererDebug } from "../debug";
+import { scheduleWrite } from "../v1-terminal-cache";
 import type { TerminalExitReason, TerminalStreamEvent } from "../types";
 
 export interface UseTerminalStreamOptions {
@@ -192,7 +193,7 @@ export function useTerminalStream({
 
 				updateModesRef.current(event.data);
 				logTerminalWrite("stream-data", event.data.length, { paneId });
-				xterm.write(event.data);
+				scheduleWrite(paneId, event.data);
 				updateCwdRef.current(event.data);
 			} else if (event.type === "exit") {
 				handleTerminalExit(event.exitCode, xterm, event.reason);

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalStream.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalStream.ts
@@ -5,8 +5,8 @@ import { useTabsStore } from "renderer/stores/tabs/store";
 import { setPaneWorkspaceRunState } from "renderer/stores/tabs/workspace-run";
 import { DEBUG_TERMINAL } from "../config";
 import { logTerminalWrite, terminalRendererDebug } from "../debug";
-import { flushWrite, scheduleWrite } from "../v1-terminal-cache";
 import type { TerminalExitReason, TerminalStreamEvent } from "../types";
+import { flushWrite, scheduleWrite } from "../v1-terminal-cache";
 
 export interface UseTerminalStreamOptions {
 	paneId: string;

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalStream.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalStream.ts
@@ -5,7 +5,7 @@ import { useTabsStore } from "renderer/stores/tabs/store";
 import { setPaneWorkspaceRunState } from "renderer/stores/tabs/workspace-run";
 import { DEBUG_TERMINAL } from "../config";
 import { logTerminalWrite, terminalRendererDebug } from "../debug";
-import { scheduleWrite } from "../v1-terminal-cache";
+import { flushWrite, scheduleWrite } from "../v1-terminal-cache";
 import type { TerminalExitReason, TerminalStreamEvent } from "../types";
 
 export interface UseTerminalStreamOptions {
@@ -196,12 +196,15 @@ export function useTerminalStream({
 				scheduleWrite(paneId, event.data);
 				updateCwdRef.current(event.data);
 			} else if (event.type === "exit") {
+				flushWrite(paneId);
 				handleTerminalExit(event.exitCode, xterm, event.reason);
 			} else if (event.type === "disconnect") {
+				flushWrite(paneId);
 				setConnectionError(
 					event.reason || "Connection to terminal daemon lost",
 				);
 			} else if (event.type === "error") {
+				flushWrite(paneId);
 				handleStreamError(event, xterm);
 			}
 		},

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/v1-terminal-cache.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/v1-terminal-cache.ts
@@ -292,6 +292,7 @@ function routeEvent(
 		logTerminalWrite("hidden-stream-data", event.data.length, { paneId });
 		scheduleWrite(paneId, event.data);
 	} else {
+		flushWrite(paneId);
 		entry.pendingLifecycleEvents.push(event);
 	}
 }
@@ -465,6 +466,8 @@ if (hot) {
 		| undefined;
 	if (existing) {
 		for (const [k, v] of existing) {
+			v.rafWriteBuffer ??= "";
+			v.rafWriteId ??= null;
 			cache.set(k, v);
 		}
 	}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/v1-terminal-cache.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/v1-terminal-cache.ts
@@ -54,6 +54,9 @@ export interface CachedTerminal {
 	subscriptionErrorHandler: ((error: unknown) => void) | null;
 	/** ResizeObserver for the attached container. Managed by attach/detach. */
 	resizeObserver: ResizeObserver | null;
+	/** rAF-batched write buffer: data accumulates here until the next frame. */
+	rafWriteBuffer: string;
+	rafWriteId: ReturnType<typeof requestAnimationFrame> | null;
 }
 
 const cache = new Map<string, CachedTerminal>();
@@ -95,6 +98,8 @@ export function getOrCreate(
 		resizeObserver: null,
 		lastCols: xterm.cols,
 		lastRows: xterm.rows,
+		rafWriteBuffer: "",
+		rafWriteId: null,
 	};
 
 	cache.set(paneId, entry);
@@ -212,6 +217,30 @@ export function updateAppearance(
 	};
 }
 
+// --- rAF write buffer ---
+
+/**
+ * Batch xterm.write calls into one per animation frame to reduce the number
+ * of parser/render cycles. Callers accumulate data here; the actual write
+ * fires in the next rAF, coalescing all chunks that arrived within ~16 ms.
+ */
+export function scheduleWrite(paneId: string, data: string): void {
+	const entry = cache.get(paneId);
+	if (!entry) return;
+	entry.rafWriteBuffer += data;
+	if (entry.rafWriteId === null) {
+		entry.rafWriteId = requestAnimationFrame(() => {
+			const e = cache.get(paneId);
+			if (!e) return;
+			if (e.rafWriteBuffer) {
+				e.xterm.write(e.rafWriteBuffer);
+				e.rafWriteBuffer = "";
+			}
+			e.rafWriteId = null;
+		});
+	}
+}
+
 // --- Stream subscription ---
 
 function routeEvent(
@@ -243,7 +272,7 @@ function routeEvent(
 			data: { paneId },
 		});
 		logTerminalWrite("hidden-stream-data", event.data.length, { paneId });
-		entry.xterm.write(event.data);
+		scheduleWrite(paneId, event.data);
 	} else {
 		entry.pendingLifecycleEvents.push(event);
 	}
@@ -402,6 +431,9 @@ export function dispose(paneId: string): void {
 
 	entry.resizeObserver?.disconnect();
 	entry.subscription?.unsubscribe();
+	if (entry.rafWriteId !== null) {
+		cancelAnimationFrame(entry.rafWriteId);
+	}
 	entry.cleanupCreation();
 	entry.xterm.dispose();
 	cache.delete(paneId);

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/v1-terminal-cache.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/v1-terminal-cache.ts
@@ -241,6 +241,24 @@ export function scheduleWrite(paneId: string, data: string): void {
 	}
 }
 
+/**
+ * Immediately flush any buffered data to xterm, cancelling the pending rAF.
+ * Must be called before processing exit/error/disconnect events so that
+ * trailing output is rendered before the exit banner or pane disposal.
+ */
+export function flushWrite(paneId: string): void {
+	const entry = cache.get(paneId);
+	if (!entry) return;
+	if (entry.rafWriteId !== null) {
+		cancelAnimationFrame(entry.rafWriteId);
+		entry.rafWriteId = null;
+	}
+	if (entry.rafWriteBuffer) {
+		entry.xterm.write(entry.rafWriteBuffer);
+		entry.rafWriteBuffer = "";
+	}
+}
+
 // --- Stream subscription ---
 
 function routeEvent(

--- a/apps/desktop/src/renderer/stores/tabs/store.ts
+++ b/apps/desktop/src/renderer/stores/tabs/store.ts
@@ -61,7 +61,10 @@ import {
 	resolveActiveTabIdForWorkspace,
 	resolveFileViewerMode,
 } from "./utils";
-import { killTerminalForPane, releaseTerminalCache } from "./utils/terminal-cleanup";
+import {
+	killTerminalForPane,
+	releaseTerminalCache,
+} from "./utils/terminal-cleanup";
 
 const DEFAULT_FILE_VIEWER_SPLIT_PERCENTAGE = 50;
 

--- a/apps/desktop/src/renderer/stores/tabs/store.ts
+++ b/apps/desktop/src/renderer/stores/tabs/store.ts
@@ -61,7 +61,7 @@ import {
 	resolveActiveTabIdForWorkspace,
 	resolveFileViewerMode,
 } from "./utils";
-import { killTerminalForPane } from "./utils/terminal-cleanup";
+import { killTerminalForPane, releaseTerminalCache } from "./utils/terminal-cleanup";
 
 const DEFAULT_FILE_VIEWER_SPLIT_PERCENTAGE = 50;
 
@@ -492,6 +492,7 @@ export const useTabsStore = create<TabsStore>()(
 					const newPanes = { ...state.panes };
 					for (const paneId of paneIds) {
 						delete newPanes[paneId];
+						releaseTerminalCache(paneId);
 					}
 
 					const newTabs = state.tabs.filter((t) => t.id !== tabId);
@@ -670,6 +671,7 @@ export const useTabsStore = create<TabsStore>()(
 								killTerminalForPane(paneId);
 							}
 							delete newPanes[paneId];
+							releaseTerminalCache(paneId);
 						}
 					}
 
@@ -1256,6 +1258,7 @@ export const useTabsStore = create<TabsStore>()(
 					const newPanes = { ...state.panes };
 					for (const id of paneIdsToRemove) {
 						delete newPanes[id];
+						releaseTerminalCache(id);
 					}
 
 					let newFocusedPaneIds = state.focusedPaneIds;

--- a/apps/desktop/src/renderer/stores/tabs/utils/terminal-cleanup.ts
+++ b/apps/desktop/src/renderer/stores/tabs/utils/terminal-cleanup.ts
@@ -1,5 +1,6 @@
 import { rejectTerminalSessionReady } from "../../../lib/terminal/session-readiness";
 import { electronTrpcClient } from "../../../lib/trpc-client";
+import * as v1TerminalCache from "../../../screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/v1-terminal-cache";
 
 /**
  * Uses standalone tRPC client to avoid React hook dependencies
@@ -9,6 +10,9 @@ export const killTerminalForPane = (paneId: string): void => {
 		paneId,
 		new Error("Terminal pane was closed before the session became ready"),
 	);
+	// Eagerly release xterm/WebGL resources in case the React unmount is delayed.
+	// v1TerminalCache.dispose is idempotent (no-op if already disposed).
+	v1TerminalCache.dispose(paneId);
 	electronTrpcClient.terminal.kill.mutate({ paneId }).catch((error) => {
 		console.warn(`Failed to kill terminal for pane ${paneId}:`, error);
 	});

--- a/apps/desktop/src/renderer/stores/tabs/utils/terminal-cleanup.ts
+++ b/apps/desktop/src/renderer/stores/tabs/utils/terminal-cleanup.ts
@@ -10,10 +10,18 @@ export const killTerminalForPane = (paneId: string): void => {
 		paneId,
 		new Error("Terminal pane was closed before the session became ready"),
 	);
-	// Eagerly release xterm/WebGL resources in case the React unmount is delayed.
-	// v1TerminalCache.dispose is idempotent (no-op if already disposed).
-	v1TerminalCache.dispose(paneId);
 	electronTrpcClient.terminal.kill.mutate({ paneId }).catch((error) => {
 		console.warn(`Failed to kill terminal for pane ${paneId}:`, error);
 	});
+};
+
+/**
+ * Release xterm/WebGL resources for a terminal pane.
+ * Call this AFTER the pane has been removed from the store so that the React
+ * component is already unmounted (or will unmount in the same batch) before
+ * xterm is disposed. dispose() is idempotent — safe to call even if the
+ * useTerminalLifecycle cleanup already ran.
+ */
+export const releaseTerminalCache = (paneId: string): void => {
+	v1TerminalCache.dispose(paneId);
 };

--- a/apps/desktop/src/shared/debug-channel.ts
+++ b/apps/desktop/src/shared/debug-channel.ts
@@ -55,7 +55,7 @@ interface AggregateState {
 	timer: ReturnType<typeof setTimeout> | null;
 }
 
-const DEFAULT_AGGREGATE_INTERVAL_MS = 1_000;
+const DEFAULT_AGGREGATE_INTERVAL_MS = 30_000;
 const DEFAULT_MAX_STRING_LENGTH = 500;
 
 function truncateString(value: string, maxLength: number): string {


### PR DESCRIPTION
## 概要

Issue #293「Codexが重い」の Sentry ログ調査（PR #341/#344）で得られた知見をもとに修正。

---

## 変更一覧

| # | ファイル | 変更内容 | デメリット |
|---|---|---|---|
| 1 | `shared/debug-channel.ts` | Sentry 集計間隔を **1秒 → 30秒** に延長 | Sentry ログの時系列粒度が粗くなる。調査中は解像度が下がるトレードオフ |
| 2 | `v1-terminal-cache.ts` | **rAF write バッファ**を追加。`scheduleWrite` で1フレーム分のデータを束ねて1回の `xterm.write` に集約 | PTY出力の描画が最大16ms（1フレーム）遅延する。人間には知覚不可だが原理上の遅延は存在する |
| 3 | `v1-terminal-cache.ts` | `flushWrite` をエクスポート。exit/disconnect/error イベント処理前と hidden経路のキュー前に呼び出し、**trailing output の消失を防止** | なし |
| 4 | `v1-terminal-cache.ts` | HMR 復元ブロックで `rafWriteBuffer ??= ""` / `rafWriteId ??= null` を追加。**ホットリロード後のフィールド欠落バグを修正** | なし（開発時のみの修正） |
| 5 | `useTerminalStream.ts` | マウント時の `xterm.write` を `scheduleWrite` 経由に変更（#2 の適用） | #2 と同じ（最大16ms遅延） |
| 6 | `terminal-cleanup.ts` | `killTerminalForPane` から dispose を除去し、`releaseTerminalCache` を独立した関数として追加 | なし |
| 7 | `store.ts` | ペイン削除後（`delete newPanes[id]` の直後）に `releaseTerminalCache` を呼び、**xterm/WebGL リソースを確実に解放** | なし（dispose は idempotent） |
| 8 | `pty-turn-runner.ts` | JSONL 発見タイムアウトを **15秒 → 30秒** に延長 | Todo Agent の失敗検出が最大15秒遅くなる |
| 8 | `pty-turn-runner.ts` | タイムアウト時のエラーメッセージに projectDir の実在ファイル一覧を追記 | なし（ローカル完結、外部送信なし） |

---

## 根本原因の整理

Sentry 9エージェント並列調査から判明した原因と対応関係:

| 原因 | 深刻度 | 本PRでの対応 |
|---|---|---|
| Sentry 集計ログが毎秒送信され、調査ログ自体が CPU/メモリ負荷を生んでいた | 中 | #1 で解消 |
| `xterm.write` がスロットリングなしで毎秒30回呼ばれ、描画負荷が高かった | 中〜大 | #2 #5 で緩和 |
| hidden keepalive は意図的設計（リークではない） | — | 対処不要 |
| mount/unmount 非対称によるリソース残留リスク | 低 | #6 #7 で解消 |
| Todo Agent が JSONL 生成タイミング差で15秒タイムアウトに引っかかっていた | 中 | #8 で解消 |

---

## 残課題

- `allowTransparency: true` の WebGL 描画コスト（視覚確認後に判断）
- scrollback 5000行のGPUメモリ消費（ユーザー設定化 or デフォルト削減を別途検討）
- Codex TUI 自体の CPU 負荷（rAF バッファの効果を次回 Sentry ログで確認予定）

Closes 一部 #293（根本的な Codex TUI 負荷自体は継続調査）