### PR TITLE
ci(desktop): タグ push で Linux AppImage/deb/rpm を自動ビルド

### DIFF
--- a/.github/workflows/release-desktop-linux-fork.yml
+++ b/.github/workflows/release-desktop-linux-fork.yml
@@ -1,0 +1,147 @@
+name: Release Desktop Linux (Fork)
+
+# フォーク独自の Linux パッケージ自動ビルドワークフロー。
+# `v*-fork.*` タグ push で発火し、AppImage / deb / rpm を ubuntu-latest 上で
+# ビルドして同名 Release に添付する。macOS リリースは現行通りローカルから
+# 手動で実施（AGENTS.md 参照）。
+
+on:
+  push:
+    tags:
+      - "v*-fork.*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing tag to (re)build Linux artifacts for (e.g. v1.5.5-fork.12)"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  build-linux:
+    name: Build Linux packages
+    # フォーク外での誤発火防止。upstream 取り込みなどで workflow が混入しても
+    # 別リポジトリでは no-op にする。
+    if: github.repository == 'MocA-Love/superset'
+    runs-on: ubuntu-latest
+    environment: production
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          # workflow_dispatch で既存タグを指定した場合はそのタグを、
+          # tag push で走った場合は github.ref (= refs/tags/v*-fork.*) を checkout。
+          ref: ${{ inputs.tag || github.ref }}
+          fetch-depth: 0
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version-file: .bun-version
+
+      - name: Install packaging tools
+        # ubuntu-latest には fakeroot / dpkg は標準で入っているが rpm は入っていない。
+        # electron-builder が rpm ターゲットを作るときに rpmbuild を呼ぶため必須。
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends rpm
+
+      - name: Cache bun dependencies
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: |
+            ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
+
+      - name: Install workspace dependencies
+        run: bun install --frozen --ignore-scripts
+
+      - name: Install desktop native dependencies
+        working-directory: apps/desktop
+        run: bun run install:deps
+
+      - name: Generate file icons
+        working-directory: apps/desktop
+        run: bun run generate:icons
+
+      - name: Compile app with electron-vite
+        working-directory: apps/desktop
+        env:
+          # フォーク/upstream 共通で必要な build-time 値。未設定 secrets は
+          # 空文字で bundle され起動時に graceful degradation する。
+          NEXT_PUBLIC_POSTHOG_KEY: ${{ secrets.NEXT_PUBLIC_POSTHOG_KEY }}
+          NEXT_PUBLIC_POSTHOG_HOST: ${{ secrets.NEXT_PUBLIC_POSTHOG_HOST }}
+          GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
+          GH_CLIENT_ID: ${{ secrets.GH_CLIENT_ID }}
+          NEXT_PUBLIC_WEB_URL: ${{ secrets.NEXT_PUBLIC_WEB_URL }}
+          NEXT_PUBLIC_API_URL: ${{ secrets.NEXT_PUBLIC_API_URL }}
+          NEXT_PUBLIC_DOCS_URL: ${{ secrets.NEXT_PUBLIC_DOCS_URL }}
+          NEXT_PUBLIC_STREAMS_URL: ${{ secrets.NEXT_PUBLIC_STREAMS_URL }}
+          NEXT_PUBLIC_ELECTRIC_URL: ${{ secrets.NEXT_PUBLIC_ELECTRIC_URL }}
+          SENTRY_DSN_DESKTOP: ${{ secrets.SENTRY_DSN_DESKTOP }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          RELAY_URL: ${{ secrets.RELAY_URL }}
+          # フォーク固有: 未指定だと bundle に "default" が焼き込まれて
+          # ワークスペースが空の初期状態を見に行ってしまう (AGENTS.md 参照)。
+          SUPERSET_WORKSPACE_NAME: superset
+        run: bun run compile:app
+
+      - name: Copy native modules and validate runtime
+        working-directory: apps/desktop
+        run: |
+          bun run copy:native-modules
+          bun run validate:native-runtime
+
+      - name: Build superset-browser-mcp single binary
+        # Bun は npm の pre/post フックを自動実行しないため、build:linux で
+        # electron-builder を叩く前に browser-mcp バイナリを明示的に生成する。
+        # これを忘れると AppImage/deb/rpm から Resources/resources/superset-browser-mcp/
+        # が脱落し、Connect モーダルで "Browser MCP binary is not available" トーストが出る
+        # (AGENTS.md / fork.12 で踏んだ過去の事故)。
+        working-directory: apps/desktop
+        run: bun run build:browser-mcp
+
+      - name: Build Linux packages (AppImage + deb + rpm)
+        working-directory: apps/desktop
+        run: bun run build:linux
+
+      - name: Verify Linux artifacts exist
+        working-directory: apps/desktop
+        run: |
+          ls -la release/
+          for pattern in "*.AppImage" "*.deb" "*.rpm" "*-linux.yml"; do
+            count=$(find release -maxdepth 1 -type f -name "$pattern" | wc -l)
+            if [ "$count" -eq 0 ]; then
+              echo "::error::No artifacts matched pattern '$pattern' in apps/desktop/release"
+              exit 1
+            fi
+          done
+
+      - name: Resolve target tag
+        id: resolve_tag
+        run: |
+          if [ -n "${{ inputs.tag }}" ]; then
+            TAG="${{ inputs.tag }}"
+          else
+            TAG="${GITHUB_REF_NAME}"
+          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "Release target tag: $TAG"
+
+      - name: Attach Linux artifacts to GitHub Release
+        # softprops/action-gh-release は既存 Release があればファイル追加、
+        # なければ作成する (macOS ビルドと競合した場合もファイル併合でよしなに処理)。
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
+        with:
+          tag_name: ${{ steps.resolve_tag.outputs.tag }}
+          fail_on_unmatched_files: true
+          files: |
+            apps/desktop/release/*.AppImage
+            apps/desktop/release/*.deb
+            apps/desktop/release/*.rpm
+            apps/desktop/release/*-linux.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-desktop-linux-fork.yml
+++ b/.github/workflows/release-desktop-linux-fork.yml
@@ -106,7 +106,13 @@ jobs:
 
       - name: Build Linux packages (AppImage + deb + rpm)
         working-directory: apps/desktop
-        run: bun run build:linux
+        # electron-builder を直接呼ぶ理由: workflow_dispatch で過去タグを
+        # backfill するとき、そのタグの package.json に `build:linux`
+        # スクリプトが無いケースがある。CLI を直接叩けば scripts に依存せず
+        # 過去リリースにも Linux パッケージを後乗せできる。
+        env:
+          CSC_IDENTITY_AUTO_DISCOVERY: "false"
+        run: bunx electron-builder --linux AppImage deb rpm --publish never
 
       - name: Verify Linux artifacts exist
         working-directory: apps/desktop

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,9 +130,15 @@ hdiutil detach "/Volumes/Superset 1.5.5-arm64"
 
 ### リリース (フォーク配布)
 
-このフォークには `release-desktop.yml` のような**自動リリースワークフローは無い**。タグ命名も upstream の `desktop-v*.*.*` ではなく **`v<package.json version>-fork.<N>`** (例: `v1.5.5-fork.9`) を使う。リリースはローカルでビルドし `gh release create` で GitHub Release を作る**手動運用**。
+タグ命名は upstream の `desktop-v*.*.*` ではなく **`v<package.json version>-fork.<N>`** (例: `v1.5.5-fork.9`) を使う。**macOS ビルドは手動**でローカルから `gh release create`、**Linux (AppImage / deb / rpm) ビルドはタグ push で自動**で走り同名 Release に添付されるハイブリッド運用。
+
+- macOS: ローカルで `bun run build` → `gh release create` で dmg / zip / latest-mac.yml をアップロード
+- Linux: `git push origin <tag>` の瞬間に [`.github/workflows/release-desktop-linux-fork.yml`](./.github/workflows/release-desktop-linux-fork.yml) が ubuntu-latest 上で発火し、AppImage + deb + rpm + latest-linux.yml を softprops/action-gh-release 経由で Release に添付する
+- 発火条件: `v*-fork.*` タグ push または workflow_dispatch (既存タグへ後乗せ用)
 
 `electron-builder.ts` の `publish` 設定は `superset-sh/superset` を向いたままなので、`bun run release` (electron-builder --publish always) は**使わない**。代わりに `bun run build` (`--publish never`) で成果物だけ作り、`gh` で MocA-Love/superset に上げる。
+
+upstream から取り込んだ `release-desktop.yml` は発火条件 (`desktop-v*.*.*`) がフォーク運用と合わないため、fork タグでは動かない (干渉しない)。
 
 #### 手順
 
@@ -185,12 +191,14 @@ SUPERSET_WORKSPACE_NAME=superset bun run build
 # 6. リリースノート作成 (後述フォーマット)
 # ファイルに保存しておくと gh release create の --notes-file で渡せる
 
-# 7. タグを切って push
+# 7. タグを切って push (← この瞬間 Linux CI が発火して並行ビルド開始)
 cd ../..
 git tag v1.5.5-fork.9
 git push origin v1.5.5-fork.9
 
-# 8. GitHub Release を作成し成果物をアップロード
+# 8. GitHub Release を作成し macOS 成果物をアップロード
+#    Linux 成果物 (AppImage / deb / rpm / latest-linux.yml) は CI が自動で
+#    追加するので、ここでは触らない。
 gh release create v1.5.5-fork.9 \
   --repo MocA-Love/superset \
   --title "v1.5.5-fork.9" \
@@ -199,9 +207,17 @@ gh release create v1.5.5-fork.9 \
   apps/desktop/release/Superset-*-mac.zip \
   apps/desktop/release/Superset-*-mac.zip.blockmap \
   apps/desktop/release/latest-mac.yml
+
+# 9. (任意) Linux CI の完了を確認。通常 5-10 分で完了する。
+gh run list --repo MocA-Love/superset --workflow="Release Desktop Linux (Fork)" --limit 3
 ```
 
-**注:** Windows / Linux ビルドは手元が macOS の場合は作成されない。必要なら各 OS で実行するか、GitHub Actions を別途仕立てる。upstream から取り込んだ `release-desktop.yml` は発火条件 (`desktop-v*.*.*`) がフォーク運用と合わないため、fork タグでは動かない。
+**注:**
+- **Linux 成果物は自動化**。`git push origin <tag>` 時点で `.github/workflows/release-desktop-linux-fork.yml` が ubuntu-latest 上で AppImage + deb + rpm + latest-linux.yml をビルドし、softprops/action-gh-release 経由で同名 Release に追加される。
+- **Windows ビルドは未対応**。必要なら Windows runner で別 workflow を立てる。
+- Linux CI が失敗した場合は `gh run rerun <run-id>` で再実行可能。タグ打ち直し (`git tag -d` → 再 push) でも再発火できる。
+- **既存の Release に後から Linux バイナリを追加**したい場合は `gh workflow run "Release Desktop Linux (Fork)" --ref main -f tag=v1.5.5-fork.9` のように workflow_dispatch で走らせる。
+- ローカル Linux/WSL で手動ビルドしたい場合は `apps/desktop` で `bun run build:linux` を叩く (AppImage + deb + rpm を一発生成)。
 
 #### リリースノート フォーマット
 

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -25,6 +25,7 @@
 		"build:browser-mcp": "bun --cwd ../../packages/superset-browser-mcp run build:bin",
 		"prebuild": "bun run clean:dev && bun run generate:icons && bun run compile:app && bun run copy:native-modules && bun run validate:native-runtime && bun run build:browser-mcp",
 		"build": "cross-env CSC_IDENTITY_AUTO_DISCOVERY=false electron-builder --publish never",
+		"build:linux": "cross-env CSC_IDENTITY_AUTO_DISCOVERY=false electron-builder --linux AppImage deb rpm --publish never",
 		"prepackage": "bun run copy:native-modules && bun run validate:native-runtime && bun run build:browser-mcp",
 		"package": "electron-builder --config electron-builder.ts",
 		"install:deps": "electron-builder install-app-deps",


### PR DESCRIPTION
## 概要

フォーク独自の Linux パッケージ自動ビルドワークフローを追加。`git push origin v*-fork.*` の瞬間に ubuntu-latest 上で AppImage + deb + rpm が並行ビルドされ、同名 GitHub Release に softprops/action-gh-release 経由で添付される。macOS ビルドは現行通りローカルから手動運用のままハイブリッド構成。

## 動機

これまでフォークのリリース成果物は **macOS の dmg / zip のみ**で、Linux ユーザは手動で AppImage を自前ビルドする必要があった。ubuntu-latest ランナーには rpm 以外の packaging 依存が既に揃っているので、CI に寄せれば「タグ push → 5〜10 分後に Release に Linux バイナリが並ぶ」世界が安いコストで実現できる。

## 追加ファイル

### `.github/workflows/release-desktop-linux-fork.yml`

| 項目 | 内容 |
|---|---|
| トリガー | `push: tags: [v*-fork.*]` / `workflow_dispatch` (既存タグ後乗せ) |
| Repo guard | `if: github.repository == 'MocA-Love/superset'` |
| Runner | ubuntu-latest (environment: production) |
| 追加依存 | `apt install -y rpm` のみ (fakeroot/dpkg は標準搭載) |
| ビルド手順 | compile:app → copy:native-modules → validate:native-runtime → build:browser-mcp → build:linux |
| Release 添付 | softprops/action-gh-release@v2 (fail_on_unmatched_files: true) |

actions/checkout / setup-bun / actions/cache / softprops は他の既存 workflow と同じ version で SHA pin。

### `apps/desktop/package.json` に `build:linux` 追加

\`\`\`json
\"build:linux\": \"cross-env CSC_IDENTITY_AUTO_DISCOVERY=false electron-builder --linux AppImage deb rpm --publish never\"
\`\`\`

electron-builder.ts の \`linux.target\` は **AppImage のみのまま触らず** に CLI 引数で override。これにより:
- upstream の \`release-desktop.yml\` / \`build-desktop.yml\` 挙動は一切変わらない (Linux は AppImage のみで互換)
- upstream 取り込み時の electron-builder.ts コンフリクトを回避
- Linux/WSL で手動ビルドしたいときは \`bun run build:linux\` で 3 フォーマット一発生成

### AGENTS.md 更新

「自動ワークフロー無し」という記述を **hybrid (Linux 自動 / macOS 手動)** に書き換え、リリース手順に CI 発火タイミング・後乗せ方法・ローカル build:linux の使い方を追記。

## 新しいリリースフロー

\`\`\`bash
# 従来どおり macOS でビルド + Release 作成
cd apps/desktop
export SUPERSET_WORKSPACE_NAME=superset
export \$(grep -v '^#' ../../.env | grep -E '^[A-Z_]+=' | tr '\n' ' ')
bun run compile:app && bun run copy:native-modules && bun run validate:native-runtime && bun run build:browser-mcp
SUPERSET_WORKSPACE_NAME=superset bun run build

cd ../..
git tag v1.5.5-fork.X
git push origin v1.5.5-fork.X  # ← この瞬間 Linux CI 発火

gh release create v1.5.5-fork.X \\
  --repo MocA-Love/superset \\
  --notes-file /tmp/notes.md \\
  apps/desktop/release/Superset-*.dmg \\
  apps/desktop/release/Superset-*-mac.zip \\
  apps/desktop/release/latest-mac.yml

# 5〜10 分後、Linux 成果物が自動で Release に追加される
gh run list --repo MocA-Love/superset --workflow=\"Release Desktop Linux (Fork)\" --limit 3
\`\`\`

## 採用した実装上の判断

- **x64 のみ**: ubuntu-latest の native arch。arm64 Linux は QEMU 経由でビルド時間 30 分超になるため別 Issue で段階導入
- **electron-builder.ts は不変**: upstream 取り込み時のコンフリクト回避 & 影響範囲最小化
- **secrets 未設定許容**: MocA-Love/superset 側で production environment の secrets (POSTHOG/SENTRY/OAuth 等) が未設定でも空文字 bundle で build 成功、起動可能
- **既存 Release への後乗せ**: \`gh workflow run \"Release Desktop Linux (Fork)\" --ref main -f tag=v1.5.5-fork.X\` で workflow_dispatch 可能

## Test plan

- [x] YAML 構文チェック (ruby yaml.load_file)
- [x] actionlint (via docker rhysd/actionlint) → warnings 0
- [x] \`bun run lint:fix\` → no fixes applied
- [ ] マージ後、次のフォークリリースで実際にタグを push して Linux 3 種が Release に並ぶことを確認
- [ ] \`gh workflow run\` で既存タグ (例: v1.5.5-fork.12) へ後乗せができることを確認

## Issue との関係

Issue #397 (Linux daemon persistence, PR #403) とは独立した配布改善で、並行して進めて問題ない。#403 がマージされた後、本 PR で配布された Linux パッケージ上で実際に systemd scope escape が効くかの検証も楽になる。

## 未対応 (スコープ外)

- **arm64 Linux**: 別 Issue で段階導入
- **Windows (.exe)**: Windows runner で別 workflow を立てる必要あり
- **Flathub 公開**: マニフェスト + サンドボックス対応 + 審査で別プロジェクト扱い