### PR TITLE
upstream 取り込み PR #10: delete dialog checkbox (#3681) + hook 補完

### DIFF
--- a/apps/desktop/src/renderer/hooks/useV2UserPreferences/useV2UserPreferences.ts
+++ b/apps/desktop/src/renderer/hooks/useV2UserPreferences/useV2UserPreferences.ts
@@ -9,6 +9,8 @@ import {
 	type V2UserPreferencesRow,
 } from "renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema";
 
+export type RightSidebarTab = V2UserPreferencesRow["rightSidebarTab"];
+
 export interface V2UserPreferencesApi {
 	preferences: V2UserPreferencesRow;
 	setFileLinks: (next: LinkTierMap) => void;

--- a/apps/desktop/src/renderer/hooks/useV2UserPreferences/useV2UserPreferences.ts
+++ b/apps/desktop/src/renderer/hooks/useV2UserPreferences/useV2UserPreferences.ts
@@ -13,6 +13,9 @@ export interface V2UserPreferencesApi {
 	preferences: V2UserPreferencesRow;
 	setFileLinks: (next: LinkTierMap) => void;
 	setUrlLinks: (next: LinkTierMap) => void;
+	setRightSidebarOpen: (next: boolean | ((prev: boolean) => boolean)) => void;
+	setRightSidebarTab: (next: RightSidebarTab) => void;
+	setDeleteLocalBranch: (next: boolean) => void;
 }
 
 export function useV2UserPreferences(): V2UserPreferencesApi {
@@ -57,5 +60,73 @@ export function useV2UserPreferences(): V2UserPreferencesApi {
 		[upsertTierMap],
 	);
 
-	return { preferences, setFileLinks, setUrlLinks };
+	const setRightSidebarOpen = useCallback(
+		(next: boolean | ((prev: boolean) => boolean)) => {
+			const existing = collections.v2UserPreferences.get(
+				V2_USER_PREFERENCES_ID,
+			);
+			const prev =
+				existing?.rightSidebarOpen ??
+				DEFAULT_V2_USER_PREFERENCES.rightSidebarOpen;
+			const value = typeof next === "function" ? next(prev) : next;
+			if (!existing) {
+				collections.v2UserPreferences.insert({
+					...DEFAULT_V2_USER_PREFERENCES,
+					rightSidebarOpen: value,
+				});
+				return;
+			}
+			collections.v2UserPreferences.update(V2_USER_PREFERENCES_ID, (draft) => {
+				draft.rightSidebarOpen = value;
+			});
+		},
+		[collections],
+	);
+
+	const setRightSidebarTab = useCallback(
+		(next: RightSidebarTab) => {
+			const existing = collections.v2UserPreferences.get(
+				V2_USER_PREFERENCES_ID,
+			);
+			if (!existing) {
+				collections.v2UserPreferences.insert({
+					...DEFAULT_V2_USER_PREFERENCES,
+					rightSidebarTab: next,
+				});
+				return;
+			}
+			collections.v2UserPreferences.update(V2_USER_PREFERENCES_ID, (draft) => {
+				draft.rightSidebarTab = next;
+			});
+		},
+		[collections],
+	);
+
+	const setDeleteLocalBranch = useCallback(
+		(next: boolean) => {
+			const existing = collections.v2UserPreferences.get(
+				V2_USER_PREFERENCES_ID,
+			);
+			if (!existing) {
+				collections.v2UserPreferences.insert({
+					...DEFAULT_V2_USER_PREFERENCES,
+					deleteLocalBranch: next,
+				});
+				return;
+			}
+			collections.v2UserPreferences.update(V2_USER_PREFERENCES_ID, (draft) => {
+				draft.deleteLocalBranch = next;
+			});
+		},
+		[collections],
+	);
+
+	return {
+		preferences,
+		setFileLinks,
+		setUrlLinks,
+		setRightSidebarOpen,
+		setRightSidebarTab,
+		setDeleteLocalBranch,
+	};
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarDeleteDialog/hooks/useDestroyDialogState/useDestroyDialogState.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarDeleteDialog/hooks/useDestroyDialogState/useDestroyDialogState.ts
@@ -45,7 +45,6 @@ export function useDestroyDialogState({
 }: UseDestroyDialogStateOptions) {
 	const { destroy } = useDestroyWorkspace(workspaceId);
 	const { markDeleting, clearDeleting } = useDeletingWorkspaces();
-
 	const navigateAway = useNavigateAwayFromWorkspace();
 	const { preferences, setDeleteLocalBranch: setDeleteBranch } =
 		useV2UserPreferences();
@@ -127,7 +126,11 @@ export function useDestroyDialogState({
 			onOpenChange,
 			onDeleted,
 			markDeleting,
-			clearDeleting,
+			clearDeleting, // Navigate off the doomed workspace FIRST. Closing the dialog
+			// and hiding the row were swallowing the nav otherwise.
+			// State (deleteBranch) preserved in case we re-open on a
+			// decision-required error.
+			navigateAway,
 		],
 	);
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarDeleteDialog/hooks/useDestroyDialogState/useDestroyDialogState.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarDeleteDialog/hooks/useDestroyDialogState/useDestroyDialogState.ts
@@ -5,7 +5,9 @@ import {
 	type DestroyWorkspaceError,
 	useDestroyWorkspace,
 } from "renderer/hooks/host-service/useDestroyWorkspace";
+import { useV2UserPreferences } from "renderer/hooks/useV2UserPreferences/useV2UserPreferences";
 import { electronTrpc } from "renderer/lib/electron-trpc";
+import { useNavigateAwayFromWorkspace } from "renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useNavigateAwayFromWorkspace";
 import { useDeletingWorkspaces } from "renderer/routes/_authenticated/providers/DeletingWorkspacesProvider";
 
 const STATUS_STALE_TIME_MS = 5_000;
@@ -31,7 +33,7 @@ interface UseDestroyDialogStateOptions {
  *   - On error, `clearDeleting` runs in the `finally` block so the row
  *     reappears. For decision-required errors (TEARDOWN_FAILED)
  *     we reopen the dialog in the matching error pane so the user can
- *     force-retry with full context. The branch opt-in is preserved.
+ *     force-retry with full context.
  *   - For unknown errors we just toast.error — no reopen.
  */
 export function useDestroyDialogState({
@@ -44,7 +46,10 @@ export function useDestroyDialogState({
 	const { destroy } = useDestroyWorkspace(workspaceId);
 	const { markDeleting, clearDeleting } = useDeletingWorkspaces();
 
-	const [deleteBranch, setDeleteBranch] = useState(false);
+	const navigateAway = useNavigateAwayFromWorkspace();
+	const { preferences, setDeleteLocalBranch: setDeleteBranch } =
+		useV2UserPreferences();
+	const deleteBranch = preferences.deleteLocalBranch;
 
 	const { data: canDeleteData, isPending: isCheckingStatus } =
 		electronTrpc.workspaces.canDelete.useQuery(
@@ -63,10 +68,7 @@ export function useDestroyDialogState({
 
 	const handleOpenChange = useCallback(
 		(next: boolean) => {
-			if (!next) {
-				setDeleteBranch(false);
-				setError(null);
-			}
+			if (!next) setError(null);
 			onOpenChange(next);
 		},
 		[onOpenChange],
@@ -77,8 +79,12 @@ export function useDestroyDialogState({
 			if (inFlight.current) return;
 			inFlight.current = true;
 
-			// Optimistic close. State (deleteBranch) preserved in case we re-open
-			// on a decision-required error.
+			// Navigate off the doomed workspace FIRST. Closing the dialog
+			// and hiding the row were swallowing the nav otherwise.
+			// State (deleteBranch) preserved in case we re-open on a
+			// decision-required error.
+			navigateAway(workspaceId);
+
 			setError(null);
 			onOpenChange(false);
 			markDeleting(workspaceId);
@@ -99,7 +105,6 @@ export function useDestroyDialogState({
 					}
 				}
 				for (const warning of result.warnings) toast.warning(warning);
-				setDeleteBranch(false);
 				onDeleted?.();
 			} catch (err) {
 				const e = err as DestroyWorkspaceError;

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useNavigateAwayFromWorkspace/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useNavigateAwayFromWorkspace/index.ts
@@ -1,0 +1,1 @@
+export { useNavigateAwayFromWorkspace } from "./useNavigateAwayFromWorkspace";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useNavigateAwayFromWorkspace/useNavigateAwayFromWorkspace.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useNavigateAwayFromWorkspace/useNavigateAwayFromWorkspace.ts
@@ -1,0 +1,27 @@
+import { useNavigate, useParams } from "@tanstack/react-router";
+import { navigateToV2Workspace } from "renderer/routes/_authenticated/_dashboard/utils/workspace-navigation";
+import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
+import { getFlattenedV2WorkspaceIds } from "../../utils/getFlattenedV2WorkspaceIds";
+
+/**
+ * If the user is viewing the workspace about to be removed, jump to the
+ * next visible sidebar sibling (or home). No-op otherwise. Called
+ * directly at the callsite — not via a callback prop — because
+ * plumbing this through dialog onDeleting was silently dropping the nav.
+ */
+export function useNavigateAwayFromWorkspace() {
+	const navigate = useNavigate();
+	const params = useParams({ strict: false });
+	const collections = useCollections();
+
+	return (workspaceId: string) => {
+		if (params.workspaceId !== workspaceId) return;
+		const ids = getFlattenedV2WorkspaceIds(collections);
+		const next = ids.find((id) => id !== workspaceId);
+		if (next) {
+			void navigateToV2Workspace(next, navigate);
+		} else {
+			void navigate({ to: "/" });
+		}
+	};
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema.ts
@@ -242,6 +242,9 @@ export const v2UserPreferencesSchema = z.object({
 	id: z.literal("preferences"),
 	fileLinks: linkTierMapSchema.default(DEFAULT_LINK_TIER_MAP),
 	urlLinks: linkTierMapSchema.default(DEFAULT_LINK_TIER_MAP),
+	rightSidebarOpen: z.boolean().default(true),
+	rightSidebarTab: z.enum(["changes", "files"]).default("changes"),
+	deleteLocalBranch: z.boolean().default(false),
 });
 
 export type V2UserPreferencesRow = z.infer<typeof v2UserPreferencesSchema>;
@@ -252,4 +255,7 @@ export const DEFAULT_V2_USER_PREFERENCES: V2UserPreferencesRow = {
 	id: V2_USER_PREFERENCES_ID,
 	fileLinks: DEFAULT_LINK_TIER_MAP,
 	urlLinks: DEFAULT_LINK_TIER_MAP,
+	rightSidebarOpen: true,
+	rightSidebarTab: "changes",
+	deleteLocalBranch: false,
 };

--- a/packages/host-service/src/trpc/router/workspace-cleanup/workspace-cleanup.ts
+++ b/packages/host-service/src/trpc/router/workspace-cleanup/workspace-cleanup.ts
@@ -23,8 +23,10 @@ export const workspaceCleanupRouter = router({
 	 * Force semantics:
 	 *   - skips preflight (step 0)
 	 *   - skips teardown  (step 1)
-	 *   - upgrades `git branch -d` to `-D` in step 3c
 	 *   - step 3b always uses `--force` (we're past the commit point)
+	 *   - step 3c always uses `-D` regardless: the `deleteBranch`
+	 *     checkbox is the user's consent, so refusing unmerged branches
+	 *     would just silently drop the opt-in.
 	 *
 	 * Typed errors for the renderer:
 	 *   - CONFLICT             → dirty worktree; prompt force-retry
@@ -147,7 +149,7 @@ export const workspaceCleanupRouter = router({
 
 				if (input.deleteBranch && local.branch) {
 					try {
-						await git.raw(["branch", input.force ? "-D" : "-d", local.branch]);
+						await git.raw(["branch", "-D", local.branch]);
 						branchDeleted = true;
 					} catch (err) {
 						const message = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
## Summary

PR #9 マージ後の残差分: `#3681 persist 'also delete local branch' checkbox in v2 delete dialog` を取り込み。

もう 1 件候補の `#3697 split workspace-creation router` は **大規模 refactor** (workspace-creation.ts を 24 ファイルに split) で fork 独自拡張 (`baseBranchSource`, PR checkout, fork note 等) と全面衝突するため、本 PR から除外。別 refactor PR で対応予定。

## 取り込み内容

- `3f2bba985` fix(desktop): persist "also delete local branch" checkbox in v2 delete dialog (#3681)
- 追加 fix commit: useNavigateAwayFromWorkspace hook 補完、RightSidebarTab type 復元、lint 自動修正

## Conflict 解消

- **`dashboardSidebarLocal/schema.ts`**: upstream の `rightSidebarOpen`, `rightSidebarTab`, `deleteLocalBranch` preferences を schema に追加
- **`useV2UserPreferences.ts`**: setter 3 種類 + `RightSidebarTab` type export 追加 (fork で欠落していた)
- **`useDestroyDialogState.ts`**: `useNavigateAwayFromWorkspace` hook を導入し、delete 開始時に現 workspace からナビ脱出。fork の UX (toast なし・楽観削除) と共存

## 追加補完

`useNavigateAwayFromWorkspace` hook は PR #2b で取り込んだ `0bc1d0a0e (#3661)` で新規追加されたが、ファイル取りこぼしがあった。upstream から以下を補完:
- `apps/desktop/.../DashboardSidebar/hooks/useNavigateAwayFromWorkspace/useNavigateAwayFromWorkspace.ts`
- `apps/desktop/.../DashboardSidebar/hooks/useNavigateAwayFromWorkspace/index.ts`

## 除外した commit

- `167542eb4` (#3697 split workspace-creation router) — workspace-creation.ts を 24 ファイルに split する大規模 refactor。fork 独自拡張 (`baseBranchSource`, PR checkout, fork note, GitHub link command) と全面衝突。別 refactor PR で対応

## Fork 固有機能ヘルスチェック

baseline 一致:
- 19 tRPC プロシージャ
- `ansi_up`, `@vscode/ripgrep`, `@xyflow/react`
- `TERMINAL_OPTIONS`, `SUPERSET_WORKSPACE_NAME`, `moonshot-ai.kimi-code`
- desktop version 1.5.10, dmg.size=4g
- v1MigrationState, TiptapPromptEditor

## Test plan

- [x] `bun run typecheck` pass (27/27)
- [x] `bun run lint` pass
- [ ] v2 delete dialog の "also delete local branch" チェック状態が次回開く時に復元される
- [ ] delete 開始時に別 workspace へナビゲート
- [ ] 既存の v1 delete dialog UX に回帰なし

## 残差分

本 PR マージ後:
- `#3697 split workspace-creation router` — 別 refactor PR で (最大のタスク)
- その他 upstream 継続前進分 — 都度精査