### PR TITLE
fix(desktop): ワークツリー自動同期をレイアウト常駐化して全画面で動くようにする

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/project/$projectId/components/ExternalWorktreesBanner/ExternalWorktreesBanner.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/project/$projectId/components/ExternalWorktreesBanner/ExternalWorktreesBanner.tsx
@@ -12,7 +12,6 @@ import {
 import { Button } from "@superset/ui/button";
 import { toast } from "@superset/ui/sonner";
 import { motion } from "framer-motion";
-import { useCallback, useEffect, useRef } from "react";
 import { GoGitBranch } from "react-icons/go";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { useImportAllWorktrees } from "renderer/react-query/workspaces/useImportAllWorktrees";
@@ -27,76 +26,30 @@ export function ExternalWorktreesBanner({ projectId }: { projectId: string }) {
 	});
 
 	const importAllWorktrees = useImportAllWorktrees();
-
-	const handleImportAll = useCallback(
-		async (silent = false): Promise<boolean> => {
-			try {
-				const result = await importAllWorktrees.mutateAsync({ projectId });
-				if (!silent) {
-					toast.success(
-						`Imported ${result.imported} workspace${result.imported === 1 ? "" : "s"}`,
-					);
-				} else if (result.imported > 0) {
-					toast.success(
-						`Auto-imported ${result.imported} worktree${result.imported === 1 ? "" : "s"}`,
-					);
-				}
-				return true;
-			} catch (err) {
-				toast.error(
-					err instanceof Error ? err.message : "Failed to import worktrees",
-				);
-				return false;
-			}
-		},
-		[importAllWorktrees, projectId],
-	);
-
-	const autoImportInFlightRef = useRef(false);
-	const lastFailedSignatureRef = useRef<string | null>(null);
 	const autoImportEnabled = project?.autoImportExternalWorktrees === true;
 
-	// Stable signature of the current external-worktree set. We remember the
-	// signature of the last auto-import attempt that failed so we do not
-	// retry the same (broken) set on every render — that previously created a
-	// tight failure loop of mutations + error toasts with no user action.
-	const externalSignature = externalWorktrees
-		.map((wt) => wt.path)
-		.sort()
-		.join("\n");
-
-	useEffect(() => {
-		if (!autoImportEnabled) return;
-		if (isLoading) return;
-		if (externalWorktrees.length === 0) return;
-		if (autoImportInFlightRef.current) return;
-		if (importAllWorktrees.isPending) return;
-		if (lastFailedSignatureRef.current === externalSignature) return;
-
-		autoImportInFlightRef.current = true;
-		handleImportAll(true)
-			.then((ok) => {
-				lastFailedSignatureRef.current = ok ? null : externalSignature;
-			})
-			.finally(() => {
-				autoImportInFlightRef.current = false;
-			});
-	}, [
-		autoImportEnabled,
-		isLoading,
-		externalWorktrees.length,
-		externalSignature,
-		importAllWorktrees.isPending,
-		handleImportAll,
-	]);
+	// When auto-import is on, WorktreeAutoSyncManager handles the import in the
+	// background; hiding the banner avoids duplicate mutations.
+	if (autoImportEnabled) {
+		return null;
+	}
 
 	if (isLoading || externalWorktrees.length === 0) {
 		return null;
 	}
 
-	if (autoImportEnabled) {
-		return null;
-	}
+	const handleImportAll = async () => {
+		try {
+			const result = await importAllWorktrees.mutateAsync({ projectId });
+			toast.success(
+				`Imported ${result.imported} workspace${result.imported === 1 ? "" : "s"}`,
+			);
+		} catch (err) {
+			toast.error(
+				err instanceof Error ? err.message : "Failed to import worktrees",
+			);
+		}
+	};
 
 	const visibleBranches = externalWorktrees.slice(0, MAX_VISIBLE_BRANCHES);
 	const remainingCount = externalWorktrees.length - visibleBranches.length;
@@ -156,7 +109,7 @@ export function ExternalWorktreesBanner({ projectId }: { projectId: string }) {
 						</AlertDialogHeader>
 						<AlertDialogFooter>
 							<AlertDialogCancel>Cancel</AlertDialogCancel>
-							<AlertDialogAction onClick={() => handleImportAll(false)}>
+							<AlertDialogAction onClick={handleImportAll}>
 								Import all
 							</AlertDialogAction>
 						</AlertDialogFooter>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/project/$projectId/components/ProjectWorktreeAutoSync/ProjectWorktreeAutoSync.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/project/$projectId/components/ProjectWorktreeAutoSync/ProjectWorktreeAutoSync.tsx
@@ -3,6 +3,8 @@ import { useEffect, useRef } from "react";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { useCleanupMissingWorktrees } from "renderer/react-query/workspaces/useCleanupMissingWorktrees";
 
+const POLL_MS = 30_000;
+
 /**
  * Background sync for externally-deleted worktrees.
  *
@@ -21,7 +23,10 @@ export function ProjectWorktreeAutoSync({ projectId }: { projectId: string }) {
 	const { data: missingWorktrees = [], isLoading } =
 		electronTrpc.workspaces.githubExtended.getMissingWorktrees.useQuery(
 			{ projectId },
-			{ enabled: autoRemoveEnabled },
+			{
+				enabled: autoRemoveEnabled,
+				refetchInterval: autoRemoveEnabled ? POLL_MS : false,
+			},
 		);
 	const cleanupMutation = useCleanupMissingWorktrees();
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/project/$projectId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/project/$projectId/page.tsx
@@ -38,7 +38,6 @@ import { useCreateWorkspace } from "renderer/react-query/workspaces";
 import { NotFound } from "renderer/routes/not-found";
 import type { SetupAction } from "shared/types/config";
 import { ExternalWorktreesBanner } from "./components/ExternalWorktreesBanner";
-import { ProjectWorktreeAutoSync } from "./components/ProjectWorktreeAutoSync";
 
 export const Route = createFileRoute(
 	"/_authenticated/_dashboard/project/$projectId/",
@@ -306,7 +305,6 @@ function ProjectPage() {
 
 	return (
 		<div className="flex-1 h-full flex flex-col overflow-hidden bg-background">
-			<ProjectWorktreeAutoSync projectId={projectId} />
 			<AnimatePresence>
 				<ExternalWorktreesBanner projectId={projectId} />
 			</AnimatePresence>

--- a/apps/desktop/src/renderer/routes/_authenticated/components/WorktreeAutoSyncManager/ProjectWorktreeAutoImport.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/WorktreeAutoSyncManager/ProjectWorktreeAutoImport.tsx
@@ -1,0 +1,86 @@
+import { toast } from "@superset/ui/sonner";
+import { useEffect, useRef } from "react";
+import { electronTrpc } from "renderer/lib/electron-trpc";
+import { useImportAllWorktrees } from "renderer/react-query/workspaces/useImportAllWorktrees";
+
+const POLL_MS = 30_000;
+
+/**
+ * Background auto-import for externally-created worktrees.
+ *
+ * Renders nothing. When `autoImportExternalWorktrees` is enabled on the
+ * project and the scanner detects git worktrees on disk that are not yet
+ * tracked in the DB, trigger the same importAllWorktrees mutation that the
+ * manual "Import all" button uses.
+ *
+ * The scanner query runs on an interval so new worktrees created after mount
+ * (e.g. by an external LLM agent) get picked up without requiring a window
+ * refocus or route change.
+ */
+export function ProjectWorktreeAutoImport({
+	projectId,
+}: {
+	projectId: string;
+}) {
+	const { data: project } = electronTrpc.projects.get.useQuery({
+		id: projectId,
+	});
+	const autoImportEnabled = project?.autoImportExternalWorktrees === true;
+
+	const { data: externalWorktrees = [], isLoading } =
+		electronTrpc.workspaces.getExternalWorktrees.useQuery(
+			{ projectId },
+			{
+				enabled: autoImportEnabled,
+				refetchInterval: autoImportEnabled ? POLL_MS : false,
+			},
+		);
+
+	const importAllWorktrees = useImportAllWorktrees();
+	const inFlightRef = useRef(false);
+	const lastFailedSignatureRef = useRef<string | null>(null);
+
+	const externalSignature = externalWorktrees
+		.map((wt) => wt.path)
+		.sort()
+		.join("\n");
+
+	useEffect(() => {
+		if (!autoImportEnabled) return;
+		if (isLoading) return;
+		if (externalWorktrees.length === 0) return;
+		if (inFlightRef.current) return;
+		if (importAllWorktrees.isPending) return;
+		if (lastFailedSignatureRef.current === externalSignature) return;
+
+		inFlightRef.current = true;
+		importAllWorktrees
+			.mutateAsync({ projectId })
+			.then((result) => {
+				lastFailedSignatureRef.current = null;
+				if (result.imported > 0) {
+					toast.success(
+						`Auto-imported ${result.imported} worktree${result.imported === 1 ? "" : "s"}`,
+					);
+				}
+			})
+			.catch((err) => {
+				lastFailedSignatureRef.current = externalSignature;
+				toast.error(
+					err instanceof Error ? err.message : "Failed to import worktrees",
+				);
+			})
+			.finally(() => {
+				inFlightRef.current = false;
+			});
+	}, [
+		autoImportEnabled,
+		isLoading,
+		externalWorktrees.length,
+		externalSignature,
+		importAllWorktrees,
+		projectId,
+	]);
+
+	return null;
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/components/WorktreeAutoSyncManager/ProjectWorktreeAutoImport/ProjectWorktreeAutoImport.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/WorktreeAutoSyncManager/ProjectWorktreeAutoImport/ProjectWorktreeAutoImport.tsx
@@ -30,14 +30,17 @@ export function ProjectWorktreeAutoImport({
 	});
 	const autoImportEnabled = project?.autoImportExternalWorktrees === true;
 
-	const { data: externalWorktrees = [], isLoading } =
-		electronTrpc.workspaces.getExternalWorktrees.useQuery(
-			{ projectId },
-			{
-				enabled: autoImportEnabled,
-				refetchInterval: autoImportEnabled ? POLL_MS : false,
-			},
-		);
+	const {
+		data: externalWorktrees = [],
+		isLoading,
+		dataUpdatedAt,
+	} = electronTrpc.workspaces.getExternalWorktrees.useQuery(
+		{ projectId },
+		{
+			enabled: autoImportEnabled,
+			refetchInterval: autoImportEnabled ? POLL_MS : false,
+		},
+	);
 
 	const importAllWorktrees = useImportAllWorktrees();
 	const inFlightRef = useRef(false);
@@ -64,11 +67,14 @@ export function ProjectWorktreeAutoImport({
 		if (inFlightRef.current) return;
 		if (importAllWorktrees.isPending) return;
 
+		// Compare against dataUpdatedAt (not Date.now()) so the cooldown expiry
+		// is re-evaluated on every poll tick — the query refetch bumps this
+		// timestamp even when the external-worktree set is unchanged.
 		const lastFailure = lastFailureRef.current;
 		if (
 			lastFailure &&
 			lastFailure.signature === externalSignature &&
-			Date.now() - lastFailure.at < FAILURE_COOLDOWN_MS
+			dataUpdatedAt - lastFailure.at < FAILURE_COOLDOWN_MS
 		) {
 			return;
 		}
@@ -103,6 +109,7 @@ export function ProjectWorktreeAutoImport({
 		externalSignature,
 		importAllWorktrees,
 		projectId,
+		dataUpdatedAt,
 	]);
 
 	return null;

--- a/apps/desktop/src/renderer/routes/_authenticated/components/WorktreeAutoSyncManager/ProjectWorktreeAutoImport/ProjectWorktreeAutoImport.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/WorktreeAutoSyncManager/ProjectWorktreeAutoImport/ProjectWorktreeAutoImport.tsx
@@ -4,6 +4,7 @@ import { electronTrpc } from "renderer/lib/electron-trpc";
 import { useImportAllWorktrees } from "renderer/react-query/workspaces/useImportAllWorktrees";
 
 const POLL_MS = 30_000;
+const FAILURE_COOLDOWN_MS = 5 * 60_000;
 
 /**
  * Background auto-import for externally-created worktrees.
@@ -15,7 +16,9 @@ const POLL_MS = 30_000;
  *
  * The scanner query runs on an interval so new worktrees created after mount
  * (e.g. by an external LLM agent) get picked up without requiring a window
- * refocus or route change.
+ * refocus or route change. Failures suppress retries for the same external
+ * set for FAILURE_COOLDOWN_MS so transient errors recover on their own, and
+ * the suppression drops as soon as the user turns the toggle off.
  */
 export function ProjectWorktreeAutoImport({
 	projectId,
@@ -38,7 +41,16 @@ export function ProjectWorktreeAutoImport({
 
 	const importAllWorktrees = useImportAllWorktrees();
 	const inFlightRef = useRef(false);
-	const lastFailedSignatureRef = useRef<string | null>(null);
+	const lastFailureRef = useRef<{ signature: string; at: number } | null>(null);
+
+	// When the user turns the toggle off, drop any suppression so the next
+	// ON attempt starts clean — matches what a user naturally expects after
+	// toggling OFF/ON to "try again".
+	useEffect(() => {
+		if (!autoImportEnabled) {
+			lastFailureRef.current = null;
+		}
+	}, [autoImportEnabled]);
 
 	const externalSignature = externalWorktrees
 		.map((wt) => wt.path)
@@ -51,13 +63,21 @@ export function ProjectWorktreeAutoImport({
 		if (externalWorktrees.length === 0) return;
 		if (inFlightRef.current) return;
 		if (importAllWorktrees.isPending) return;
-		if (lastFailedSignatureRef.current === externalSignature) return;
+
+		const lastFailure = lastFailureRef.current;
+		if (
+			lastFailure &&
+			lastFailure.signature === externalSignature &&
+			Date.now() - lastFailure.at < FAILURE_COOLDOWN_MS
+		) {
+			return;
+		}
 
 		inFlightRef.current = true;
 		importAllWorktrees
 			.mutateAsync({ projectId })
 			.then((result) => {
-				lastFailedSignatureRef.current = null;
+				lastFailureRef.current = null;
 				if (result.imported > 0) {
 					toast.success(
 						`Auto-imported ${result.imported} worktree${result.imported === 1 ? "" : "s"}`,
@@ -65,7 +85,10 @@ export function ProjectWorktreeAutoImport({
 				}
 			})
 			.catch((err) => {
-				lastFailedSignatureRef.current = externalSignature;
+				lastFailureRef.current = {
+					signature: externalSignature,
+					at: Date.now(),
+				};
 				toast.error(
 					err instanceof Error ? err.message : "Failed to import worktrees",
 				);

--- a/apps/desktop/src/renderer/routes/_authenticated/components/WorktreeAutoSyncManager/ProjectWorktreeAutoImport/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/WorktreeAutoSyncManager/ProjectWorktreeAutoImport/index.ts
@@ -1,0 +1,1 @@
+export { ProjectWorktreeAutoImport } from "./ProjectWorktreeAutoImport";

--- a/apps/desktop/src/renderer/routes/_authenticated/components/WorktreeAutoSyncManager/WorktreeAutoSyncManager.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/WorktreeAutoSyncManager/WorktreeAutoSyncManager.tsx
@@ -1,0 +1,31 @@
+import { electronTrpc } from "renderer/lib/electron-trpc";
+import { ProjectWorktreeAutoSync } from "renderer/routes/_authenticated/_dashboard/project/$projectId/components/ProjectWorktreeAutoSync";
+import { ProjectWorktreeAutoImport } from "./ProjectWorktreeAutoImport";
+
+/**
+ * Drives auto-import / auto-remove for every tracked project.
+ *
+ * Mounted once at the _authenticated layout so the sync runs while the user
+ * is on any signed-in screen (dashboard, settings, workspace, v2) — not only
+ * on the project onboarding page where the controls were originally wired.
+ */
+export function WorktreeAutoSyncManager() {
+	const { data: projects = [] } = electronTrpc.projects.getRecents.useQuery();
+
+	return (
+		<>
+			{projects.map((project) => (
+				<ProjectWorktreeSyncPair key={project.id} projectId={project.id} />
+			))}
+		</>
+	);
+}
+
+function ProjectWorktreeSyncPair({ projectId }: { projectId: string }) {
+	return (
+		<>
+			<ProjectWorktreeAutoImport projectId={projectId} />
+			<ProjectWorktreeAutoSync projectId={projectId} />
+		</>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/components/WorktreeAutoSyncManager/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/WorktreeAutoSyncManager/index.ts
@@ -1,0 +1,1 @@
+export { WorktreeAutoSyncManager } from "./WorktreeAutoSyncManager";

--- a/apps/desktop/src/renderer/routes/_authenticated/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/layout.tsx
@@ -35,6 +35,7 @@ import { MOCK_ORG_ID, NOTIFICATION_EVENTS } from "shared/constants";
 import { GlobalTerminalLifecycle } from "./components/GlobalTerminalLifecycle";
 import { MainWindowEffects } from "./components/MainWindowEffects";
 import { TeardownLogsDialog } from "./components/TeardownLogsDialog";
+import { WorktreeAutoSyncManager } from "./components/WorktreeAutoSyncManager";
 import { createPierreWorker } from "./lib/pierreWorker";
 import { CollectionsProvider } from "./providers/CollectionsProvider";
 import { DeletingWorkspacesProvider } from "./providers/DeletingWorkspacesProvider";
@@ -192,6 +193,7 @@ function AuthenticatedLayout() {
 						>
 							<LanguageServicesProvider />
 							<MainWindowEffects />
+							<WorktreeAutoSyncManager />
 							<Outlet />
 							{isV2CloudEnabled ? (
 								<DashboardNewWorkspaceModal />

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/project/$projectId/components/ProjectSettings/ProjectSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/project/$projectId/components/ProjectSettings/ProjectSettings.tsx
@@ -516,11 +516,20 @@ export function ProjectSettings({
 												<Button
 													size="sm"
 													className="w-22"
-													disabled={importAllWorktrees.isPending}
+													disabled={
+														autoImportEnabled || importAllWorktrees.isPending
+													}
+													title={
+														autoImportEnabled
+															? "Auto-import is handling this automatically"
+															: undefined
+													}
 												>
-													{importAllWorktrees.isPending
-														? "Importing..."
-														: "Import all"}
+													{autoImportEnabled
+														? "Auto-import on"
+														: importAllWorktrees.isPending
+															? "Importing..."
+															: "Import all"}
 												</Button>
 											</AlertDialogTrigger>
 											<AlertDialogContent>


### PR DESCRIPTION
## 背景

Settings の「Auto-import detected worktrees」「Auto-remove missing worktrees」トグルを ON にしても実際には何も起きず、外部 LLM agent が作った worktree が v1 サイドバーに自動反映されない不具合。Settings 上では「17 external worktrees found on disk」と検知自体は正常なのに、自動 import / 自動 remove だけが不発だった。

## 原因

自動同期ロジックはそれぞれ下記 2 コンポーネントの `useEffect` にだけ置かれていた。

- `_authenticated/_dashboard/project/\$projectId/components/ExternalWorktreesBanner/ExternalWorktreesBanner.tsx`
- `_authenticated/_dashboard/project/\$projectId/components/ProjectWorktreeAutoSync/ProjectWorktreeAutoSync.tsx`

両方とも `_dashboard/project/\$projectId/page.tsx` だけからマウントされており、このページは実質「Step 1 of 2 / Create your first workspace」の初回オンボ画面。ワークスペースが 1 つでもあるプロジェクトでは開かれないので、**ユーザーが普段アプリを使っている状態ではこれらのコンポーネントが永遠にマウントされず、両 effect が一度も走らない**。Settings 画面は `_dashboard` 配下ではないため、トグルを ON にしている最中にもマウントされない。

加えて `useQuery` に `refetchInterval` が無く、仮にあのページを開いても「開いた瞬間のスナップショット 1 回」しか見えなかった。

## 修正

### 中核: 自動同期を layout 常駐に引き上げる

- 新規 `WorktreeAutoSyncManager` を `_authenticated/layout.tsx` にマウント。`projects.getRecents`（サイドバー表示中のプロジェクト）をループして、各プロジェクトに対し headless な `ProjectWorktreeAutoImport` と `ProjectWorktreeAutoSync` をレンダリングする。
- `_dashboard/project/\$projectId/page.tsx` から `ProjectWorktreeAutoSync` マウントを削除（Manager との二重実行防止）。
- `ExternalWorktreesBanner` は UI 専用に戻す。`autoImportEnabled` 時は null を返し、Manager と mutation が競合しないようにする。

### ポーリングと確実なリトライ

- 両 query（`getExternalWorktrees` / `getMissingWorktrees`）に `refetchInterval: 30_000`（トグル有効時のみ）を追加。
- 失敗時の抑止を永続フラグから **5 分クールダウン** に変更。`lastFailureRef` に `{ signature, at }` を持たせる。
- cooldown の時刻比較に `getExternalWorktrees.dataUpdatedAt` を使用。これにより **cooldown 明け後のリトライが「外部 worktree セット不変」のときでも確実に発火**する（Codex 再レビュー P2 指摘への対応）。
- `autoImportEnabled` が false に落ちた瞬間に `lastFailureRef` をクリアする effect を追加。Manager は layout 常駐でマウントされ続けるため、トグル OFF→ON 操作で素直に再試行解禁されるようにした。

### Settings UI の整合性

- `ProjectSettings.tsx` の手動「Import all」ボタンを `autoImportEnabled` 時に disabled にし、ラベルを「Auto-import on」に差し替え。これで手動操作と Manager による自動 import が同じ mutation を並列に打ち合うリスクを回避する。

## 挙動

- Settings で toggle ON にした瞬間、`projects.get` が invalidate → Manager の query が refetch → effect 発火、で即座に反映される。
- アプリを開いている間は 30 秒おきに `getExternalWorktrees` / `getMissingWorktrees` が refetch される（toggle 有効なプロジェクトのみ）。外部ツールが worktree を作った直後に反映される。
- toggle OFF のプロジェクトでは query そのものが無効化され、コストはゼロ。
- 一過性エラー（ネットワーク断等）で失敗しても、5 分後に自動で再試行される。

## スコープ外（既知の設計判断）

- `projects.getRecents` は `tabOrder IS NOT NULL` のプロジェクトのみ返す。つまり **v1 サイドバーから外した（Hide）プロジェクトは自動同期対象外**。サイドバー外は Superset の管理対象外と見なす設計判断で、この PR では変更しない。

## レビュー対応履歴

- **CodeRabbit (ファイル配置)**: `ProjectWorktreeAutoImport.tsx` を `WorktreeAutoSyncManager/` 直下から専用フォルダ + `index.ts` 構成へ移動済み。
- **CodeRabbit (\`getExternalWorktrees\` invalidate)**: セルフコレクトされたため対応不要（`useImportAllWorktrees.onSuccess` で `workspaces.invalidate()` 呼び出し済み）。
- **CodeRabbit + Codex P2 (失敗フラグ永続抑止)**: 5 分 cooldown + toggle OFF クリア + `dataUpdatedAt` 依存で対応済み。
- **Codex P2 (手動 × 自動の race)**: Settings の Import all ボタンを gating 済み。

## Test plan

- [ ] Dev 起動（\`SUPERSET_WORKSPACE_NAME=superset SKIP_ENV_VALIDATION=1 DESKTOP_VITE_PORT=5222 bun run dev\`）
- [ ] Settings → Project → 「Auto-import detected worktrees」を ON にし、外部で \`git worktree add\` した直後（最大 30 秒待ち）に v1 サイドバーへ自動追加されることを確認
- [ ] 同じく「Auto-remove missing worktrees」を ON にし、disk 上の worktree ディレクトリを削除した際にサイドバーから消えることを確認
- [ ] toggle ON 時に Settings 画面の「Import all」ボタンが disabled、ラベルが「Auto-import on」になることを確認
- [ ] Toggle OFF のプロジェクトでは Network タブに `getExternalWorktrees` の定期リクエストが出ないことを確認
- [ ] 初回オンボ画面（Step 1 of 2）では従来どおり手動 Banner が表示され Import all ボタンが動くことを確認
- [ ] 失敗シナリオ（例: git worktree の壊れた path を混ぜる）で cooldown が効き、5 分後に自動リトライされることを確認
- [ ] toggle OFF → ON で cooldown が即座にクリアされ再試行されることを確認