### PR TITLE
upstream 取り込み PR #4: terminal 系 / 3 commits + dedupe fix

### DIFF
--- a/apps/desktop/src/shared/utils/agent-launch-request.test.ts
+++ b/apps/desktop/src/shared/utils/agent-launch-request.test.ts
@@ -46,7 +46,7 @@ describe("buildPromptAgentLaunchRequest", () => {
 			agentType: "codex",
 			terminal: {
 				command:
-					'codex -c model_reasoning_effort="high" --dangerously-bypass-approvals-and-sandbox -c model_reasoning_summary="detailed" -c model_supports_reasoning_summaries=true',
+					'codex -c model_reasoning_effort="high" -c model_reasoning_summary="detailed" -c model_supports_reasoning_summaries=true --full-auto',
 			},
 		});
 	});

--- a/apps/docs/content/docs/terminal-presets.mdx
+++ b/apps/docs/content/docs/terminal-presets.mdx
@@ -41,15 +41,17 @@ Presets are parallel by default.
 
 ## Quick-Add Templates
 
-Pre-configured presets for popular AI agents:
+Pre-configured presets for popular AI agents. Defaults are safe-by-default — agents can read and edit files, but still prompt before running shell commands or touching files outside your workspace. Edit any preset to opt into a more permissive mode.
 
-- **amp** - `amp`
-- **claude** - `claude --dangerously-skip-permissions`
-- **codex** - Full danger mode with high reasoning effort
-- **gemini** - `gemini --yolo`
-- **pi** - `pi`
-- **cursor-agent** - Cursor AI agent
-- **opencode** - Open-source AI coding agent
+- **amp** - `amp` (built-in permission rules auto-deny destructive ops)
+- **claude** - `claude --permission-mode acceptEdits`
+- **codex** - `codex ... --full-auto` (workspace-sandboxed)
+- **gemini** - `gemini --approval-mode=auto_edit`
+- **copilot** - `copilot --allow-tool=write`
+- **cursor-agent** - `cursor-agent` (prompts for every action)
+- **mastracode** - Mastra's coding agent (opt-in: auto-approves all actions by default at the CLI; no startup flag to restrict)
+- **opencode** - Open-source AI coding agent (opt-in: full file and shell access by default at the CLI; no startup flag to restrict)
+- **pi** - Minimal terminal coding harness (opt-in: auto-approves all actions by default at the CLI; no startup flag to restrict)
 
 ## Preset Bar
 

--- a/bun.lock
+++ b/bun.lock
@@ -109,7 +109,7 @@
     },
     "apps/desktop": {
       "name": "@superset/desktop",
-      "version": "1.5.6",
+      "version": "1.5.5",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.43",
         "@ai-sdk/openai": "3.0.36",
@@ -7304,8 +7304,6 @@
     "prosemirror-markdown/@types/markdown-it": ["@types/markdown-it@14.1.2", "", { "dependencies": { "@types/linkify-it": "^5", "@types/mdurl": "^2" } }, "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog=="],
 
     "proxy-agent/lru-cache": ["lru-cache@7.18.3", "", {}, "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA=="],
-
-    "proxy-agent/proxy-from-env": ["proxy-from-env@1.1.0", "", {}, "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="],
 
     "radix-ui/@radix-ui/react-aspect-ratio": ["@radix-ui/react-aspect-ratio@1.1.7", "", { "dependencies": { "@radix-ui/react-primitive": "2.1.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-Yq6lvO9HQyPwev1onK1daHCHqXVLzPhSVjmsNjCa2Zcxy2f7uJD2itDtxknv6FzAKCwD1qQkeVDmX/cev13n/g=="],
 

--- a/packages/host-service/src/terminal/env.test.ts
+++ b/packages/host-service/src/terminal/env.test.ts
@@ -393,7 +393,7 @@ describe("buildV2TerminalEnv", () => {
 		const env = buildV2TerminalEnv(baseParams);
 		expect(env).toMatchObject({
 			TERM: "xterm-256color",
-			TERM_PROGRAM: "Superset",
+			TERM_PROGRAM: "kitty",
 			TERM_PROGRAM_VERSION: "2.0.0",
 			COLORTERM: "truecolor",
 			PWD: "/tmp/workspace",
@@ -405,7 +405,7 @@ describe("buildV2TerminalEnv", () => {
 			SUPERSET_AGENT_HOOK_PORT: "51741",
 			SUPERSET_AGENT_HOOK_VERSION: "2",
 		});
-		expect(env.TERM_PROGRAM).toBe("Superset");
+		expect(env.TERM_PROGRAM).toBe("kitty");
 		expect(env.LANG).toContain("UTF-8");
 	});
 

--- a/packages/host-service/src/terminal/env.ts
+++ b/packages/host-service/src/terminal/env.ts
@@ -144,7 +144,11 @@ export function buildV2TerminalEnv(
 	Object.assign(env, getShellBootstrapEnv({ shell, baseEnv, supersetHomeDir }));
 
 	env.TERM = "xterm-256color";
-	env.TERM_PROGRAM = "Superset";
+	// claude-code and similar chat TUIs only parse kitty CSI-u (e.g. Shift+Enter
+	// → \x1b[13;2u) when TERM_PROGRAM ∈ {ghostty, kitty, iTerm.app, WezTerm,
+	// WarpTerminal}. xterm.js already emits the right bytes — claim kitty so
+	// they're parsed instead of submitted as plain Enter.
+	env.TERM_PROGRAM = "kitty";
 	env.TERM_PROGRAM_VERSION = hostServiceVersion;
 	env.COLORTERM = "truecolor";
 	env.COLORFGBG = themeType === "light" ? "0;15" : "15;0";

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -48,10 +48,6 @@
 			"types": "./src/agent-permissions-migration.ts",
 			"default": "./src/agent-permissions-migration.ts"
 		},
-		"./agent-permissions-migration": {
-			"types": "./src/agent-permissions-migration.ts",
-			"default": "./src/agent-permissions-migration.ts"
-		},
 		"./task-slug": {
 			"types": "./src/task-slug.ts",
 			"default": "./src/task-slug.ts"

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -48,6 +48,10 @@
 			"types": "./src/agent-permissions-migration.ts",
 			"default": "./src/agent-permissions-migration.ts"
 		},
+		"./agent-permissions-migration": {
+			"types": "./src/agent-permissions-migration.ts",
+			"default": "./src/agent-permissions-migration.ts"
+		},
 		"./task-slug": {
 			"types": "./src/task-slug.ts",
 			"default": "./src/task-slug.ts"

--- a/packages/shared/src/agent-command.test.ts
+++ b/packages/shared/src/agent-command.test.ts
@@ -13,7 +13,7 @@ describe("buildAgentPromptCommand", () => {
 		});
 
 		expect(command).toContain(
-			"model_supports_reasoning_summaries=true -- \"$(cat <<'SUPERSET_PROMPT_12345678'",
+			"model_supports_reasoning_summaries=true --full-auto -- \"$(cat <<'SUPERSET_PROMPT_12345678'",
 		);
 		expect(command).toContain("- Only modified file: runtime.ts");
 	});
@@ -26,7 +26,7 @@ describe("buildAgentPromptCommand", () => {
 		});
 
 		expect(command).toStartWith(
-			"claude --dangerously-skip-permissions \"$(cat <<'SUPERSET_PROMPT_abcdefgh'",
+			"claude --permission-mode acceptEdits \"$(cat <<'SUPERSET_PROMPT_abcdefgh'",
 		);
 	});
 

--- a/packages/shared/src/builtin-terminal-agents.ts
+++ b/packages/shared/src/builtin-terminal-agents.ts
@@ -62,7 +62,7 @@ export const BUILTIN_TERMINAL_AGENTS = [
 		label: "Claude",
 		description:
 			"Anthropic's coding agent for reading code, editing files, and running terminal workflows.",
-		command: "claude --dangerously-skip-permissions",
+		command: "claude --permission-mode acceptEdits",
 		includeInDefaultTerminalPresets: true,
 	}),
 	createBuiltinTerminalAgent({
@@ -80,9 +80,9 @@ export const BUILTIN_TERMINAL_AGENTS = [
 		description:
 			"OpenAI's coding agent for reading, modifying, and running code across tasks.",
 		command:
-			'codex -c model_reasoning_effort="high" --dangerously-bypass-approvals-and-sandbox -c model_reasoning_summary="detailed" -c model_supports_reasoning_summaries=true',
+			'codex -c model_reasoning_effort="high" -c model_reasoning_summary="detailed" -c model_supports_reasoning_summaries=true --full-auto',
 		promptCommand:
-			'codex -c model_reasoning_effort="high" --dangerously-bypass-approvals-and-sandbox -c model_reasoning_summary="detailed" -c model_supports_reasoning_summaries=true --',
+			'codex -c model_reasoning_effort="high" -c model_reasoning_summary="detailed" -c model_supports_reasoning_summaries=true --full-auto --',
 		includeInDefaultTerminalPresets: true,
 	}),
 	createBuiltinTerminalAgent({
@@ -90,9 +90,8 @@ export const BUILTIN_TERMINAL_AGENTS = [
 		label: "Gemini",
 		description:
 			"Google's open-source terminal agent for coding, problem-solving, and task work.",
-		command: "gemini --yolo",
-		promptCommand: "gemini",
-		promptCommandSuffix: "--yolo",
+		command: "gemini --approval-mode=auto_edit",
+		promptCommand: "gemini --approval-mode=auto_edit",
 		includeInDefaultTerminalPresets: true,
 	}),
 	createBuiltinTerminalAgent({
@@ -101,7 +100,6 @@ export const BUILTIN_TERMINAL_AGENTS = [
 		description:
 			"Mastra's coding agent for building, debugging, and shipping code from the terminal.",
 		command: "mastracode",
-		includeInDefaultTerminalPresets: true,
 	}),
 	createBuiltinTerminalAgent({
 		id: "opencode",
@@ -109,7 +107,6 @@ export const BUILTIN_TERMINAL_AGENTS = [
 		description: "Open-source coding agent for the terminal, IDE, and desktop.",
 		command: "opencode",
 		promptCommand: "opencode --prompt",
-		includeInDefaultTerminalPresets: true,
 	}),
 	createBuiltinTerminalAgent({
 		id: "pi",
@@ -117,7 +114,6 @@ export const BUILTIN_TERMINAL_AGENTS = [
 		description:
 			"Minimal terminal coding harness for flexible coding workflows.",
 		command: "pi",
-		includeInDefaultTerminalPresets: true,
 	}),
 	createBuiltinTerminalAgent({
 		id: "kimi",
@@ -134,9 +130,8 @@ export const BUILTIN_TERMINAL_AGENTS = [
 		label: "Copilot",
 		description:
 			"GitHub's coding agent for planning, editing, and building in your repo.",
-		command: "copilot --allow-all",
-		promptCommand: "copilot -i --allow-all",
-		promptCommandSuffix: "--yolo",
+		command: "copilot --allow-tool=write",
+		promptCommand: "copilot -i --allow-tool=write",
 		includeInDefaultTerminalPresets: true,
 	}),
 	createBuiltinTerminalAgent({
@@ -145,7 +140,6 @@ export const BUILTIN_TERMINAL_AGENTS = [
 		description:
 			"Cursor's coding agent for editing, running, and debugging code in parallel.",
 		command: "cursor-agent",
-		promptCommandSuffix: "--yolo",
 	}),
 ] as const;
 


### PR DESCRIPTION
## Summary

upstream 取り込みバッチ 4: **terminal 系 3 commits + dedupe fix**。Codex 事前調査を経て、対象 11 commits のうち大部分が fork で既に同等実装を持つ領域と判明し、残る 3 commits を取り込み。

### 取り込み内容（3 commits + 1 dedupe fix）

- feat(desktop): safer defaults for builtin terminal agent presets (#3546)
- fix(desktop): backfill legacy permissions for canary users exposed to #3546 (#3615) — **TypeScript 部分のみ**（SQL migration は fork の `0070_*` と重複のため skip）
- fix(desktop): claim TERM_PROGRAM=kitty so TUIs parse Shift+Enter CSI-u (#3667)
- chore(shared): #3615 由来の重複 export を dedupe

### 除外した 8 commits（理由別）

**fork 既取り込み相当（cherry-pick で empty commit 判定 = 実質変化ゼロ）**

- `0169f1430a66` (#3650 URL allowlist) — fork `safeOpenExternal` 相当
- `b2278b1f7e3b` (#3582 paste auto-submit) — fork の bracketed paste で既対応
- `aa23ae3b1850` (#3547 port scanner excessive lsof) — fork は既に `getProcessName`/`getProcessCommand` Windows 分岐 + lsof throttle 実装済み
- `c8f34d874828` (#3550 v1 shell init input unblock) — fork の broadcast coalescing / `preReadyStdinQueue` 廃止で同等動作
- `56e6652ef91b` (#3554 non-monospace font crash) — fork は既に `sanitizeTerminalFontFamily` 導入済み
- `19c0d13b47b8` (#3581 Unicode 11 buffer restore) — fork terminal buffer 機能で対応済み
- `5e8fc2d49e4e` (#3552 v2 terminal link tooltip) — fork v2 lifecycle で対応済み

**PR #4 scope 外へ移動**

- `ae5cd60bc2fa` (#3674 v2 file-open CMD+O editor choice) — conflict 範囲が 5 ファイルに跨り fork の v1/v2 共通領域 (`external/index.ts`, `usePathActions`, `FileTreeItem` など) と衝突。**PR #2b (大物 feature)** で #3566 と一緒に処理

### Fork 側のコンフリクト解決

- **`apps/desktop/src/main/lib/terminal/port-scanner.ts`** (#3547 の conflict): fork の `getProcessName`/`getProcessCommand` / `getProcessCommandWindows` Windows 分岐 (`wmic` + PowerShell fallback) を完全維持（PR #388 で復元した機能）
- **`apps/desktop/src/main/terminal-host/session.ts`** (#3550 の conflict): fork の broadcast coalescing (`queueBroadcastData` / `flushPendingBroadcastData`) を維持
- **`apps/desktop/src/renderer/.../Terminal/Terminal.tsx`** (#3554 の conflict): fork の `TERMINAL_OPTIONS` import を維持
- **`apps/desktop/package.json` / `bun.lock`** (#3581 の conflict): fork 固有依存 `@vscode/ripgrep`, `@xyflow/react` を維持
- **`packages/local-db/drizzle/meta/_journal.json` / `0040_snapshot.json`** (#3615 の conflict): PR #388 で修復した fork 側 migration state を維持し、upstream の `0040_agent_preset_permissions_migrated_at.sql` は取り込まない (fork の `0070_*` と重複)

### Fork 固有機能ヘルスチェック

作業前 baseline (`/tmp/pr4-baseline/fork-features.txt`) と作業後を grep で照合。**全 14 項目変化なし**:

- 19 tRPC プロシージャ全数
- `ansi_up`, `@vscode/ripgrep`, `@xyflow/react` 依存
- `TERMINAL_OPTIONS` (5 ファイル)
- `SUPERSET_WORKSPACE_NAME` (24 箇所)
- `moonshot-ai.kimi-code`, `MainWindowEffects`, `INCEPTION_AUTH_PROVIDER_ID`
- `listBranches` sortOrder/pinDefault
- port-scanner.ts Windows 分岐 (3 箇所)
- `BROWSER_RELOAD`, `dmg.size="4g"`

### Codex 事前調査レポート

`/tmp/pr4-codex-preanalysis.md` 参照。PR #388 で既に大半の terminal fixes が取り込まれていたため、今回の取り込み実質差分は 3 commits に留まる。

## Test plan

- [x] `bun install` 正常完了
- [x] `bun run typecheck` グリーン (27/27 task)
- [x] `bun run lint` グリーン (4058 files checked)
- [x] fork 固有機能 regression ゼロ
- [ ] terminal agent presets の default が新しいほうに
- [ ] 既存ユーザー (canary) の permissions が backfill される
- [ ] TUI (vim, neovim 等) で Shift+Enter が CSI-u として解釈される

## 次の PR

- **PR #2b** (大物 feature): `1f2c093` + `#3674` v2 file-open + #3566 + Chat UX + scheduled agent runs
- **PR #5** (#3295 + 19 プロシージャ再設計 案 A)
- **PR #6** (version bump / auto-updater)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * ターミナルエージェントの CLI フラグを更新しました（Claude、Codex、Gemini、Copilot）
  * ターミナル環境変数の報告を修正しました

* **ドキュメント**
  * ターミナルプリセットのデフォルトコマンド設定を更新しました
  * 権限および承認モードの説明を改善しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->