### PR TITLE
fix(desktop): Diff Viewer / File Viewer の Cmd+F 検索フォーカス修正

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/FileViewerPane.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/FileViewerPane.tsx
@@ -5,6 +5,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { MosaicBranch } from "react-mosaic-component";
 import { createChatServiceIpcClient } from "renderer/components/Chat/utils/chat-service-client";
 import type { MarkdownEditorAdapter } from "renderer/components/MarkdownRenderer";
+import { useHotkey } from "renderer/hotkeys";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { resolveLanguageServiceLanguageId } from "renderer/lib/language-services";
 import {
@@ -51,13 +52,13 @@ import { isHtmlFile, isImageFile, isMarkdownFile } from "shared/file-types";
 import type { FileViewerMode } from "shared/tabs-types";
 import type { CodeEditorAdapter } from "../../../components";
 import { BasePaneWindow } from "../components";
+import type { CodeMirrorDiffViewerHandle } from "./components/CodeMirrorDiffViewer";
 import {
 	FileViewerContent,
 	type HtmlPreviewHandle,
 } from "./components/FileViewerContent";
 import { FileViewerToolbar } from "./components/FileViewerToolbar";
 import { ExternalChangeDialog } from "./ExternalChangeDialog";
-import { useDiffSearch } from "./hooks/useDiffSearch";
 import { useFileContent } from "./hooks/useFileContent";
 import { useFileSave } from "./hooks/useFileSave";
 import { useMarkdownSearch } from "./hooks/useMarkdownSearch";
@@ -236,12 +237,15 @@ export function FileViewerPane({
 		filePath,
 	});
 
-	const diffSearch = useDiffSearch({
-		containerRef: diffContainerRef,
-		isFocused,
-		isDiffMode: viewMode === "diff",
-		filePath,
-	});
+	const diffViewerRef = useRef<CodeMirrorDiffViewerHandle | null>(null);
+
+	useHotkey(
+		"FIND_IN_FILE_VIEWER",
+		() => {
+			diffViewerRef.current?.openFind();
+		},
+		{ enabled: isFocused && viewMode === "diff", preventDefault: true },
+	);
 
 	const getCurrentContent = useCallback(() => {
 		if (hasEditorDocumentInitialized(documentKey)) {
@@ -869,7 +873,19 @@ export function FileViewerPane({
 							onMoveToTab={onMoveToTab}
 							onMoveToNewTab={onMoveToNewTab}
 							diffContainerRef={diffContainerRef}
-							diffSearch={diffSearch}
+							diffSearch={{
+								isSearchOpen: false,
+								query: "",
+								caseSensitive: false,
+								matchCount: 0,
+								activeMatchIndex: -1,
+								setQuery: () => {},
+								setCaseSensitive: () => {},
+								findNext: () => {},
+								findPrevious: () => {},
+								closeSearch: () => {},
+							}}
+							diffViewerRef={diffViewerRef}
 							markdownContainerRef={markdownContainerRef}
 							markdownSearch={markdownSearch}
 							htmlZoomLevel={htmlZoomLevel}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/components/CodeMirrorDiffViewer/CodeMirrorDiffViewer.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/components/CodeMirrorDiffViewer/CodeMirrorDiffViewer.tsx
@@ -28,9 +28,19 @@ import {
 	ViewPlugin,
 	type ViewUpdate,
 } from "@codemirror/view";
-import { useEffect, useRef, useState } from "react";
+import {
+	type ForwardedRef,
+	forwardRef,
+	useEffect,
+	useImperativeHandle,
+	useRef,
+	useState,
+} from "react";
 import { electronTrpc } from "renderer/lib/electron-trpc";
-import { CodeEditorSearchOverlay } from "renderer/screens/main/components/WorkspaceView/components/CodeEditor/components/CodeEditorSearchOverlay";
+import {
+	CodeEditorSearchOverlay,
+	type CodeEditorSearchOverlayHandle,
+} from "renderer/screens/main/components/WorkspaceView/components/CodeEditor/components/CodeEditorSearchOverlay";
 import {
 	type BlameEntry,
 	createBlamePlugin,
@@ -206,6 +216,10 @@ const suppressDeletions = makeSuppressPlugin(
 	(chunk, change) => chunk.fromA + change.toA,
 );
 
+export interface CodeMirrorDiffViewerHandle {
+	openFind: () => void;
+}
+
 interface CodeMirrorDiffViewerProps {
 	original: string;
 	modified: string;
@@ -290,23 +304,30 @@ function buildDiagnosticDecorations(
 	return Decoration.set(decorations, true);
 }
 
-export function CodeMirrorDiffViewer({
-	original,
-	modified,
-	language,
-	worktreePath,
-	viewMode,
-	onChange,
-	onSave,
-	blameEntries,
-	diagnostics = [],
-	inlineCompletionRequest,
-	resolveSymbolHover,
-	onGoToDefinition,
-}: CodeMirrorDiffViewerProps) {
+export const CodeMirrorDiffViewer = forwardRef<
+	CodeMirrorDiffViewerHandle,
+	CodeMirrorDiffViewerProps
+>(function CodeMirrorDiffViewer(
+	{
+		original,
+		modified,
+		language,
+		worktreePath,
+		viewMode,
+		onChange,
+		onSave,
+		blameEntries,
+		diagnostics = [],
+		inlineCompletionRequest,
+		resolveSymbolHover,
+		onGoToDefinition,
+	},
+	ref: ForwardedRef<CodeMirrorDiffViewerHandle>,
+) {
 	const containerRef = useRef<HTMLDivElement>(null);
 	const mergeViewRef = useRef<MergeView | null>(null);
 	const activeEditorRef = useRef<EditorView | null>(null);
+	const overlayRef = useRef<CodeEditorSearchOverlayHandle>(null);
 	const [isSearchOpen, setIsSearchOpen] = useState(false);
 	const [searchQueryText, setSearchQueryText] = useState("");
 	const [isCaseSensitive, setIsCaseSensitive] = useState(false);
@@ -387,15 +408,37 @@ export function CodeMirrorDiffViewer({
 	};
 	syncSearchOverlayStateRef.current = syncSearchOverlayState;
 
+	const ensureOverlaySearchOpenRef = useRef<(() => void) | null>(null);
+
+	useImperativeHandle(
+		ref,
+		() => ({
+			openFind: () => {
+				const mv = mergeViewRef.current;
+				if (!mv) return;
+				const target = activeEditorRef.current ?? mv.b;
+				target.focus();
+				ensureOverlaySearchOpenRef.current?.();
+				requestAnimationFrame(() => {
+					overlayRef.current?.focusInput();
+				});
+			},
+		}),
+		[],
+	);
+
 	const ensureOverlaySearchOpen = () => {
 		const mv = mergeViewRef.current;
 		if (!mv) return;
-		// Open hidden panel on both editors so setSearchQuery effects are accepted.
 		openSearchPanel(mv.a);
 		openSearchPanel(mv.b);
 		setIsSearchOpen(true);
 		syncSearchOverlayState();
+		requestAnimationFrame(() => {
+			overlayRef.current?.focusInput();
+		});
 	};
+	ensureOverlaySearchOpenRef.current = ensureOverlaySearchOpen;
 
 	const updateOverlaySearchQuery = (
 		overrides: Partial<{
@@ -740,6 +783,7 @@ export function CodeMirrorDiffViewer({
 		<div className="relative h-full w-full">
 			<div ref={containerRef} className="h-full w-full overflow-auto" />
 			<CodeEditorSearchOverlay
+				ref={overlayRef}
 				isOpen={isSearchOpen}
 				query={searchQueryText}
 				replaceText=""
@@ -771,4 +815,4 @@ export function CodeMirrorDiffViewer({
 			/>
 		</div>
 	);
-}
+});

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/components/CodeMirrorDiffViewer/index.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/components/CodeMirrorDiffViewer/index.ts
@@ -1,1 +1,4 @@
-export { CodeMirrorDiffViewer } from "./CodeMirrorDiffViewer";
+export {
+	CodeMirrorDiffViewer,
+	type CodeMirrorDiffViewerHandle,
+} from "./CodeMirrorDiffViewer";

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/components/FileViewerContent/FileViewerContent.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/components/FileViewerContent/FileViewerContent.tsx
@@ -42,7 +42,10 @@ import {
 import type { FileViewerMode } from "shared/tabs-types";
 import { useNextEditCompletion } from "../../hooks/useNextEditCompletion";
 import { useScrollToFirstDiffChange } from "../../hooks/useScrollToFirstDiffChange";
-import { CodeMirrorDiffViewer } from "../CodeMirrorDiffViewer";
+import {
+	CodeMirrorDiffViewer,
+	type CodeMirrorDiffViewerHandle,
+} from "../CodeMirrorDiffViewer";
 import { ConflictViewer } from "../ConflictViewer";
 import { DiffViewerContextMenu } from "../DiffViewerContextMenu";
 import { FileEditorContextMenu } from "../FileEditorContextMenu";
@@ -263,6 +266,7 @@ interface FileViewerContentProps {
 	onMoveToNewTab: () => void;
 	diffContainerRef: RefObject<HTMLDivElement | null>;
 	diffSearch: TextSearchState;
+	diffViewerRef?: MutableRefObject<CodeMirrorDiffViewerHandle | null>;
 	markdownContainerRef: RefObject<HTMLDivElement | null>;
 	markdownSearch: TextSearchState;
 	htmlZoomLevel?: number;
@@ -307,6 +311,7 @@ export function FileViewerContent({
 	diffContainerRef,
 	// biome-ignore lint/correctness/noUnusedFunctionParameters: reserved for future use
 	diffSearch,
+	diffViewerRef,
 	markdownContainerRef,
 	markdownSearch,
 	htmlZoomLevel = 0,
@@ -783,6 +788,7 @@ export function FileViewerContent({
 						}}
 					>
 						<CodeMirrorDiffViewer
+							ref={diffViewerRef}
 							original={diffData.original}
 							modified={diffData.modified}
 							language={diffData.language}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/components/CodeEditor/CodeEditor.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/components/CodeEditor/CodeEditor.tsx
@@ -43,7 +43,10 @@ import { getCodeSyntaxHighlighting } from "renderer/screens/main/components/Work
 import { useResolvedTheme } from "renderer/stores/theme";
 import { useVibrancyStore } from "renderer/stores/vibrancy";
 import { getEditorTheme } from "shared/themes";
-import { CodeEditorSearchOverlay } from "./components/CodeEditorSearchOverlay";
+import {
+	CodeEditorSearchOverlay,
+	type CodeEditorSearchOverlayHandle,
+} from "./components/CodeEditorSearchOverlay";
 import { type BlameEntry, createBlamePlugin } from "./createBlamePlugin";
 import { createCodeMirrorTheme } from "./createCodeMirrorTheme";
 import { createIndentRainbowPlugin } from "./createIndentRainbowPlugin";
@@ -561,6 +564,7 @@ export function CodeEditor({
 	const searchModeRef = useRef(searchMode);
 	const onChangeRef = useRef(onChange);
 	const onSaveRef = useRef(onSave);
+	const overlayRef = useRef<CodeEditorSearchOverlayHandle>(null);
 	const searchControlsRef = useRef<{
 		openFind: () => void;
 	} | null>(null);
@@ -647,6 +651,9 @@ export function CodeEditor({
 			openSearchPanel(view);
 			setIsSearchOpen(true);
 			syncSearchOverlayState();
+			requestAnimationFrame(() => {
+				overlayRef.current?.focusInput();
+			});
 			return;
 		}
 
@@ -1126,6 +1133,7 @@ export function CodeEditor({
 			/>
 			{searchMode === "overlay" ? (
 				<CodeEditorSearchOverlay
+					ref={overlayRef}
 					isOpen={isSearchOpen}
 					query={searchQuery}
 					replaceText={replaceQuery}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/components/CodeEditor/components/CodeEditorSearchOverlay/CodeEditorSearchOverlay.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/components/CodeEditor/components/CodeEditorSearchOverlay/CodeEditorSearchOverlay.tsx
@@ -1,8 +1,11 @@
 import {
+	type ForwardedRef,
+	forwardRef,
 	type KeyboardEvent as ReactKeyboardEvent,
 	type MouseEvent as ReactMouseEvent,
 	useCallback,
 	useEffect,
+	useImperativeHandle,
 	useRef,
 	useState,
 } from "react";
@@ -29,6 +32,10 @@ interface CodeEditorSearchOverlayProps {
 	onReplaceNext: () => void;
 	onReplaceAll: () => void;
 	onClose: () => void;
+}
+
+export interface CodeEditorSearchOverlayHandle {
+	focusInput: () => void;
 }
 
 function OptionToggle({
@@ -58,29 +65,49 @@ function OptionToggle({
 	);
 }
 
-export function CodeEditorSearchOverlay({
-	isOpen,
-	query,
-	replaceText,
-	caseSensitive,
-	regexp,
-	wholeWord,
-	matchCount,
-	activeMatchIndex,
-	readOnly,
-	onQueryChange,
-	onReplaceTextChange,
-	onCaseSensitiveChange,
-	onRegexpChange,
-	onWholeWordChange,
-	onFindNext,
-	onFindPrevious,
-	onSelectAllMatches,
-	onReplaceNext,
-	onReplaceAll,
-	onClose,
-}: CodeEditorSearchOverlayProps) {
+export const CodeEditorSearchOverlay = forwardRef<
+	CodeEditorSearchOverlayHandle,
+	CodeEditorSearchOverlayProps
+>(function CodeEditorSearchOverlay(
+	{
+		isOpen,
+		query,
+		replaceText,
+		caseSensitive,
+		regexp,
+		wholeWord,
+		matchCount,
+		activeMatchIndex,
+		readOnly,
+		onQueryChange,
+		onReplaceTextChange,
+		onCaseSensitiveChange,
+		onRegexpChange,
+		onWholeWordChange,
+		onFindNext,
+		onFindPrevious,
+		onSelectAllMatches,
+		onReplaceNext,
+		onReplaceAll,
+		onClose,
+	},
+	ref: ForwardedRef<CodeEditorSearchOverlayHandle>,
+) {
 	const searchInputRef = useRef<HTMLInputElement>(null);
+
+	useImperativeHandle(
+		ref,
+		() => ({
+			focusInput: () => {
+				if (searchInputRef.current) {
+					searchInputRef.current.focus();
+					searchInputRef.current.select();
+				}
+			},
+		}),
+		[],
+	);
+
 	const MIN_WIDTH = 400;
 	const [width, setWidth] = useState(416); // default ~26rem
 	const dragStartX = useRef<number | null>(null);
@@ -292,4 +319,4 @@ export function CodeEditorSearchOverlay({
 			</div>
 		</div>
 	);
-}
+});

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/components/CodeEditor/components/CodeEditorSearchOverlay/index.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/components/CodeEditor/components/CodeEditorSearchOverlay/index.ts
@@ -1,1 +1,4 @@
-export { CodeEditorSearchOverlay } from "./CodeEditorSearchOverlay";
+export {
+	CodeEditorSearchOverlay,
+	type CodeEditorSearchOverlayHandle,
+} from "./CodeEditorSearchOverlay";


### PR DESCRIPTION

## Summary

- **Diff Viewer で Cmd+F が効かない問題を修正**: グローバルホットキー `FIND_IN_FILE_VIEWER` が `useDiffSearch`（DOM ベース検索）にバインドされていたが、その UI がどこにもレンダリングされていなかった。代わりに `CodeMirrorDiffViewer` に `openFind()` メソッドを expose し、ホットキーから直接呼ぶように変更
- **File Viewer で検索窓にフォーカスが遷移しない問題を修正**: `CodeEditorSearchOverlay` のフォーカス useEffect が `[isOpen]` 依存のみで、既に開いている状態での再フォーカスに対応していなかった。`focusInput()` メソッドを expose し、`ensureOverlaySearchOpen()` から毎回確実に呼ぶよう変更

## 変更点

| ファイル | 変更 |
|---|---|
| `CodeEditorSearchOverlay` | `forwardRef` + `useImperativeHandle` で `focusInput()` を expose |
| `CodeEditor` | `overlayRef` を追加、`ensureOverlaySearchOpen` から `focusInput()` を呼ぶ |
| `CodeMirrorDiffViewer` | `forwardRef` + `openFind()` を expose（フォーカス対象エディター選択 → 検索オープン → フォーカス遷移） |
| `FileViewerContent` | `diffViewerRef` prop を追加して CodeMirrorDiffViewer に渡す |
| `FileViewerPane` | `useDiffSearch` → `useHotkey` + `diffViewerRef.current.openFind()` に置き換え |

## Test plan

- [ ] Diff Viewer を開き、Cmd+F → 検索オーバーレイが表示され、入力フィールドにフォーカスが遷移する
- [ ] File Viewer (raw) を開き、Cmd+F → 検索オーバーレイが表示され、入力フィールドにフォーカスが遷移する
- [ ] 検索が既に開いている状態で再度 Cmd+F → フォーカスが再度検索窓に遷移する
- [ ] 検索窓で Escape → 検索が閉じる
- [ ] F3 / Shift+F3 / Enter / Shift+Enter で前後ナビゲーションが動作する


💘 Generated with Crush