### PR TITLE
upstream 取り込み PR #11: use task title as workspace name (#3678)

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/$taskId/components/PropertiesSidebar/components/OpenInWorkspace/OpenInWorkspace.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/$taskId/components/PropertiesSidebar/components/OpenInWorkspace/OpenInWorkspace.tsx
@@ -121,7 +121,7 @@ export function OpenInWorkspace({ task }: OpenInWorkspaceProps) {
 			const result = await createWorkspace.mutateAsyncWithPendingSetup(
 				{
 					projectId,
-					name: task.slug,
+					name: task.title,
 					branchName,
 				},
 				{ agentLaunchRequest: launchRequestTemplate ?? undefined },

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/components/TasksTopBar/components/RunInWorkspacePopover/RunInWorkspacePopover.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/components/TasksTopBar/components/RunInWorkspacePopover/RunInWorkspacePopover.tsx
@@ -174,7 +174,7 @@ export function RunInWorkspacePopover({
 				const result = await createWorkspace.mutateAsyncWithPendingSetup(
 					{
 						projectId: effectiveProjectId,
-						name: task.slug,
+						name: task.title,
 						branchName,
 					},
 					{ agentLaunchRequest: launchRequestTemplate ?? undefined },


### PR DESCRIPTION
## Summary

upstream `#3678` を軽量取り込み。1 commit / 2 files / +2 / -2 の最小変更。

## 取り込み内容

- `5611677d4` fix(desktop): use task title as workspace name when opening a task (#3678)

## 変更詳細

task を workspace として開く際の workspace name を、Linear/GitHub 識別子 (例: "SUPER-172") から人間向けタイトルに切り替え。branch 名は `deriveBranchName({slug, title})` のまま維持され、Linear/GitHub 識別子はトレーサビリティのため branch 側で保たれる。

変更ファイル:
- `apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/$taskId/components/PropertiesSidebar/components/OpenInWorkspace/OpenInWorkspace.tsx`
- `apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/$taskId/components/RunInWorkspacePopover/RunInWorkspacePopover.tsx`

## コンフリクト解消

なし (clean cherry-pick)。

## Fork 固有機能ヘルスチェック

本 PR は task UI の naming のみ変更。fork 固有機能 (19 procedure, TERMINAL_OPTIONS, SUPERSET_WORKSPACE_NAME, dmg.size, 依存, TiptapPromptEditor, v1MigrationState) には触れず、影響なし。

## Test plan

- [x] `bun install` 正常完了
- [x] `bun run typecheck` グリーン (27/27)
- [x] `bun run lint` グリーン
- [ ] task を workspace として開くと workspace 名がタイトル表記になる
- [ ] branch 名は従来通り `slug/title` 形式

## 残 upstream 取り込み

本 PR で計画 scope は実質完了。残る真の未取り込みは `#3697 split workspace-creation router` の 1 件のみ。これは fork 独自拡張 (baseBranchSource / PR checkout / fork note) と全面衝突する大規模 refactor で、別 refactor PR として別途対応予定。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * ワークスペース作成時のネーミングロジックを改善しました。ワークスペース作成時に、より意味のあるタスクタイトルをワークスペース名として使用するようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->