### PR TITLE
fix(desktop): Search タブの list/tree 切替を永続化

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/SearchView/SearchView.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/SearchView/SearchView.tsx
@@ -20,7 +20,6 @@ import type {
 	SearchContentResult,
 	SearchLineResult,
 	SearchResultGroup,
-	SearchResultViewMode,
 	SearchTreeFolderNode,
 	SearchTreeNode as SearchTreeNodeType,
 } from "./types";
@@ -220,8 +219,10 @@ export function SearchView({
 	const [ignoredMatchIds, setIgnoredMatchIds] = useState<Record<string, true>>(
 		{},
 	);
-	const [resultViewMode, setResultViewMode] =
-		useState<SearchResultViewMode>("tree");
+	const resultViewMode = useSearchDialogStore((state) => state.resultViewMode);
+	const setResultViewMode = useSearchDialogStore(
+		(state) => state.setResultViewMode,
+	);
 	const includePattern = useSearchDialogStore(
 		(state) => state.byMode.keywordSearch.includePattern,
 	);

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/SearchView/types.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/SearchView/types.ts
@@ -42,5 +42,3 @@ export interface SearchTreeFolderNode {
 }
 
 export type SearchTreeNode = SearchTreeFileNode | SearchTreeFolderNode;
-
-export type SearchResultViewMode = "tree" | "list";

--- a/apps/desktop/src/renderer/stores/search-dialog-state.ts
+++ b/apps/desktop/src/renderer/stores/search-dialog-state.ts
@@ -3,6 +3,7 @@ import { devtools, persist } from "zustand/middleware";
 
 export type SearchDialogMode = "quickOpen" | "keywordSearch";
 export type SearchScope = "workspace" | "global";
+export type SearchResultViewMode = "tree" | "list";
 
 interface SearchDialogModeState {
 	includePattern: string;
@@ -13,10 +14,12 @@ interface SearchDialogModeState {
 
 interface SearchDialogState {
 	byMode: Record<SearchDialogMode, SearchDialogModeState>;
+	resultViewMode: SearchResultViewMode;
 	setIncludePattern: (mode: SearchDialogMode, value: string) => void;
 	setExcludePattern: (mode: SearchDialogMode, value: string) => void;
 	setFiltersOpen: (mode: SearchDialogMode, open: boolean) => void;
 	setScope: (mode: SearchDialogMode, scope: SearchScope) => void;
+	setResultViewMode: (mode: SearchResultViewMode) => void;
 }
 
 const DEFAULT_MODE_STATE: SearchDialogModeState = {
@@ -33,6 +36,7 @@ export const useSearchDialogStore = create<SearchDialogState>()(
 					quickOpen: { ...DEFAULT_MODE_STATE },
 					keywordSearch: { ...DEFAULT_MODE_STATE },
 				},
+				resultViewMode: "tree",
 
 				setIncludePattern: (mode, value) => {
 					set((state) => ({
@@ -81,13 +85,17 @@ export const useSearchDialogStore = create<SearchDialogState>()(
 						},
 					}));
 				},
+
+				setResultViewMode: (mode) => {
+					set({ resultViewMode: mode });
+				},
 			}),
 			{
 				name: "search-dialog-store",
-				version: 1,
+				version: 2,
 				migrate: (persisted, version) => {
+					const state = persisted as Record<string, unknown>;
 					if (version === 0) {
-						const state = persisted as Record<string, unknown>;
 						const byMode = state.byMode as
 							| Record<string, Record<string, unknown>>
 							| undefined;
@@ -99,7 +107,10 @@ export const useSearchDialogStore = create<SearchDialogState>()(
 							}
 						}
 					}
-					return persisted as SearchDialogState;
+					if (version < 2 && state.resultViewMode === undefined) {
+						state.resultViewMode = "tree";
+					}
+					return state as unknown as SearchDialogState;
 				},
 			},
 		),


### PR DESCRIPTION
## Summary

- 右サイドバーの Search タブにある list/tree 切替が毎回 `tree` にリセットされる問題を修正
- `resultViewMode` はコンポーネント内 `useState` で持っていたため、SearchView がアンマウントされる度に初期化されていた（右サイドバー開閉、ワークスペース切替、アプリ再起動）
- `useSearchDialogStore` (zustand + persist) に `resultViewMode` を追加し、`includePattern` / `excludePattern` と同じく localStorage 経由で復元されるように変更

## Changes

- `apps/desktop/src/renderer/stores/search-dialog-state.ts`
  - `SearchResultViewMode` 型を store 側で定義・export
  - state に `resultViewMode` と `setResultViewMode` を追加
  - persist version を `1` → `2` に bump、`migrate` で既存データにデフォルト `"tree"` を補完
- `apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/SearchView/SearchView.tsx`
  - `useState<SearchResultViewMode>("tree")` を store セレクタに置換
- `apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/SearchView/types.ts`
  - 重複する `SearchResultViewMode` の定義を削除（単一の出所は store）

## Test plan

- [ ] Search タブで `List` に切り替え後、右サイドバーを閉じて開き直しても `List` のままであること
- [ ] ワークスペースを切り替えても `List` のままであること
- [ ] アプリを再起動しても `List` のままであること
- [ ] 初回起動（localStorage 空）では既定値の `Tree` で表示されること
- [ ] version 1 データを持つ既存ユーザーで migrate 後に `Tree` が設定され、切替も正常に動くこと
- [ ] `bun run lint` / `bun run typecheck` 通過