### PR TITLE
fix(desktop): TodoComposer / PresetsDialog に AgentRuntimePicker を適用

### DIFF
--- a/apps/desktop/src/renderer/features/todo-agent/TodoManager/PresetsDialog/PresetsDialog.tsx
+++ b/apps/desktop/src/renderer/features/todo-agent/TodoManager/PresetsDialog/PresetsDialog.tsx
@@ -1,3 +1,4 @@
+import { type AgentKind, DEFAULT_AGENT_KIND } from "main/todo-agent/types";
 import type { SelectTodoPromptPreset } from "@superset/local-db";
 import { Button } from "@superset/ui/button";
 import { Dialog, DialogContent, DialogTitle } from "@superset/ui/dialog";
@@ -16,12 +17,19 @@ import {
 } from "react-icons/hi2";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import {
+	AgentRuntimePicker,
 	type ClaudeEffortPick,
 	type ClaudeModelPick,
 	ClaudeRuntimePicker,
+	type CodexEffortPick,
+	type CodexModelPick,
 	DEFAULT_SENTINEL,
+	fromPersistedCodexEffort,
+	fromPersistedCodexModel,
 	fromPersistedEffort,
 	fromPersistedModel,
+	toPersistedCodexEffort,
+	toPersistedCodexModel,
 	toPersistedEffort,
 	toPersistedModel,
 } from "../../ClaudeRuntimePicker";
@@ -115,6 +123,11 @@ function SettingsTab() {
 		useState<ClaudeModelPick>(DEFAULT_SENTINEL);
 	const [defaultEffort, setDefaultEffort] =
 		useState<ClaudeEffortPick>(DEFAULT_SENTINEL);
+	const [defaultAgentKind, setDefaultAgentKind] = useState<AgentKind>(DEFAULT_AGENT_KIND);
+	const [defaultCodexModel, setDefaultCodexModel] =
+		useState<CodexModelPick>(DEFAULT_SENTINEL);
+	const [defaultCodexEffort, setDefaultCodexEffort] =
+		useState<CodexEffortPick>(DEFAULT_SENTINEL);
 
 	// Hydrate form state the first time settings arrive from the main
 	// process. A React Query background refetch (window focus, etc.)
@@ -144,7 +157,12 @@ function SettingsTab() {
 			toPersistedModel(defaultModel) !==
 				(settings.defaultClaudeModel ?? null) ||
 			toPersistedEffort(defaultEffort) !==
-				(settings.defaultClaudeEffort ?? null));
+				(settings.defaultClaudeEffort ?? null) ||
+			defaultAgentKind !== (settings.defaultAgentKind ?? DEFAULT_AGENT_KIND) ||
+			toPersistedCodexModel(defaultCodexModel) !==
+				(settings.defaultCodexModel ?? null) ||
+			toPersistedCodexEffort(defaultCodexEffort) !==
+				(settings.defaultCodexEffort ?? null));
 
 	const handleSave = useCallback(async () => {
 		try {
@@ -155,6 +173,9 @@ function SettingsTab() {
 				sessionRetentionDays: retentionDays,
 				defaultClaudeModel: toPersistedModel(defaultModel),
 				defaultClaudeEffort: toPersistedEffort(defaultEffort),
+				defaultAgentKind,
+				defaultCodexModel: toPersistedCodexModel(defaultCodexModel),
+				defaultCodexEffort: toPersistedCodexEffort(defaultCodexEffort),
 			});
 			await utils.todoAgent.settings.get.invalidate();
 			toast.success("設定を保存しました");
@@ -242,12 +263,18 @@ function SettingsTab() {
 					</p>
 				</div>
 				<div className="flex flex-col gap-1.5">
-					<Label>新規 TODO / スケジュールの Claude 既定値</Label>
-					<ClaudeRuntimePicker
-						model={defaultModel}
-						effort={defaultEffort}
-						onModelChange={setDefaultModel}
-						onEffortChange={setDefaultEffort}
+					<Label>新規 TODO / スケジュールの既定値</Label>
+					<AgentRuntimePicker
+						agentKind={defaultAgentKind}
+						onAgentKindChange={setDefaultAgentKind}
+						claudeModel={defaultModel}
+						claudeEffort={defaultEffort}
+						onClaudeModelChange={setDefaultModel}
+						onClaudeEffortChange={setDefaultEffort}
+						codexModel={defaultCodexModel}
+						codexEffort={defaultCodexEffort}
+						onCodexModelChange={setDefaultCodexModel}
+						onCodexEffortChange={setDefaultCodexEffort}
 						compact={false}
 					/>
 					<p className="text-[10px] text-muted-foreground">

--- a/apps/desktop/src/renderer/features/todo-agent/TodoManager/PresetsDialog/PresetsDialog.tsx
+++ b/apps/desktop/src/renderer/features/todo-agent/TodoManager/PresetsDialog/PresetsDialog.tsx
@@ -185,6 +185,9 @@ function SettingsTab() {
 			);
 		}
 	}, [
+		defaultAgentKind,
+		defaultCodexEffort,
+		defaultCodexModel,
 		defaultEffort,
 		defaultModel,
 		maxIter,

--- a/apps/desktop/src/renderer/features/todo-agent/TodoManager/TodoManager.tsx
+++ b/apps/desktop/src/renderer/features/todo-agent/TodoManager/TodoManager.tsx
@@ -37,9 +37,11 @@ import {
 	SquareTerminal,
 	Wrench,
 } from "lucide-react";
-import type {
-	TodoSessionListEntry,
-	TodoStreamEvent,
+import {
+	type AgentKind,
+	DEFAULT_AGENT_KIND,
+	type TodoSessionListEntry,
+	type TodoStreamEvent,
 } from "main/todo-agent/types";
 import {
 	type KeyboardEvent as ReactKeyboardEvent,
@@ -74,14 +76,21 @@ import { MarkdownRenderer } from "renderer/components/MarkdownRenderer";
 import { todoAgentRendererDebug } from "renderer/features/todo-agent/debug";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import {
+	AgentRuntimePicker,
 	type ClaudeEffortPick,
 	type ClaudeModelPick,
 	ClaudeRuntimePicker,
+	type CodexEffortPick,
+	type CodexModelPick,
 	DEFAULT_SENTINEL,
+	fromPersistedCodexEffort,
+	fromPersistedCodexModel,
 	fromPersistedEffort,
 	fromPersistedModel,
 	getClaudeEffortLabel,
 	getClaudeModelLabel,
+	toPersistedCodexEffort,
+	toPersistedCodexModel,
 	toPersistedEffort,
 	toPersistedModel,
 } from "../ClaudeRuntimePicker";
@@ -2752,6 +2761,11 @@ function TodoComposer({
 		useState<ClaudeModelPick>(DEFAULT_SENTINEL);
 	const [claudeEffort, setClaudeEffort] =
 		useState<ClaudeEffortPick>(DEFAULT_SENTINEL);
+	const [agentKind, setAgentKind] = useState<AgentKind>(DEFAULT_AGENT_KIND);
+	const [codexModel, setCodexModel] =
+		useState<CodexModelPick>(DEFAULT_SENTINEL);
+	const [codexEffort, setCodexEffort] =
+		useState<CodexEffortPick>(DEFAULT_SENTINEL);
 	const [submitting, setSubmitting] = useState(false);
 
 	useEffect(() => {
@@ -2768,6 +2782,13 @@ function TodoComposer({
 		setClaudeModel(fromPersistedModel(todoSettings.defaultClaudeModel ?? null));
 		setClaudeEffort(
 			fromPersistedEffort(todoSettings.defaultClaudeEffort ?? null),
+		);
+		setAgentKind(todoSettings.defaultAgentKind ?? DEFAULT_AGENT_KIND);
+		setCodexModel(
+			fromPersistedCodexModel(todoSettings.defaultCodexModel ?? null),
+		);
+		setCodexEffort(
+			fromPersistedCodexEffort(todoSettings.defaultCodexEffort ?? null),
 		);
 		claudeSeededRef.current = true;
 	}, [todoSettings]);
@@ -2801,14 +2822,16 @@ function TodoComposer({
 		}
 	}, [createWorktree, workspaceId, projectWorkspaces, currentWorkspaceId]);
 
-	// Remote Control requires the PTY engine — clear the RC toggle
-	// whenever the user disables PTY so an invalid combination cannot
-	// slip through to the submit call.
 	useEffect(() => {
+		if (agentKind !== "claude") {
+			setPtyEnabled(false);
+			setRemoteControlEnabled(false);
+			return;
+		}
 		if (!ptyEnabled && remoteControlEnabled) {
 			setRemoteControlEnabled(false);
 		}
-	}, [ptyEnabled, remoteControlEnabled]);
+	}, [agentKind, ptyEnabled, remoteControlEnabled]);
 
 	const maxIterations = todoSettings?.defaultMaxIterations ?? 10;
 	const maxWallClockSec = (todoSettings?.defaultMaxWallClockMin ?? 30) * 60;
@@ -2898,8 +2921,11 @@ function TodoComposer({
 				maxIterations,
 				maxWallClockSec,
 				customSystemPrompt: selected?.content ?? undefined,
+				agentKind,
 				claudeModel: toPersistedModel(claudeModel),
 				claudeEffort: toPersistedEffort(claudeEffort),
+				codexModel: toPersistedCodexModel(codexModel),
+				codexEffort: toPersistedCodexEffort(codexEffort),
 				ptyEnabled,
 				remoteControlEnabled,
 			});
@@ -2977,6 +3003,9 @@ function TodoComposer({
 		onCreated,
 		projectId,
 		ptyEnabled,
+		agentKind,
+		codexEffort,
+		codexModel,
 		remoteControlEnabled,
 		scopedPresets.system,
 		selectedPresetId,
@@ -3054,12 +3083,18 @@ function TodoComposer({
 								ptyEnabled
 									? "border-emerald-400/50 bg-emerald-500/5"
 									: "border-border/40 hover:bg-muted/40",
+								agentKind !== "claude" && "opacity-60 cursor-not-allowed",
 							)}
-							title="beta: Claude を interactive PTY モードで起動します。従来の headless (`-p`) 経路よりも実環境に近く、Remote Control など TUI 専用機能が使えます。"
+							title={
+								agentKind !== "claude"
+									? "PTY モードは Claude のみ利用可能です"
+									: "beta: Claude を interactive PTY モードで起動します。従来の headless (`-p`) 経路よりも実環境に近く、Remote Control など TUI 専用機能が使えます。"
+							}
 						>
 							<Checkbox
 								id="composer-pty-mode"
-								checked={ptyEnabled}
+								checked={agentKind === "claude" && ptyEnabled}
+								disabled={agentKind !== "claude"}
 								onCheckedChange={(checked) => setPtyEnabled(checked === true)}
 							/>
 							<div className="flex-1 flex flex-col gap-0.5">
@@ -3077,18 +3112,21 @@ function TodoComposer({
 								remoteControlEnabled
 									? "border-indigo-400/50 bg-indigo-500/5"
 									: "border-border/40 hover:bg-muted/40",
-								!ptyEnabled && "opacity-60 cursor-not-allowed",
+								(agentKind !== "claude" || !ptyEnabled) &&
+									"opacity-60 cursor-not-allowed",
 							)}
 							title={
-								ptyEnabled
-									? "claude.ai/code や Claude モバイルアプリからこのセッションを閲覧・操作できるようにします。Pro/Max プランと claude.ai ログイン済みの CLI が必要です。"
-									: "Remote Control は PTY モード時のみ有効です。"
+								agentKind !== "claude"
+									? "Remote Control は Claude のみ利用可能です"
+									: ptyEnabled
+										? "claude.ai/code や Claude モバイルアプリからこのセッションを閲覧・操作できるようにします。Pro/Max プランと claude.ai ログイン済みの CLI が必要です。"
+										: "Remote Control は PTY モード時のみ有効です。"
 							}
 						>
 							<Checkbox
 								id="composer-remote-control"
-								checked={remoteControlEnabled}
-								disabled={!ptyEnabled}
+								checked={agentKind === "claude" && remoteControlEnabled}
+								disabled={agentKind !== "claude" || !ptyEnabled}
 								onCheckedChange={(checked) =>
 									setRemoteControlEnabled(checked === true)
 								}
@@ -3185,11 +3223,17 @@ function TodoComposer({
 							/>
 						</div>
 
-						<ClaudeRuntimePicker
-							model={claudeModel}
-							effort={claudeEffort}
-							onModelChange={setClaudeModel}
-							onEffortChange={setClaudeEffort}
+						<AgentRuntimePicker
+							agentKind={agentKind}
+							onAgentKindChange={setAgentKind}
+							claudeModel={claudeModel}
+							claudeEffort={claudeEffort}
+							onClaudeModelChange={setClaudeModel}
+							onClaudeEffortChange={setClaudeEffort}
+							codexModel={codexModel}
+							codexEffort={codexEffort}
+							onCodexModelChange={setCodexModel}
+							onCodexEffortChange={setCodexEffort}
 							disabled={submitting}
 						/>
 


### PR DESCRIPTION
## Summary

- PR #385 で `TodoModal` に `AgentRuntimePicker` (Claude Code / Codex CLI 切替) が導入されたが、`TodoManager` 内の **`TodoComposer`** と **`PresetsDialog` 設定タブ** には旧 `ClaudeRuntimePicker` が残っていた
- 両コンポーネントに `agentKind` / `codexModel` / `codexEffort` の state・送信・保存処理を追加
- PTY / Remote Control チェックボックスを `agentKind` に連動 (Codex 選択時は無効化)
- PresetsDialog の設定タブのラベルを「Claude 既定値」→「既定値」に変更

## 変更ファイル

| ファイル | 変更 |
|---|---|
| `TodoManager.tsx` | `TodoComposer` の `ClaudeRuntimePicker` → `AgentRuntimePicker` 差替え、agentKind/codex state 追加、create mutation に codex フィールド追加 |
| `PresetsDialog.tsx` | `SettingsTab` の既定値ピッカー → `AgentRuntimePicker` 差替え、codex 規定値の hydrate / dirty check / save 追加 |

## Test plan

- [ ] TODO Agent Manager → 「新しい TODO」→ Agent セレクター (Claude Code / Codex CLI) が表示される
- [ ] Codex CLI 選択時 → Model / Effort が Codex 用オプションに切り替わる
- [ ] Codex CLI 選択時 → PTY / Remote Control が無効化される
- [ ] 設定タブ → Agent 種別の既定値を変更 → 保存 → 再表示で反映される
- [ ] 既存の Claude セッション作成・実行に影響がない

**Full Changelog**: https://github.com/MocA-Love/superset/compare/main...fix/todo-composer-agent-picker

 💘 Generated with Crush