### PR TITLE
feat(desktop): Quick Open で :行番号 入力時に指定行へジャンプ

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/FilePane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/FilePane.tsx
@@ -186,6 +186,9 @@ function FilePaneContent({ context, workspaceId }: FilePaneProps) {
 					document={document}
 					filePath={filePath}
 					workspaceId={workspaceId}
+					initialLine={data.line}
+					initialColumn={data.column}
+					cursorRequestId={data.cursorRequestId}
 					onChangeView={handleChangeView}
 					onForceView={handleForceView}
 				/>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/registry/types.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/registry/types.ts
@@ -34,6 +34,9 @@ export interface ViewProps {
 	document: SharedFileDocument;
 	filePath: string;
 	workspaceId: string;
+	initialLine?: number;
+	initialColumn?: number;
+	cursorRequestId?: string;
 	onChangeView: (viewId: string) => void;
 	onForceView: (viewId: string) => void;
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/registry/views/CodeView/CodeView.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/registry/views/CodeView/CodeView.tsx
@@ -2,7 +2,13 @@ import { detectLanguage } from "shared/detect-language";
 import type { ViewProps } from "../../types";
 import { CodeEditor } from "./components/CodeEditor";
 
-export function CodeView({ document, filePath }: ViewProps) {
+export function CodeView({
+	document,
+	filePath,
+	initialLine,
+	initialColumn,
+	cursorRequestId,
+}: ViewProps) {
 	if (document.content.kind !== "text") {
 		return null;
 	}
@@ -12,6 +18,9 @@ export function CodeView({ document, filePath }: ViewProps) {
 			key={document.id}
 			value={document.content.value}
 			language={detectLanguage(filePath)}
+			initialLine={initialLine}
+			initialColumn={initialColumn}
+			cursorRequestId={cursorRequestId}
 			onChange={(next) => document.setContent(next)}
 			onSave={() => void document.save()}
 			fillHeight

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/registry/views/CodeView/components/CodeEditor/CodeEditor.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/registry/views/CodeView/components/CodeEditor/CodeEditor.tsx
@@ -26,7 +26,7 @@ import {
 import { colorPicker } from "@replit/codemirror-css-color-picker";
 import { cn } from "@superset/ui/utils";
 import { useQuery } from "@tanstack/react-query";
-import { type MutableRefObject, useEffect, useRef } from "react";
+import { type MutableRefObject, useEffect, useRef, useState } from "react";
 import { electronTrpcClient } from "renderer/lib/trpc-client";
 import { useResolvedTheme } from "renderer/stores/theme";
 import {
@@ -44,6 +44,9 @@ import { getCodeSyntaxHighlighting } from "./syntax-highlighting";
 interface CodeEditorProps {
 	value: string;
 	language: string;
+	initialLine?: number;
+	initialColumn?: number;
+	cursorRequestId?: string;
 	readOnly?: boolean;
 	fillHeight?: boolean;
 	className?: string;
@@ -55,6 +58,9 @@ interface CodeEditorProps {
 export function CodeEditor({
 	value,
 	language,
+	initialLine,
+	initialColumn,
+	cursorRequestId,
 	readOnly = false,
 	fillHeight = true,
 	className,
@@ -64,6 +70,7 @@ export function CodeEditor({
 }: CodeEditorProps) {
 	const containerRef = useRef<HTMLDivElement | null>(null);
 	const viewRef = useRef<EditorView | null>(null);
+	const [viewReady, setViewReady] = useState(false);
 	const languageCompartment = useRef(new Compartment()).current;
 	const themeCompartment = useRef(new Compartment()).current;
 	const editableCompartment = useRef(new Compartment()).current;
@@ -160,6 +167,7 @@ export function CodeEditor({
 		if (editorRef) {
 			editorRef.current = adapter;
 		}
+		setViewReady(true);
 
 		return () => {
 			if (editorRef?.current === adapter) {
@@ -257,6 +265,22 @@ export function CodeEditor({
 			cancelled = true;
 		};
 	}, [language, languageCompartment]);
+
+	useEffect(() => {
+		if (initialLine === undefined) {
+			return;
+		}
+		if (cursorRequestId === undefined) {
+			return;
+		}
+		const view = viewRef.current;
+		if (!view || !viewReady) {
+			return;
+		}
+
+		const adapter = createCodeMirrorAdapter(view);
+		adapter.revealPosition(initialLine, initialColumn);
+	}, [cursorRequestId, viewReady, initialLine, initialColumn]);
 
 	return (
 		<div

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/registry/views/CodeView/components/CodeEditor/CodeEditor.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/registry/views/CodeView/components/CodeEditor/CodeEditor.tsx
@@ -275,10 +275,7 @@ export function CodeEditor({
 			return;
 		}
 
-		const safeLine = Math.max(
-			1,
-			Math.min(initialLine, view.state.doc.lines),
-		);
+		const safeLine = Math.max(1, Math.min(initialLine, view.state.doc.lines));
 		const lineInfo = view.state.doc.line(safeLine);
 		const col = initialColumn ?? 1;
 		const offset = Math.min(col - 1, lineInfo.length);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/registry/views/CodeView/components/CodeEditor/CodeEditor.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/registry/views/CodeView/components/CodeEditor/CodeEditor.tsx
@@ -12,7 +12,7 @@ import {
 	indentOnInput,
 } from "@codemirror/language";
 import { highlightSelectionMatches, searchKeymap } from "@codemirror/search";
-import { Compartment, EditorState } from "@codemirror/state";
+import { Compartment, EditorSelection, EditorState } from "@codemirror/state";
 import {
 	drawSelection,
 	dropCursor,
@@ -267,10 +267,7 @@ export function CodeEditor({
 	}, [language, languageCompartment]);
 
 	useEffect(() => {
-		if (initialLine === undefined) {
-			return;
-		}
-		if (cursorRequestId === undefined) {
+		if (initialLine === undefined || cursorRequestId === undefined) {
 			return;
 		}
 		const view = viewRef.current;
@@ -278,8 +275,20 @@ export function CodeEditor({
 			return;
 		}
 
-		const adapter = createCodeMirrorAdapter(view);
-		adapter.revealPosition(initialLine, initialColumn);
+		const safeLine = Math.max(
+			1,
+			Math.min(initialLine, view.state.doc.lines),
+		);
+		const lineInfo = view.state.doc.line(safeLine);
+		const col = initialColumn ?? 1;
+		const offset = Math.min(col - 1, lineInfo.length);
+		const anchor = lineInfo.from + Math.max(0, offset);
+
+		view.dispatch({
+			selection: EditorSelection.cursor(anchor),
+			scrollIntoView: true,
+		});
+		view.focus();
 	}, [cursorRequestId, viewReady, initialLine, initialColumn]);
 
 	return (

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
@@ -239,9 +239,7 @@ function WorkspaceContent({
 			recordRecentlyViewed(filePath);
 			const state = store.getState();
 			const cursorRequestId =
-				location?.line !== undefined
-					? `${Date.now()}:${Math.random().toString(36).slice(2, 10)}`
-					: undefined;
+				location?.line !== undefined ? crypto.randomUUID() : undefined;
 			const active = state.getActivePane();
 			if (
 				active?.pane.kind === "file" &&
@@ -257,7 +255,7 @@ function WorkspaceContent({
 						paneId: active.pane.id,
 						data: {
 							...activeData,
-							displayName,
+							displayName: displayName ?? activeData.displayName,
 							line: location?.line,
 							column: location?.column,
 							cursorRequestId,

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
@@ -231,23 +231,36 @@ function WorkspaceContent({
 	// sidebar open into a single `openFilePane(filePath, openInNewTab)`; the
 	// fork keeps two variants so memo tabs can forward the derived title.
 	const openFilePane = useCallback(
-		(filePath: string, displayName?: string) => {
+		(
+			filePath: string,
+			displayName?: string,
+			location?: { line?: number; column?: number },
+		) => {
 			recordRecentlyViewed(filePath);
 			const state = store.getState();
+			const cursorRequestId =
+				location?.line !== undefined
+					? `${Date.now()}:${Math.random().toString(36).slice(2, 10)}`
+					: undefined;
 			const active = state.getActivePane();
 			if (
 				active?.pane.kind === "file" &&
 				(active.pane.data as FilePaneData).filePath === filePath
 			) {
-				if (
-					displayName &&
-					(active.pane.data as FilePaneData).displayName !== displayName
-				) {
+				const activeData = active.pane.data as FilePaneData;
+				const shouldUpdateData =
+					(displayName && activeData.displayName !== displayName) ||
+					location?.line !== undefined ||
+					location?.column !== undefined;
+				if (shouldUpdateData) {
 					state.setPaneData({
 						paneId: active.pane.id,
 						data: {
-							...(active.pane.data as FilePaneData),
+							...activeData,
 							displayName,
+							line: location?.line,
+							column: location?.column,
+							cursorRequestId,
 						} as FilePaneData,
 					});
 				}
@@ -261,6 +274,9 @@ function WorkspaceContent({
 						filePath,
 						mode: "editor",
 						displayName,
+						line: location?.line,
+						column: location?.column,
+						cursorRequestId,
 					} as FilePaneData,
 				},
 			});
@@ -506,7 +522,7 @@ function WorkspaceContent({
 		navigate,
 		openFilePaths: openFilePathsList,
 		recentFilePaths: recentFilePathsList,
-		onSelectFile: ({ close, filePath, targetWorkspaceId }) => {
+		onSelectFile: ({ close, filePath, targetWorkspaceId, line, column }) => {
 			close();
 			if (targetWorkspaceId !== workspaceId) {
 				void navigate({
@@ -515,7 +531,7 @@ function WorkspaceContent({
 				});
 				return;
 			}
-			openFilePane(filePath);
+			openFilePane(filePath, undefined, { line, column });
 		},
 	});
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/types.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/types.ts
@@ -4,6 +4,9 @@ export interface FilePaneData {
 	/** FORK NOTE: carried for memo tabs so the tab title shows the
 	 * memo-derived displayName instead of the random filename. */
 	displayName?: string;
+	line?: number;
+	column?: number;
+	cursorRequestId?: string;
 	language?: string;
 	viewId?: string;
 	forceViewId?: string;

--- a/apps/desktop/src/renderer/screens/main/components/CommandPalette/index.ts
+++ b/apps/desktop/src/renderer/screens/main/components/CommandPalette/index.ts
@@ -1,2 +1,3 @@
 export { CommandPalette } from "./CommandPalette";
-export { parseQuickOpenQuery, useCommandPalette } from "./useCommandPalette";
+export { parseQuickOpenQuery } from "./parseQuickOpenQuery";
+export { useCommandPalette } from "./useCommandPalette";

--- a/apps/desktop/src/renderer/screens/main/components/CommandPalette/index.ts
+++ b/apps/desktop/src/renderer/screens/main/components/CommandPalette/index.ts
@@ -1,2 +1,2 @@
 export { CommandPalette } from "./CommandPalette";
-export { useCommandPalette } from "./useCommandPalette";
+export { parseQuickOpenQuery, useCommandPalette } from "./useCommandPalette";

--- a/apps/desktop/src/renderer/screens/main/components/CommandPalette/parseQuickOpenQuery.test.ts
+++ b/apps/desktop/src/renderer/screens/main/components/CommandPalette/parseQuickOpenQuery.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "bun:test";
+import { parseQuickOpenQuery } from "./parseQuickOpenQuery";
+
+describe("parseQuickOpenQuery", () => {
+	it("returns the query as-is when no line suffix", () => {
+		expect(parseQuickOpenQuery("foo.ts")).toEqual({
+			searchQuery: "foo.ts",
+		});
+	});
+
+	it("returns the query as-is for empty string", () => {
+		expect(parseQuickOpenQuery("")).toEqual({
+			searchQuery: "",
+		});
+	});
+
+	it("parses file:line", () => {
+		expect(parseQuickOpenQuery("foo.ts:123")).toEqual({
+			searchQuery: "foo.ts",
+			line: 123,
+		});
+	});
+
+	it("parses file:line:column", () => {
+		expect(parseQuickOpenQuery("foo.ts:123:45")).toEqual({
+			searchQuery: "foo.ts",
+			line: 123,
+			column: 45,
+		});
+	});
+
+	it("parses path with directories and line", () => {
+		expect(parseQuickOpenQuery("src/components/App.tsx:42")).toEqual({
+			searchQuery: "src/components/App.tsx",
+			line: 42,
+		});
+	});
+
+	it("returns query as-is when line is zero", () => {
+		expect(parseQuickOpenQuery("foo.ts:0")).toEqual({
+			searchQuery: "foo.ts:0",
+		});
+	});
+
+	it("returns query as-is when line is negative", () => {
+		expect(parseQuickOpenQuery("foo.ts:-5")).toEqual({
+			searchQuery: "foo.ts:-5",
+		});
+	});
+
+	it("returns query as-is for non-numeric suffix", () => {
+		expect(parseQuickOpenQuery("foo.ts:abc")).toEqual({
+			searchQuery: "foo.ts:abc",
+		});
+	});
+
+	it("returns query as-is when path part is empty", () => {
+		expect(parseQuickOpenQuery(":123")).toEqual({
+			searchQuery: ":123",
+		});
+	});
+
+	it("trims whitespace", () => {
+		expect(parseQuickOpenQuery("  foo.ts:10  ")).toEqual({
+			searchQuery: "foo.ts",
+			line: 10,
+		});
+	});
+
+	it("returns query as-is for column zero", () => {
+		expect(parseQuickOpenQuery("foo.ts:10:0")).toEqual({
+			searchQuery: "foo.ts:10:0",
+		});
+	});
+
+	it("handles Windows-style paths", () => {
+		expect(parseQuickOpenQuery("src\\utils\\helpers.ts:99")).toEqual({
+			searchQuery: "src\\utils\\helpers.ts",
+			line: 99,
+		});
+	});
+});

--- a/apps/desktop/src/renderer/screens/main/components/CommandPalette/parseQuickOpenQuery.ts
+++ b/apps/desktop/src/renderer/screens/main/components/CommandPalette/parseQuickOpenQuery.ts
@@ -1,0 +1,66 @@
+interface ParsedQuickOpenQuery {
+	searchQuery: string;
+	line?: number;
+	column?: number;
+}
+
+export function parseQuickOpenQuery(query: string): ParsedQuickOpenQuery {
+	const trimmedQuery = query.trim();
+	if (!trimmedQuery) {
+		return { searchQuery: "" };
+	}
+
+	// Try to extract :line[:column] from the end of the query.
+	// We need to handle paths like "foo.ts:123" and "foo.ts:123:45"
+	// but NOT "C:\path" (drive letter colon).
+	const lastColon = trimmedQuery.lastIndexOf(":");
+	if (lastColon <= 0) {
+		return { searchQuery: trimmedQuery };
+	}
+
+	const afterLastColon = trimmedQuery.slice(lastColon + 1);
+	if (!/^\d+$/.test(afterLastColon)) {
+		return { searchQuery: trimmedQuery };
+	}
+
+	const maybeColumn = Number.parseInt(afterLastColon, 10);
+
+	// Check if there's another colon:digits before this one (line:column pattern)
+	const beforeLastColon = trimmedQuery.slice(0, lastColon);
+	const secondLastColon = beforeLastColon.lastIndexOf(":");
+	let pathPart: string;
+	let line: number;
+	let column: number | undefined;
+
+	if (
+		secondLastColon > 0 &&
+		/^\d+$/.test(beforeLastColon.slice(secondLastColon + 1))
+	) {
+		// Pattern: path:line:column
+		const maybeLine = Number.parseInt(
+			beforeLastColon.slice(secondLastColon + 1),
+			10,
+		);
+		pathPart = beforeLastColon.slice(0, secondLastColon).trim();
+		line = maybeLine;
+		column = maybeColumn;
+
+		if (!pathPart || line <= 0 || column <= 0) {
+			return { searchQuery: trimmedQuery };
+		}
+	} else {
+		// Pattern: path:line
+		pathPart = beforeLastColon.trim();
+		line = maybeColumn;
+
+		if (!pathPart || line <= 0) {
+			return { searchQuery: trimmedQuery };
+		}
+	}
+
+	return {
+		searchQuery: pathPart,
+		line,
+		column,
+	};
+}

--- a/apps/desktop/src/renderer/screens/main/components/CommandPalette/useCommandPalette.ts
+++ b/apps/desktop/src/renderer/screens/main/components/CommandPalette/useCommandPalette.ts
@@ -15,8 +15,6 @@ import { parseQuickOpenQuery } from "./parseQuickOpenQuery";
 
 const SEARCH_LIMIT = 50;
 
-export { parseQuickOpenQuery } from "./parseQuickOpenQuery";
-
 interface UseCommandPaletteParams {
 	workspaceId: string;
 	navigate: UseNavigateResult<string>;

--- a/apps/desktop/src/renderer/screens/main/components/CommandPalette/useCommandPalette.ts
+++ b/apps/desktop/src/renderer/screens/main/components/CommandPalette/useCommandPalette.ts
@@ -11,8 +11,11 @@ import {
 	useSearchDialogStore,
 } from "renderer/stores/search-dialog-state";
 import { useTabsStore } from "renderer/stores/tabs/store";
+import { parseQuickOpenQuery } from "./parseQuickOpenQuery";
 
 const SEARCH_LIMIT = 50;
+
+export { parseQuickOpenQuery } from "./parseQuickOpenQuery";
 
 interface UseCommandPaletteParams {
 	workspaceId: string;
@@ -21,6 +24,8 @@ interface UseCommandPaletteParams {
 	onSelectFile?: (input: {
 		filePath: string;
 		targetWorkspaceId: string;
+		line?: number;
+		column?: number;
 		close: () => void;
 		navigate: UseNavigateResult<string>;
 	}) => void;
@@ -160,11 +165,13 @@ export function useCommandPalette({
 	const toggleIncludeIgnored = useFileExplorerStore(
 		(s) => s.toggleIncludeIgnored,
 	);
+	const parsedQuery = useMemo(() => parseQuickOpenQuery(query), [query]);
+	const searchQuery = parsedQuery.searchQuery;
 
 	// Single-workspace search (existing behavior)
 	const singleSearch = useFileSearch({
 		workspaceId: open && scope === "workspace" ? workspaceId : undefined,
-		searchTerm: query,
+		searchTerm: searchQuery,
 		includePattern,
 		excludePattern,
 		limit: SEARCH_LIMIT,
@@ -177,7 +184,7 @@ export function useCommandPalette({
 	// Multi-workspace search. Note that MRU/open boosts aren't forwarded here
 	// because the recency lists are scoped to the current workspace; applying
 	// them across other workspaces would mis-rank unrelated paths.
-	const debouncedQuery = useDebouncedValue(query.trim(), 150);
+	const debouncedQuery = useDebouncedValue(searchQuery, 150);
 	const multiSearchQueries = electronTrpc.useQueries((t) =>
 		open && scope === "global" && roots.length > 0 && debouncedQuery.length > 0
 			? roots.map((root) =>
@@ -220,7 +227,7 @@ export function useCommandPalette({
 		scope === "workspace"
 			? singleSearch.isFetching
 			: multiSearchQueries.some((query) => query.isFetching) ||
-				(query.trim().length > 0 && query.trim() !== debouncedQuery);
+				(searchQuery.length > 0 && searchQuery !== debouncedQuery);
 
 	const handleOpenChange = useCallback((nextOpen: boolean) => {
 		setOpen(nextOpen);
@@ -252,6 +259,8 @@ export function useCommandPalette({
 				onSelectFile({
 					filePath,
 					targetWorkspaceId: targetWs,
+					line: parsedQuery.line,
+					column: parsedQuery.column,
 					close: () => handleOpenChange(false),
 					navigate,
 				});
@@ -259,6 +268,8 @@ export function useCommandPalette({
 			}
 			useTabsStore.getState().addFileViewerPane(targetWs, {
 				filePath,
+				line: parsedQuery.line,
+				column: parsedQuery.column,
 				useRightSidebarOpenViewWidth: true,
 			});
 			handleOpenChange(false);
@@ -266,7 +277,14 @@ export function useCommandPalette({
 				navigateToWorkspace(targetWs, navigate);
 			}
 		},
-		[workspaceId, onSelectFile, handleOpenChange, navigate],
+		[
+			workspaceId,
+			onSelectFile,
+			handleOpenChange,
+			navigate,
+			parsedQuery.line,
+			parsedQuery.column,
+		],
 	);
 
 	const setIncludePattern = useCallback(


### PR DESCRIPTION

## Summary

- Cmd+P (Quick Open) で `foo.ts:123` や `foo.ts:123:45` のように入力した際、ファイルを開いた後指定行/列に自動スクロール・ジャンプする機能を追加
- VS Code の Quick Open と同じ `:line[:column]` 記法に対応

## 変更点

- **`parseQuickOpenQuery()`**: 入力テキストから `path:line[:column]` を分離する純粋関数（テスト 12 件）
- **`useCommandPalette`**: クエリをパースし、ファイル検索はパス部分のみで実行、選択時に行/列をコールバックに渡す
- **v1 workspace**: `addFileViewerPane` に `line`/`column` を渡すよう修正（既存の `initialLine`/`initialColumn` 機構が消費）
- **v2 workspace**: `FilePaneData` に `line`/`column`/`cursorRequestId` を追加し、`CodeEditor` の `revealPosition` に接続
- `cursorRequestId` は一意 ID で、同じファイルに連続で異なる行を指定した場合でも React が effect を再実行する仕組み

## Test plan

- [x] `parseQuickOpenQuery` のユニットテスト 12 件（全通過）
- [x] 既存の renderer テスト 785 件（事前失敗 3 件は無関係）
- [ ] 手動確認: `foo.ts:42` 入力 → ファイルが開き 42 行目にジャンプ
- [ ] 手動確認: `src/bar.tsx:10:5` 入力 → 10 行 5 列にジャンプ
- [ ] 手動確認: `foo.ts` 単独 → 従来どおりファイルを開くのみ

Closes #383

💘 Generated with Crush

Assisted-by: GLM-5 via Crush <crush@charm.land>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新機能

* クイックオープン機能でファイルを開く際に、行番号と列番号を指定できるようになりました。「filename.ts:10:5」の形式で入力すると、指定された位置にカーソルが自動的に移動します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->