### PR TITLE
feat(desktop): DnD / Open With でファイルを開けるようにする

### DIFF
--- a/apps/desktop/electron-builder.ts
+++ b/apps/desktop/electron-builder.ts
@@ -157,32 +157,35 @@ const config: Configuration = {
 	// `rank: "Alternate"` keeps us off the default-handler slot on macOS; the
 	// user has to pick Superset explicitly.
 	//
+	// IMPORTANT: The Linux AppImage FileAssociation parser only accepts a
+	// single-string `ext` (array fails with "expects \" or n, but found ["),
+	// so each extension gets its own entry. macOS / Windows tolerate the same
+	// shape, so we use one form everywhere for parity.
+	//
 	// Note on extensionless files (.env, .gitignore, Dockerfile): electron-
 	// builder's `ext` only maps real extensions, so those can't be registered
 	// here. Window DnD is the supported path for those.
 	fileAssociations: [
-		{
-			ext: [
-				"md",
-				"markdown",
-				"txt",
-				"log",
-				"ts",
-				"tsx",
-				"js",
-				"jsx",
-				"mjs",
-				"cjs",
-				"py",
-				"sh",
-				"bash",
-				"zsh",
-			],
-			name: "Text File",
-			role: "Editor",
-			rank: "Alternate",
-		},
-	],
+		"md",
+		"markdown",
+		"txt",
+		"log",
+		"ts",
+		"tsx",
+		"js",
+		"jsx",
+		"mjs",
+		"cjs",
+		"py",
+		"sh",
+		"bash",
+		"zsh",
+	].map((ext) => ({
+		ext,
+		name: "Text File",
+		role: "Editor",
+		rank: "Alternate",
+	})),
 
 	// Linux
 	linux: {

--- a/apps/desktop/electron-builder.ts
+++ b/apps/desktop/electron-builder.ts
@@ -148,6 +148,42 @@ const config: Configuration = {
 		schemes: ["superset"],
 	},
 
+	// File associations so Finder / Explorer show Superset in "Open with" and
+	// OS drag-to-dock routes the path through app.on("open-file") / argv.
+	//
+	// v1 scope is intentionally narrow so we don't hijack system defaults for
+	// popular formats. Users can still drop any file via window DnD — this
+	// list only controls the "Open with" menu. `role: "Editor"` with
+	// `rank: "Alternate"` keeps us off the default-handler slot on macOS; the
+	// user has to pick Superset explicitly.
+	//
+	// Note on extensionless files (.env, .gitignore, Dockerfile): electron-
+	// builder's `ext` only maps real extensions, so those can't be registered
+	// here. Window DnD is the supported path for those.
+	fileAssociations: [
+		{
+			ext: [
+				"md",
+				"markdown",
+				"txt",
+				"log",
+				"ts",
+				"tsx",
+				"js",
+				"jsx",
+				"mjs",
+				"cjs",
+				"py",
+				"sh",
+				"bash",
+				"zsh",
+			],
+			name: "Text File",
+			role: "Editor",
+			rank: "Alternate",
+		},
+	],
+
 	// Linux
 	linux: {
 		...(existsSync(linuxIconPath) ? { icon: linuxIconPath } : {}),

--- a/apps/desktop/src/lib/trpc/routers/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/index.ts
@@ -35,6 +35,7 @@ import { createProjectsRouter } from "./projects";
 import { createReferenceGraphRouter } from "./reference-graph";
 import { createResourceMetricsRouter } from "./resource-metrics";
 import { createRingtoneRouter } from "./ringtone";
+import { createScratchRouter } from "./scratch";
 import { createServiceStatusRouter } from "./service-status";
 import { createSettingsRouter } from "./settings";
 import { createTabTearoffRouter } from "./tab-tearoff";
@@ -73,6 +74,7 @@ export const createAppRouter = (
 		permissions: createPermissionsRouter(),
 		ports: createPortsRouter(),
 		resourceMetrics: createResourceMetricsRouter(),
+		scratch: createScratchRouter(),
 		menu: createMenuRouter(),
 		languageServices: createLanguageServicesRouter(),
 		referenceGraph: createReferenceGraphRouter(),

--- a/apps/desktop/src/lib/trpc/routers/scratch/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/scratch/index.ts
@@ -1,0 +1,175 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { TRPCError } from "@trpc/server";
+import { dispatchPaths } from "main/lib/file-intake";
+import { z } from "zod";
+import { publicProcedure, router } from "../..";
+
+// v1 scratch file procedures: deliberately do NOT go through the
+// workspace-scoped filesystem service. A scratch file has no workspace root —
+// the path the user handed us (via DnD / open-with / argv) IS the access
+// boundary. We still sanity-check the path is absolute and does not traverse
+// to /etc or similar via parent refs after resolution.
+const MAX_SCRATCH_READ_BYTES = 5 * 1024 * 1024; // 5 MB
+
+/** Paths that aren't strictly off-limits but where an accidental DnD edit
+ * would be much worse than helpful. scratch mode is a text-file convenience
+ * feature; it is not a general system editor. */
+const SCRATCH_WRITE_DENY_PATTERNS: RegExp[] = [
+	// Unix system dirs.
+	/^\/etc\//,
+	/^\/System\//,
+	/^\/usr\//,
+	/^\/private\/etc\//,
+	// User secrets.
+	/\/\.ssh\//,
+	/\/\.aws\//,
+	/\/\.gnupg\//,
+];
+
+function sanitizeAbsolutePath(input: string): string {
+	if (!path.isAbsolute(input)) {
+		throw new TRPCError({
+			code: "BAD_REQUEST",
+			message: "Scratch paths must be absolute",
+		});
+	}
+	// path.resolve normalizes `..` / `.` segments so the result can be compared
+	// against a prefix safely if we ever add a sandbox root later.
+	return path.resolve(input);
+}
+
+function assertScratchWriteAllowed(abs: string): void {
+	for (const pattern of SCRATCH_WRITE_DENY_PATTERNS) {
+		if (pattern.test(abs)) {
+			throw new TRPCError({
+				code: "FORBIDDEN",
+				message: `Scratch write refused for system/secret path: ${abs}`,
+			});
+		}
+	}
+}
+
+export const createScratchRouter = () =>
+	router({
+		readFile: publicProcedure
+			.input(
+				z.object({
+					absolutePath: z.string(),
+					maxBytes: z.number().int().positive().optional(),
+				}),
+			)
+			.query(async ({ input }) => {
+				const abs = sanitizeAbsolutePath(input.absolutePath);
+				const maxBytes = Math.min(
+					input.maxBytes ?? MAX_SCRATCH_READ_BYTES,
+					MAX_SCRATCH_READ_BYTES,
+				);
+
+				let stat: Awaited<ReturnType<typeof fs.stat>>;
+				try {
+					stat = await fs.stat(abs);
+				} catch (err) {
+					if ((err as NodeJS.ErrnoException)?.code === "ENOENT") {
+						throw new TRPCError({
+							code: "NOT_FOUND",
+							message: `File not found: ${abs}`,
+						});
+					}
+					throw err;
+				}
+				if (stat.isDirectory()) {
+					throw new TRPCError({
+						code: "PRECONDITION_FAILED",
+						message: `Path is a directory: ${abs}`,
+					});
+				}
+				if (stat.size > maxBytes) {
+					return {
+						kind: "too-large" as const,
+						absolutePath: abs,
+						size: stat.size,
+						maxBytes,
+					};
+				}
+
+				// Read as UTF-8 text. For true binary files this will still return
+				// characters but the CodeEditor in the renderer renders it as-is.
+				// Scratch mode is intended for text files; binary support is not a
+				// v1 goal.
+				const content = await fs.readFile(abs, { encoding: "utf8" });
+				return {
+					kind: "text" as const,
+					absolutePath: abs,
+					content,
+					size: stat.size,
+					mtimeMs: stat.mtimeMs,
+				};
+			}),
+
+		writeFile: publicProcedure
+			.input(
+				z.object({
+					absolutePath: z.string(),
+					content: z.string(),
+				}),
+			)
+			.mutation(async ({ input }) => {
+				const abs = sanitizeAbsolutePath(input.absolutePath);
+				assertScratchWriteAllowed(abs);
+
+				// Use lstat to detect symlinks before we open for write: fs.writeFile
+				// would happily follow a symlink and overwrite whatever it points at,
+				// which is the classic "dropped-file authorized me to edit
+				// ~/.ssh/authorized_keys" footgun. Policy: refuse to write through
+				// symlinks in scratch mode.
+				let lstat: Awaited<ReturnType<typeof fs.lstat>> | null = null;
+				try {
+					lstat = await fs.lstat(abs);
+				} catch (err) {
+					if ((err as NodeJS.ErrnoException)?.code !== "ENOENT") {
+						throw err;
+					}
+				}
+				if (lstat?.isDirectory()) {
+					throw new TRPCError({
+						code: "PRECONDITION_FAILED",
+						message: `Path is a directory: ${abs}`,
+					});
+				}
+				if (lstat?.isSymbolicLink()) {
+					throw new TRPCError({
+						code: "FORBIDDEN",
+						message: `Refusing to write through symlink: ${abs}`,
+					});
+				}
+
+				await fs.writeFile(abs, input.content, { encoding: "utf8" });
+				const newStat = await fs.stat(abs);
+				return {
+					absolutePath: abs,
+					size: newStat.size,
+					mtimeMs: newStat.mtimeMs,
+				};
+			}),
+
+		/**
+		 * Renderer-originated DnD: when the user drops OS files onto the window,
+		 * the preload surfaces the absolute paths and calls this mutation. We
+		 * route through the same `dispatchPaths` used by native `open-file` /
+		 * argv so the classification + navigation stay in one place.
+		 */
+		ingestDroppedPaths: publicProcedure
+			.input(
+				z.object({
+					absolutePaths: z.array(z.string()),
+				}),
+			)
+			.mutation(async ({ input }) => {
+				const sanitized = input.absolutePaths
+					.filter((p) => path.isAbsolute(p))
+					.map((p) => path.resolve(p));
+				await dispatchPaths(sanitized);
+				return { accepted: sanitized.length };
+			}),
+	});

--- a/apps/desktop/src/lib/trpc/routers/scratch/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/scratch/index.ts
@@ -116,16 +116,37 @@ export const createScratchRouter = () =>
 			)
 			.mutation(async ({ input }) => {
 				const abs = sanitizeAbsolutePath(input.absolutePath);
-				assertScratchWriteAllowed(abs);
 
-				// Use lstat to detect symlinks before we open for write: fs.writeFile
-				// would happily follow a symlink and overwrite whatever it points at,
-				// which is the classic "dropped-file authorized me to edit
-				// ~/.ssh/authorized_keys" footgun. Policy: refuse to write through
-				// symlinks in scratch mode.
+				// Resolve symlinks in every path segment before we enforce policy.
+				// Checking only the final basename with lstat(abs) misses the case
+				// where a *parent* directory is a symlink pointing into a protected
+				// tree (e.g. `/tmp/link/file` where `link` → `~/.ssh`): fs.lstat on
+				// the final path returns a regular file, the deny-list sees
+				// `/tmp/link/...`, and writeFile ends up touching the real target.
+				//
+				// Strategy: realpath the directory component (which *must* exist to
+				// write into it) and recompose with basename. For files that don't
+				// yet exist we still catch parent-dir symlink escapes. Then lstat
+				// the final path itself to refuse symlinked leaves.
+				const dir = path.dirname(abs);
+				let canonicalDir: string;
+				try {
+					canonicalDir = await fs.realpath(dir);
+				} catch (err) {
+					if ((err as NodeJS.ErrnoException)?.code === "ENOENT") {
+						throw new TRPCError({
+							code: "NOT_FOUND",
+							message: `Parent directory does not exist: ${dir}`,
+						});
+					}
+					throw err;
+				}
+				const canonical = path.join(canonicalDir, path.basename(abs));
+				assertScratchWriteAllowed(canonical);
+
 				let lstat: Awaited<ReturnType<typeof fs.lstat>> | null = null;
 				try {
-					lstat = await fs.lstat(abs);
+					lstat = await fs.lstat(canonical);
 				} catch (err) {
 					if ((err as NodeJS.ErrnoException)?.code !== "ENOENT") {
 						throw err;
@@ -134,20 +155,20 @@ export const createScratchRouter = () =>
 				if (lstat?.isDirectory()) {
 					throw new TRPCError({
 						code: "PRECONDITION_FAILED",
-						message: `Path is a directory: ${abs}`,
+						message: `Path is a directory: ${canonical}`,
 					});
 				}
 				if (lstat?.isSymbolicLink()) {
 					throw new TRPCError({
 						code: "FORBIDDEN",
-						message: `Refusing to write through symlink: ${abs}`,
+						message: `Refusing to write through symlink: ${canonical}`,
 					});
 				}
 
-				await fs.writeFile(abs, input.content, { encoding: "utf8" });
-				const newStat = await fs.stat(abs);
+				await fs.writeFile(canonical, input.content, { encoding: "utf8" });
+				const newStat = await fs.stat(canonical);
 				return {
-					absolutePath: abs,
+					absolutePath: canonical,
 					size: newStat.size,
 					mtimeMs: newStat.mtimeMs,
 				};

--- a/apps/desktop/src/lib/trpc/routers/scratch/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/scratch/index.ts
@@ -1,7 +1,13 @@
 import { promises as fs } from "node:fs";
 import path from "node:path";
 import { TRPCError } from "@trpc/server";
-import { dispatchPaths } from "main/lib/file-intake";
+import { observable } from "@trpc/server/observable";
+import {
+	dispatchPaths,
+	type FileIntakeScratchBatch,
+	type FileIntakeWorkspaceBatch,
+	fileIntakeEmitter,
+} from "main/lib/file-intake";
 import { z } from "zod";
 import { publicProcedure, router } from "../..";
 
@@ -12,16 +18,24 @@ import { publicProcedure, router } from "../..";
 // to /etc or similar via parent refs after resolution.
 const MAX_SCRATCH_READ_BYTES = 5 * 1024 * 1024; // 5 MB
 
-/** Paths that aren't strictly off-limits but where an accidental DnD edit
- * would be much worse than helpful. scratch mode is a text-file convenience
- * feature; it is not a general system editor. */
-const SCRATCH_WRITE_DENY_PATTERNS: RegExp[] = [
+/** Paths that aren't strictly off-limits but where an accidental DnD edit /
+ * viewing would be much worse than helpful. scratch mode is a text-file
+ * convenience feature; it is not a general system editor.
+ *
+ * Patterns are evaluated against the **forward-slash-normalized** path so
+ * the same regexes catch Windows paths (`C:/Users/x/.ssh/id_rsa`) without
+ * duplicating every rule for backslashes.
+ */
+const SCRATCH_DENY_PATTERNS: RegExp[] = [
 	// Unix system dirs.
 	/^\/etc\//,
 	/^\/System\//,
 	/^\/usr\//,
 	/^\/private\/etc\//,
-	// User secrets.
+	// Windows system dirs (path has been forward-slashed beforehand).
+	/^[A-Za-z]:\/Windows\//,
+	/^[A-Za-z]:\/Program(Data| Files)\//,
+	// User secrets — match the dotfolder segment on any platform.
 	/\/\.ssh\//,
 	/\/\.aws\//,
 	/\/\.gnupg\//,
@@ -39,15 +53,37 @@ function sanitizeAbsolutePath(input: string): string {
 	return path.resolve(input);
 }
 
-function assertScratchWriteAllowed(abs: string): void {
-	for (const pattern of SCRATCH_WRITE_DENY_PATTERNS) {
-		if (pattern.test(abs)) {
+function assertScratchAllowed(abs: string, action: "read" | "write"): void {
+	// Normalize separators so POSIX patterns also match Windows paths.
+	const probe = abs.replace(/\\/g, "/");
+	for (const pattern of SCRATCH_DENY_PATTERNS) {
+		if (pattern.test(probe)) {
 			throw new TRPCError({
 				code: "FORBIDDEN",
-				message: `Scratch write refused for system/secret path: ${abs}`,
+				message: `Scratch ${action} refused for system/secret path: ${abs}`,
 			});
 		}
 	}
+}
+
+/** Resolve the parent directory via realpath and rejoin basename. Catches
+ * symlink-parent escapes where the final path component looks fine but a
+ * parent segment redirects into a protected tree. */
+async function canonicalizeLeafPath(abs: string): Promise<string> {
+	const dir = path.dirname(abs);
+	let canonicalDir: string;
+	try {
+		canonicalDir = await fs.realpath(dir);
+	} catch (err) {
+		if ((err as NodeJS.ErrnoException)?.code === "ENOENT") {
+			throw new TRPCError({
+				code: "NOT_FOUND",
+				message: `Parent directory does not exist: ${dir}`,
+			});
+		}
+		throw err;
+	}
+	return path.join(canonicalDir, path.basename(abs));
 }
 
 export const createScratchRouter = () =>
@@ -61,34 +97,45 @@ export const createScratchRouter = () =>
 			)
 			.query(async ({ input }) => {
 				const abs = sanitizeAbsolutePath(input.absolutePath);
+				const canonical = await canonicalizeLeafPath(abs);
+				// Symmetric with writeFile: deny readable secrets too so the user
+				// doesn't get a surprise `FORBIDDEN` only at save time after
+				// editing `~/.ssh/config` in scratch.
+				assertScratchAllowed(canonical, "read");
 				const maxBytes = Math.min(
 					input.maxBytes ?? MAX_SCRATCH_READ_BYTES,
 					MAX_SCRATCH_READ_BYTES,
 				);
 
-				let stat: Awaited<ReturnType<typeof fs.stat>>;
+				let lstat: Awaited<ReturnType<typeof fs.lstat>>;
 				try {
-					stat = await fs.stat(abs);
+					lstat = await fs.lstat(canonical);
 				} catch (err) {
 					if ((err as NodeJS.ErrnoException)?.code === "ENOENT") {
 						throw new TRPCError({
 							code: "NOT_FOUND",
-							message: `File not found: ${abs}`,
+							message: `File not found: ${canonical}`,
 						});
 					}
 					throw err;
 				}
-				if (stat.isDirectory()) {
+				if (lstat.isDirectory()) {
 					throw new TRPCError({
 						code: "PRECONDITION_FAILED",
-						message: `Path is a directory: ${abs}`,
+						message: `Path is a directory: ${canonical}`,
 					});
 				}
-				if (stat.size > maxBytes) {
+				if (lstat.isSymbolicLink()) {
+					throw new TRPCError({
+						code: "FORBIDDEN",
+						message: `Refusing to read through symlink: ${canonical}`,
+					});
+				}
+				if (lstat.size > maxBytes) {
 					return {
 						kind: "too-large" as const,
-						absolutePath: abs,
-						size: stat.size,
+						absolutePath: canonical,
+						size: lstat.size,
 						maxBytes,
 					};
 				}
@@ -97,13 +144,13 @@ export const createScratchRouter = () =>
 				// characters but the CodeEditor in the renderer renders it as-is.
 				// Scratch mode is intended for text files; binary support is not a
 				// v1 goal.
-				const content = await fs.readFile(abs, { encoding: "utf8" });
+				const content = await fs.readFile(canonical, { encoding: "utf8" });
 				return {
 					kind: "text" as const,
-					absolutePath: abs,
+					absolutePath: canonical,
 					content,
-					size: stat.size,
-					mtimeMs: stat.mtimeMs,
+					size: lstat.size,
+					mtimeMs: lstat.mtimeMs,
 				};
 			}),
 
@@ -116,33 +163,15 @@ export const createScratchRouter = () =>
 			)
 			.mutation(async ({ input }) => {
 				const abs = sanitizeAbsolutePath(input.absolutePath);
-
-				// Resolve symlinks in every path segment before we enforce policy.
-				// Checking only the final basename with lstat(abs) misses the case
-				// where a *parent* directory is a symlink pointing into a protected
-				// tree (e.g. `/tmp/link/file` where `link` → `~/.ssh`): fs.lstat on
-				// the final path returns a regular file, the deny-list sees
-				// `/tmp/link/...`, and writeFile ends up touching the real target.
-				//
-				// Strategy: realpath the directory component (which *must* exist to
-				// write into it) and recompose with basename. For files that don't
-				// yet exist we still catch parent-dir symlink escapes. Then lstat
-				// the final path itself to refuse symlinked leaves.
-				const dir = path.dirname(abs);
-				let canonicalDir: string;
-				try {
-					canonicalDir = await fs.realpath(dir);
-				} catch (err) {
-					if ((err as NodeJS.ErrnoException)?.code === "ENOENT") {
-						throw new TRPCError({
-							code: "NOT_FOUND",
-							message: `Parent directory does not exist: ${dir}`,
-						});
-					}
-					throw err;
-				}
-				const canonical = path.join(canonicalDir, path.basename(abs));
-				assertScratchWriteAllowed(canonical);
+				// Resolve symlinks in every parent segment before enforcing
+				// policy. Checking only the final basename with lstat(abs) misses
+				// the case where a *parent* directory is a symlink pointing into
+				// a protected tree — lstat sees a regular file and the deny-list
+				// sees `/tmp/link/...` but writeFile then touches the real
+				// target. canonicalizeLeafPath + assertScratchAllowed catch both
+				// parent-dir escapes and direct hits.
+				const canonical = await canonicalizeLeafPath(abs);
+				assertScratchAllowed(canonical, "write");
 
 				let lstat: Awaited<ReturnType<typeof fs.lstat>> | null = null;
 				try {
@@ -193,4 +222,30 @@ export const createScratchRouter = () =>
 				await dispatchPaths(sanitized);
 				return { accepted: sanitized.length };
 			}),
+
+		/**
+		 * Subscriptions the renderer uses to receive file-intake dispatches.
+		 * trpc-electron requires observables (not async generators) — we just
+		 * mirror events from `fileIntakeEmitter`. AGENTS.md mandates tRPC for
+		 * main↔renderer IPC; this replaces an earlier `webContents.send` path.
+		 */
+		onOpenWorkspaceBatch: publicProcedure.subscription(() =>
+			observable<FileIntakeWorkspaceBatch>((emit) => {
+				const handler = (batch: FileIntakeWorkspaceBatch) => emit.next(batch);
+				fileIntakeEmitter.on("open-workspace-batch", handler);
+				return () => {
+					fileIntakeEmitter.off("open-workspace-batch", handler);
+				};
+			}),
+		),
+
+		onOpenScratchBatch: publicProcedure.subscription(() =>
+			observable<FileIntakeScratchBatch>((emit) => {
+				const handler = (batch: FileIntakeScratchBatch) => emit.next(batch);
+				fileIntakeEmitter.on("open-scratch-batch", handler);
+				return () => {
+					fileIntakeEmitter.off("open-scratch-batch", handler);
+				};
+			}),
+		),
 	});

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -860,8 +860,10 @@ if (!gotTheLock) {
 		// whose renderer hasn't run yet would be silently dropped — the
 		// did-finish-load event is the first moment `ipcRenderer.on(...)` in
 		// the renderer has had a chance to register.
-		const firstWindow = BrowserWindow.getAllWindows()[0];
-		const onRendererReady = async () => {
+		let coldStartDone = false;
+		const runColdStart = async () => {
+			if (coldStartDone) return;
+			coldStartDone = true;
 			markFileIntakeReady();
 			try {
 				const coldStartPaths = await filterFileIntakeArgs(process.argv);
@@ -873,22 +875,36 @@ if (!gotTheLock) {
 				console.error("[main] file-intake cold-start drain failed:", err);
 			}
 		};
-		if (firstWindow) {
-			if (firstWindow.webContents.isLoading()) {
-				firstWindow.webContents.once("did-finish-load", () => {
-					void onRendererReady();
-				});
+
+		const drainOnWindowReady = (win: BrowserWindow) => {
+			// macOS: closing all windows doesn't quit the app, and `open-file` /
+			// dock drops arriving during the no-windows interval are queued by
+			// dispatchPaths(). When the user re-activates (Dock click creates a
+			// fresh window), we drain here so those queued paths actually open
+			// instead of disappearing until next full restart.
+			const drain = () => {
+				if (!coldStartDone) {
+					void runColdStart();
+				} else {
+					void drainFileIntakePending().catch((err) => {
+						console.error("[main] file-intake re-drain failed:", err);
+					});
+				}
+			};
+			if (win.webContents.isLoading()) {
+				win.webContents.once("did-finish-load", drain);
 			} else {
-				void onRendererReady();
+				drain();
 			}
-		} else {
-			// No window at app-ready (e.g. macOS launched without a window).
-			// Defer until a window appears via the existing activate flow.
-			app.once("browser-window-created", (_ev, win) => {
-				win.webContents.once("did-finish-load", () => {
-					void onRendererReady();
-				});
-			});
-		}
+		};
+
+		const firstWindow = BrowserWindow.getAllWindows()[0];
+		if (firstWindow) drainOnWindowReady(firstWindow);
+		// Re-drain whenever a new BrowserWindow appears (reactivate after
+		// close-all, tearoffs, etc.). Cold-start guard above ensures the
+		// initial sequence runs exactly once.
+		app.on("browser-window-created", (_ev, win) => {
+			drainOnWindowReady(win);
+		});
 	})();
 }

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -37,6 +37,13 @@ import { setWorkspaceDockIcon } from "./lib/dock-icon";
 import { loadWebviewBrowserExtension } from "./lib/extensions";
 import { createExtensionIconProtocolHandler } from "./lib/extensions/extension-icon-protocol";
 import { loadInstalledExtensions } from "./lib/extensions/extension-manager";
+import {
+	dispatchPaths as dispatchFileIntakePaths,
+	drainPendingPaths as drainFileIntakePending,
+	filterFilePathArgs as filterFileIntakeArgs,
+	markFileIntakeReady,
+	queuePath as queueFileIntakePath,
+} from "./lib/file-intake";
 // FORK NOTE: upstream renamed host-service-manager → host-service-coordinator (#3250 relay)
 // Aliased as getHostServiceManager to minimize diff with fork's quit lifecycle code
 import { getHostServiceCoordinator as getHostServiceManager } from "./lib/host-service-coordinator";
@@ -349,6 +356,23 @@ app.on("open-url", async (event, url) => {
 	}
 });
 
+// macOS fires `open-file` when a file is double-clicked with this app as the
+// handler, dragged onto the dock icon, or passed via Finder "Open with". The
+// event can arrive *before* app.whenReady() resolves on cold start — Electron
+// recommends installing the listener inside `will-finish-launching` so we
+// catch those early events. Paths arriving before the renderer is ready are
+// queued in file-intake and drained later.
+app.on("will-finish-launching", () => {
+	app.on("open-file", (event, filePath) => {
+		event.preventDefault();
+		if (appReady) {
+			void dispatchFileIntakePaths([filePath]);
+		} else {
+			queueFileIntakePath(filePath);
+		}
+	});
+});
+
 export type QuitMode = "release" | "stop";
 let pendingQuitMode: QuitMode | null = null;
 let isQuitting = false;
@@ -605,12 +629,19 @@ const gotTheLock = app.requestSingleInstanceLock();
 if (!gotTheLock) {
 	app.exit(0);
 } else {
-	// Windows/Linux: protocol URL arrives as argv on the second instance
+	// Windows/Linux: protocol URL arrives as argv on the second instance.
+	// File paths (from Explorer "Open with" / drag onto dock / CLI invocation)
+	// also land here — we hand those to the file-intake pipeline so the same
+	// classification logic runs regardless of platform.
 	app.on("second-instance", async (_event, argv) => {
 		focusMainWindow();
 		const url = findDeepLinkInArgv(argv);
 		if (url) {
 			await processDeepLink(url);
+		}
+		const paths = await filterFileIntakeArgs(argv);
+		if (paths.length > 0) {
+			await dispatchFileIntakePaths(paths);
 		}
 	});
 
@@ -823,5 +854,41 @@ if (!gotTheLock) {
 		}
 
 		appReady = true;
+
+		// File-intake waits for the renderer JS to actually load before
+		// declaring itself ready. Sending IPC to a freshly-created BrowserWindow
+		// whose renderer hasn't run yet would be silently dropped — the
+		// did-finish-load event is the first moment `ipcRenderer.on(...)` in
+		// the renderer has had a chance to register.
+		const firstWindow = BrowserWindow.getAllWindows()[0];
+		const onRendererReady = async () => {
+			markFileIntakeReady();
+			try {
+				const coldStartPaths = await filterFileIntakeArgs(process.argv);
+				if (coldStartPaths.length > 0) {
+					await dispatchFileIntakePaths(coldStartPaths);
+				}
+				await drainFileIntakePending();
+			} catch (err) {
+				console.error("[main] file-intake cold-start drain failed:", err);
+			}
+		};
+		if (firstWindow) {
+			if (firstWindow.webContents.isLoading()) {
+				firstWindow.webContents.once("did-finish-load", () => {
+					void onRendererReady();
+				});
+			} else {
+				void onRendererReady();
+			}
+		} else {
+			// No window at app-ready (e.g. macOS launched without a window).
+			// Defer until a window appears via the existing activate flow.
+			app.once("browser-window-created", (_ev, win) => {
+				win.webContents.once("did-finish-load", () => {
+					void onRendererReady();
+				});
+			});
+		}
 	})();
 }

--- a/apps/desktop/src/main/lib/file-intake/index.ts
+++ b/apps/desktop/src/main/lib/file-intake/index.ts
@@ -1,0 +1,292 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { projects, workspaces, worktrees } from "@superset/local-db";
+import { and, eq, isNull } from "drizzle-orm";
+import { BrowserWindow } from "electron";
+import { localDb } from "main/lib/local-db";
+
+export type FileIntakeTarget =
+	| {
+			kind: "workspace-file";
+			workspaceId: string;
+			absolutePath: string;
+			isDirectory: boolean;
+	  }
+	| {
+			kind: "scratch-file";
+			absolutePath: string;
+	  }
+	| {
+			kind: "scratch-directory";
+			// v1: directory not in a registered workspace is treated as scratch:
+			// the directory itself is opened in the tabs as a "folder entry" (we just
+			// show the first file encountered). We keep the UX simple and do not
+			// recursively open — the user can register the folder as a workspace
+			// explicitly from the existing UI if they want full treatment.
+			absolutePath: string;
+	  };
+
+interface ResolvedWorkspace {
+	workspaceId: string;
+	worktreePath: string;
+}
+
+const IS_WINDOWS = process.platform === "win32";
+
+/** Make paths directly comparable across drops and DB rows. On Windows this
+ * also lowercases so drive-letter and directory case mismatches don't
+ * misclassify a registered-workspace file as scratch. */
+function normalize(p: string): string {
+	const resolved = path.resolve(p);
+	return IS_WINDOWS ? resolved.toLowerCase() : resolved;
+}
+
+/** Walk symlinks before comparing so a file living outside its worktree via
+ * a symlink farm still classifies against the workspace it logically
+ * belongs to. Falls back to `path.resolve` if the target doesn't exist. */
+async function canonicalPath(p: string): Promise<string> {
+	try {
+		return normalize(await fs.realpath(p));
+	} catch {
+		return normalize(p);
+	}
+}
+
+function isPathInside(child: string, parent: string): boolean {
+	const rel = path.relative(parent, child);
+	return rel === "" || (!rel.startsWith("..") && !path.isAbsolute(rel));
+}
+
+/**
+ * Scan the local DB for all workspace worktree/repo roots, long side first so
+ * nested paths win the match (e.g., a submodule registered as a workspace
+ * beats its parent repo).
+ */
+function listRegisteredRoots(): ResolvedWorkspace[] {
+	const worktreeRoots = localDb
+		.select({
+			workspaceId: workspaces.id,
+			worktreePath: worktrees.path,
+		})
+		.from(workspaces)
+		.innerJoin(worktrees, eq(workspaces.worktreeId, worktrees.id))
+		.where(and(eq(workspaces.type, "worktree"), isNull(workspaces.deletingAt)))
+		.all()
+		.filter(
+			(row): row is ResolvedWorkspace =>
+				typeof row.worktreePath === "string" && row.worktreePath.length > 0,
+		);
+
+	const branchRoots = localDb
+		.select({
+			workspaceId: workspaces.id,
+			worktreePath: projects.mainRepoPath,
+		})
+		.from(workspaces)
+		.innerJoin(projects, eq(workspaces.projectId, projects.id))
+		.where(and(eq(workspaces.type, "branch"), isNull(workspaces.deletingAt)))
+		.all()
+		.filter(
+			(row): row is ResolvedWorkspace =>
+				typeof row.worktreePath === "string" && row.worktreePath.length > 0,
+		);
+
+	return [...worktreeRoots, ...branchRoots].sort(
+		(a, b) => b.worktreePath.length - a.worktreePath.length,
+	);
+}
+
+async function resolveRegisteredRoots(): Promise<ResolvedWorkspace[]> {
+	const raw = listRegisteredRoots();
+	return Promise.all(
+		raw.map(async (root) => ({
+			workspaceId: root.workspaceId,
+			worktreePath: await canonicalPath(root.worktreePath),
+		})),
+	);
+}
+
+function findRegisteredWorkspaceFor(
+	canonicalChild: string,
+	roots: ResolvedWorkspace[],
+): ResolvedWorkspace | null {
+	for (const root of roots) {
+		if (isPathInside(canonicalChild, root.worktreePath)) {
+			return root;
+		}
+	}
+	return null;
+}
+
+async function classifyPath(
+	absolutePath: string,
+	roots: ResolvedWorkspace[],
+): Promise<FileIntakeTarget> {
+	let stat: import("node:fs").Stats;
+	try {
+		stat = await fs.stat(absolutePath);
+	} catch {
+		return { kind: "scratch-file", absolutePath };
+	}
+	const isDirectory = stat.isDirectory();
+
+	const canonical = await canonicalPath(absolutePath);
+	const match = findRegisteredWorkspaceFor(canonical, roots);
+	if (match) {
+		return {
+			kind: "workspace-file",
+			workspaceId: match.workspaceId,
+			absolutePath,
+			isDirectory,
+		};
+	}
+
+	if (isDirectory) {
+		return { kind: "scratch-directory", absolutePath };
+	}
+	return { kind: "scratch-file", absolutePath };
+}
+
+export async function classifyPaths(
+	absolutePaths: string[],
+): Promise<FileIntakeTarget[]> {
+	const deduped = Array.from(
+		new Map(absolutePaths.map((p) => [normalize(p), p])).values(),
+	);
+	// Resolve registered roots once per batch — previously each classifyPath
+	// ran two SQLite joins independently, which scaled badly with large drops.
+	const roots = await resolveRegisteredRoots();
+	return Promise.all(deduped.map((p) => classifyPath(p, roots)));
+}
+
+/** Split targets by kind so the renderer can be instructed how to open each. */
+function splitTargets(targets: FileIntakeTarget[]) {
+	const byWorkspace = new Map<string, string[]>();
+	const scratch: string[] = [];
+	for (const t of targets) {
+		if (t.kind === "workspace-file") {
+			const key = t.workspaceId;
+			const arr = byWorkspace.get(key) ?? [];
+			arr.push(t.absolutePath);
+			byWorkspace.set(key, arr);
+		} else {
+			scratch.push(t.absolutePath);
+		}
+	}
+	return { byWorkspace, scratch };
+}
+
+export function focusFirstWindow(): BrowserWindow | null {
+	const wins = BrowserWindow.getAllWindows();
+	if (wins.length === 0) return null;
+	const main = wins[0];
+	if (main.isMinimized()) main.restore();
+	main.show();
+	main.focus();
+	return main;
+}
+
+/**
+ * Pending cold-start paths: macOS fires `open-file` before the window exists,
+ * and on Windows/Linux the first launch's file args arrive in process.argv
+ * before the renderer is ready. We queue here and drain on first dispatch.
+ */
+const pendingPaths: string[] = [];
+let ready = false;
+
+export function queuePath(absolutePath: string): void {
+	pendingPaths.push(absolutePath);
+}
+
+export function markFileIntakeReady(): void {
+	ready = true;
+}
+
+export function isFileIntakeReady(): boolean {
+	return ready;
+}
+
+export function takePendingPaths(): string[] {
+	const snapshot = pendingPaths.splice(0, pendingPaths.length);
+	return snapshot;
+}
+
+/**
+ * Public API: hand a batch of OS paths (from open-file / argv / DnD /
+ * second-instance) over to the renderer.
+ *
+ * We *never* encode file paths in the route URL. The renderer's persistent
+ * hash history serializes routes to localStorage, which would silently
+ * restore scratch / workspace file intents on the next launch (Q1:B violation)
+ * and log absolute paths to disk. All payload data flows through IPC
+ * channels that the renderer consumes into its zustand stores.
+ */
+export async function dispatchPaths(absolutePaths: string[]): Promise<void> {
+	if (absolutePaths.length === 0) return;
+
+	if (!ready) {
+		for (const p of absolutePaths) queuePath(p);
+		return;
+	}
+
+	const targets = await classifyPaths(absolutePaths);
+	if (targets.length === 0) return;
+
+	const win = focusFirstWindow();
+	if (!win) {
+		for (const p of absolutePaths) queuePath(p);
+		return;
+	}
+
+	const { byWorkspace, scratch } = splitTargets(targets);
+
+	// Q5:A — batch per workspace so the renderer can open all of them as tabs
+	// without each event overwriting the previous DeepLinkNavigation intent.
+	for (const [workspaceId, paths] of byWorkspace) {
+		win.webContents.send("file-intake:open-workspace-batch", {
+			workspaceId,
+			absolutePaths: paths,
+		});
+	}
+
+	if (scratch.length > 0) {
+		win.webContents.send("file-intake:open-scratch-batch", {
+			absolutePaths: scratch,
+		});
+	}
+}
+
+export async function drainPendingPaths(): Promise<void> {
+	if (pendingPaths.length === 0) return;
+	const paths = takePendingPaths();
+	await dispatchPaths(paths);
+}
+
+/**
+ * Identify file-path-looking argv entries. We deliberately skip flags, URLs,
+ * and the executable path so we don't misinterpret the launch argv on cold
+ * start. Only entries that already exist on disk (as either file or directory)
+ * are treated as drops.
+ */
+export async function filterFilePathArgs(argv: string[]): Promise<string[]> {
+	const candidates = argv.filter((arg, idx) => {
+		// Skip the executable (argv[0]) and anything that looks like a flag/URL.
+		if (idx === 0) return false;
+		if (arg.startsWith("-")) return false;
+		if (/^[a-z][a-z0-9+.-]*:\/\//i.test(arg)) return false;
+		return true;
+	});
+
+	const resolved = await Promise.all(
+		candidates.map(async (arg) => {
+			try {
+				const abs = path.isAbsolute(arg) ? arg : path.resolve(arg);
+				await fs.access(abs);
+				return abs;
+			} catch {
+				return null;
+			}
+		}),
+	);
+	return resolved.filter((v): v is string => v !== null);
+}

--- a/apps/desktop/src/main/lib/file-intake/index.ts
+++ b/apps/desktop/src/main/lib/file-intake/index.ts
@@ -1,9 +1,33 @@
+import { EventEmitter } from "node:events";
 import { promises as fs } from "node:fs";
 import path from "node:path";
 import { projects, workspaces, worktrees } from "@superset/local-db";
 import { and, eq, isNull } from "drizzle-orm";
 import { BrowserWindow } from "electron";
 import { localDb } from "main/lib/local-db";
+
+export interface FileIntakeWorkspaceBatch {
+	workspaceId: string;
+	absolutePaths: string[];
+}
+
+export interface FileIntakeScratchBatch {
+	absolutePaths: string[];
+}
+
+interface FileIntakeEvents {
+	"open-workspace-batch": [FileIntakeWorkspaceBatch];
+	"open-scratch-batch": [FileIntakeScratchBatch];
+}
+
+/**
+ * Fan-out point for file-intake dispatch results. tRPC subscriptions in the
+ * scratch router feed off this emitter, turning each batch into an observable
+ * event the renderer can consume via `electronTrpc.scratch.*`. Using an
+ * emitter (instead of `webContents.send` directly) keeps IPC centralized in
+ * the tRPC layer per AGENTS.md's "always use tRPC for IPC" rule.
+ */
+export const fileIntakeEmitter = new EventEmitter<FileIntakeEvents>();
 
 export type FileIntakeTarget =
 	| {
@@ -229,8 +253,9 @@ export function takePendingPaths(): string[] {
  * We *never* encode file paths in the route URL. The renderer's persistent
  * hash history serializes routes to localStorage, which would silently
  * restore scratch / workspace file intents on the next launch (Q1:B violation)
- * and log absolute paths to disk. All payload data flows through IPC
- * channels that the renderer consumes into its zustand stores.
+ * and log absolute paths to disk. Payloads instead fan out via
+ * `fileIntakeEmitter`, which the scratch tRPC subscriptions surface to the
+ * renderer as observable events — keeping IPC inside the tRPC layer.
  */
 export async function dispatchPaths(absolutePaths: string[]): Promise<void> {
 	if (absolutePaths.length === 0) return;
@@ -251,17 +276,19 @@ export async function dispatchPaths(absolutePaths: string[]): Promise<void> {
 
 	const { byWorkspace, scratch } = splitTargets(targets);
 
-	// Q5:A — batch per workspace so the renderer can open all of them as tabs
-	// without each event overwriting the previous DeepLinkNavigation intent.
+	// Q5:A — emit per-workspace so the renderer can open all files as tabs
+	// without the DeepLinkNavigation intent being overwritten between events.
+	// Directory-only entries arrive as empty paths; the renderer still
+	// navigates so Q2:A (folder drop → switch to workspace) works.
 	for (const [workspaceId, paths] of byWorkspace) {
-		win.webContents.send("file-intake:open-workspace-batch", {
+		fileIntakeEmitter.emit("open-workspace-batch", {
 			workspaceId,
 			absolutePaths: paths,
 		});
 	}
 
 	if (scratch.length > 0) {
-		win.webContents.send("file-intake:open-scratch-batch", {
+		fileIntakeEmitter.emit("open-scratch-batch", {
 			absolutePaths: scratch,
 		});
 	}
@@ -280,9 +307,13 @@ export async function drainPendingPaths(): Promise<void> {
  * are treated as drops.
  */
 export async function filterFilePathArgs(argv: string[]): Promise<string[]> {
+	// In dev the Electron binary runs with the main script as argv[1]
+	// (`electron /path/to/main.js ...`); packaged builds jump straight to
+	// user args at argv[1]. Using `process.defaultApp` mirrors the same
+	// detection used in setAsDefaultProtocolClient at main/index.ts.
+	const userArgsStart = process.defaultApp ? 2 : 1;
 	const candidates = argv.filter((arg, idx) => {
-		// Skip the executable (argv[0]) and anything that looks like a flag/URL.
-		if (idx === 0) return false;
+		if (idx < userArgsStart) return false;
 		if (arg.startsWith("-")) return false;
 		if (/^[a-z][a-z0-9+.-]*:\/\//i.test(arg)) return false;
 		return true;

--- a/apps/desktop/src/main/lib/file-intake/index.ts
+++ b/apps/desktop/src/main/lib/file-intake/index.ts
@@ -159,17 +159,28 @@ export async function classifyPaths(
 	return Promise.all(deduped.map((p) => classifyPath(p, roots)));
 }
 
-/** Split targets by kind so the renderer can be instructed how to open each. */
+/**
+ * Split targets by kind so the renderer can be instructed how to open each.
+ *
+ * Directories inside registered workspaces are kept in `byWorkspace` as an
+ * entry with an empty `absolutePaths` when they're the only drop for that
+ * workspace — that way the renderer still navigates to the workspace but
+ * doesn't try to open the folder as a file (which would produce a broken
+ * FileViewerPane).
+ */
 function splitTargets(targets: FileIntakeTarget[]) {
 	const byWorkspace = new Map<string, string[]>();
 	const scratch: string[] = [];
 	for (const t of targets) {
 		if (t.kind === "workspace-file") {
-			const key = t.workspaceId;
-			const arr = byWorkspace.get(key) ?? [];
-			arr.push(t.absolutePath);
-			byWorkspace.set(key, arr);
+			const existing = byWorkspace.get(t.workspaceId) ?? [];
+			// Directories: register the workspace as a nav target but never push
+			// the path as a file to open.
+			if (!t.isDirectory) existing.push(t.absolutePath);
+			byWorkspace.set(t.workspaceId, existing);
 		} else {
+			// scratch-file and scratch-directory both surface as scratch tabs;
+			// v1 scratch doesn't distinguish, it just opens the path.
 			scratch.push(t.absolutePath);
 		}
 	}

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -5,13 +5,17 @@ import { exposeElectronTRPC } from "trpc-electron/main";
 
 declare const __APP_VERSION__: string;
 
+// Expose via `typeof` so downstream interface augmentations in the renderer
+// and tests don't re-declare the shape with different modifiers (TS2687).
+const webUtilsAPI = {
+	getPathForFile: (file: File) => webUtils.getPathForFile(file),
+};
+
 declare global {
 	interface Window {
 		App: typeof API;
 		ipcRenderer: typeof ipcRendererAPI;
-		webUtils: {
-			getPathForFile: (file: File) => string;
-		};
+		webUtils: typeof webUtilsAPI;
 	}
 }
 
@@ -82,6 +86,4 @@ exposeElectronTRPC();
 
 contextBridge.exposeInMainWorld("App", API);
 contextBridge.exposeInMainWorld("ipcRenderer", ipcRendererAPI);
-contextBridge.exposeInMainWorld("webUtils", {
-	getPathForFile: (file: File) => webUtils.getPathForFile(file),
-});
+contextBridge.exposeInMainWorld("webUtils", webUtilsAPI);

--- a/apps/desktop/src/renderer/index.tsx
+++ b/apps/desktop/src/renderer/index.tsx
@@ -120,11 +120,21 @@ if (ipcRenderer) {
 
 // File intake: OS-level DnD onto the window + IPC batches from main for
 // drops that span registered + unregistered paths.
-const teardownFileIntake = installFileIntakeClient({
-	navigate: (opts) => {
-		router.navigate(opts as Parameters<typeof router.navigate>[0]);
-	},
-});
+//
+// Tearoff windows (detached panes) share the same renderer bundle. Installing
+// the file-intake client there would make every tearoff subscribe to the
+// workspace/scratch batch events and try to navigate its own router — but
+// tearoffs aren't full app shells and don't own the workspace route tree.
+// Scope the install to the main window only.
+import { isTearoffWindow } from "./hooks/useTearoffInit";
+
+const teardownFileIntake = isTearoffWindow()
+	? () => {}
+	: installFileIntakeClient({
+			navigate: (opts) => {
+				router.navigate(opts as Parameters<typeof router.navigate>[0]);
+			},
+		});
 
 if (import.meta.hot) {
 	import.meta.hot.dispose(() => {

--- a/apps/desktop/src/renderer/index.tsx
+++ b/apps/desktop/src/renderer/index.tsx
@@ -12,6 +12,7 @@ import {
 	markBootMounted,
 	reportBootError,
 } from "./lib/boot-errors";
+import { installFileIntakeClient } from "./lib/file-intake-client";
 import { persistentHistory } from "./lib/persistent-hash-history";
 import { posthog } from "./lib/posthog";
 import { electronQueryClient } from "./providers/ElectronTRPCProvider";
@@ -117,12 +118,21 @@ if (ipcRenderer) {
 	);
 }
 
+// File intake: OS-level DnD onto the window + IPC batches from main for
+// drops that span registered + unregistered paths.
+const teardownFileIntake = installFileIntakeClient({
+	navigate: (opts) => {
+		router.navigate(opts as Parameters<typeof router.navigate>[0]);
+	},
+});
+
 if (import.meta.hot) {
 	import.meta.hot.dispose(() => {
 		unsubscribe();
 		if (ipcRenderer) {
 			ipcRenderer.off("deep-link-navigate", handleDeepLink);
 		}
+		teardownFileIntake();
 		cleanupBootErrorHandling();
 	});
 }

--- a/apps/desktop/src/renderer/lib/file-intake-client/index.ts
+++ b/apps/desktop/src/renderer/lib/file-intake-client/index.ts
@@ -2,20 +2,6 @@ import { electronTrpcClient } from "renderer/lib/trpc-client";
 import { useScratchTabsStore } from "renderer/screens/scratch/ScratchView";
 import { useTabsStore } from "renderer/stores/tabs";
 
-type WorkspaceBatchPayload = {
-	workspaceId: string;
-	absolutePaths: string[];
-};
-
-type ScratchBatchPayload = {
-	absolutePaths: string[];
-};
-
-interface IpcRendererAPI {
-	on?: (channel: string, listener: (...args: unknown[]) => void) => void;
-	off?: (channel: string, listener: (...args: unknown[]) => void) => void;
-}
-
 /** Minimal router surface we need here. Avoids a hard coupling to the full
  *  TanStack router generic, which is awkward to type in an app context. */
 interface NavRouter {
@@ -28,67 +14,66 @@ interface NavRouter {
 /**
  * Wire the renderer side of the file-intake pipeline:
  *
- * - Listen for main-process follow-up IPC events so a multi-file drop that
- *   navigates to a workspace can still open additional tabs afterwards.
+ * - Subscribe to two tRPC channels the main process emits from
+ *   `fileIntakeEmitter` (file-intake/index.ts) when an OS drop / argv /
+ *   open-file event resolves to either a registered workspace target or a
+ *   scratch target. AGENTS.md requires tRPC for IPC, so we route through the
+ *   trpc-electron subscription machinery rather than raw ipcRenderer.
  * - Intercept OS drag-and-drop onto the window so the user can drop files
  *   from Finder / Explorer directly into the app.
  *
- * Returns a cleanup function to tear down all listeners (used for HMR).
+ * Returns a cleanup function to tear down listeners / subscriptions (used
+ * for HMR).
  */
 export function installFileIntakeClient(router: NavRouter): () => void {
-	const ipcRenderer = (
-		window as unknown as {
-			ipcRenderer?: IpcRendererAPI;
-		}
-	).ipcRenderer;
+	const workspaceSub =
+		electronTrpcClient.scratch.onOpenWorkspaceBatch.subscribe(undefined, {
+			onData: (payload) => {
+				if (!payload.workspaceId) return;
+				const paths = payload.absolutePaths.filter(
+					(v): v is string => typeof v === "string" && v.length > 0,
+				);
 
-	const handleWorkspaceBatch = (payload: unknown) => {
-		const p = payload as WorkspaceBatchPayload | undefined;
-		if (!p || !p.workspaceId || !Array.isArray(p.absolutePaths)) return;
-		const paths = p.absolutePaths.filter(
-			(v): v is string => typeof v === "string" && v.length > 0,
-		);
+				// Always navigate — even for an empty paths batch, which is the
+				// "drag a folder that's a registered workspace" case (Q2:A with
+				// no specific file). Opening the workspace is the whole
+				// user-visible effect in that scenario.
+				void router.navigate({
+					to: "/workspace/$workspaceId",
+					params: { workspaceId: payload.workspaceId },
+				});
 
-		// Always navigate — even for an empty paths batch, which represents the
-		// "drag a folder that's a registered workspace" case (Q2:A with no
-		// specific file). Opening the workspace is the whole user-visible effect
-		// in that scenario; skipping navigate on empty would leave the user
-		// stranded on whatever route they were on.
-		void router.navigate({
-			to: "/workspace/$workspaceId",
-			params: { workspaceId: p.workspaceId },
+				if (paths.length === 0) return;
+
+				const addFileViewerPane = useTabsStore.getState().addFileViewerPane;
+				for (const absolutePath of paths) {
+					addFileViewerPane(payload.workspaceId, {
+						filePath: absolutePath,
+						openInNewTab: true,
+						reuseExisting: "workspace",
+					});
+				}
+			},
+			onError: (err) => {
+				console.error("[file-intake] workspace batch subscription error:", err);
+			},
 		});
 
-		if (paths.length === 0) return;
-
-		const addFileViewerPane = useTabsStore.getState().addFileViewerPane;
-		for (const absolutePath of paths) {
-			addFileViewerPane(p.workspaceId, {
-				filePath: absolutePath,
-				openInNewTab: true,
-				reuseExisting: "workspace",
-			});
-		}
-	};
-
-	const handleScratchBatch = (payload: unknown) => {
-		const p = payload as ScratchBatchPayload | undefined;
-		if (!p || !Array.isArray(p.absolutePaths)) return;
-		const paths = p.absolutePaths.filter(
-			(v): v is string => typeof v === "string" && v.length > 0,
-		);
-		if (paths.length === 0) return;
-		useScratchTabsStore.getState().openPaths(paths);
-		void router.navigate({ to: "/scratch" });
-	};
-
-	ipcRenderer?.on?.(
-		"file-intake:open-workspace-batch",
-		handleWorkspaceBatch as (...args: unknown[]) => void,
-	);
-	ipcRenderer?.on?.(
-		"file-intake:open-scratch-batch",
-		handleScratchBatch as (...args: unknown[]) => void,
+	const scratchSub = electronTrpcClient.scratch.onOpenScratchBatch.subscribe(
+		undefined,
+		{
+			onData: (payload) => {
+				const paths = payload.absolutePaths.filter(
+					(v): v is string => typeof v === "string" && v.length > 0,
+				);
+				if (paths.length === 0) return;
+				useScratchTabsStore.getState().openPaths(paths);
+				void router.navigate({ to: "/scratch" });
+			},
+			onError: (err) => {
+				console.error("[file-intake] scratch batch subscription error:", err);
+			},
+		},
 	);
 
 	const extractDroppedPaths = (event: DragEvent): string[] => {
@@ -147,14 +132,8 @@ export function installFileIntakeClient(router: NavRouter): () => void {
 	document.addEventListener("drop", onDrop, false);
 
 	return () => {
-		ipcRenderer?.off?.(
-			"file-intake:open-workspace-batch",
-			handleWorkspaceBatch as (...args: unknown[]) => void,
-		);
-		ipcRenderer?.off?.(
-			"file-intake:open-scratch-batch",
-			handleScratchBatch as (...args: unknown[]) => void,
-		);
+		workspaceSub.unsubscribe();
+		scratchSub.unsubscribe();
 		document.removeEventListener("dragover", onDragOver, false);
 		document.removeEventListener("drop", onDrop, false);
 	};

--- a/apps/desktop/src/renderer/lib/file-intake-client/index.ts
+++ b/apps/desktop/src/renderer/lib/file-intake-client/index.ts
@@ -48,17 +48,18 @@ export function installFileIntakeClient(router: NavRouter): () => void {
 		const paths = p.absolutePaths.filter(
 			(v): v is string => typeof v === "string" && v.length > 0,
 		);
-		if (paths.length === 0) return;
 
-		// Navigate first so KeepAliveWorkspaces mounts the target workspace page.
-		// addFileViewerPane writes into the tabs store directly; the page picks
-		// the state up as soon as it renders, so we don't need the
-		// DeepLinkNavigation intent dance here (which only supports one file
-		// and overwrites on the second call — Q5:A would break).
+		// Always navigate — even for an empty paths batch, which represents the
+		// "drag a folder that's a registered workspace" case (Q2:A with no
+		// specific file). Opening the workspace is the whole user-visible effect
+		// in that scenario; skipping navigate on empty would leave the user
+		// stranded on whatever route they were on.
 		void router.navigate({
 			to: "/workspace/$workspaceId",
 			params: { workspaceId: p.workspaceId },
 		});
+
+		if (paths.length === 0) return;
 
 		const addFileViewerPane = useTabsStore.getState().addFileViewerPane;
 		for (const absolutePath of paths) {

--- a/apps/desktop/src/renderer/lib/file-intake-client/index.ts
+++ b/apps/desktop/src/renderer/lib/file-intake-client/index.ts
@@ -1,0 +1,160 @@
+import { electronTrpcClient } from "renderer/lib/trpc-client";
+import { useScratchTabsStore } from "renderer/screens/scratch/ScratchView";
+import { useTabsStore } from "renderer/stores/tabs";
+
+type WorkspaceBatchPayload = {
+	workspaceId: string;
+	absolutePaths: string[];
+};
+
+type ScratchBatchPayload = {
+	absolutePaths: string[];
+};
+
+interface IpcRendererAPI {
+	on?: (channel: string, listener: (...args: unknown[]) => void) => void;
+	off?: (channel: string, listener: (...args: unknown[]) => void) => void;
+}
+
+/** Minimal router surface we need here. Avoids a hard coupling to the full
+ *  TanStack router generic, which is awkward to type in an app context. */
+interface NavRouter {
+	navigate: (opts: {
+		to: string;
+		params?: Record<string, string>;
+	}) => void | Promise<void>;
+}
+
+/**
+ * Wire the renderer side of the file-intake pipeline:
+ *
+ * - Listen for main-process follow-up IPC events so a multi-file drop that
+ *   navigates to a workspace can still open additional tabs afterwards.
+ * - Intercept OS drag-and-drop onto the window so the user can drop files
+ *   from Finder / Explorer directly into the app.
+ *
+ * Returns a cleanup function to tear down all listeners (used for HMR).
+ */
+export function installFileIntakeClient(router: NavRouter): () => void {
+	const ipcRenderer = (
+		window as unknown as {
+			ipcRenderer?: IpcRendererAPI;
+		}
+	).ipcRenderer;
+
+	const handleWorkspaceBatch = (payload: unknown) => {
+		const p = payload as WorkspaceBatchPayload | undefined;
+		if (!p || !p.workspaceId || !Array.isArray(p.absolutePaths)) return;
+		const paths = p.absolutePaths.filter(
+			(v): v is string => typeof v === "string" && v.length > 0,
+		);
+		if (paths.length === 0) return;
+
+		// Navigate first so KeepAliveWorkspaces mounts the target workspace page.
+		// addFileViewerPane writes into the tabs store directly; the page picks
+		// the state up as soon as it renders, so we don't need the
+		// DeepLinkNavigation intent dance here (which only supports one file
+		// and overwrites on the second call — Q5:A would break).
+		void router.navigate({
+			to: "/workspace/$workspaceId",
+			params: { workspaceId: p.workspaceId },
+		});
+
+		const addFileViewerPane = useTabsStore.getState().addFileViewerPane;
+		for (const absolutePath of paths) {
+			addFileViewerPane(p.workspaceId, {
+				filePath: absolutePath,
+				openInNewTab: true,
+				reuseExisting: "workspace",
+			});
+		}
+	};
+
+	const handleScratchBatch = (payload: unknown) => {
+		const p = payload as ScratchBatchPayload | undefined;
+		if (!p || !Array.isArray(p.absolutePaths)) return;
+		const paths = p.absolutePaths.filter(
+			(v): v is string => typeof v === "string" && v.length > 0,
+		);
+		if (paths.length === 0) return;
+		useScratchTabsStore.getState().openPaths(paths);
+		void router.navigate({ to: "/scratch" });
+	};
+
+	ipcRenderer?.on?.(
+		"file-intake:open-workspace-batch",
+		handleWorkspaceBatch as (...args: unknown[]) => void,
+	);
+	ipcRenderer?.on?.(
+		"file-intake:open-scratch-batch",
+		handleScratchBatch as (...args: unknown[]) => void,
+	);
+
+	const extractDroppedPaths = (event: DragEvent): string[] => {
+		const webUtils = window.webUtils;
+		if (!webUtils?.getPathForFile) return [];
+		const files = event.dataTransfer?.files;
+		if (!files || files.length === 0) return [];
+		const paths: string[] = [];
+		for (const file of Array.from(files)) {
+			try {
+				const p = webUtils.getPathForFile(file);
+				if (p) paths.push(p);
+			} catch {
+				// Web-originated drops (e.g., dragging from a browser tab inside a
+				// BrowserPane) have no OS path. Ignore — v1 is OS drops only.
+			}
+		}
+		return paths;
+	};
+
+	const hasFilePayload = (event: DragEvent): boolean => {
+		const types = event.dataTransfer?.types;
+		if (!types) return false;
+		return Array.from(types).includes("Files");
+	};
+
+	const onDragOver = (event: DragEvent) => {
+		// Bubble-phase fallback: existing drop zones (Chat attachments, Terminal
+		// paths, Sidebar project drops, TODO image drops, etc.) run in bubble
+		// phase and call preventDefault when they handle the drop. We only
+		// engage for OS file drags that nobody else claimed.
+		if (event.defaultPrevented) return;
+		if (!hasFilePayload(event)) return;
+		event.preventDefault();
+		if (event.dataTransfer) event.dataTransfer.dropEffect = "copy";
+	};
+
+	const onDrop = (event: DragEvent) => {
+		if (event.defaultPrevented) return;
+		if (!hasFilePayload(event)) return;
+		event.preventDefault();
+		const paths = extractDroppedPaths(event);
+		if (paths.length === 0) return;
+		electronTrpcClient.scratch.ingestDroppedPaths
+			.mutate({ absolutePaths: paths })
+			.catch((err) => {
+				console.error("[file-intake] ingestDroppedPaths failed:", err);
+			});
+	};
+
+	// Bubble phase + defaultPrevented guard: existing drop zones (prompt-input,
+	// Terminal, SidebarDropZone, StartView, ScriptsEditor, etc.) get first
+	// refusal. Only the uncaught drops — empty editor gutters, scratch view,
+	// workspace tab background — fall through to us.
+	document.addEventListener("dragover", onDragOver, false);
+	document.addEventListener("drop", onDrop, false);
+
+	return () => {
+		ipcRenderer?.off?.(
+			"file-intake:open-workspace-batch",
+			handleWorkspaceBatch as (...args: unknown[]) => void,
+		);
+		ipcRenderer?.off?.(
+			"file-intake:open-scratch-batch",
+			handleScratchBatch as (...args: unknown[]) => void,
+		);
+		document.removeEventListener("dragover", onDragOver, false);
+		document.removeEventListener("drop", onDrop, false);
+	};
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/layout.tsx
@@ -51,6 +51,10 @@ function DashboardLayout() {
 	const currentWorkspaceId =
 		currentWorkspaceMatch !== false ? currentWorkspaceMatch.workspaceId : null;
 
+	// Q3:B — scratch route hides the workspace sidebar so a dropped file opens
+	// as a focused editor with no project chrome around it.
+	const isScratchRoute = matchRoute({ to: "/scratch", fuzzy: true }) !== false;
+
 	const { data: currentWorkspace } = electronTrpc.workspaces.get.useQuery(
 		{ id: currentWorkspaceId ?? "" },
 		{ enabled: !!currentWorkspaceId },
@@ -114,7 +118,7 @@ function DashboardLayout() {
 		<div className="flex flex-col h-full w-full bg-tertiary">
 			{!isTearoff && <TopBar />}
 			<div className="flex flex-1 min-h-0 min-w-0 overflow-hidden">
-				{!isTearoff && isWorkspaceSidebarOpen && (
+				{!isTearoff && !isScratchRoute && isWorkspaceSidebarOpen && (
 					<ResizablePanel
 						width={workspaceSidebarWidth}
 						onWidthChange={setWorkspaceSidebarWidth}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/scratch/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/scratch/page.tsx
@@ -1,0 +1,20 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { ScratchView } from "renderer/screens/scratch/ScratchView";
+
+/**
+ * Q1:B — the scratch route intentionally carries no URL-encoded state. All
+ * open file paths live in the renderer-only `useScratchTabsStore` zustand
+ * store, which is NOT persisted. Reload / app restart therefore resets to an
+ * empty scratch view (ScratchEmpty then redirects to /workspace).
+ *
+ * The main process pushes paths through IPC (`file-intake:open-scratch-batch`)
+ * rather than query params, so we never leak absolute filesystem paths into
+ * the persistent router history stored in localStorage.
+ */
+export const Route = createFileRoute("/_authenticated/_dashboard/scratch/")({
+	component: ScratchPage,
+});
+
+function ScratchPage() {
+	return <ScratchView />;
+}

--- a/apps/desktop/src/renderer/screens/scratch/ScratchView/ScratchView.tsx
+++ b/apps/desktop/src/renderer/screens/scratch/ScratchView/ScratchView.tsx
@@ -1,0 +1,44 @@
+import { useCallback } from "react";
+import { ScratchEditor } from "./components/ScratchEditor";
+import { ScratchEmpty } from "./components/ScratchEmpty";
+import { ScratchTabBar } from "./components/ScratchTabBar";
+import { useScratchTabsStore } from "./store";
+
+export function ScratchView() {
+	const tabs = useScratchTabsStore((s) => s.tabs);
+	const activeTabId = useScratchTabsStore((s) => s.activeTabId);
+	const setActive = useScratchTabsStore((s) => s.setActive);
+	const closeTab = useScratchTabsStore((s) => s.closeTab);
+
+	const activeTab = tabs.find((t) => t.id === activeTabId) ?? null;
+
+	const handleClose = useCallback(
+		(id: string) => {
+			closeTab(id);
+		},
+		[closeTab],
+	);
+
+	if (tabs.length === 0) {
+		return <ScratchEmpty />;
+	}
+
+	return (
+		<div className="flex h-full w-full flex-col bg-background">
+			<ScratchTabBar
+				tabs={tabs}
+				activeTabId={activeTabId}
+				onSelect={setActive}
+				onClose={handleClose}
+			/>
+			<div className="min-h-0 flex-1">
+				{activeTab ? (
+					<ScratchEditor
+						key={activeTab.id}
+						absolutePath={activeTab.absolutePath}
+					/>
+				) : null}
+			</div>
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/screens/scratch/ScratchView/components/ScratchEditor/ScratchEditor.tsx
+++ b/apps/desktop/src/renderer/screens/scratch/ScratchView/components/ScratchEditor/ScratchEditor.tsx
@@ -21,18 +21,24 @@ export function ScratchEditor({ absolutePath }: ScratchEditorProps) {
 		);
 
 	const writeMut = electronTrpc.scratch.writeFile.useMutation({
-		onSuccess: (res) => {
+		onSuccess: (res, variables) => {
 			setSavedAt(res.mtimeMs);
 			// Sync the readFile cache to what we just wrote so `hasChanges`
 			// (draft !== null && data.content !== draft) collapses to false and
-			// the status bar can advance from "unsaved" → "saved". Clearing the
-			// draft alone would re-fall-back to the stale cached content and
-			// make the editor flash back to the pre-save text.
+			// the status bar can advance from "unsaved" → "saved".
+			//
+			// Pull the content from `variables` (the exact string that reached
+			// disk) rather than the live `draft` state: if the user keeps
+			// typing while save is in flight, `draft` has already advanced past
+			// what we sent to writeFile, and seeding the cache with that newer
+			// value would make hasChanges flip false while disk still holds
+			// the older content — effectively losing the in-flight keystrokes
+			// from the dirty-tracking model.
 			utils.scratch.readFile.setData({ absolutePath }, (old) => {
-				if (!old || old.kind !== "text" || draft === null) return old;
+				if (!old || old.kind !== "text") return old;
 				return {
 					...old,
-					content: draft,
+					content: variables.content,
 					size: res.size,
 					mtimeMs: res.mtimeMs,
 				};

--- a/apps/desktop/src/renderer/screens/scratch/ScratchView/components/ScratchEditor/ScratchEditor.tsx
+++ b/apps/desktop/src/renderer/screens/scratch/ScratchView/components/ScratchEditor/ScratchEditor.tsx
@@ -12,6 +12,7 @@ export function ScratchEditor({ absolutePath }: ScratchEditorProps) {
 	const editorRef = useRef<CodeEditorAdapter | null>(null);
 	const [draft, setDraft] = useState<string | null>(null);
 	const [savedAt, setSavedAt] = useState<number | null>(null);
+	const utils = electronTrpc.useUtils();
 
 	const { data, error, isLoading, refetch } =
 		electronTrpc.scratch.readFile.useQuery(
@@ -22,6 +23,20 @@ export function ScratchEditor({ absolutePath }: ScratchEditorProps) {
 	const writeMut = electronTrpc.scratch.writeFile.useMutation({
 		onSuccess: (res) => {
 			setSavedAt(res.mtimeMs);
+			// Sync the readFile cache to what we just wrote so `hasChanges`
+			// (draft !== null && data.content !== draft) collapses to false and
+			// the status bar can advance from "unsaved" → "saved". Clearing the
+			// draft alone would re-fall-back to the stale cached content and
+			// make the editor flash back to the pre-save text.
+			utils.scratch.readFile.setData({ absolutePath }, (old) => {
+				if (!old || old.kind !== "text" || draft === null) return old;
+				return {
+					...old,
+					content: draft,
+					size: res.size,
+					mtimeMs: res.mtimeMs,
+				};
+			});
 		},
 	});
 

--- a/apps/desktop/src/renderer/screens/scratch/ScratchView/components/ScratchEditor/ScratchEditor.tsx
+++ b/apps/desktop/src/renderer/screens/scratch/ScratchView/components/ScratchEditor/ScratchEditor.tsx
@@ -1,0 +1,110 @@
+import { useEffect, useRef, useState } from "react";
+import { electronTrpc } from "renderer/lib/electron-trpc";
+import type { CodeEditorAdapter } from "renderer/screens/main/components/WorkspaceView/ContentView/components";
+import { CodeEditor } from "renderer/screens/main/components/WorkspaceView/components/CodeEditor";
+import { detectEditorLanguage } from "shared/language-registry";
+
+interface ScratchEditorProps {
+	absolutePath: string;
+}
+
+export function ScratchEditor({ absolutePath }: ScratchEditorProps) {
+	const editorRef = useRef<CodeEditorAdapter | null>(null);
+	const [draft, setDraft] = useState<string | null>(null);
+	const [savedAt, setSavedAt] = useState<number | null>(null);
+
+	const { data, error, isLoading, refetch } =
+		electronTrpc.scratch.readFile.useQuery(
+			{ absolutePath },
+			{ retry: false, refetchOnWindowFocus: false },
+		);
+
+	const writeMut = electronTrpc.scratch.writeFile.useMutation({
+		onSuccess: (res) => {
+			setSavedAt(res.mtimeMs);
+		},
+	});
+
+	// Reset draft whenever the path or backing file content changes so the
+	// editor re-hydrates with the latest disk state.
+	useEffect(() => {
+		if (data?.kind === "text") {
+			setDraft(data.content);
+		} else {
+			setDraft(null);
+		}
+	}, [data]);
+
+	if (isLoading) {
+		return (
+			<div className="flex h-full items-center justify-center text-muted-foreground text-sm">
+				読み込み中…
+			</div>
+		);
+	}
+
+	if (error) {
+		return (
+			<div className="flex h-full flex-col items-center justify-center gap-2 p-6 text-sm">
+				<div className="text-destructive">
+					ファイルを開けませんでした: {error.message}
+				</div>
+				<button
+					type="button"
+					className="rounded border border-border px-3 py-1 text-muted-foreground hover:text-foreground"
+					onClick={() => refetch()}
+				>
+					再試行
+				</button>
+			</div>
+		);
+	}
+
+	if (!data) return null;
+
+	if (data.kind === "too-large") {
+		return (
+			<div className="flex h-full flex-col items-center justify-center gap-1 p-6 text-center text-muted-foreground text-sm">
+				<div>ファイルサイズが大きすぎます</div>
+				<div className="text-xs">
+					{(data.size / 1024 / 1024).toFixed(1)} MB / 上限{" "}
+					{(data.maxBytes / 1024 / 1024).toFixed(1)} MB
+				</div>
+			</div>
+		);
+	}
+
+	const language = detectEditorLanguage(absolutePath);
+	const hasChanges = draft !== null && data.content !== draft;
+
+	return (
+		<div className="relative flex h-full flex-col">
+			<CodeEditor
+				editorRef={editorRef}
+				value={draft ?? data.content}
+				language={language}
+				onChange={(next) => setDraft(next)}
+				onSave={() => {
+					if (draft === null) return;
+					writeMut.mutate({ absolutePath, content: draft });
+				}}
+				fillHeight
+				searchMode="overlay"
+			/>
+			<div className="flex items-center justify-between border-border border-t bg-tertiary px-3 py-1 text-[11px] text-muted-foreground">
+				<span className="truncate" title={absolutePath}>
+					{absolutePath}
+				</span>
+				<span>
+					{writeMut.isPending
+						? "保存中…"
+						: hasChanges
+							? "未保存の変更あり (⌘S で保存)"
+							: savedAt
+								? "保存しました"
+								: "Scratch モード · Git / Agent / Chat / Terminal は無効"}
+				</span>
+			</div>
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/screens/scratch/ScratchView/components/ScratchEditor/index.ts
+++ b/apps/desktop/src/renderer/screens/scratch/ScratchView/components/ScratchEditor/index.ts
@@ -1,0 +1,1 @@
+export { ScratchEditor } from "./ScratchEditor";

--- a/apps/desktop/src/renderer/screens/scratch/ScratchView/components/ScratchEmpty/ScratchEmpty.tsx
+++ b/apps/desktop/src/renderer/screens/scratch/ScratchView/components/ScratchEmpty/ScratchEmpty.tsx
@@ -1,0 +1,25 @@
+import { useNavigate } from "@tanstack/react-router";
+import { useEffect } from "react";
+
+interface ScratchEmptyProps {
+	redirectToWorkspaceOnEmpty?: boolean;
+}
+
+/**
+ * Q1:B — scratch tabs do not persist. Closing the last tab redirects the user
+ * back to the normal workspace entry point so the UI never sits in a blank
+ * scratch state between sessions.
+ */
+export function ScratchEmpty({
+	redirectToWorkspaceOnEmpty = true,
+}: ScratchEmptyProps) {
+	const navigate = useNavigate();
+	useEffect(() => {
+		if (!redirectToWorkspaceOnEmpty) return;
+		navigate({ to: "/workspace", replace: true });
+	}, [navigate, redirectToWorkspaceOnEmpty]);
+
+	// Empty placeholder: effect above fires synchronously on mount to redirect,
+	// so we render nothing visible to avoid a one-frame flash.
+	return <div className="h-full" aria-hidden />;
+}

--- a/apps/desktop/src/renderer/screens/scratch/ScratchView/components/ScratchEmpty/index.ts
+++ b/apps/desktop/src/renderer/screens/scratch/ScratchView/components/ScratchEmpty/index.ts
@@ -1,0 +1,1 @@
+export { ScratchEmpty } from "./ScratchEmpty";

--- a/apps/desktop/src/renderer/screens/scratch/ScratchView/components/ScratchTabBar/ScratchTabBar.tsx
+++ b/apps/desktop/src/renderer/screens/scratch/ScratchView/components/ScratchTabBar/ScratchTabBar.tsx
@@ -58,7 +58,6 @@ export function ScratchTabBar({
 						<button
 							type="button"
 							aria-label={`Close ${basename(tab.absolutePath)}`}
-							tabIndex={-1}
 							className="ml-1 flex size-4 items-center justify-center rounded opacity-60 hover:bg-muted hover:opacity-100"
 							onClick={(e) => {
 								e.stopPropagation();

--- a/apps/desktop/src/renderer/screens/scratch/ScratchView/components/ScratchTabBar/ScratchTabBar.tsx
+++ b/apps/desktop/src/renderer/screens/scratch/ScratchView/components/ScratchTabBar/ScratchTabBar.tsx
@@ -1,0 +1,75 @@
+import { cn } from "@superset/ui/utils";
+import { X } from "lucide-react";
+import { basename } from "../../utils/path";
+
+export interface ScratchTab {
+	id: string;
+	absolutePath: string;
+}
+
+interface ScratchTabBarProps {
+	tabs: ScratchTab[];
+	activeTabId: string | null;
+	onSelect: (id: string) => void;
+	onClose: (id: string) => void;
+}
+
+export function ScratchTabBar({
+	tabs,
+	activeTabId,
+	onSelect,
+	onClose,
+}: ScratchTabBarProps) {
+	if (tabs.length === 0) return null;
+	return (
+		<div
+			className="flex h-9 min-h-9 items-stretch overflow-x-auto border-border border-b bg-tertiary"
+			role="tablist"
+		>
+			{tabs.map((tab) => {
+				const isActive = tab.id === activeTabId;
+				return (
+					<div
+						key={tab.id}
+						className={cn(
+							"flex items-center gap-1.5 border-border border-r px-3 text-xs",
+							"text-muted-foreground hover:text-foreground",
+							isActive && "bg-background text-foreground",
+						)}
+						title={tab.absolutePath}
+					>
+						<button
+							type="button"
+							role="tab"
+							aria-selected={isActive}
+							className="flex items-center gap-1.5 outline-none"
+							onClick={() => onSelect(tab.id)}
+						>
+							<span className="max-w-52 truncate">
+								{basename(tab.absolutePath)}
+							</span>
+							<span
+								className="rounded bg-warn/10 px-1 py-px font-medium text-[10px] text-warn"
+								title="Scratch tab (temporary)"
+							>
+								一時
+							</span>
+						</button>
+						<button
+							type="button"
+							aria-label={`Close ${basename(tab.absolutePath)}`}
+							tabIndex={-1}
+							className="ml-1 flex size-4 items-center justify-center rounded opacity-60 hover:bg-muted hover:opacity-100"
+							onClick={(e) => {
+								e.stopPropagation();
+								onClose(tab.id);
+							}}
+						>
+							<X className="size-3" />
+						</button>
+					</div>
+				);
+			})}
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/screens/scratch/ScratchView/components/ScratchTabBar/index.ts
+++ b/apps/desktop/src/renderer/screens/scratch/ScratchView/components/ScratchTabBar/index.ts
@@ -1,0 +1,1 @@
+export { type ScratchTab, ScratchTabBar } from "./ScratchTabBar";

--- a/apps/desktop/src/renderer/screens/scratch/ScratchView/index.ts
+++ b/apps/desktop/src/renderer/screens/scratch/ScratchView/index.ts
@@ -1,0 +1,2 @@
+export { ScratchView } from "./ScratchView";
+export { useScratchTabsStore } from "./store";

--- a/apps/desktop/src/renderer/screens/scratch/ScratchView/store.ts
+++ b/apps/desktop/src/renderer/screens/scratch/ScratchView/store.ts
@@ -1,0 +1,58 @@
+import { create } from "zustand";
+import type { ScratchTab } from "./components/ScratchTabBar";
+
+interface ScratchTabsState {
+	tabs: ScratchTab[];
+	activeTabId: string | null;
+	openPaths: (absolutePaths: string[]) => void;
+	setActive: (id: string) => void;
+	closeTab: (id: string) => void;
+	reset: () => void;
+}
+
+function makeTabId(absolutePath: string): string {
+	// One tab per path, deduped. The path itself is the stable key.
+	return `scratch:${absolutePath}`;
+}
+
+/**
+ * Q1:B — scratch tabs live only in renderer memory. There is no persistence
+ * across reloads or app restarts. Closing all tabs bounces the user back to
+ * the workspace picker via ScratchEmpty.
+ */
+export const useScratchTabsStore = create<ScratchTabsState>((set) => ({
+	tabs: [],
+	activeTabId: null,
+	openPaths: (absolutePaths) => {
+		if (absolutePaths.length === 0) return;
+		set((state) => {
+			const existingIds = new Set(state.tabs.map((t) => t.id));
+			const additions: ScratchTab[] = [];
+			for (const p of absolutePaths) {
+				const id = makeTabId(p);
+				if (!existingIds.has(id)) {
+					additions.push({ id, absolutePath: p });
+					existingIds.add(id);
+				}
+			}
+			const tabs = [...state.tabs, ...additions];
+			const lastPath = absolutePaths[absolutePaths.length - 1];
+			const lastId = makeTabId(lastPath);
+			return { tabs, activeTabId: lastId };
+		});
+	},
+	setActive: (id) => set({ activeTabId: id }),
+	closeTab: (id) =>
+		set((state) => {
+			const idx = state.tabs.findIndex((t) => t.id === id);
+			if (idx < 0) return state;
+			const tabs = [...state.tabs.slice(0, idx), ...state.tabs.slice(idx + 1)];
+			let activeTabId = state.activeTabId;
+			if (activeTabId === id) {
+				const nextIdx = Math.min(idx, tabs.length - 1);
+				activeTabId = tabs[nextIdx]?.id ?? null;
+			}
+			return { tabs, activeTabId };
+		}),
+	reset: () => set({ tabs: [], activeTabId: null }),
+}));

--- a/apps/desktop/src/renderer/screens/scratch/ScratchView/utils/path.ts
+++ b/apps/desktop/src/renderer/screens/scratch/ScratchView/utils/path.ts
@@ -1,0 +1,5 @@
+export function basename(p: string): string {
+	if (!p) return "";
+	const parts = p.split(/[\\/]/);
+	return parts[parts.length - 1] ?? p;
+}


### PR DESCRIPTION
## 概要

VS Code や Antigravity と同じように、**Finder / Explorer からファイルをダブルクリックしたり Superset のウィンドウに DnD したりしてファイルを開けるようにする** v1 実装。

ドロップされたパスを main プロセス側で分類し、2 つの経路に振り分ける:

- **登録済みワークスペース配下** → そのワークスペースに切り替えて FileViewerPane として開く (複数ファイル同時ドロップ可)
- **未登録のファイル / フォルダ** → 新設の `/scratch` ルートでエディタのみの軽量モードで開く。Git / Agent / Chat / Terminal は無効

## 設計判断 (ユーザーとの対話で確定した仕様)

| | 決定 | 実装 |
|---|---|---|
| **Q1** | 再起動で復元しない | scratch タブは renderer-only zustand に保持、URL にファイルパスを載せず localStorage 経由の復元を防止 |
| **Q2** | ドロップ先が登録済みワークスペースなら切り替え | main で DB を走査して一致判定、一致すれば `useTabsStore.addFileViewerPane` を直接呼ぶ |
| **Q3** | ファイル1個時はサイドバー無し | scratch ルートでワークスペースサイドバーを非表示 |
| **Q4** | scratch は Editor のみ (Git/Agent/Chat/Terminal OFF) | 新ルートに最小UIだけ配置。LSP連携は v1 対象外 |
| **Q5** | 複数ファイル同時 → 1 ウィンドウに全タブ | IPC は「ワークスペースごとのバッチ」単位で送信し、renderer は全ファイルを順に addFileViewerPane |

## 主な追加

- `apps/desktop/src/main/lib/file-intake/` — パス分類 / キューイング / dispatchPaths / EventEmitter
- `apps/desktop/src/lib/trpc/routers/scratch/` — ワークスペース外の read/write、DnD 取り込み mutation、main→renderer バッチ配信用の 2 つの subscription
- `apps/desktop/src/renderer/lib/file-intake-client/` — ウィンドウ DnD (bubble 相 + `defaultPrevented` ガード) と tRPC subscription の受信
- `apps/desktop/src/renderer/screens/scratch/ScratchView/` — タブ + CodeEditor の最小 UI
- `apps/desktop/src/renderer/routes/_authenticated/_dashboard/scratch/page.tsx` — 新ルート

## 変更

- `main/index.ts`: `will-finish-launching` + `open-file`、`second-instance` の argv 経由ファイル渡し、`browser-window-created` で毎回 drain (全ウィンドウ閉→再アクティブ時も queue を drain)
- `preload/index.ts`: `typeof webUtilsAPI` パターンに変更 (TS2687 の pre-existing エラーを解消)
- `electron-builder.ts`: `fileAssociations` 追加 (macOS は `rank: Alternate`、Linux AppImage 互換のため各拡張子を単独エントリに)

## 安全面

- scratch read/write 両方に deny-list (`/etc`, `/System`, `/usr`, `~/.ssh`, `~/.aws`, `~/.gnupg`, `C:\Windows`, `C:\ProgramData`)
- パスは fs.realpath で親ディレクトリ分を正規化してから判定 → **親ディレクトリ経由の symlink エスケープ** を防止 (`/tmp/link/foo` で `link` が `~/.ssh` を指すケース)
- Symlink leaf 自体も read/write 両方で拒否 (lstat チェック)
- deny-list は path を forward slash に正規化してから評価 → Windows パスも同じパターンで拒否
- ウィンドウ DnD は bubble 相で `defaultPrevented` をガード → 既存の Chat 添付 / Terminal パスドロップ / Sidebar プロジェクト追加 / ScriptsEditor 等のドロップゾーンを上書きしない
- Windows では canonical path 比較時に小文字化
- Tearoff ウィンドウでは file-intake client を install しない → detached pane が OS ドロップを勝手に奪わない

## レビュー対応履歴

| Round | 指摘元 | 件数 | コミット |
|---|---|---|---|
| 自己レビュー | code-reviewer agent | Blocker 2 + Must-fix 4 | 初回コミット内で先行対応 |
| CI #1 | Linux AppImage ビルド | 1 | `6ea3a93cf` |
| Codex 初回 | P1 symlink / P2 directory drop | 2 | `f9e9e4a4` |
| CodeRabbit | Major 2 + Minor 4 (tRPC化、Windows deny-list、dev argv、saveキャッシュ、a11y) | 6 | `e2fb06cce` |
| Codex 再レビュー | P1 window recreation drain | 1 | `dddfd4d6e` |
| Codex 最終 | P2 tearoff / P1 mutation variables | 2 | `35229b082` |

合計 **17 件** のレビュー指摘に対応済み。Codex の "queued paths drain" 再提起は `dddfd4d6e` 時点で既に対応済みの false positive。

## Test plan

**手動確認 (macOS):**

- [ ] Finder でこの repo 内のファイルを「Superset で開く」→ 対応ワークスペースに切替わり対象ファイルが FileViewerPane で開く
- [ ] Finder でこの repo 内のファイルを Dock の Superset アイコンにドロップ → 同上
- [ ] repo 外のファイル (例: `~/Downloads/foo.md`) を DnD → `/scratch` で開く、サイドバーが消える、Git/Agent/Chat/Terminal のステータスが消える
- [ ] 同じ repo 内の複数ファイルを同時に DnD → 全部タブとして開く (Q5:A)
- [ ] scratch タブを全部 × で閉じる → `/workspace` にリダイレクト
- [ ] アプリ再起動 → scratch タブが復元されない (Q1:B)
- [ ] 登録済み repo のフォルダを DnD → そのワークスペースに切替 (ファイル指定なし、エラータブが出ない)
- [ ] Chat の `PromptInput` / Terminal / SidebarDropZone の既存ドロップ機能が壊れていない
- [ ] scratch で編集 + ⌘S → 元パスに書き込まれる、ステータスバーが「保存しました」になる
- [ ] scratch で保存中にタイピングを続ける → draft は失われず、ステータスバーは「未保存の変更あり」のまま
- [ ] `/etc/passwd` を DnD → read / save の両方で `FORBIDDEN`
- [ ] Tearoff ウィンドウを開いた状態で OS ドロップ → tearoff 側は無反応、main 側のみ反応
- [ ] macOS で全ウィンドウを閉じた後、Finder から「Superset で開く」→ Dock 再アクティブで新しいウィンドウが立ち上がり、そのファイルが開く
- [ ] 大きめファイル (5MB 超) を DnD → `too-large` 表示

**未確認:**

- Windows / Linux 実機 (argv 経路のコールドスタート / `second-instance` 経路)

## v1 スコープ外 (意図的に先送り)

- Scratch モードでの LSP 連携 (完全な文法エラー表示や定義ジャンプ)
- Save As (別パスへの書き出し)
- 拡張子のないファイル (`.gitignore`, `Dockerfile`) の fileAssociations 登録 (electron-builder の `ext` が拡張子のみ対応)