### PR TITLE
fix(todo-agent): ChangesSidebar の検知ロジック 6 件を修正

### DIFF
--- a/apps/desktop/src/main/todo-agent/git-status.ts
+++ b/apps/desktop/src/main/todo-agent/git-status.ts
@@ -11,12 +11,35 @@ import { execGitWithShellPath } from "lib/trpc/routers/workspaces/utils/git-clie
  * made before the session are never attributed to it.
  */
 
+/**
+ * Swallow-errors variant that returns "" on failure. Use when a failure
+ * is semantically equivalent to "no data" (e.g. `git rev-parse HEAD` on
+ * a repo with zero commits yet).
+ */
 async function gitOut(args: string[], cwd: string): Promise<string> {
 	try {
 		const { stdout } = await execGitWithShellPath(args, { cwd });
 		return stdout;
 	} catch {
 		return "";
+	}
+}
+
+/**
+ * Distinguish "git ran and returned empty" from "git failed". Needed for
+ * ahead/behind: `rev-list HEAD...@{u}` throws when no upstream is
+ * configured, which must be surfaced as `hasUpstream: false` in the UI
+ * rather than silently reported as "synced" (ahead = 0, behind = 0).
+ */
+async function gitOutOrNull(
+	args: string[],
+	cwd: string,
+): Promise<string | null> {
+	try {
+		const { stdout } = await execGitWithShellPath(args, { cwd });
+		return stdout;
+	} catch {
+		return null;
 	}
 }
 
@@ -57,19 +80,44 @@ export interface SessionGitFile {
 	stage: SessionGitFileStage;
 	/** Raw git status letter — M / A / D / R / C / U / ? */
 	code: string;
+	/**
+	 * Original path before rename/copy. Populated only when `code` is
+	 * `R` or `C`, so the UI can render `oldPath → path` instead of the
+	 * broken `old.ts -> new.ts` single string the non-`-z` porcelain
+	 * output used to stuff into `path`.
+	 */
+	oldPath?: string | null;
 }
 
 export interface SessionGitChangedFile {
 	path: string;
 	/** First letter of git's name-status code: A / M / D / R / C / T */
 	code: string;
+	/**
+	 * Original path, populated only for rename/copy entries. Lets the UI
+	 * render `oldPath → path` instead of losing the rename information.
+	 */
+	oldPath?: string | null;
 }
 
 export interface SessionGitSnapshot {
 	branch: string | null;
+	/**
+	 * True when HEAD is detached (not on a branch). Distinguishes a
+	 * detached HEAD from "ブランチ取得中…" (git rev-parse failed) so the
+	 * sidebar can show `(detached HEAD)` instead of misleadingly
+	 * labelling the current state as branch "HEAD".
+	 */
+	detachedHead: boolean;
 	startHeadSha: string | null;
 	currentHeadSha: string | null;
 	commits: SessionGitCommit[];
+	/**
+	 * True when `git log <range>` was truncated by `--max-count`. The UI
+	 * surfaces this so users know additional commits exist without
+	 * overwhelming the sidebar for sessions that produce 1000+ commits.
+	 */
+	commitsTruncated: boolean;
 	workingTree: SessionGitFile[];
 	/**
 	 * Files whose contents differ between `startHeadSha` and HEAD
@@ -89,10 +137,29 @@ export interface SessionGitSnapshot {
 	startHeadUnreachable: boolean;
 	ahead: number;
 	behind: number;
+	/**
+	 * True when the current branch has an upstream configured.
+	 * `ahead`/`behind` are only meaningful when this is true — without
+	 * it, the two fields are always zero and must not be rendered as
+	 * "synced" because they are simply unmeasured.
+	 */
+	hasUpstream: boolean;
 }
 
-const COMMIT_DELIM = "\x00";
-const COMMIT_FORMAT = ["%H", "%h", "%s", "%an", "%aI"].join(COMMIT_DELIM);
+// Field separator inside the %s (subject) etc. line. Unit Separator (US,
+// 0x1F) is control-class so real commit text basically never contains it,
+// and it plays nicely with `-z`'s record terminator (NUL).
+const COMMIT_FIELD_DELIM = "\x1f";
+const COMMIT_RECORD_DELIM = "\x00";
+const COMMIT_FORMAT = ["%H", "%h", "%s", "%an", "%aI"].join(COMMIT_FIELD_DELIM);
+
+/**
+ * Upper bound on commits fetched per snapshot. Protects the 3-second
+ * refetch loop from choking on sessions that produce hundreds of commits
+ * (e.g. long-running refactors). The UI surfaces the truncation state so
+ * users know the list is capped.
+ */
+const SESSION_COMMITS_MAX = 500;
 
 export async function getSessionGitSnapshot(params: {
 	cwd: string;
@@ -104,7 +171,13 @@ export async function getSessionGitSnapshot(params: {
 		gitOut(["rev-parse", "--abbrev-ref", "HEAD"], cwd),
 		gitOut(["rev-parse", "HEAD"], cwd),
 	]);
-	const branch = branchOut.trim() || null;
+	const branchRaw = branchOut.trim();
+	// `git rev-parse --abbrev-ref HEAD` returns the literal string
+	// `"HEAD"` when HEAD is detached, which is useless as a branch label
+	// and actively misleading in the sidebar. Collapse it to null and
+	// surface the detached state via a dedicated flag.
+	const detachedHead = branchRaw === "HEAD";
+	const branch = !branchRaw || detachedHead ? null : branchRaw;
 	const currentHeadSha = currentOut.trim() || null;
 
 	// Commits produced since the session started. Scoped to the range
@@ -113,6 +186,7 @@ export async function getSessionGitSnapshot(params: {
 	// return an empty list, and we surface cumulative file-level
 	// changes via `sessionFiles` below so the sidebar isn't empty.
 	let commits: SessionGitCommit[] = [];
+	let commitsTruncated = false;
 	let sessionFiles: SessionGitChangedFile[] = [];
 	let startHeadUnreachable = false;
 	if (startHeadSha && currentHeadSha && startHeadSha !== currentHeadSha) {
@@ -120,28 +194,36 @@ export async function getSessionGitSnapshot(params: {
 		if (!reachable) {
 			startHeadUnreachable = true;
 		} else {
+			// `-z` terminates each commit record with NUL and keeps
+			// multi-line values intact, so we no longer depend on
+			// commit subjects being newline-free. The fixed number of
+			// fields is separated by `\x1f` inside a single record.
+			// `--max-count` caps the response for runaway sessions.
 			const logOut = await gitOut(
 				[
 					"log",
+					"-z",
+					`--max-count=${SESSION_COMMITS_MAX + 1}`,
 					`${startHeadSha}..${currentHeadSha}`,
 					`--format=${COMMIT_FORMAT}`,
 				],
 				cwd,
 			);
-			commits = logOut
-				.split("\n")
-				.filter((l) => l.length > 0)
-				.map((line) => {
-					const [sha, shortSha, subject, authorName, authorDate] =
-						line.split(COMMIT_DELIM);
-					return {
-						sha: sha ?? "",
-						shortSha: shortSha ?? "",
-						subject: subject ?? "",
-						authorName: authorName ?? "",
-						authorDate: authorDate ?? "",
-					};
-				});
+			const records = logOut
+				.split(COMMIT_RECORD_DELIM)
+				.filter((r) => r.length > 0);
+			commits = records.slice(0, SESSION_COMMITS_MAX).map((rec) => {
+				const [sha, shortSha, subject, authorName, authorDate] =
+					rec.split(COMMIT_FIELD_DELIM);
+				return {
+					sha: sha ?? "",
+					shortSha: shortSha ?? "",
+					subject: subject ?? "",
+					authorName: authorName ?? "",
+					authorDate: authorDate ?? "",
+				};
+			});
+			commitsTruncated = records.length > SESSION_COMMITS_MAX;
 
 			// `git diff --name-status -z A B` compares the two commits
 			// directly (two-dot in diff has no range semantics), so it
@@ -156,66 +238,57 @@ export async function getSessionGitSnapshot(params: {
 		}
 	}
 
-	// Working tree state via porcelain v1 for stable parsing.
+	// Working tree state via `--porcelain=v1 -z`. The `-z` flag is
+	// *required* here — without it, rename entries come out as
+	// `"old.ts -> new.ts"` stuffed into a single line, which then ends
+	// up as `file.path` and breaks the downstream `git diff --cached --
+	// <path>` call (there is no literal file named `"old.ts -> new.ts"`
+	// in git's index). Paths containing spaces or non-ASCII characters
+	// also get C-quoted without `-z`, which the split-by-newline parser
+	// can't undo. Using `-z` preserves both correctness and the ability
+	// to diff the file the user clicks on.
 	const statusOut = await gitOut(
-		["status", "--porcelain=v1", "--untracked-files=all"],
+		["status", "--porcelain=v1", "-z", "--untracked-files=all"],
 		cwd,
 	);
-	const workingTree: SessionGitFile[] = [];
-	const seen = new Set<string>();
-	for (const line of statusOut.split("\n")) {
-		if (line.length < 3) continue;
-		const indexStatus = line[0] ?? " ";
-		const wtStatus = line[1] ?? " ";
-		const filePath = line.slice(3);
-		const key = `${filePath}|${indexStatus}${wtStatus}`;
-		if (seen.has(key)) continue;
-		seen.add(key);
-		if (indexStatus === "?" && wtStatus === "?") {
-			workingTree.push({ path: filePath, stage: "untracked", code: "?" });
-			continue;
-		}
-		if (indexStatus !== " " && indexStatus !== "?") {
-			workingTree.push({
-				path: filePath,
-				stage: "staged",
-				code: indexStatus,
-			});
-		}
-		if (wtStatus !== " " && wtStatus !== "?") {
-			workingTree.push({
-				path: filePath,
-				stage: "unstaged",
-				code: wtStatus,
-			});
-		}
-	}
+	const workingTree: SessionGitFile[] = parsePorcelainV1Nul(statusOut);
 
 	// Ahead/behind relative to upstream, if configured. Failure is
-	// expected when no upstream is set, so swallow silently.
+	// expected when no upstream is set, so we distinguish it from
+	// "synced" by returning null from `gitOutOrNull` and propagating
+	// that through `hasUpstream`.
 	let ahead = 0;
 	let behind = 0;
-	const rlOut = (
-		await gitOut(["rev-list", "--left-right", "--count", "HEAD...@{u}"], cwd)
-	).trim();
-	if (rlOut) {
-		const parts = rlOut.split(/\s+/);
-		if (parts.length === 2) {
-			ahead = Number(parts[0]) || 0;
-			behind = Number(parts[1]) || 0;
+	let hasUpstream = false;
+	const rlOut = await gitOutOrNull(
+		["rev-list", "--left-right", "--count", "HEAD...@{u}"],
+		cwd,
+	);
+	if (rlOut !== null) {
+		const trimmed = rlOut.trim();
+		if (trimmed) {
+			const parts = trimmed.split(/\s+/);
+			if (parts.length === 2) {
+				ahead = Number(parts[0]) || 0;
+				behind = Number(parts[1]) || 0;
+				hasUpstream = true;
+			}
 		}
 	}
 
 	return {
 		branch,
+		detachedHead,
 		startHeadSha,
 		currentHeadSha,
 		commits,
+		commitsTruncated,
 		workingTree,
 		sessionFiles,
 		startHeadUnreachable,
 		ahead,
 		behind,
+		hasUpstream,
 	};
 }
 
@@ -223,9 +296,9 @@ export async function getSessionGitSnapshot(params: {
  * Parse `git diff --name-status -z` output.
  *
  * Standard entries are `<CODE>\0<path>\0`; rename/copy entries are
- * `<CODE><score>\0<oldPath>\0<newPath>\0` — we keep only the new path
- * and collapse the code to its first letter so the UI can render a
- * single badge per file.
+ * `<CODE><score>\0<oldPath>\0<newPath>\0` — we keep the new path as
+ * `path` and retain the old path as `oldPath` so the UI can render
+ * `oldPath → path` instead of losing the rename information.
  */
 function parseNameStatusNul(raw: string): SessionGitChangedFile[] {
 	const files: SessionGitChangedFile[] = [];
@@ -239,8 +312,15 @@ function parseNameStatusNul(raw: string): SessionGitChangedFile[] {
 		}
 		const letter = token[0] ?? "";
 		if (letter === "R" || letter === "C") {
+			const oldPath = parts[i + 1] ?? null;
 			const newPath = parts[i + 2];
-			if (newPath) files.push({ path: newPath, code: letter });
+			if (newPath) {
+				files.push({
+					path: newPath,
+					code: letter,
+					oldPath: oldPath || null,
+				});
+			}
 			i += 3;
 			continue;
 		}
@@ -249,6 +329,76 @@ function parseNameStatusNul(raw: string): SessionGitChangedFile[] {
 		i += 2;
 	}
 	return files;
+}
+
+/**
+ * Parse `git status --porcelain=v1 -z --untracked-files=all` output.
+ *
+ * Each entry is `XY<space>path\0`. Rename/copy entries additionally
+ * carry the *old* path as the next NUL-terminated token (i.e.
+ * `R<space><space>newpath\0oldpath\0`). Collapsing that into a single
+ * `SessionGitFile` keeps the downstream `git diff --cached -- <path>`
+ * lookup working (it needs the *new* path, not `old -> new`).
+ */
+function parsePorcelainV1Nul(raw: string): SessionGitFile[] {
+	const out: SessionGitFile[] = [];
+	const seen = new Set<string>();
+	const entries = raw.split("\0");
+	let i = 0;
+	// Trailing NUL produces an empty final segment; the loop guards on
+	// `entry.length < 3` so no special-case is required.
+	while (i < entries.length) {
+		const entry = entries[i];
+		if (!entry || entry.length < 3) {
+			i += 1;
+			continue;
+		}
+		const indexStatus = entry[0] ?? " ";
+		const wtStatus = entry[1] ?? " ";
+		const filePath = entry.slice(3);
+		const isRenameOrCopy =
+			indexStatus === "R" ||
+			indexStatus === "C" ||
+			wtStatus === "R" ||
+			wtStatus === "C";
+		let oldPath: string | null = null;
+		if (isRenameOrCopy) {
+			const oldPathToken = entries[i + 1];
+			oldPath = oldPathToken && oldPathToken.length > 0 ? oldPathToken : null;
+			// Consume both the header entry and the trailing old-path token so
+			// the outer loop doesn't re-parse the old path as a standalone
+			// entry (which would emit a bogus duplicate file row).
+			i += 2;
+		} else {
+			i += 1;
+		}
+
+		const key = `${filePath}|${indexStatus}${wtStatus}`;
+		if (seen.has(key)) continue;
+		seen.add(key);
+
+		if (indexStatus === "?" && wtStatus === "?") {
+			out.push({ path: filePath, stage: "untracked", code: "?" });
+			continue;
+		}
+		if (indexStatus !== " " && indexStatus !== "?") {
+			out.push({
+				path: filePath,
+				stage: "staged",
+				code: indexStatus,
+				oldPath: indexStatus === "R" || indexStatus === "C" ? oldPath : null,
+			});
+		}
+		if (wtStatus !== " " && wtStatus !== "?") {
+			out.push({
+				path: filePath,
+				stage: "unstaged",
+				code: wtStatus,
+				oldPath: wtStatus === "R" || wtStatus === "C" ? oldPath : null,
+			});
+		}
+	}
+	return out;
 }
 
 export type SessionDiffScope = "session" | "staged" | "unstaged" | "commit";

--- a/apps/desktop/src/renderer/features/todo-agent/TodoManager/ChangesSidebar/ChangesSidebar.tsx
+++ b/apps/desktop/src/renderer/features/todo-agent/TodoManager/ChangesSidebar/ChangesSidebar.tsx
@@ -71,6 +71,7 @@ export function ChangesSidebar({ sessionId, active }: ChangesSidebarProps) {
 
 	const data = snapshot.data;
 	const commits = data?.commits ?? [];
+	const commitsTruncated = data?.commitsTruncated ?? false;
 	const workingTree = data?.workingTree ?? [];
 	const sessionFiles = data?.sessionFiles ?? [];
 	const startHeadUnreachable = data?.startHeadUnreachable ?? false;
@@ -106,6 +107,10 @@ export function ChangesSidebar({ sessionId, active }: ChangesSidebarProps) {
 								<span className="font-mono text-xs">{data.branch}</span>
 							</TooltipContent>
 						</Tooltip>
+					) : data?.detachedHead ? (
+						<div className="text-xs truncate">
+							<span className="text-muted-foreground">(detached HEAD)</span>
+						</div>
 					) : (
 						<div className="text-xs truncate">
 							<span className="text-muted-foreground">（ブランチ取得中…）</span>
@@ -143,9 +148,15 @@ export function ChangesSidebar({ sessionId, active }: ChangesSidebarProps) {
 									</>
 								) : null}
 							</div>
-							{(data.ahead > 0 || data.behind > 0) && (
+							{data.hasUpstream ? (
+								data.ahead > 0 || data.behind > 0 ? (
+									<div className="text-[10px] text-muted-foreground mt-1">
+										↑ {data.ahead} · ↓ {data.behind}
+									</div>
+								) : null
+							) : (
 								<div className="text-[10px] text-muted-foreground mt-1">
-									↑ {data.ahead} · ↓ {data.behind}
+									upstream 未設定
 								</div>
 							)}
 						</div>
@@ -198,6 +209,9 @@ export function ChangesSidebar({ sessionId, active }: ChangesSidebarProps) {
 								) : (
 									sessionFiles.map((file) => {
 										const key = `session:${file.path}`;
+										const displayPath = file.oldPath
+											? `${file.oldPath} → ${file.path}`
+											: file.path;
 										// Deletions ARE the diff at session scope —
 										// `git diff <start>..HEAD -- <path>` still emits
 										// a valid deletion patch, so keep every entry
@@ -214,7 +228,7 @@ export function ChangesSidebar({ sessionId, active }: ChangesSidebarProps) {
 																key,
 																path: file.path,
 																scope: "session",
-																label: file.path,
+																label: displayPath,
 															})
 														}
 														className={cn(
@@ -225,13 +239,13 @@ export function ChangesSidebar({ sessionId, active }: ChangesSidebarProps) {
 													>
 														<StatusBadge code={file.code} stage="session" />
 														<span className="text-[11px] font-mono truncate flex-1">
-															{file.path}
+															{displayPath}
 														</span>
 													</button>
 												</TooltipTrigger>
 												<TooltipContent side="left" align="start">
 													<span className="font-mono text-[11px] break-all">
-														{file.path}
+														{displayPath}
 													</span>
 												</TooltipContent>
 											</Tooltip>
@@ -256,11 +270,18 @@ export function ChangesSidebar({ sessionId, active }: ChangesSidebarProps) {
 							)}
 							コミット
 							<span className="ml-1 text-muted-foreground/70">
-								({commits.length})
+								({commits.length}
+								{commitsTruncated ? "+" : ""})
 							</span>
 						</button>
 						{commitsOpen && (
 							<div className="flex flex-col gap-1">
+								{commitsTruncated && (
+									<p className="text-[10px] text-muted-foreground px-1 pb-1 border-b border-border/30">
+										表示は上限 {commits.length}{" "}
+										件まで。実際にはこれより多くのコミットがあります。
+									</p>
+								)}
 								{commits.length === 0 ? (
 									<p className="text-[11px] text-muted-foreground px-1 py-2">
 										このセッションでの新規コミットはありません。
@@ -362,6 +383,9 @@ export function ChangesSidebar({ sessionId, active }: ChangesSidebarProps) {
 											file.stage === "staged" ? "staged" : "unstaged";
 										const canDiff =
 											file.stage !== "untracked" && file.code !== "D";
+										const displayPath = file.oldPath
+											? `${file.oldPath} → ${file.path}`
+											: file.path;
 										return (
 											<Tooltip key={key} delayDuration={300}>
 												<TooltipTrigger asChild>
@@ -374,7 +398,7 @@ export function ChangesSidebar({ sessionId, active }: ChangesSidebarProps) {
 																key,
 																path: file.path,
 																scope,
-																label: file.path,
+																label: displayPath,
 															});
 														}}
 														className={cn(
@@ -386,13 +410,13 @@ export function ChangesSidebar({ sessionId, active }: ChangesSidebarProps) {
 													>
 														<StatusBadge code={file.code} stage={file.stage} />
 														<span className="text-[11px] font-mono truncate flex-1">
-															{file.path}
+															{displayPath}
 														</span>
 													</button>
 												</TooltipTrigger>
 												<TooltipContent side="left" align="start">
 													<span className="font-mono text-[11px] break-all">
-														{file.path}
+														{displayPath}
 													</span>
 												</TooltipContent>
 											</Tooltip>


### PR DESCRIPTION
Issue #419 の調査の副産物として、Agent Manager の右側 ChangesSidebar（コミット / セッション全体 / ワーキングツリー）のバグと UX 問題を 6 件洗い出したのでまとめて潰しました。

## 何を直したか

### 1. Rename ファイルの path 破損（実害バグ）
`apps/desktop/src/main/todo-agent/git-status.ts` が `git status --porcelain=v1` を `-z` なしで呼んでいたため、rename エントリーが `"old.ts -> new.ts"` という単一文字列として `file.path` に入っていました。これを `git diff --cached -- "old.ts -> new.ts"` に渡すと該当ファイルが存在しないので **rename されたファイルをクリックしても diff が常に空**になっていました。

- `--porcelain=v1 -z` に切り替え、rename/copy のときは次の NUL-terminated token を「旧パス」として読み取り、`oldPath` フィールドに保持。
- UI では `oldPath → path` の形で表示し、クリック時の diff は新パスに対して正しく発行される。

### 2. detached HEAD が branch "HEAD" として表示
`git rev-parse --abbrev-ref HEAD` は detached HEAD 時に文字列 `"HEAD"` を返します。それがそのまま branch 名として UI に表示されていて、あたかも「HEAD」というブランチにいるように見えていました。

- `detachedHead: boolean` を snapshot に追加。
- ChangesSidebar は `(detached HEAD)` として明示。

### 3. upstream 未設定と「同期済み」が区別不能
`rev-list --left-right --count HEAD...@{u}` は upstream が無いと例外を投げますが、既存ヘルパ `gitOut` が全て `""` に丸めていたため `ahead=0 / behind=0` となり、UI 上は「upstream と同期済み」と誤認されていました。

- `gitOutOrNull` を追加して null / 空文字を区別。
- `hasUpstream: boolean` を snapshot に追加し、UI は upstream 未設定時に「upstream 未設定」と出す。

### 4. Rename/Copy の旧パス情報が消失（sessionFiles 側）
`parseNameStatusNul` は R / C エントリーの oldPath を読んでから捨てていました。

- `SessionGitChangedFile.oldPath?` を追加して保持し、「セッション全体」セクションで `oldPath → newPath` の形で表示。

### 5. コミットリストに上限なし
`git log <range>` の結果件数に制限が無く、長時間セッションで 1000 件単位のコミットが積まれると 3 秒ごとの refetch で UI が重くなる可能性がありました。

- `--max-count=501` で取得、最大 500 件を保持。
- 超過時は `commitsTruncated: true` を返し、UI は件数の後ろに `+` を付けて truncation を明示。

### 6. \`git log\` のパースが newline split 依存
`\n` 区切りは commit subject / author name が改行を含むと壊れます（頻度は低いが）。

- `git log -z` + Unit Separator (`\x1f`) でフィールド区切りに切り替え、NUL-terminated レコードから field-level に分解する堅牢な方式に。

## 影響範囲

- 挙動ベース: ChangesSidebar の rename 表示・detached HEAD 表示・upstream 未設定表示が正しくなる。rename ファイルをクリックしたときに diff が出るようになる（今までは空のまま）。
- API: `SessionGitSnapshot` / `SessionGitFile` / `SessionGitChangedFile` にフィールドが増えるのみ（非破壊）。
- パフォーマンス: コミット取得が 500 件上限に。

## 検証
- [x] \`bun run lint\`
- [x] \`bun run typecheck\` (27/27 successful)
- [ ] 手動動作確認（rename / detached HEAD / upstream なしの 3 ケース）

## 関連
Issue #419 の調査から派生したバグ修正。Issue 本体（PR 検知 / UI 整理 / PTY タイムアウト）は別 PR で対応予定。