### PR TITLE
fix(desktop): Linux でアプリ終了後もターミナル/TODO Agent を維持 (#397)

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -386,7 +386,7 @@ app.on("before-quit", async (event) => {
 	if (isQuitting) return;
 
 	// Consume the quit mode so it doesn't persist across aborted quits
-	const quitMode = pendingQuitMode;
+	let quitMode = pendingQuitMode;
 	pendingQuitMode = null;
 
 	// FORK NOTE: macOS tray-stay-alive block removed to match upstream (#3205).
@@ -396,17 +396,41 @@ app.on("before-quit", async (event) => {
 		event.preventDefault();
 
 		try {
-			const { response } = await dialog.showMessageBox({
-				type: "question",
-				buttons: ["Quit", "Cancel"],
-				defaultId: 0,
-				cancelId: 1,
-				title: "Quit Superset",
-				message: "Are you sure you want to quit?",
-			});
+			// FORK NOTE: Linux has no tray UI to choose between "release"
+			// (keep host-services running for reattach) vs "stop" (tear them
+			// down). Surface the same choice as dialog buttons when services
+			// are active. macOS already exposes this via the tray menu.
+			const showServiceAwareDialog =
+				process.platform === "linux" &&
+				getHostServiceManager().hasActiveInstances();
 
-			if (response === 1) {
-				return;
+			if (showServiceAwareDialog) {
+				const { response } = await dialog.showMessageBox({
+					type: "question",
+					buttons: [
+						"Quit (Keep Services Running)",
+						"Quit & Stop Services",
+						"Cancel",
+					],
+					defaultId: 0,
+					cancelId: 2,
+					title: "Quit Superset",
+					message: "Services are running in the background.",
+					detail:
+						"Keep them running so you can reattach on next launch, or stop them entirely.",
+				});
+				if (response === 2) return;
+				quitMode = response === 1 ? "stop" : "release";
+			} else {
+				const { response } = await dialog.showMessageBox({
+					type: "question",
+					buttons: ["Quit", "Cancel"],
+					defaultId: 0,
+					cancelId: 1,
+					title: "Quit Superset",
+					message: "Are you sure you want to quit?",
+				});
+				if (response === 1) return;
 			}
 		} catch (error) {
 			console.error("[main] Quit confirmation dialog failed:", error);

--- a/apps/desktop/src/main/lib/host-service-coordinator.ts
+++ b/apps/desktop/src/main/lib/host-service-coordinator.ts
@@ -26,7 +26,7 @@ import {
 	pollHealthCheck,
 } from "./host-service-utils";
 import { localDb } from "./local-db";
-import { spawnPersistent } from "./process-persistence";
+import { killPersistentScope, spawnPersistent } from "./process-persistence";
 import { HOOK_PROTOCOL_VERSION } from "./terminal/env";
 
 /** Minimum host-service version this app can work with. */
@@ -56,6 +56,14 @@ interface HostServiceProcess {
 	port: number;
 	secret: string;
 	status: HostServiceStatus;
+	/**
+	 * Linux-only: the systemd transient scope name (`<unit>.scope`) that
+	 * contains this daemon, when the spawn was wrapped with `systemd-run`.
+	 * Used by `stop()` to kill every PID in the scope via `systemctl`,
+	 * which works even if the manifest has not been written yet (early
+	 * in startup) or the wrapper PID is useless. `null` otherwise.
+	 */
+	scopeUnit: string | null;
 }
 
 const ADOPTED_LIVENESS_INTERVAL = 5_000;
@@ -110,15 +118,24 @@ export class HostServiceCoordinator extends EventEmitter {
 		const previousStatus = instance.status;
 		instance.status = "stopped";
 
-		// On Linux, when we spawned via `systemd-run --user --scope`,
-		// `instance.pid` is the systemd-run wrapper PID, not the host-service
-		// daemon PID. The daemon writes its own `process.pid` into the manifest
-		// on start, so prefer that.
-		const manifest = readManifest(organizationId);
-		const killPid = manifest?.pid ?? instance.pid;
-		try {
-			process.kill(killPid, "SIGTERM");
-		} catch {}
+		// Linux + systemd-run: kill every PID in the transient scope. This
+		// is reliable even while the daemon is still starting (manifest not
+		// yet written) and when `instance.pid` is only the wrapper PID.
+		let killedViaScope = false;
+		if (instance.scopeUnit) {
+			killedViaScope = killPersistentScope(instance.scopeUnit, "SIGTERM");
+		}
+
+		if (!killedViaScope) {
+			// Fallback: kill by PID. Prefer the manifest PID (written by the
+			// daemon itself) over `instance.pid`, because on Linux the latter
+			// may be the `systemd-run` wrapper.
+			const manifest = readManifest(organizationId);
+			const killPid = manifest?.pid ?? instance.pid;
+			try {
+				process.kill(killPid, "SIGTERM");
+			} catch {}
+		}
 
 		this.instances.delete(organizationId);
 		removeManifest(organizationId);
@@ -310,6 +327,9 @@ export class HostServiceCoordinator extends EventEmitter {
 			port,
 			secret: manifest.authToken,
 			status: "running",
+			// Adopted instances: the scope name is not recoverable after an
+			// app restart, so fall back to PID-based kill on stop.
+			scopeUnit: null,
 		});
 		this.startAdoptedLivenessCheck(organizationId, manifest.pid);
 
@@ -368,6 +388,7 @@ export class HostServiceCoordinator extends EventEmitter {
 			port,
 			secret,
 			status: "starting",
+			scopeUnit: null,
 		};
 		this.instances.set(organizationId, instance);
 		this.emitStatus(organizationId, "starting", null);
@@ -399,13 +420,14 @@ export class HostServiceCoordinator extends EventEmitter {
 				: ["ignore", "ignore", "ignore"];
 
 		let child: childProcess.ChildProcess;
+		let scopeUnit: string | null = null;
 		try {
 			// On Linux, spawnPersistent wraps packaged-build spawns with
 			// `systemd-run --user --scope` so the host-service survives
 			// Electron's systemd-logind app scope terminating on quit.
 			// In dev builds (`!isPackaged`) we keep plain pipes for log flow
 			// and spawnPersistent falls back to regular spawn automatically.
-			child = spawnPersistent(
+			const spawned = spawnPersistent(
 				process.execPath,
 				[this.scriptPath],
 				{
@@ -417,6 +439,8 @@ export class HostServiceCoordinator extends EventEmitter {
 				},
 				{ unitLabel: `superset-host-service-${organizationId}` },
 			);
+			child = spawned.child;
+			scopeUnit = spawned.scopeUnit;
 		} finally {
 			if (logFd >= 0) {
 				try {
@@ -434,6 +458,7 @@ export class HostServiceCoordinator extends EventEmitter {
 		}
 
 		instance.pid = childPid;
+		instance.scopeUnit = scopeUnit;
 
 		if (!isPackaged) {
 			child.stdout?.on("data", (data: Buffer) => {

--- a/apps/desktop/src/main/lib/host-service-coordinator.ts
+++ b/apps/desktop/src/main/lib/host-service-coordinator.ts
@@ -487,7 +487,23 @@ export class HostServiceCoordinator extends EventEmitter {
 		const endpoint = `http://127.0.0.1:${port}`;
 		const healthy = await pollHealthCheck(endpoint, secret);
 		if (!healthy) {
-			child.kill("SIGTERM");
+			// Linux + systemd-run: `child` is the wrapper PID, so `child.kill()`
+			// alone can leave the scoped daemon running. Kill every PID in the
+			// transient scope first, then fall back to the wrapper and any
+			// manifest PID the daemon may have written before timing out.
+			let killedViaScope = false;
+			if (scopeUnit) {
+				killedViaScope = killPersistentScope(scopeUnit, "SIGTERM");
+			}
+			if (!killedViaScope) {
+				child.kill("SIGTERM");
+				const manifest = readManifest(organizationId);
+				if (manifest && manifest.pid !== childPid) {
+					try {
+						process.kill(manifest.pid, "SIGTERM");
+					} catch {}
+				}
+			}
 			this.instances.delete(organizationId);
 			throw new Error(
 				`Host service failed to start within ${HEALTH_POLL_TIMEOUT_MS}ms`,

--- a/apps/desktop/src/main/lib/host-service-coordinator.ts
+++ b/apps/desktop/src/main/lib/host-service-coordinator.ts
@@ -1,4 +1,4 @@
-import * as childProcess from "node:child_process";
+import type * as childProcess from "node:child_process";
 import { randomBytes } from "node:crypto";
 import { EventEmitter } from "node:events";
 import * as fs from "node:fs";
@@ -26,6 +26,7 @@ import {
 	pollHealthCheck,
 } from "./host-service-utils";
 import { localDb } from "./local-db";
+import { spawnPersistent } from "./process-persistence";
 import { HOOK_PROTOCOL_VERSION } from "./terminal/env";
 
 /** Minimum host-service version this app can work with. */
@@ -109,8 +110,14 @@ export class HostServiceCoordinator extends EventEmitter {
 		const previousStatus = instance.status;
 		instance.status = "stopped";
 
+		// On Linux, when we spawned via `systemd-run --user --scope`,
+		// `instance.pid` is the systemd-run wrapper PID, not the host-service
+		// daemon PID. The daemon writes its own `process.pid` into the manifest
+		// on start, so prefer that.
+		const manifest = readManifest(organizationId);
+		const killPid = manifest?.pid ?? instance.pid;
 		try {
-			process.kill(instance.pid, "SIGTERM");
+			process.kill(killPid, "SIGTERM");
 		} catch {}
 
 		this.instances.delete(organizationId);
@@ -391,15 +398,25 @@ export class HostServiceCoordinator extends EventEmitter {
 				? ["ignore", logFd, logFd]
 				: ["ignore", "ignore", "ignore"];
 
-		let child: ReturnType<typeof childProcess.spawn>;
+		let child: childProcess.ChildProcess;
 		try {
-			child = childProcess.spawn(process.execPath, [this.scriptPath], {
-				detached: isPackaged,
-				stdio,
-				env: childEnv,
-				// Avoid a flashing CMD window on Windows for the detached child.
-				windowsHide: true,
-			});
+			// On Linux, spawnPersistent wraps packaged-build spawns with
+			// `systemd-run --user --scope` so the host-service survives
+			// Electron's systemd-logind app scope terminating on quit.
+			// In dev builds (`!isPackaged`) we keep plain pipes for log flow
+			// and spawnPersistent falls back to regular spawn automatically.
+			child = spawnPersistent(
+				process.execPath,
+				[this.scriptPath],
+				{
+					detached: isPackaged,
+					stdio,
+					env: childEnv,
+					// Avoid a flashing CMD window on Windows for the detached child.
+					windowsHide: true,
+				},
+				{ unitLabel: `superset-host-service-${organizationId}` },
+			);
 		} finally {
 			if (logFd >= 0) {
 				try {

--- a/apps/desktop/src/main/lib/process-persistence.ts
+++ b/apps/desktop/src/main/lib/process-persistence.ts
@@ -1,0 +1,110 @@
+/**
+ * Process persistence helper for cross-platform "detached daemon" spawning.
+ *
+ * On macOS/Windows, Node's `detached: true` + `child.unref()` is enough:
+ * the child survives the parent's exit. On modern Linux with systemd-logind
+ * user scopes (Ubuntu 22.04+, Fedora, Arch, etc.), every GUI app runs inside
+ * an `app-*.scope` cgroup. When the scope's main PID (Electron) exits,
+ * systemd kills every process in the cgroup — including `setsid`-detached
+ * children. The `detached` flag only separates the POSIX session; it does
+ * not escape the cgroup.
+ *
+ * This helper wraps the spawn in `systemd-run --user --scope` on Linux so
+ * the daemon lands in its own transient scope, outside Electron's cgroup.
+ * When `systemd-run` or a user D-Bus session is unavailable we fall back
+ * to a plain spawn — matches current behaviour rather than failing hard.
+ */
+import * as childProcess from "node:child_process";
+import { randomBytes } from "node:crypto";
+
+export interface SpawnPersistentExtraOptions {
+	/** Stable label used to build the systemd unit name on Linux. */
+	unitLabel: string;
+}
+
+let systemdRunAvailable: boolean | null = null;
+
+function canUseSystemdRun(): boolean {
+	if (systemdRunAvailable !== null) return systemdRunAvailable;
+
+	if (process.platform !== "linux") {
+		systemdRunAvailable = false;
+		return false;
+	}
+
+	// `systemd-run --user` needs a D-Bus user session. Without it the call
+	// fails with "Failed to connect to user bus" (e.g. raw SSH, containers).
+	if (!process.env.DBUS_SESSION_BUS_ADDRESS && !process.env.XDG_RUNTIME_DIR) {
+		systemdRunAvailable = false;
+		return false;
+	}
+
+	try {
+		childProcess.execFileSync("systemd-run", ["--version"], {
+			stdio: "ignore",
+			timeout: 2000,
+		});
+		systemdRunAvailable = true;
+	} catch {
+		systemdRunAvailable = false;
+	}
+	return systemdRunAvailable;
+}
+
+function buildUnitName(label: string): string {
+	// systemd unit names accept only [A-Za-z0-9:_.\\-]. Replace anything else
+	// so callers can pass identifiers (e.g. organizationId) straight through.
+	const safeLabel = label.replace(/[^A-Za-z0-9._-]/g, "_");
+	const suffix = `${process.pid}-${Date.now()}-${randomBytes(3).toString("hex")}`;
+	// systemd caps unit names at 256 chars including the ".scope" suffix that
+	// systemd-run appends. Leave headroom for the suffix we add below.
+	const maxLabelLen = 200;
+	const truncated =
+		safeLabel.length > maxLabelLen
+			? safeLabel.slice(0, maxLabelLen)
+			: safeLabel;
+	return `${truncated}-${suffix}`;
+}
+
+/**
+ * Spawn a daemon that must outlive the current Electron process.
+ *
+ * Caller is responsible for `detached: true` + `child.unref()` in `options` —
+ * this helper does not set them, because the non-Linux fallback path relies
+ * on them and a few call sites need to condition them on `app.isPackaged`.
+ */
+export function spawnPersistent(
+	execPath: string,
+	args: ReadonlyArray<string>,
+	options: childProcess.SpawnOptions,
+	extra: SpawnPersistentExtraOptions,
+): childProcess.ChildProcess {
+	if (!canUseSystemdRun()) {
+		return childProcess.spawn(execPath, [...args], options);
+	}
+
+	const unit = buildUnitName(extra.unitLabel);
+	const systemdArgs = [
+		"--user",
+		"--scope",
+		// Auto-remove the scope unit once all processes exit. Without this
+		// `systemctl --user list-units` accumulates a dead-scope entry per run.
+		"--collect",
+		// Suppress "Running scope as unit: xxx.scope" info lines that would
+		// otherwise land in our logFd-backed stdio.
+		"--quiet",
+		`--unit=${unit}`,
+		"--",
+		execPath,
+		...args,
+	];
+
+	try {
+		return childProcess.spawn("systemd-run", systemdArgs, options);
+	} catch (error) {
+		console.warn(
+			`[spawnPersistent] systemd-run spawn failed, falling back to plain spawn: ${String(error)}`,
+		);
+		return childProcess.spawn(execPath, [...args], options);
+	}
+}

--- a/apps/desktop/src/main/lib/process-persistence.ts
+++ b/apps/desktop/src/main/lib/process-persistence.ts
@@ -35,6 +35,12 @@ export interface SpawnPersistentResult {
 	scopeUnit: string | null;
 }
 
+// Cached for the lifetime of the process. A failure is sticky on purpose:
+// we don't want every daemon spawn to re-probe systemd-run (adds ~100ms
+// each time and can spam the journal). The trade-off is that a transient
+// D-Bus outage at startup disables systemd-run for the whole session —
+// daemons then land in Electron's cgroup and die on quit, which is the
+// pre-fix behaviour. Restarting Superset re-runs the probe.
 let systemdRunAvailable: boolean | null = null;
 
 function canUseSystemdRun(): boolean {
@@ -57,11 +63,14 @@ function canUseSystemdRun(): boolean {
 	// reach the user bus or that scope creation is allowed. Doing a real
 	// `--user --scope -- /bin/true` catches every failure mode up front
 	// so we fall back to plain spawn instead of leaving the daemon to
-	// time out on health checks (see PR #403 review).
+	// time out on health checks (see PR #403 review). `--collect` tells
+	// systemd to garbage-collect the dead unit immediately, matching
+	// `spawnPersistent` below — without it, `systemctl --user list-units`
+	// accumulates a `run-r<hex>.scope` inactive entry per app launch.
 	try {
 		childProcess.execFileSync(
 			"systemd-run",
-			["--user", "--scope", "--quiet", "--", "true"],
+			["--user", "--scope", "--collect", "--quiet", "--", "true"],
 			{ stdio: "ignore", timeout: 3000 },
 		);
 		systemdRunAvailable = true;

--- a/apps/desktop/src/main/lib/process-persistence.ts
+++ b/apps/desktop/src/main/lib/process-persistence.ts
@@ -22,6 +22,19 @@ export interface SpawnPersistentExtraOptions {
 	unitLabel: string;
 }
 
+export interface SpawnPersistentResult {
+	child: childProcess.ChildProcess;
+	/**
+	 * systemd unit name of the transient scope when the spawn was wrapped
+	 * with `systemd-run --user --scope`. `null` on non-Linux, when
+	 * `systemd-run` is unavailable, or when we fell back to plain spawn.
+	 * Callers that need a guaranteed hard kill (e.g. "stop service" on
+	 * Linux where the wrapper PID is useless) should feed this to
+	 * `systemctl --user kill <unit>` to terminate every PID in the scope.
+	 */
+	scopeUnit: string | null;
+}
+
 let systemdRunAvailable: boolean | null = null;
 
 function canUseSystemdRun(): boolean {
@@ -39,11 +52,18 @@ function canUseSystemdRun(): boolean {
 		return false;
 	}
 
+	// Probe by actually creating a throwaway transient scope. `--version`
+	// alone only tells us the binary exists — it does not prove we can
+	// reach the user bus or that scope creation is allowed. Doing a real
+	// `--user --scope -- /bin/true` catches every failure mode up front
+	// so we fall back to plain spawn instead of leaving the daemon to
+	// time out on health checks (see PR #403 review).
 	try {
-		childProcess.execFileSync("systemd-run", ["--version"], {
-			stdio: "ignore",
-			timeout: 2000,
-		});
+		childProcess.execFileSync(
+			"systemd-run",
+			["--user", "--scope", "--quiet", "--", "true"],
+			{ stdio: "ignore", timeout: 3000 },
+		);
 		systemdRunAvailable = true;
 	} catch {
 		systemdRunAvailable = false;
@@ -78,9 +98,12 @@ export function spawnPersistent(
 	args: ReadonlyArray<string>,
 	options: childProcess.SpawnOptions,
 	extra: SpawnPersistentExtraOptions,
-): childProcess.ChildProcess {
+): SpawnPersistentResult {
 	if (!canUseSystemdRun()) {
-		return childProcess.spawn(execPath, [...args], options);
+		return {
+			child: childProcess.spawn(execPath, [...args], options),
+			scopeUnit: null,
+		};
 	}
 
 	const unit = buildUnitName(extra.unitLabel);
@@ -100,11 +123,43 @@ export function spawnPersistent(
 	];
 
 	try {
-		return childProcess.spawn("systemd-run", systemdArgs, options);
+		return {
+			child: childProcess.spawn("systemd-run", systemdArgs, options),
+			scopeUnit: `${unit}.scope`,
+		};
 	} catch (error) {
 		console.warn(
 			`[spawnPersistent] systemd-run spawn failed, falling back to plain spawn: ${String(error)}`,
 		);
-		return childProcess.spawn(execPath, [...args], options);
+		return {
+			child: childProcess.spawn(execPath, [...args], options),
+			scopeUnit: null,
+		};
+	}
+}
+
+/**
+ * Send SIGTERM (or a custom signal) to every PID inside a transient scope
+ * created by `spawnPersistent`. Works even when the wrapper `systemd-run`
+ * process has already exited and when the daemon has not yet written its
+ * PID file / manifest.
+ *
+ * Returns `true` if `systemctl` was invoked successfully, `false`
+ * otherwise (caller should fall back to a plain `process.kill`).
+ */
+export function killPersistentScope(
+	scopeUnit: string,
+	signal: NodeJS.Signals = "SIGTERM",
+): boolean {
+	if (process.platform !== "linux") return false;
+	try {
+		childProcess.execFileSync(
+			"systemctl",
+			["--user", "kill", `--signal=${signal}`, scopeUnit],
+			{ stdio: "ignore", timeout: 2000 },
+		);
+		return true;
+	} catch {
+		return false;
 	}
 }

--- a/apps/desktop/src/main/lib/terminal-host/client.ts
+++ b/apps/desktop/src/main/lib/terminal-host/client.ts
@@ -9,7 +9,7 @@
  * - Event streaming
  */
 
-import { spawn } from "node:child_process";
+import type { ChildProcess } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { EventEmitter } from "node:events";
 import {
@@ -28,6 +28,7 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import { app } from "electron";
 import { SUPERSET_DIR_NAME } from "shared/constants";
+import { spawnPersistent } from "../process-persistence";
 import { throwIfAborted } from "../terminal/abort";
 import { TerminalAttachCanceledError } from "../terminal/errors";
 import {
@@ -1185,18 +1186,26 @@ export class TerminalHostClient extends EventEmitter {
 				logFd = -1;
 			}
 
-			// Spawn daemon as detached process
-			let child: ReturnType<typeof spawn> | null = null;
+			// Spawn daemon as detached process.
+			// On Linux, spawnPersistent wraps with `systemd-run --user --scope`
+			// so the daemon survives Electron's systemd-logind app scope
+			// terminating on quit.
+			let child: ChildProcess | null = null;
 			try {
-				child = spawn(process.execPath, [daemonScript], {
-					detached: true,
-					stdio: logFd >= 0 ? ["ignore", logFd, logFd] : "ignore",
-					env: {
-						...process.env,
-						ELECTRON_RUN_AS_NODE: "1",
-						NODE_ENV: process.env.NODE_ENV,
+				child = spawnPersistent(
+					process.execPath,
+					[daemonScript],
+					{
+						detached: true,
+						stdio: logFd >= 0 ? ["ignore", logFd, logFd] : "ignore",
+						env: {
+							...process.env,
+							ELECTRON_RUN_AS_NODE: "1",
+							NODE_ENV: process.env.NODE_ENV,
+						},
 					},
-				});
+					{ unitLabel: "superset-terminal-host" },
+				);
 			} finally {
 				if (logFd >= 0) {
 					try {

--- a/apps/desktop/src/main/lib/terminal-host/client.ts
+++ b/apps/desktop/src/main/lib/terminal-host/client.ts
@@ -1189,7 +1189,9 @@ export class TerminalHostClient extends EventEmitter {
 			// Spawn daemon as detached process.
 			// On Linux, spawnPersistent wraps with `systemd-run --user --scope`
 			// so the daemon survives Electron's systemd-logind app scope
-			// terminating on quit.
+			// terminating on quit. We don't use the returned `scopeUnit` —
+			// terminal-host is stopped via IPC `shutdown`, not signals, so
+			// per-scope kill isn't needed.
 			let child: ChildProcess | null = null;
 			try {
 				child = spawnPersistent(
@@ -1205,7 +1207,7 @@ export class TerminalHostClient extends EventEmitter {
 						},
 					},
 					{ unitLabel: "superset-terminal-host" },
-				);
+				).child;
 			} finally {
 				if (logFd >= 0) {
 					try {

--- a/apps/desktop/src/main/lib/todo-daemon/client.ts
+++ b/apps/desktop/src/main/lib/todo-daemon/client.ts
@@ -9,7 +9,7 @@
  * app restarts — see issue #237.
  */
 
-import { spawn } from "node:child_process";
+import type { ChildProcess } from "node:child_process";
 import { randomBytes, randomUUID } from "node:crypto";
 import { EventEmitter } from "node:events";
 import {
@@ -29,6 +29,7 @@ import { join } from "node:path";
 import { app } from "electron";
 import { todoAgentMainDebug } from "main/todo-agent/debug";
 import { SUPERSET_DIR_NAME } from "shared/constants";
+import { spawnPersistent } from "../process-persistence";
 import {
 	type AbortRequest,
 	type EmptyResponse,
@@ -554,17 +555,25 @@ export class TodoDaemonClient extends EventEmitter {
 				logFd = -1;
 			}
 
-			let child: ReturnType<typeof spawn> | null = null;
+			// On Linux, spawnPersistent wraps with `systemd-run --user --scope`
+			// so the daemon survives Electron's systemd-logind app scope
+			// terminating on quit.
+			let child: ChildProcess | null = null;
 			try {
-				child = spawn(process.execPath, [daemonScript], {
-					detached: true,
-					stdio: logFd >= 0 ? ["ignore", logFd, logFd] : "ignore",
-					env: {
-						...process.env,
-						ELECTRON_RUN_AS_NODE: "1",
-						NODE_ENV: process.env.NODE_ENV,
+				child = spawnPersistent(
+					process.execPath,
+					[daemonScript],
+					{
+						detached: true,
+						stdio: logFd >= 0 ? ["ignore", logFd, logFd] : "ignore",
+						env: {
+							...process.env,
+							ELECTRON_RUN_AS_NODE: "1",
+							NODE_ENV: process.env.NODE_ENV,
+						},
 					},
-				});
+					{ unitLabel: "superset-todo-daemon" },
+				);
 			} finally {
 				if (logFd >= 0) {
 					try {

--- a/apps/desktop/src/main/lib/todo-daemon/client.ts
+++ b/apps/desktop/src/main/lib/todo-daemon/client.ts
@@ -557,7 +557,8 @@ export class TodoDaemonClient extends EventEmitter {
 
 			// On Linux, spawnPersistent wraps with `systemd-run --user --scope`
 			// so the daemon survives Electron's systemd-logind app scope
-			// terminating on quit.
+			// terminating on quit. We don't use the returned `scopeUnit` —
+			// todo-daemon is stopped via IPC, not signals.
 			let child: ChildProcess | null = null;
 			try {
 				child = spawnPersistent(
@@ -573,7 +574,7 @@ export class TodoDaemonClient extends EventEmitter {
 						},
 					},
 					{ unitLabel: "superset-todo-daemon" },
-				);
+				).child;
 			} finally {
 				if (logFd >= 0) {
 					try {


### PR DESCRIPTION
Closes #397

## 概要

Linux で Superset を終了するとバックグラウンドで動いていたターミナル / TODO Agent のプロセスが道連れで強制終了される問題を修正。macOS と同じく「アプリを閉じて再度開いたら続きの作業をできる」状態を実現する。

## 原因

modern Linux (systemd-logind, Ubuntu 22.04+ / Fedora / Arch 等) では、GUI アプリは必ず \`app-*.scope\` という cgroup 内で起動される。scope の main PID (= Electron) が終了すると、systemd が scope 内の全プロセスに SIGTERM → 10 秒後 SIGKILL を一斉送信する。

Node の \`detached: true\` が呼ぶ \`setsid()\` は POSIX **session** を分けるだけで **cgroup** は分離しない。結果、以下 3 つの daemon が全て道連れで死ぬ:

- \`terminal-host\` (ターミナルタブの PTY 保持)
- \`todo-daemon\` (TODO Agent の \`claude -p\` 保持、#237/#246)
- \`host-service\` (組織ごとの tRPC バックエンド)

macOS には同等の cgroup ベース一斉終了機構がないため、\`detached: true\` だけで逃げ切れており、この問題は Linux 固有だった。

## 修正

### 1. \`spawnPersistent\` ヘルパ (新規)

\`apps/desktop/src/main/lib/process-persistence.ts\` を追加。Linux 時のみ daemon spawn を \`systemd-run --user --scope\` で包み、専用の transient scope に逃がす:

\`\`\`
app-gnome-Superset-12345.scope
└── Electron (閉じると scope ごと死ぬ)

superset-terminal-host-<uniq>.scope  ← 別 cgroup
└── terminal-host.js                 ← 道連れにならない
\`\`\`

- \`systemd-run\` 不在 / D-Bus user session 不在時は通常 \`spawn\` にフォールバック (既存挙動を維持)
- \`--collect\` で scope 終了時に unit を自動削除
- unit 名は \`[A-Za-z0-9._-]\` 以外を sanitize、pid + timestamp + random 3 byte で一意化
- **非 Linux プラットフォームは完全に素通し**: macOS/Windows の挙動・PID・stdio は一切変わらない

### 2. 3 daemon の spawn 差し替え

- \`terminal-host/client.ts\`
- \`todo-daemon/client.ts\`
- \`host-service-coordinator.ts\`

の \`spawn(...)\` を \`spawnPersistent(...)\` に置換。

### 3. \`host-service-coordinator.stop()\` の kill 対象を manifest PID に

Linux で systemd-run を経由すると \`instance.pid\` は systemd-run ラッパの PID になってしまい、\`process.kill(instance.pid)\` しても daemon 本体は死なない。daemon は自分の \`process.pid\` を manifest に書いているので、stop 時はそちらを優先する。

### 4. Linux 向け Quit 3 択ダイアログ

Linux はトレイ UI が無く、macOS のトレイメニューにある「Quit (Keep Services Running)」/「Quit & Stop Services」選択肢を使えない。host-service が active な時に限り、既存の Quit 確認ダイアログを 3 択化:

- \`Quit (Keep Services Running)\` → \`releaseAll()\`
- \`Quit & Stop Services\` → \`stopAll()\`
- \`Cancel\` → 終了キャンセル

macOS はトレイで同じ選択ができるので無変更。

## 影響範囲

| シナリオ | 修正前 macOS | 修正前 Linux | 修正後 Linux |
|---|---|---|---|
| アプリを閉じて再起動 | ✅ ターミナル維持 | ❌ 消える | ✅ 維持 |
| アプリがクラッシュ | ✅ 維持 | ❌ 消える | ✅ 維持 |
| OS 再起動 | ❌ 消える | ❌ 消える | ❌ 消える (scope cleanup) |

macOS ユーザへの影響: **なし** (非 Linux は素通し、UI 無変更)。

## Test plan

- [x] \`bun run lint:fix\` 通過
- [x] \`bun run typecheck\` 通過
- [x] \`terminal-host\` 既存テスト 66 pass / 0 fail
- [ ] Linux (Ubuntu 22.04+) で AppImage ビルド → ターミナル起動 → アプリ終了 → \`systemctl --user list-units --type=scope | grep superset\` で scope 残存を確認
- [ ] 再起動して該当ターミナルに再アタッチできることを確認
- [ ] 「Quit & Stop Services」選択で daemon が実際に停止することを確認
- [ ] macOS でトレイ経由の quit / window close による quit が従来通り動くことを確認

## 未対応 (スコープ外)

- OS 再起動越えの永続化 (systemd user service 化 + .deb 配布) — macOS も同等に未対応のため Issue #397 の範囲外
- Linux tray 対応 (AppIndicator 系) — 今回は dialog で代替

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# リリースノート

* **新機能**
  * Linux環境において、アプリケーション終了時にホストサービスの状態に応じた選択ダイアログを追加しました。

* **バグ修正**
  * デーモンプロセスのライフサイクル管理を改善し、より安定した動作を実現しました。
  * Linuxでのプロセス永続化メカニズムの信頼性を向上させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->