### PR TITLE
feat(desktop): 通知音と Aivis 音声の重なりを防ぐ AudioScheduler 導入

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Works with any CLI agent. Built for local worktree-based development.
 | **TODO 詳細の添付画像 chip 化＋プレビュー** | TODO 作成時に「やってほしいこと」「ゴール」へ貼り付けた画像を、タスク詳細画面でクリップマーク + ファイル名の chip として表示。クリックでネスト Dialog の画像プレビューを開ける（AgentManager は閉じない）。`todo-agent/attachments/` 配下のみを許可するパス検証付き `readAttachment` tRPC を追加 | [#229](https://github.com/MocA-Love/superset/pull/229) | 2026-04-16 |
 | **AgentManager 見切れ救済** | AgentManager 左サイドバーのワークスペース見出し・セッションタイトル、右 ChangesSidebar のブランチ/ファイルパス/コミット subject/選択ヘッダーが狭幅で見切れていた問題を修正。`truncate` + ホバー時 `Tooltip` で全文表示 | [#254](https://github.com/MocA-Love/superset/pull/254) | 2026-04-17 |
 | **Excel diff / raw viewer の透過抑止** | Appearance の透過設定 (vibrancy) ON 時に Excel ビューア / Excel diff / 画像プレビュー / HTML プレビューの背景まで透けていた問題を修正。これらの読み取り専用サーフェスは `bg-background-solid` に差し替えてダイアログと同様に不透明で維持 | [#266](https://github.com/MocA-Love/superset/pull/266) | 2026-04-17 |
+| **通知音・Aivis 音声の重なり防止** | 通知音と Aivis TTS を AudioScheduler で直列化。通知音は他の音が鳴っていれば破棄、Aivis は FIFO キューで直列再生し、PermissionRequest は優先キューで前に割り込む。Aivis API の 429 は `X-Aivis-RateLimit-Requests-Reset` を尊重、401/402/404 はキューを破棄して OS 通知で一時停止を知らせる | [#405](https://github.com/MocA-Love/superset/pull/405) | 2026-04-24 |
 
 ## Fork のビルド方法 (macOS)
 

--- a/apps/desktop/src/main/lib/notifications/aivis-tts.ts
+++ b/apps/desktop/src/main/lib/notifications/aivis-tts.ts
@@ -5,6 +5,12 @@ import { join } from "node:path";
 import { settings } from "@superset/local-db";
 import { localDb } from "../local-db";
 import { playSoundFile } from "../play-sound";
+import {
+	AivisError,
+	type AivisRateLimit,
+	type AivisSynthesizeResult,
+	type AivisTaskRunner,
+} from "./audio-scheduler";
 
 export type AivisEventKind = "complete" | "permission";
 
@@ -19,6 +25,7 @@ export interface AivisPlaceholders {
 }
 
 const AIVIS_ENDPOINT = "https://api.aivis-project.com/v1/tts/synthesize";
+const SYNTHESIZE_TIMEOUT_MS = 30_000;
 
 export const AIVIS_PLACEHOLDER_KEYS = [
 	"branch",
@@ -66,40 +73,138 @@ function readAivisSettings() {
 	}
 }
 
-async function synthesize(
-	apiKey: string,
-	modelUuid: string,
-	text: string,
-	userDictionaryUuid?: string,
-	speakingRate?: number,
-): Promise<Buffer> {
+function parseIntHeader(value: string | null): number | undefined {
+	if (value === null) return undefined;
+	const parsed = Number.parseInt(value, 10);
+	return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function extractRateLimit(headers: Headers): AivisRateLimit | undefined {
+	const remaining = parseIntHeader(
+		headers.get("X-Aivis-RateLimit-Requests-Remaining"),
+	);
+	const resetSeconds = parseIntHeader(
+		headers.get("X-Aivis-RateLimit-Requests-Reset"),
+	);
+	if (remaining === undefined || resetSeconds === undefined) return undefined;
+	return { remaining, resetSeconds, capturedAt: Date.now() };
+}
+
+function classifyStatus(
+	status: number,
+): "retryable" | "fatal" | "item-specific" {
+	if (status === 401 || status === 402 || status === 404) return "fatal";
+	if (status === 422) return "item-specific";
+	if (status === 429) return "retryable";
+	if (status >= 500 && status < 600) return "retryable";
+	// Unknown 4xx — don't keep hammering, treat as item-specific.
+	return "item-specific";
+}
+
+function reasonForStatus(status: number, bodyHint: string): string {
+	switch (status) {
+		case 401:
+			return "Aivis API キーが無効です。設定画面でキーを確認してください";
+		case 402:
+			return "Aivis のクレジット残高が不足しています";
+		case 404:
+			return "Aivis の音声合成モデルが見つかりません";
+		case 422:
+			return `Aivis リクエスト形式が不正です: ${bodyHint.slice(0, 120)}`;
+		case 429:
+			return "Aivis API のレート制限に到達しました";
+		case 500:
+		case 502:
+		case 503:
+		case 504:
+			return `Aivis サーバー側の一時障害 (HTTP ${status})`;
+		default:
+			return `Aivis API エラー (HTTP ${status}) ${bodyHint.slice(0, 120)}`;
+	}
+}
+
+/**
+ * Low-level synthesize call. Returns audio + rate limit snapshot, or throws
+ * AivisError with classified kind.
+ */
+export async function synthesizeAivisAudio(options: {
+	apiKey: string;
+	modelUuid: string;
+	text: string;
+	speakingRate?: number;
+	userDictionaryUuid?: string;
+	signal?: AbortSignal;
+}): Promise<AivisSynthesizeResult> {
 	const body: Record<string, unknown> = {
-		model_uuid: modelUuid,
-		text,
+		model_uuid: options.modelUuid,
+		text: options.text,
 		output_format: "mp3",
 	};
-	if (userDictionaryUuid) body.user_dictionary_uuid = userDictionaryUuid;
-	if (speakingRate !== undefined) body.speaking_rate = speakingRate;
+	if (options.userDictionaryUuid)
+		body.user_dictionary_uuid = options.userDictionaryUuid;
+	if (options.speakingRate !== undefined)
+		body.speaking_rate = options.speakingRate;
 
-	const res = await fetch(AIVIS_ENDPOINT, {
-		method: "POST",
-		headers: {
-			Authorization: `Bearer ${apiKey}`,
-			"Content-Type": "application/json",
-			Accept: "audio/mpeg",
-		},
-		body: JSON.stringify(body),
-	});
+	// Compose an abort signal that times out after SYNTHESIZE_TIMEOUT_MS even
+	// if the caller didn't pass one.
+	const timeoutController = new AbortController();
+	const timeoutId = setTimeout(
+		() => timeoutController.abort(),
+		SYNTHESIZE_TIMEOUT_MS,
+	);
+	const signal = options.signal
+		? anySignal([options.signal, timeoutController.signal])
+		: timeoutController.signal;
+
+	let res: Response;
+	try {
+		res = await fetch(AIVIS_ENDPOINT, {
+			method: "POST",
+			headers: {
+				Authorization: `Bearer ${options.apiKey}`,
+				"Content-Type": "application/json",
+				Accept: "audio/mpeg",
+			},
+			body: JSON.stringify(body),
+			signal,
+		});
+	} catch (err) {
+		clearTimeout(timeoutId);
+		if (err instanceof Error && err.name === "AbortError") {
+			throw new AivisError(
+				"retryable",
+				"Aivis API のリクエストがタイムアウトしました",
+				undefined,
+				undefined,
+				err,
+			);
+		}
+		throw new AivisError(
+			"retryable",
+			err instanceof Error ? err.message : String(err),
+			undefined,
+			undefined,
+			err,
+		);
+	}
+	clearTimeout(timeoutId);
 
 	if (!res.ok) {
-		const body = await res.text().catch(() => "");
-		throw new Error(
-			`Aivis API error: ${res.status} ${res.statusText} ${body.slice(0, 200)}`,
-		);
+		const bodyText = await res.text().catch(() => "");
+		const kind = classifyStatus(res.status);
+		const reason = reasonForStatus(res.status, bodyText);
+		let rateLimitReset: number | undefined;
+		if (res.status === 429) {
+			rateLimitReset = parseIntHeader(
+				res.headers.get("X-Aivis-RateLimit-Requests-Reset"),
+			);
+		}
+		throw new AivisError(kind, reason, res.status, rateLimitReset);
 	}
 
 	const arrayBuffer = await res.arrayBuffer();
-	return Buffer.from(arrayBuffer);
+	const audio = Buffer.from(arrayBuffer);
+	return { audio, rateLimit: extractRateLimit(res.headers) };
 }
 
 function uniqueTmpPath(): string {
@@ -109,16 +214,43 @@ function uniqueTmpPath(): string {
 	);
 }
 
-function cleanup(path: string): void {
+function removeFile(path: string): void {
 	execFile("rm", ["-f", path], () => {
 		/* ignore */
 	});
 }
 
 /**
- * Synthesize text via Aivis API and play it.
- * Called with explicit apiKey/modelUuid (used by both the test endpoint
- * and the runtime notification flow).
+ * Play pre-synthesized Aivis audio. Resolves when playback completes (or
+ * is skipped because no player is available). Rejects if the player binary
+ * can't be spawned at all.
+ */
+export async function playAivisAudio(
+	audio: Buffer,
+	volume: number,
+): Promise<void> {
+	const path = uniqueTmpPath();
+	await writeFile(path, audio);
+
+	return new Promise<void>((resolve) => {
+		const proc = playSoundFile(path, volume, {
+			onComplete: () => {
+				removeFile(path);
+				resolve();
+			},
+		});
+		if (!proc) {
+			// playSoundFile returned null (missing file / no player) — clean
+			// up and resolve so the scheduler doesn't hang forever.
+			removeFile(path);
+			resolve();
+		}
+	});
+}
+
+/**
+ * One-shot synthesize + play (used by the settings "test voice" button,
+ * which deliberately bypasses the scheduler). Throws AivisError on failure.
  */
 export async function playAivisTts(options: {
 	apiKey: string;
@@ -134,47 +266,60 @@ export async function playAivisTts(options: {
 		throw new Error("Aivis API key and model UUID are required");
 	}
 
-	const audio = await synthesize(
-		options.apiKey,
-		options.modelUuid,
-		trimmed,
-		options.userDictionaryUuid,
-		options.speakingRate,
-	);
-	const path = uniqueTmpPath();
-	await writeFile(path, audio);
-
-	playSoundFile(path, options.volume ?? 100, {
-		onComplete: () => cleanup(path),
+	const { audio } = await synthesizeAivisAudio({
+		apiKey: options.apiKey,
+		modelUuid: options.modelUuid,
+		text: trimmed,
+		speakingRate: options.speakingRate,
+		userDictionaryUuid: options.userDictionaryUuid || undefined,
 	});
+	await playAivisAudio(audio, options.volume ?? 100);
 }
 
 /**
- * Render the configured template for the given event and play it.
- * No-op if aivis is disabled, not configured, or the rendered text is empty.
+ * Build an AivisTaskRunner for the scheduler. Returns null when Aivis is
+ * disabled, not configured, or the rendered text is empty — the caller
+ * should treat null as "nothing to enqueue".
  */
-export async function playAivisNotification(
+export function buildAivisTaskRunner(
 	event: AivisEventKind,
 	vars: AivisPlaceholders,
-): Promise<void> {
+): AivisTaskRunner | null {
 	const cfg = readAivisSettings();
-	if (!cfg || !cfg.enabled) return;
-	if (!cfg.apiKey || !cfg.modelUuid) return;
+	if (!cfg || !cfg.enabled) return null;
+	if (!cfg.apiKey || !cfg.modelUuid) return null;
 
 	const template = event === "permission" ? cfg.formatPermission : cfg.format;
 	const text = renderAivisTemplate(template, vars).trim();
-	if (!text) return;
+	if (!text) return null;
 
-	try {
-		await playAivisTts({
-			apiKey: cfg.apiKey,
-			modelUuid: cfg.modelUuid,
-			text,
-			volume: cfg.volume,
-			speakingRate: cfg.speakingRate,
-			userDictionaryUuid: cfg.userDictionaryUuid || undefined,
-		});
-	} catch (err) {
-		console.warn("[aivis-tts] playback failed", err);
+	return {
+		synthesize: () =>
+			synthesizeAivisAudio({
+				apiKey: cfg.apiKey,
+				modelUuid: cfg.modelUuid,
+				text,
+				speakingRate: cfg.speakingRate,
+				userDictionaryUuid: cfg.userDictionaryUuid || undefined,
+			}),
+		play: (audio) => playAivisAudio(audio, cfg.volume),
+	};
+}
+
+/**
+ * Compose multiple AbortSignals into one (Node 20 has AbortSignal.any but
+ * we keep a small shim for clarity / portability).
+ */
+function anySignal(signals: AbortSignal[]): AbortSignal {
+	const controller = new AbortController();
+	const onAbort = (signal: AbortSignal) => () =>
+		controller.abort(signal.reason);
+	for (const signal of signals) {
+		if (signal.aborted) {
+			controller.abort(signal.reason);
+			return controller.signal;
+		}
+		signal.addEventListener("abort", onAbort(signal), { once: true });
 	}
+	return controller.signal;
 }

--- a/apps/desktop/src/main/lib/notifications/aivis-tts.ts
+++ b/apps/desktop/src/main/lib/notifications/aivis-tts.ts
@@ -156,22 +156,13 @@ export async function synthesizeAivisAudio(options: {
 		? anySignal([options.signal, timeoutController.signal])
 		: timeoutController.signal;
 
-	let res: Response;
-	try {
-		res = await fetch(AIVIS_ENDPOINT, {
-			method: "POST",
-			headers: {
-				Authorization: `Bearer ${options.apiKey}`,
-				"Content-Type": "application/json",
-				Accept: "audio/mpeg",
-			},
-			body: JSON.stringify(body),
-			signal,
-		});
-	} catch (err) {
-		clearTimeout(timeoutId);
+	// fetch() resolves once response headers arrive, so the body read below
+	// must stay under the same timeout. We keep the timer armed until the
+	// whole Response has been consumed (or an error is thrown) to guard
+	// against stalled / half-dead connections that keep trickling bytes.
+	const wrapFetchError = (err: unknown): AivisError => {
 		if (err instanceof Error && err.name === "AbortError") {
-			throw new AivisError(
+			return new AivisError(
 				"retryable",
 				"Aivis API のリクエストがタイムアウトしました",
 				undefined,
@@ -179,32 +170,67 @@ export async function synthesizeAivisAudio(options: {
 				err,
 			);
 		}
-		throw new AivisError(
+		return new AivisError(
 			"retryable",
 			err instanceof Error ? err.message : String(err),
 			undefined,
 			undefined,
 			err,
 		);
-	}
-	clearTimeout(timeoutId);
+	};
 
-	if (!res.ok) {
-		const bodyText = await res.text().catch(() => "");
-		const kind = classifyStatus(res.status);
-		const reason = reasonForStatus(res.status, bodyText);
-		let rateLimitReset: number | undefined;
-		if (res.status === 429) {
-			rateLimitReset = parseIntHeader(
-				res.headers.get("X-Aivis-RateLimit-Requests-Reset"),
-			);
+	try {
+		let res: Response;
+		try {
+			res = await fetch(AIVIS_ENDPOINT, {
+				method: "POST",
+				headers: {
+					Authorization: `Bearer ${options.apiKey}`,
+					"Content-Type": "application/json",
+					Accept: "audio/mpeg",
+				},
+				body: JSON.stringify(body),
+				signal,
+			});
+		} catch (err) {
+			throw wrapFetchError(err);
 		}
-		throw new AivisError(kind, reason, res.status, rateLimitReset);
-	}
 
-	const arrayBuffer = await res.arrayBuffer();
-	const audio = Buffer.from(arrayBuffer);
-	return { audio, rateLimit: extractRateLimit(res.headers) };
+		if (!res.ok) {
+			let bodyText = "";
+			try {
+				bodyText = await res.text();
+			} catch (err) {
+				// Even reading an error body can stall — surface as retryable
+				// so the scheduler can retry rather than hang on an
+				// unclassified HTTP error.
+				if (err instanceof Error && err.name === "AbortError") {
+					throw wrapFetchError(err);
+				}
+				// Fall through with empty bodyText.
+			}
+			const kind = classifyStatus(res.status);
+			const reason = reasonForStatus(res.status, bodyText);
+			let rateLimitReset: number | undefined;
+			if (res.status === 429) {
+				rateLimitReset = parseIntHeader(
+					res.headers.get("X-Aivis-RateLimit-Requests-Reset"),
+				);
+			}
+			throw new AivisError(kind, reason, res.status, rateLimitReset);
+		}
+
+		let arrayBuffer: ArrayBuffer;
+		try {
+			arrayBuffer = await res.arrayBuffer();
+		} catch (err) {
+			throw wrapFetchError(err);
+		}
+		const audio = Buffer.from(arrayBuffer);
+		return { audio, rateLimit: extractRateLimit(res.headers) };
+	} finally {
+		clearTimeout(timeoutId);
+	}
 }
 
 function uniqueTmpPath(): string {

--- a/apps/desktop/src/main/lib/notifications/aivis-tts.ts
+++ b/apps/desktop/src/main/lib/notifications/aivis-tts.ts
@@ -1,5 +1,4 @@
-import { execFile } from "node:child_process";
-import { writeFile } from "node:fs/promises";
+import { unlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { settings } from "@superset/local-db";
@@ -241,7 +240,10 @@ function uniqueTmpPath(): string {
 }
 
 function removeFile(path: string): void {
-	execFile("rm", ["-f", path], () => {
+	// Fire-and-forget. `rm` shelling-out would fail on Windows and leak
+	// temp files; unlink works cross-platform. ENOENT is fine — the file
+	// may already be gone if the player cleaned up early.
+	void unlink(path).catch(() => {
 		/* ignore */
 	});
 }

--- a/apps/desktop/src/main/lib/notifications/audio-scheduler.test.ts
+++ b/apps/desktop/src/main/lib/notifications/audio-scheduler.test.ts
@@ -121,6 +121,56 @@ describe("AudioScheduler", () => {
 			await flush();
 			expect(scheduler.isAivisBusy).toBe(false);
 		});
+
+		it("defers aivis playback until ringtone finishes", async () => {
+			const deps = createDeps();
+			const scheduler = new AudioScheduler(deps);
+
+			scheduler.playRingtone();
+			expect(deps.ringtoneCalls).toHaveLength(1);
+
+			let synthesized = false;
+			const playSpy = mock(async () => {});
+			const runner = makeRunner({
+				synthesize: async () => {
+					synthesized = true;
+					return { audio: Buffer.alloc(0), rateLimit: undefined };
+				},
+				play: playSpy,
+			});
+			scheduler.enqueueAivis(runner);
+			await flush();
+			await flush();
+
+			// Synthesis happens in parallel with ringtone, but play must wait.
+			expect(synthesized).toBe(true);
+			expect(playSpy).not.toHaveBeenCalled();
+
+			// Ringtone finishes → aivis play proceeds.
+			deps.ringtoneCalls[0].onComplete();
+			await flush();
+			await flush();
+			expect(playSpy).toHaveBeenCalled();
+		});
+
+		it("unblocks pending aivis playback on dispose", async () => {
+			const deps = createDeps();
+			const scheduler = new AudioScheduler(deps);
+			scheduler.playRingtone();
+			const playSpy = mock(async () => {});
+			scheduler.enqueueAivis(makeRunner({ play: playSpy }));
+			await flush();
+			await flush();
+			expect(playSpy).not.toHaveBeenCalled();
+
+			// Dispose must not leave the scheduler hanging on
+			// waitForRingtoneIdle; the pending runOne should short-circuit.
+			scheduler.dispose();
+			await flush();
+			await flush();
+			expect(playSpy).not.toHaveBeenCalled();
+			expect(scheduler.isAivisBusy).toBe(false);
+		});
 	});
 
 	describe("aivis queue", () => {

--- a/apps/desktop/src/main/lib/notifications/audio-scheduler.test.ts
+++ b/apps/desktop/src/main/lib/notifications/audio-scheduler.test.ts
@@ -153,6 +153,28 @@ describe("AudioScheduler", () => {
 			expect(playSpy).toHaveBeenCalled();
 		});
 
+		it("force-releases busy flag if onComplete never fires (safety timer)", async () => {
+			const deps = createDeps({
+				ringtoneSafetyTimeoutMs: 20,
+				// deliberately discard onComplete to simulate contract violation
+				playRingtone: () => {},
+			});
+			const scheduler = new AudioScheduler(deps);
+			const playSpy = mock(async () => {});
+			scheduler.playRingtone();
+			scheduler.enqueueAivis(makeRunner({ play: playSpy }));
+			await flush();
+			await flush();
+			// Aivis synth ran but play is parked behind the (hung) ringtone.
+			expect(playSpy).not.toHaveBeenCalled();
+
+			// Wait for the real setTimeout to fire the safety net.
+			await new Promise((r) => setTimeout(r, 40));
+			await flush();
+			await flush();
+			expect(playSpy).toHaveBeenCalled();
+		});
+
 		it("unblocks pending aivis playback on dispose", async () => {
 			const deps = createDeps();
 			const scheduler = new AudioScheduler(deps);

--- a/apps/desktop/src/main/lib/notifications/audio-scheduler.test.ts
+++ b/apps/desktop/src/main/lib/notifications/audio-scheduler.test.ts
@@ -1,0 +1,407 @@
+import { describe, expect, it, mock } from "bun:test";
+import {
+	AivisError,
+	type AivisTaskRunner,
+	AudioScheduler,
+	type AudioSchedulerDeps,
+} from "./audio-scheduler";
+
+interface RingtoneCall {
+	onComplete: () => void;
+}
+
+interface SleepCall {
+	ms: number;
+	resolve: () => void;
+}
+
+function createDeps(
+	overrides: Partial<AudioSchedulerDeps> = {},
+): AudioSchedulerDeps & {
+	ringtoneCalls: RingtoneCall[];
+	pausedReasons: string[];
+	errors: AivisError[];
+	sleepCalls: SleepCall[];
+	advance: (ms?: number) => void;
+} {
+	const ringtoneCalls: RingtoneCall[] = [];
+	const pausedReasons: string[] = [];
+	const errors: AivisError[] = [];
+	const sleepCalls: SleepCall[] = [];
+
+	return {
+		ringtoneCalls,
+		pausedReasons,
+		errors,
+		sleepCalls,
+		playRingtone: (onComplete) => {
+			ringtoneCalls.push({ onComplete });
+		},
+		notifyAivisPaused: (reason) => {
+			pausedReasons.push(reason);
+		},
+		onError: (err) => {
+			errors.push(err);
+		},
+		now: () => 0,
+		// Deterministic sleep: return a promise that only resolves when
+		// advance() flushes the matching pending call.
+		sleep: (ms: number) =>
+			new Promise<void>((resolve) => {
+				sleepCalls.push({ ms, resolve });
+			}),
+		advance: () => {
+			const call = sleepCalls.shift();
+			call?.resolve();
+		},
+		...overrides,
+	};
+}
+
+function makeRunner(overrides: Partial<AivisTaskRunner> = {}): AivisTaskRunner {
+	return {
+		synthesize: mock(async () => ({
+			audio: Buffer.from("audio"),
+			rateLimit: undefined,
+		})),
+		play: mock(async () => {}),
+		...overrides,
+	};
+}
+
+async function flush(): Promise<void> {
+	// Yield a few microtask turns so queued .then() callbacks run.
+	for (let i = 0; i < 5; i++) await Promise.resolve();
+}
+
+describe("AudioScheduler", () => {
+	describe("ringtone", () => {
+		it("plays the ringtone when idle", () => {
+			const deps = createDeps();
+			const scheduler = new AudioScheduler(deps);
+			scheduler.playRingtone();
+			expect(deps.ringtoneCalls).toHaveLength(1);
+		});
+
+		it("drops a second ringtone while one is playing", () => {
+			const deps = createDeps();
+			const scheduler = new AudioScheduler(deps);
+			scheduler.playRingtone();
+			scheduler.playRingtone();
+			expect(deps.ringtoneCalls).toHaveLength(1);
+		});
+
+		it("allows the next ringtone after the previous one completes", () => {
+			const deps = createDeps();
+			const scheduler = new AudioScheduler(deps);
+			scheduler.playRingtone();
+			deps.ringtoneCalls[0].onComplete();
+			scheduler.playRingtone();
+			expect(deps.ringtoneCalls).toHaveLength(2);
+		});
+
+		it("drops ringtone while an aivis task is running", async () => {
+			const deps = createDeps();
+			const scheduler = new AudioScheduler(deps);
+			let resolvePlay: () => void = () => {};
+			const runner = makeRunner({
+				play: () =>
+					new Promise<void>((r) => {
+						resolvePlay = r;
+					}),
+			});
+			scheduler.enqueueAivis(runner);
+			await flush();
+			expect(scheduler.isAivisBusy).toBe(true);
+
+			scheduler.playRingtone();
+			expect(deps.ringtoneCalls).toHaveLength(0);
+
+			resolvePlay();
+			await flush();
+			expect(scheduler.isAivisBusy).toBe(false);
+		});
+	});
+
+	describe("aivis queue", () => {
+		it("plays tasks in FIFO order", async () => {
+			const deps = createDeps();
+			const scheduler = new AudioScheduler(deps);
+			const order: string[] = [];
+			const r1 = makeRunner({
+				play: async () => {
+					order.push("a");
+				},
+			});
+			const r2 = makeRunner({
+				play: async () => {
+					order.push("b");
+				},
+			});
+			scheduler.enqueueAivis(r1);
+			scheduler.enqueueAivis(r2);
+			await flush();
+			await flush();
+			await flush();
+			expect(order).toEqual(["a", "b"]);
+		});
+
+		it("places high-priority entries before pending normal entries", async () => {
+			const deps = createDeps();
+			const scheduler = new AudioScheduler(deps);
+			const order: string[] = [];
+
+			// r1 is in-flight; r2 (normal) is queued; r3 (high) should jump ahead of r2.
+			let resolveR1: () => void = () => {};
+			const r1 = makeRunner({
+				play: () =>
+					new Promise<void>((resolve) => {
+						resolveR1 = () => {
+							order.push("r1");
+							resolve();
+						};
+					}),
+			});
+			const r2 = makeRunner({
+				play: async () => {
+					order.push("r2");
+				},
+			});
+			const r3 = makeRunner({
+				play: async () => {
+					order.push("r3");
+				},
+			});
+			scheduler.enqueueAivis(r1);
+			await flush();
+			scheduler.enqueueAivis(r2, "normal");
+			scheduler.enqueueAivis(r3, "high");
+
+			resolveR1();
+			await flush();
+			await flush();
+			await flush();
+
+			expect(order).toEqual(["r1", "r3", "r2"]);
+		});
+
+		it("does not preempt the currently speaking task", async () => {
+			const deps = createDeps();
+			const scheduler = new AudioScheduler(deps);
+			let resolvePlay: () => void = () => {};
+			const ongoing = makeRunner({
+				play: () =>
+					new Promise<void>((r) => {
+						resolvePlay = r;
+					}),
+			});
+			const highPriority = makeRunner();
+			scheduler.enqueueAivis(ongoing);
+			await flush();
+			expect(scheduler.isAivisBusy).toBe(true);
+
+			scheduler.enqueueAivis(highPriority, "high");
+			// ongoing still runs — high-priority queued behind it.
+			expect(highPriority.synthesize).not.toHaveBeenCalled();
+			resolvePlay();
+			await flush();
+			await flush();
+			expect(highPriority.synthesize).toHaveBeenCalled();
+		});
+	});
+
+	describe("error handling", () => {
+		it("retries retryable errors with exponential backoff", async () => {
+			const deps = createDeps();
+			const scheduler = new AudioScheduler(deps);
+			let attempts = 0;
+			const runner = makeRunner({
+				synthesize: async () => {
+					attempts++;
+					if (attempts < 3) {
+						throw new AivisError("retryable", "boom", 500);
+					}
+					return { audio: Buffer.alloc(0), rateLimit: undefined };
+				},
+			});
+			scheduler.enqueueAivis(runner);
+
+			// attempt 1 throws — scheduler enters sleep
+			await flush();
+			expect(deps.sleepCalls).toHaveLength(1);
+			expect(deps.sleepCalls[0].ms).toBe(1000);
+			deps.advance();
+
+			// attempt 2 throws — second backoff 2000
+			await flush();
+			expect(deps.sleepCalls[0].ms).toBe(2000);
+			deps.advance();
+
+			// attempt 3 succeeds
+			await flush();
+			expect(attempts).toBe(3);
+			expect(deps.errors).toHaveLength(2); // two retryable errors observed
+		});
+
+		it("honors X-Aivis-RateLimit Reset on 429", async () => {
+			const deps = createDeps();
+			const scheduler = new AudioScheduler(deps);
+			let attempts = 0;
+			const runner = makeRunner({
+				synthesize: async () => {
+					attempts++;
+					if (attempts === 1) {
+						throw new AivisError(
+							"retryable",
+							"rate limited",
+							429,
+							7 /* reset seconds */,
+						);
+					}
+					return { audio: Buffer.alloc(0), rateLimit: undefined };
+				},
+			});
+			scheduler.enqueueAivis(runner);
+			await flush();
+			// 7s reset + 0.5s margin = 7500ms
+			expect(deps.sleepCalls[0].ms).toBe(7500);
+			deps.advance();
+			await flush();
+			expect(attempts).toBe(2);
+		});
+
+		it("drains queue and pauses on fatal error", async () => {
+			const deps = createDeps();
+			const scheduler = new AudioScheduler(deps);
+			const runner1 = makeRunner({
+				synthesize: async () => {
+					throw new AivisError(
+						"fatal",
+						"Aivis のクレジット残高が不足しています",
+						402,
+					);
+				},
+			});
+			const runner2 = makeRunner();
+			scheduler.enqueueAivis(runner1);
+			scheduler.enqueueAivis(runner2); // should be drained before it runs
+			await flush();
+			await flush();
+
+			expect(scheduler.isPaused).toBe(true);
+			expect(scheduler.aivisQueueSize).toBe(0);
+			expect(runner2.synthesize).not.toHaveBeenCalled();
+			expect(deps.pausedReasons).toEqual([
+				"Aivis のクレジット残高が不足しています",
+			]);
+		});
+
+		it("ignores new enqueues while paused", async () => {
+			const deps = createDeps();
+			const scheduler = new AudioScheduler(deps);
+			scheduler.enqueueAivis(
+				makeRunner({
+					synthesize: async () => {
+						throw new AivisError("fatal", "kaput", 401);
+					},
+				}),
+			);
+			await flush();
+			await flush();
+			expect(scheduler.isPaused).toBe(true);
+
+			const later = makeRunner();
+			scheduler.enqueueAivis(later);
+			expect(later.synthesize).not.toHaveBeenCalled();
+			expect(scheduler.aivisQueueSize).toBe(0);
+		});
+
+		it("skips item-specific errors but keeps processing queue", async () => {
+			const deps = createDeps();
+			const scheduler = new AudioScheduler(deps);
+			const bad = makeRunner({
+				synthesize: async () => {
+					throw new AivisError("item-specific", "bad payload", 422);
+				},
+			});
+			const good = makeRunner();
+			scheduler.enqueueAivis(bad);
+			scheduler.enqueueAivis(good);
+			await flush();
+			await flush();
+			await flush();
+
+			expect(scheduler.isPaused).toBe(false);
+			expect(good.synthesize).toHaveBeenCalled();
+		});
+	});
+
+	describe("proactive rate limit", () => {
+		it("waits for reset window when Remaining is 0", async () => {
+			let currentTime = 0;
+			const deps = createDeps({
+				now: () => currentTime,
+			});
+			const scheduler = new AudioScheduler(deps);
+
+			// First task returns rateLimit with remaining=0, reset=5s
+			const first = makeRunner({
+				synthesize: async () => ({
+					audio: Buffer.alloc(0),
+					rateLimit: {
+						remaining: 0,
+						resetSeconds: 5,
+						capturedAt: currentTime,
+					},
+				}),
+			});
+			const second = makeRunner();
+
+			scheduler.enqueueAivis(first);
+			scheduler.enqueueAivis(second);
+			await flush();
+			await flush();
+
+			// Second task should be waiting for 5000ms + 500ms margin
+			expect(deps.sleepCalls).toHaveLength(1);
+			expect(deps.sleepCalls[0].ms).toBe(5500);
+			currentTime = 5500;
+			deps.advance();
+			await flush();
+			expect(second.synthesize).toHaveBeenCalled();
+		});
+
+		it("does not wait when Remaining > 0", async () => {
+			const deps = createDeps();
+			const scheduler = new AudioScheduler(deps);
+			const first = makeRunner({
+				synthesize: async () => ({
+					audio: Buffer.alloc(0),
+					rateLimit: { remaining: 5, resetSeconds: 60, capturedAt: 0 },
+				}),
+			});
+			const second = makeRunner();
+			scheduler.enqueueAivis(first);
+			scheduler.enqueueAivis(second);
+			await flush();
+			await flush();
+			await flush();
+			expect(deps.sleepCalls).toHaveLength(0);
+			expect(second.synthesize).toHaveBeenCalled();
+		});
+	});
+
+	describe("dispose", () => {
+		it("clears queue and rejects new tasks", () => {
+			const deps = createDeps();
+			const scheduler = new AudioScheduler(deps);
+			scheduler.enqueueAivis(makeRunner());
+			scheduler.enqueueAivis(makeRunner());
+			scheduler.dispose();
+			expect(scheduler.aivisQueueSize).toBe(0);
+			const later = makeRunner();
+			scheduler.enqueueAivis(later);
+			expect(later.synthesize).not.toHaveBeenCalled();
+		});
+	});
+});

--- a/apps/desktop/src/main/lib/notifications/audio-scheduler.ts
+++ b/apps/desktop/src/main/lib/notifications/audio-scheduler.ts
@@ -1,0 +1,275 @@
+/**
+ * Coordinates audible notifications (ringtone + Aivis TTS) so they never
+ * overlap.
+ *
+ * Rules (see plans / conversation that introduced this file):
+ * - Ringtone: drop if any audio channel is busy. A ringtone carries no
+ *   information, so silently skipping a second one is safe.
+ * - Aivis: FIFO queue so spoken context is never lost. PermissionRequest
+ *   events cut in front of pending Stop events (but never preempt the
+ *   currently speaking utterance).
+ * - Rate limit: Aivis Cloud returns X-Aivis-RateLimit-Requests-* headers
+ *   (subscription plans). When Remaining reaches 0, wait Reset+0.5s before
+ *   sending the next request instead of hitting 429.
+ * - Error policy:
+ *     Retryable (429, 5xx, network/timeout) - exponential backoff, max 3.
+ *     Fatal (401, 402, 404) - drain the queue, mark paused, surface an
+ *       OS notification. The user has to fix their API key / credit /
+ *       model config; no automatic resume.
+ *     Item-specific (422) - skip just this item, keep processing others.
+ */
+
+export type AivisErrorKind = "retryable" | "fatal" | "item-specific";
+
+export interface AivisRateLimit {
+	/** Requests remaining in the current window (from response header). */
+	remaining: number;
+	/** Seconds until the window resets (from response header). */
+	resetSeconds: number;
+	/** Local timestamp when the header was observed. */
+	capturedAt: number;
+}
+
+export class AivisError extends Error {
+	constructor(
+		readonly kind: AivisErrorKind,
+		readonly reason: string,
+		readonly status?: number,
+		/** For 429: seconds to wait before retrying (from header). */
+		readonly rateLimitReset?: number,
+		cause?: unknown,
+	) {
+		super(reason);
+		this.name = "AivisError";
+		if (cause !== undefined) (this as { cause?: unknown }).cause = cause;
+	}
+}
+
+export interface AivisSynthesizeResult {
+	audio: Buffer;
+	rateLimit?: AivisRateLimit;
+}
+
+/**
+ * A single queueable Aivis task. Scheduler calls synthesize() (may throw
+ * AivisError), then play() with the returned audio. play() resolves on
+ * playback completion (or rejects — treated as item-specific failure).
+ */
+export interface AivisTaskRunner {
+	synthesize(): Promise<AivisSynthesizeResult>;
+	play(audio: Buffer): Promise<void>;
+}
+
+export type AivisPriority = "normal" | "high";
+
+export interface AudioSchedulerDeps {
+	/**
+	 * Play the configured notification ringtone. onComplete must fire
+	 * exactly once, whether playback succeeded, was skipped (muted / no
+	 * file), or failed.
+	 */
+	playRingtone(onComplete: () => void): void;
+	/**
+	 * Surface a visible "Aivis paused" notification to the user when the
+	 * queue is drained due to a fatal error.
+	 */
+	notifyAivisPaused(reason: string): void;
+	/** Hook for telemetry / logging. Optional. */
+	onError?(err: AivisError): void;
+	/** Injected clock for tests. Defaults to Date.now. */
+	now?(): number;
+	/** Injected sleep for tests. Defaults to setTimeout. */
+	sleep?(ms: number): Promise<void>;
+}
+
+const MAX_RETRY_ATTEMPTS = 3;
+const DEFAULT_BACKOFF_MS = [1000, 2000, 4000];
+const RATE_LIMIT_MARGIN_MS = 500;
+
+function defaultSleep(ms: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+interface QueueEntry {
+	priority: AivisPriority;
+	runner: AivisTaskRunner;
+}
+
+export class AudioScheduler {
+	private ringtoneBusy = false;
+	private aivisBusy = false;
+	private queue: QueueEntry[] = [];
+	private paused = false;
+	private rateLimit?: AivisRateLimit;
+	private disposed = false;
+
+	constructor(private readonly deps: AudioSchedulerDeps) {}
+
+	playRingtone(): void {
+		if (this.disposed) return;
+		if (this.ringtoneBusy || this.aivisBusy) return;
+		this.ringtoneBusy = true;
+		try {
+			this.deps.playRingtone(() => {
+				this.ringtoneBusy = false;
+			});
+		} catch (err) {
+			this.ringtoneBusy = false;
+			console.warn("[audio-scheduler] ringtone failed", err);
+		}
+	}
+
+	enqueueAivis(
+		runner: AivisTaskRunner,
+		priority: AivisPriority = "normal",
+	): void {
+		if (this.disposed || this.paused) return;
+		const entry: QueueEntry = { priority, runner };
+		if (priority === "high") {
+			const firstNormal = this.queue.findIndex((e) => e.priority === "normal");
+			if (firstNormal < 0) this.queue.push(entry);
+			else this.queue.splice(firstNormal, 0, entry);
+		} else {
+			this.queue.push(entry);
+		}
+		void this.pump();
+	}
+
+	get aivisQueueSize(): number {
+		return this.queue.length;
+	}
+
+	get isAivisBusy(): boolean {
+		return this.aivisBusy;
+	}
+
+	get isPaused(): boolean {
+		return this.paused;
+	}
+
+	/** Clear the pause state (e.g. after the user fixes their API key). */
+	resume(): void {
+		if (this.disposed) return;
+		this.paused = false;
+	}
+
+	dispose(): void {
+		this.disposed = true;
+		this.queue = [];
+	}
+
+	private async pump(): Promise<void> {
+		if (this.aivisBusy) return;
+		if (this.disposed || this.paused) return;
+		const entry = this.queue.shift();
+		if (!entry) return;
+		this.aivisBusy = true;
+		try {
+			await this.runOne(entry.runner);
+		} finally {
+			this.aivisBusy = false;
+			if (!this.disposed && !this.paused && this.queue.length > 0) {
+				void this.pump();
+			}
+		}
+	}
+
+	private async runOne(runner: AivisTaskRunner): Promise<void> {
+		await this.waitForRateLimitWindow();
+
+		let lastErr: AivisError | undefined;
+		for (let attempt = 1; attempt <= MAX_RETRY_ATTEMPTS; attempt++) {
+			if (this.disposed) return;
+			try {
+				const { audio, rateLimit } = await runner.synthesize();
+				if (rateLimit) this.rateLimit = rateLimit;
+				try {
+					await runner.play(audio);
+				} catch (playErr) {
+					// Playback failures don't justify retrying synthesis.
+					const wrapped = new AivisError(
+						"item-specific",
+						"Aivis 音声の再生に失敗しました",
+						undefined,
+						undefined,
+						playErr,
+					);
+					this.deps.onError?.(wrapped);
+				}
+				return;
+			} catch (err) {
+				const aivisErr = toAivisError(err);
+				lastErr = aivisErr;
+				this.deps.onError?.(aivisErr);
+
+				if (aivisErr.kind === "fatal") {
+					this.drainAndPause(aivisErr.reason);
+					return;
+				}
+				if (aivisErr.kind === "item-specific") {
+					return;
+				}
+				// Retryable — sleep and retry (unless last attempt).
+				if (attempt >= MAX_RETRY_ATTEMPTS) break;
+				const waitMs = this.computeBackoffMs(aivisErr, attempt);
+				await (this.deps.sleep ?? defaultSleep)(waitMs);
+			}
+		}
+
+		if (lastErr) {
+			console.warn(
+				`[audio-scheduler] aivis task gave up after ${MAX_RETRY_ATTEMPTS} attempts: ${lastErr.reason}`,
+			);
+		}
+	}
+
+	private computeBackoffMs(err: AivisError, attempt: number): number {
+		if (err.status === 429 && err.rateLimitReset !== undefined) {
+			return Math.max(0, err.rateLimitReset * 1000 + RATE_LIMIT_MARGIN_MS);
+		}
+		return DEFAULT_BACKOFF_MS[attempt - 1] ?? DEFAULT_BACKOFF_MS.at(-1) ?? 4000;
+	}
+
+	private async waitForRateLimitWindow(): Promise<void> {
+		const rl = this.rateLimit;
+		if (!rl || rl.remaining > 0) return;
+		const now = (this.deps.now ?? Date.now)();
+		const elapsedMs = now - rl.capturedAt;
+		const waitMs = rl.resetSeconds * 1000 - elapsedMs + RATE_LIMIT_MARGIN_MS;
+		if (waitMs <= 0) return;
+		await (this.deps.sleep ?? defaultSleep)(waitMs);
+	}
+
+	private drainAndPause(reason: string): void {
+		const dropped = this.queue.length;
+		this.queue = [];
+		this.paused = true;
+		this.deps.notifyAivisPaused(reason);
+		if (dropped > 0) {
+			console.info(
+				`[audio-scheduler] dropped ${dropped} queued Aivis task(s) after fatal error: ${reason}`,
+			);
+		}
+	}
+}
+
+function toAivisError(err: unknown): AivisError {
+	if (err instanceof AivisError) return err;
+	if (err instanceof Error && err.name === "AbortError") {
+		return new AivisError(
+			"retryable",
+			"Aivis API のリクエストがタイムアウトしました",
+			undefined,
+			undefined,
+			err,
+		);
+	}
+	// Network errors from fetch land here — treat as retryable.
+	return new AivisError(
+		"retryable",
+		err instanceof Error ? err.message : String(err),
+		undefined,
+		undefined,
+		err,
+	);
+}

--- a/apps/desktop/src/main/lib/notifications/audio-scheduler.ts
+++ b/apps/desktop/src/main/lib/notifications/audio-scheduler.ts
@@ -39,9 +39,8 @@ export class AivisError extends Error {
 		readonly rateLimitReset?: number,
 		cause?: unknown,
 	) {
-		super(reason);
+		super(reason, cause !== undefined ? { cause } : undefined);
 		this.name = "AivisError";
-		if (cause !== undefined) (this as { cause?: unknown }).cause = cause;
 	}
 }
 
@@ -80,11 +79,22 @@ export interface AudioSchedulerDeps {
 	now?(): number;
 	/** Injected sleep for tests. Defaults to setTimeout. */
 	sleep?(ms: number): Promise<void>;
+	/**
+	 * Safety net against a misbehaving `playRingtone` that never calls
+	 * onComplete. If the callback hasn't fired by this deadline, the
+	 * scheduler force-releases its busy flag and wakes any pending Aivis
+	 * tasks. Defaults to 30s. Tests can shrink this.
+	 */
+	ringtoneSafetyTimeoutMs?: number;
 }
 
 const MAX_RETRY_ATTEMPTS = 3;
-const DEFAULT_BACKOFF_MS = [1000, 2000, 4000];
+// One entry per "sleep between attempt N and N+1". With MAX_RETRY_ATTEMPTS=3
+// we only sleep after attempts 1 and 2 (attempt 3 is the last, we break
+// before sleeping), so two entries is all we need.
+const DEFAULT_BACKOFF_MS = [1000, 2000];
 const RATE_LIMIT_MARGIN_MS = 500;
+const RINGTONE_SAFETY_TIMEOUT_MS = 30_000;
 
 function defaultSleep(ms: number): Promise<void> {
 	return new Promise((resolve) => setTimeout(resolve, ms));
@@ -103,6 +113,7 @@ export class AudioScheduler {
 	private rateLimit?: AivisRateLimit;
 	private disposed = false;
 	private ringtoneIdleWaiters: Array<() => void> = [];
+	private ringtoneSafetyTimer: ReturnType<typeof setTimeout> | null = null;
 
 	constructor(private readonly deps: AudioSchedulerDeps) {}
 
@@ -110,6 +121,18 @@ export class AudioScheduler {
 		if (this.disposed) return;
 		if (this.ringtoneBusy || this.aivisBusy) return;
 		this.ringtoneBusy = true;
+		// Defense in depth: if deps.playRingtone forgets to call onComplete
+		// (contract regression), waitForRingtoneIdle would hang forever and
+		// the whole Aivis queue would stall. A generous safety timer
+		// force-releases the busy flag instead.
+		this.ringtoneSafetyTimer = setTimeout(() => {
+			if (this.ringtoneBusy) {
+				console.warn(
+					"[audio-scheduler] ringtone onComplete did not fire within safety timeout; force-releasing",
+				);
+				this.onRingtoneComplete();
+			}
+		}, this.deps.ringtoneSafetyTimeoutMs ?? RINGTONE_SAFETY_TIMEOUT_MS);
 		try {
 			this.deps.playRingtone(() => {
 				this.onRingtoneComplete();
@@ -122,6 +145,10 @@ export class AudioScheduler {
 
 	private onRingtoneComplete(): void {
 		this.ringtoneBusy = false;
+		if (this.ringtoneSafetyTimer) {
+			clearTimeout(this.ringtoneSafetyTimer);
+			this.ringtoneSafetyTimer = null;
+		}
 		const waiters = this.ringtoneIdleWaiters;
 		this.ringtoneIdleWaiters = [];
 		for (const resolve of waiters) resolve();
@@ -171,6 +198,10 @@ export class AudioScheduler {
 	dispose(): void {
 		this.disposed = true;
 		this.queue = [];
+		if (this.ringtoneSafetyTimer) {
+			clearTimeout(this.ringtoneSafetyTimer);
+			this.ringtoneSafetyTimer = null;
+		}
 		// Flush pending ringtone-idle waiters so any in-flight runOne() can
 		// unblock and finish instead of hanging forever.
 		const waiters = this.ringtoneIdleWaiters;

--- a/apps/desktop/src/main/lib/notifications/audio-scheduler.ts
+++ b/apps/desktop/src/main/lib/notifications/audio-scheduler.ts
@@ -102,6 +102,7 @@ export class AudioScheduler {
 	private paused = false;
 	private rateLimit?: AivisRateLimit;
 	private disposed = false;
+	private ringtoneIdleWaiters: Array<() => void> = [];
 
 	constructor(private readonly deps: AudioSchedulerDeps) {}
 
@@ -111,12 +112,26 @@ export class AudioScheduler {
 		this.ringtoneBusy = true;
 		try {
 			this.deps.playRingtone(() => {
-				this.ringtoneBusy = false;
+				this.onRingtoneComplete();
 			});
 		} catch (err) {
-			this.ringtoneBusy = false;
+			this.onRingtoneComplete();
 			console.warn("[audio-scheduler] ringtone failed", err);
 		}
+	}
+
+	private onRingtoneComplete(): void {
+		this.ringtoneBusy = false;
+		const waiters = this.ringtoneIdleWaiters;
+		this.ringtoneIdleWaiters = [];
+		for (const resolve of waiters) resolve();
+	}
+
+	private waitForRingtoneIdle(): Promise<void> {
+		if (!this.ringtoneBusy || this.disposed) return Promise.resolve();
+		return new Promise<void>((resolve) => {
+			this.ringtoneIdleWaiters.push(resolve);
+		});
 	}
 
 	enqueueAivis(
@@ -156,6 +171,11 @@ export class AudioScheduler {
 	dispose(): void {
 		this.disposed = true;
 		this.queue = [];
+		// Flush pending ringtone-idle waiters so any in-flight runOne() can
+		// unblock and finish instead of hanging forever.
+		const waiters = this.ringtoneIdleWaiters;
+		this.ringtoneIdleWaiters = [];
+		for (const resolve of waiters) resolve();
 	}
 
 	private async pump(): Promise<void> {
@@ -183,6 +203,11 @@ export class AudioScheduler {
 			try {
 				const { audio, rateLimit } = await runner.synthesize();
 				if (rateLimit) this.rateLimit = rateLimit;
+				// Synthesis can run in parallel with a ringtone (it's just a
+				// network call), but playback must wait so the two audio
+				// streams don't overlap.
+				await this.waitForRingtoneIdle();
+				if (this.disposed) return;
 				try {
 					await runner.play(audio);
 				} catch (playErr) {

--- a/apps/desktop/src/main/lib/notifications/notification-manager.test.ts
+++ b/apps/desktop/src/main/lib/notifications/notification-manager.test.ts
@@ -3,6 +3,7 @@ import type {
 	AgentLifecycleEvent,
 	NotificationIds,
 } from "shared/notification-types";
+import type { AivisPriority, AivisTaskRunner } from "./audio-scheduler";
 import {
 	type NativeNotification,
 	NotificationManager,
@@ -33,6 +34,7 @@ function createMockNotification(): MockNotification {
 interface TestDeps extends NotificationManagerDeps {
 	notifications: MockNotification[];
 	clickedIds: NotificationIds[];
+	enqueued: { runner: AivisTaskRunner; priority: AivisPriority }[];
 }
 
 function createDeps(
@@ -40,17 +42,28 @@ function createDeps(
 ): TestDeps {
 	const notifications: MockNotification[] = [];
 	const clickedIds: NotificationIds[] = [];
+	const enqueued: { runner: AivisTaskRunner; priority: AivisPriority }[] = [];
+	const stubRunner: AivisTaskRunner = {
+		synthesize: () =>
+			Promise.resolve({ audio: Buffer.alloc(0), rateLimit: undefined }),
+		play: () => Promise.resolve(),
+	};
 
 	return {
 		notifications,
 		clickedIds,
+		enqueued,
 		isSupported: () => true,
 		createNotification: () => {
 			const n = createMockNotification();
 			notifications.push(n);
 			return n;
 		},
-		playSound: mock(() => {}),
+		playRingtone: mock(() => {}),
+		buildAivisRunner: () => stubRunner,
+		enqueueAivis: (runner, priority) => {
+			enqueued.push({ runner, priority });
+		},
 		onNotificationClick: (ids) => clickedIds.push(ids),
 		getVisibilityContext: () => ({
 			isFocused: false,
@@ -114,9 +127,30 @@ describe("NotificationManager", () => {
 			expect(localManager.activeCount).toBe(0);
 		});
 
-		it("plays sound on notification", () => {
+		it("plays ringtone on notification", () => {
 			manager.handleAgentLifecycle(makeEvent());
-			expect(deps.playSound).toHaveBeenCalled();
+			expect(deps.playRingtone).toHaveBeenCalled();
+		});
+
+		it("enqueues aivis with normal priority for Stop events", () => {
+			manager.handleAgentLifecycle(makeEvent({ eventType: "Stop" }));
+			expect(deps.enqueued).toHaveLength(1);
+			expect(deps.enqueued[0].priority).toBe("normal");
+		});
+
+		it("enqueues aivis with high priority for PermissionRequest events", () => {
+			manager.handleAgentLifecycle(
+				makeEvent({ eventType: "PermissionRequest" }),
+			);
+			expect(deps.enqueued).toHaveLength(1);
+			expect(deps.enqueued[0].priority).toBe("high");
+		});
+
+		it("skips aivis enqueue when buildAivisRunner returns null", () => {
+			const localDeps = createDeps({ buildAivisRunner: () => null });
+			const localManager = new NotificationManager(localDeps);
+			localManager.handleAgentLifecycle(makeEvent());
+			expect(localDeps.enqueued).toHaveLength(0);
 		});
 	});
 

--- a/apps/desktop/src/main/lib/notifications/notification-manager.ts
+++ b/apps/desktop/src/main/lib/notifications/notification-manager.ts
@@ -2,6 +2,7 @@ import type {
 	AgentLifecycleEvent,
 	NotificationIds,
 } from "shared/notification-types";
+import type { AivisPriority, AivisTaskRunner } from "./audio-scheduler";
 import { isPaneVisible } from "./utils";
 
 const NOTIFICATION_TTL_MS = 10 * 60 * 1000;
@@ -21,8 +22,20 @@ export interface NotificationManagerDeps {
 		body: string;
 		silent: boolean;
 	}) => NativeNotification;
-	playSound: (onComplete?: () => void) => void;
-	playAivis?: (event: AgentLifecycleEvent) => void;
+	/**
+	 * Ask the audio scheduler to play a ringtone. The scheduler decides
+	 * whether it actually plays (it drops the request while any audio is
+	 * already busy). No onComplete is exposed — aivis is scheduled
+	 * independently below.
+	 */
+	playRingtone: () => void;
+	/**
+	 * Build an AivisTaskRunner for the given event. Return null when
+	 * Aivis is disabled / not configured / yields empty text.
+	 */
+	buildAivisRunner?: (event: AgentLifecycleEvent) => AivisTaskRunner | null;
+	/** Enqueue an Aivis utterance at the given priority. */
+	enqueueAivis?: (runner: AivisTaskRunner, priority: AivisPriority) => void;
 	onNotificationClick: (ids: NotificationIds) => void;
 	getVisibilityContext: () => {
 		isFocused: boolean;
@@ -78,9 +91,15 @@ export class NotificationManager {
 		const key = event.sessionId ?? event.paneId ?? `_anon_${this.counter++}`;
 		this.track(key, notification);
 
-		// Chain Aivis after the ringtone so the voice announcement plays
-		// once the notification sound finishes rather than in parallel.
-		this.deps.playSound(() => this.deps.playAivis?.(event));
+		// Ringtone and Aivis go through independent scheduler channels:
+		// the ringtone may be dropped if audio is already playing, while
+		// the Aivis runner is always enqueued so spoken context is never
+		// lost. PermissionRequest events cut in front of Stop events.
+		this.deps.playRingtone();
+		const runner = this.deps.buildAivisRunner?.(event);
+		if (runner) {
+			this.deps.enqueueAivis?.(runner, isPermissionRequest ? "high" : "normal");
+		}
 
 		notification.on("click", () => {
 			this.deps.onNotificationClick({

--- a/apps/desktop/src/main/windows/main.ts
+++ b/apps/desktop/src/main/windows/main.ts
@@ -20,7 +20,8 @@ import { appState } from "../lib/app-state";
 import { browserManager } from "../lib/browser/browser-manager";
 import { createApplicationMenu } from "../lib/menu";
 import { playNotificationSound } from "../lib/notification-sound";
-import { playAivisNotification } from "../lib/notifications/aivis-tts";
+import { buildAivisTaskRunner } from "../lib/notifications/aivis-tts";
+import { AudioScheduler } from "../lib/notifications/audio-scheduler";
 import { NotificationManager } from "../lib/notifications/notification-manager";
 import {
 	notificationsApp,
@@ -109,6 +110,11 @@ let mainWindowCleanup: (() => void) | null = null;
 let notificationsInitialized = false;
 let notificationsServer: Server | null = null;
 let notificationManager: NotificationManager | null = null;
+let audioScheduler: AudioScheduler | null = null;
+// Rate-limit the "Aivis paused" OS notification so a storm of fatal errors
+// produces at most one banner per minute.
+let lastPausedNotificationAt = 0;
+const PAUSED_NOTIFICATION_COOLDOWN_MS = 60_000;
 let agentLifecycleListener: ((event: AgentLifecycleEvent) => void) | null =
 	null;
 let terminalExitListener:
@@ -190,17 +196,59 @@ nativeTheme.on("updated", () => {
 	}
 });
 
+function showAivisPausedNotification(reason: string): void {
+	if (!Notification.isSupported()) return;
+	const now = Date.now();
+	if (now - lastPausedNotificationAt < PAUSED_NOTIFICATION_COOLDOWN_MS) return;
+	lastPausedNotificationAt = now;
+	try {
+		const notification = new Notification({
+			title: "Aivis 音声通知を一時停止しました",
+			body: reason,
+			silent: true,
+		});
+		notification.show();
+	} catch (err) {
+		console.warn("[notifications] failed to show Aivis paused banner", err);
+	}
+}
+
 export function initNotifications(): void {
 	if (notificationsInitialized) return;
+
+	audioScheduler = new AudioScheduler({
+		playRingtone: (onComplete) => {
+			playNotificationSound(onComplete);
+		},
+		notifyAivisPaused: (reason) => {
+			showAivisPausedNotification(reason);
+		},
+		onError: (err) => {
+			if (err.kind === "retryable") {
+				console.info(
+					`[audio-scheduler] retryable Aivis error (status=${err.status}): ${err.reason}`,
+				);
+			} else {
+				console.warn(
+					`[audio-scheduler] Aivis error (kind=${err.kind}, status=${err.status}): ${err.reason}`,
+				);
+			}
+		},
+	});
 
 	notificationManager = new NotificationManager({
 		isSupported: () => Notification.isSupported(),
 		createNotification: (opts) => new Notification(opts),
-		playSound: playNotificationSound,
-		playAivis: (event) => {
+		playRingtone: () => {
+			audioScheduler?.playRingtone();
+		},
+		buildAivisRunner: (event) => {
 			const kind =
 				event.eventType === "PermissionRequest" ? "permission" : "complete";
-			void playAivisNotification(kind, buildAivisVars(event));
+			return buildAivisTaskRunner(kind, buildAivisVars(event));
+		},
+		enqueueAivis: (runner, priority) => {
+			audioScheduler?.enqueueAivis(runner, priority);
 		},
 		onNotificationClick: (ids) => {
 			const window = getWindow();
@@ -287,6 +335,9 @@ function cleanupNotifications(): void {
 
 	notificationManager?.dispose();
 	notificationManager = null;
+
+	audioScheduler?.dispose();
+	audioScheduler = null;
 
 	notificationsServer?.close();
 	notificationsServer = null;


### PR DESCRIPTION
## Summary

通知音（ringtone）と Aivis 音声通知が同時イベントで重なって再生されてしまう問題を解消します。

### 変更の要点

- **通知音は "ドロップ"**: ringtone / Aivis のいずれかが再生中なら、新しく発生した通知音は無視する。通知音は情報量がないので捨てて構わない。
- **Aivis は "FIFO キュー"**: 発話中のキューに積んで直列再生。ワークスペース名や branch を読み上げるため、捨てず順番に喋らせる。
- **PermissionRequest は優先**: 進行中の発話は打ち切らないが、`Stop` イベントより先にキューの前に割り込ませる。
- **Aivis API エラーを分類**:
  - Retryable（`429` / `5xx` / network / timeout）: 指数バックオフで最大 3 回リトライ。`429` は `X-Aivis-RateLimit-Requests-Reset` ヘッダーの秒数 + 0.5s を優先。
  - Fatal（`401` / `402` / `404`）: キューを破棄して一時停止。原因を OS 通知で 1 回だけ表示（1 分クールダウン）。ユーザー対応待ちなので自動再開はしない。
  - Item-specific（`422`）: そのアイテムだけスキップしてキュー継続。
- **Proactive レート制限**: 成功レスポンスの `X-Aivis-RateLimit-Requests-Remaining` / `-Reset` を記録し、`Remaining=0` なら次の送信を `Reset + 0.5s` 待機して先回りで回避。
- **タイムアウト**: `/v1/tts/synthesize` に 30s の `AbortSignal` を追加（通常 1 秒未満で返る API なのに永久 hang しないように）。

### 新規ファイル

- `apps/desktop/src/main/lib/notifications/audio-scheduler.ts` — ドロップ / キュー / 再試行 / 停止ロジックを集約
- `apps/desktop/src/main/lib/notifications/audio-scheduler.test.ts` — スケジューラー単体テスト（13 ケース）

### 既存ファイルの変更

- `aivis-tts.ts`: `synthesizeAivisAudio` / `playAivisAudio` / `buildAivisTaskRunner` に分離。`AivisError` を throw するよう再実装。設定画面の「テスト発声」用 `playAivisTts` はそのまま維持（スケジューラーをバイパスする一発実行）。
- `notification-manager.ts`: `playSound` / `playAivis` の依存を `playRingtone` / `buildAivisRunner` / `enqueueAivis` に置き換え。
- `main.ts`: `AudioScheduler` を初期化して `NotificationManager` に配線。致命的エラー時の OS 通知ハンドラ `showAivisPausedNotification` を追加。

### 設計の補足

- 設定画面の ringtone プレビューと Aivis テスト発声は別チャネル扱いで、スケジューラーをバイパスします（プレビュー中でも本番通知は普通に鳴る）。
- `dispose()` でキューを破棄するので、ウィンドウ閉鎖時に未処理タスクが残ることはありません。
- `Aivis paused` OS 通知は 1 分クールダウン。致命的エラーが連発しても OS 通知を爆撃しません。

## Test plan

- [x] `bun test src/main/lib/notifications/` — 87 pass / 0 fail（うち audio-scheduler 単独で 13 ケース）
- [x] `bun run typecheck` — 通過
- [x] `bun run lint` — 通過
- [ ] 配布ビルドで実機確認（Stop + PermissionRequest を同時に発火させて重ならないこと）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 通知音の重複再生を防止し、他のオーディオ再生中は通知音を自動的にキューイング
  * Permission Request通知に優先処理を実装
  * Aivis API レート制限への対応を強化（リセット時間の自動管理）

* **テスト**
  * オーディオスケジューリング機能の包括的なテストカバレッジを追加

<!-- end of auto-generated comment: release notes by coderabbit.ai -->