### PR TITLE
fix(desktop): vibrancy 有効時に codex / Claude Code の TUI 背景が黒く残る問題を修正

### DIFF
--- a/apps/desktop/src/renderer/globals.css
+++ b/apps/desktop/src/renderer/globals.css
@@ -155,6 +155,20 @@
 	background-color: var(--background-solid);
 }
 
+/*
+ * xterm.js WebGL RectangleRenderer hardcodes alpha=1 for cells with explicit
+ * palette/RGB backgrounds (_updateRectangle in @xterm/addon-webgl), so codex
+ * and Claude Code TUI blocks render as opaque black rectangles even when the
+ * terminal theme background is rgba(0,0,0,0). Mirror Warp's approach by
+ * scaling the whole xterm canvas with the same alpha used for chrome surfaces
+ * — blends every rendered pixel (default bg, explicit bg, glyphs) uniformly
+ * with the vibrancy layer. Scoped to the dedicated attach div so the search
+ * UI and scroll overlays in Terminal.tsx keep full opacity.
+ */
+:root[data-vibrancy="on"] .xterm-vibrancy-layer {
+	opacity: var(--vibrancy-alpha);
+}
+
 :root[data-vibrancy="on"].light {
 	--background: rgb(255 255 255 / var(--vibrancy-alpha));
 	--card: rgb(255 255 255 / min(1, calc(var(--vibrancy-alpha) + 0.1)));

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/Terminal.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/Terminal.tsx
@@ -605,7 +605,7 @@ export const Terminal = memo(function Terminal({
 			<div className="h-full w-full min-h-0 min-w-0 overflow-hidden p-2">
 				<div
 					ref={terminalRef}
-					className="h-full w-full min-h-0 min-w-0 overflow-hidden"
+					className="xterm-vibrancy-layer h-full w-full min-h-0 min-w-0 overflow-hidden"
 				/>
 			</div>
 			{xtermInstance && typingPreviewText && (


### PR DESCRIPTION
## 背景

ウィンドウ透過 (Settings → Appearance → ウィンドウ透過 macOS) を有効にしても、`apps/desktop` 内のターミナルで **codex / Claude Code の TUI ブロック背景だけ黒く不透明に残ってしまう** 問題があった。空セル（プロンプト周りの余白）は透けているのに、TUI のパネルや状態行だけ黒いままで、Warp のような綺麗な透過が得られない。

## 原因

`useEffectiveTerminalTheme` (`apps/desktop/src/renderer/stores/vibrancy/store.ts`) が vibrancy 有効時に xterm の `theme.background` を `rgba(0, 0, 0, 0)` に差し替えるが、これが効くのは **`CM_DEFAULT` のセルだけ**。

xterm.js の WebGL アドオン (`@xterm/addon-webgl` の `RectangleRenderer._updateRectangle`) は、`CM_P16 / CM_P256 / CM_RGB` のセル（= `\x1b[40m` / `\x1b[48;5;0m` / `\x1b[48;2;0;0;0m` 等で codex / Claude Code が引く明示背景）については **`$a = 1` をハードコード** していて、`theme.ansi[]` に alpha を指定しても無視されてしまう。結果として明示背景セルが opaque black で残り続ける。

Warp 等は compositor レベルで全ピクセルに一律透過をかけているため、明示背景セルも文字もまとめて背景に溶ける（テキストもわずかに減光するが可読性は保たれる）。

## 修正方針

3 案を比較検討（案 A: CSS opacity / 案 B: WebglAddon を runtime monkey-patch / 案 C: PTY ストリームの SGR 書き換え）し、案 A を採用。

- 案 A: `--vibrancy-alpha` を使って xterm の attach div に CSS `opacity` を適用するだけ。既存の `--vibrancy-alpha` / `data-vibrancy="on"` / `previewOpacity` 連携にそのまま乗れる。
- 案 B は `(webglAddon as any)._renderer._rectangleRenderer` 等の private 経路依存で、xterm.js 6.1.0-beta が bump した際に壊れる恐れあり。
- 案 C は SGR のパース・副作用（他 TUI の意図的な黒背景まで潰す）でリスク過多。

Codex に 4 軸（正しさ / 保守性 / 性能 / 既存整合）で分析させた上での推奨も案 A。

## 変更内容

- `apps/desktop/src/renderer/globals.css`: `:root[data-vibrancy=\"on\"] .xterm-vibrancy-layer { opacity: var(--vibrancy-alpha); }` を追加。コメントで WebGL 側の根本原因を記述。
- `apps/desktop/src/renderer/.../Terminal/Terminal.tsx`: xterm の attach 用 div にだけ `xterm-vibrancy-layer` クラスを付与（検索 UI / スクロールオーバーレイ / killed オーバーレイは対象外）。

合計 2 ファイル、+15 / -1 行。

## 効果

- 空セル: `rgba(0,0,0,0) × α = 0` → 従来通り完全透過。
- 明示 BG セル (codex / Claude Code ブロック): `opaque × α` → 背景に半透過で溶ける（Warp 相当）。
- 文字: `× α` だけ減光（Warp と同等のトレードオフ）。
- vibrancy OFF 時は `data-vibrancy=\"on\"` ガードで完全にゼロ影響。
- スライダードラッグ中のライブプレビューも `previewOpacity` が `--vibrancy-alpha` CSS 変数を書き換えるだけなので、React 再レンダ無しで反映される。

## 注意点

- 低 opacity (例: 30%) に設定するとテキストもその分薄くなる。Warp と同じ挙動だが、主観的な可読性は好み次第。
- tearoff ウィンドウでも同じ `globals.css` が効くので追加対応不要。
- WebGL コンテキストロスト → 再生成経路 (`terminal-addons.ts`) でも DOM 側の class はそのままなので再接続後も維持される。

## Test plan

- [ ] `bun dev` で desktop を起動し、Settings → Appearance → ウィンドウ透過を ON にする。
- [ ] ターミナルで `codex` を起動し、TUI ブロック背景が不透明な黒矩形ではなく、vibrancy で透けることを確認。
- [ ] `claude` (Claude Code) も同様に確認。
- [ ] 不透明度スライダーをドラッグしてライブプレビューが効くことを確認。
- [ ] 不透明度 100% にしたとき、ターミナル全体が通常通り表示されることを確認。
- [ ] vibrancy OFF に戻したとき、以前と完全に同じ見た目であることを確認。
- [ ] 検索バー (Cmd+F) と Scroll-to-bottom ボタンが opacity の影響を受けていないことを確認。