### PR TITLE
upstream: 2026-04-25 batch (PR A) — picker/workspace/diff/Tiptap/terminal lifecycle 8 件

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/projects/projects.ts
+++ b/apps/desktop/src/lib/trpc/routers/projects/projects.ts
@@ -480,7 +480,12 @@ export const createProjectsRouter = (getWindow: () => BrowserWindow | null) => {
 		}),
 
 		listPullRequests: publicProcedure
-			.input(z.object({ projectId: z.string() }))
+			.input(
+				z.object({
+					projectId: z.string(),
+					includeClosed: z.boolean().optional(),
+				}),
+			)
 			.query(async ({ input }) => {
 				const project = localDb
 					.select()
@@ -496,7 +501,7 @@ export const createProjectsRouter = (getWindow: () => BrowserWindow | null) => {
 							"pr",
 							"list",
 							"--state",
-							"open",
+							input.includeClosed ? "all" : "open",
 							"--limit",
 							"30",
 							"--json",
@@ -517,6 +522,7 @@ export const createProjectsRouter = (getWindow: () => BrowserWindow | null) => {
 				z.object({
 					projectId: z.string(),
 					query: z.string(),
+					includeClosed: z.boolean().optional(),
 				}),
 			)
 			.query(async ({ input }) => {
@@ -534,7 +540,7 @@ export const createProjectsRouter = (getWindow: () => BrowserWindow | null) => {
 							"pr",
 							"list",
 							"--state",
-							"all",
+							input.includeClosed ? "all" : "open",
 							"--search",
 							input.query,
 							"--limit",
@@ -553,7 +559,12 @@ export const createProjectsRouter = (getWindow: () => BrowserWindow | null) => {
 			}),
 
 		listIssues: publicProcedure
-			.input(z.object({ projectId: z.string() }))
+			.input(
+				z.object({
+					projectId: z.string(),
+					includeClosed: z.boolean().optional(),
+				}),
+			)
 			.query(async ({ input }) => {
 				const project = localDb
 					.select()
@@ -569,7 +580,7 @@ export const createProjectsRouter = (getWindow: () => BrowserWindow | null) => {
 							"issue",
 							"list",
 							"--state",
-							"open",
+							input.includeClosed ? "all" : "open",
 							"--limit",
 							"30",
 							"--json",

--- a/apps/desktop/src/renderer/components/Chat/ChatInterface/components/ChatInputFooter/ChatInputFooter.tsx
+++ b/apps/desktop/src/renderer/components/Chat/ChatInterface/components/ChatInputFooter/ChatInputFooter.tsx
@@ -51,6 +51,7 @@ interface ChatInputFooterProps {
 	pendingQuestion?: {
 		questionId: string;
 		question: string;
+		description?: string;
 		options?: { label: string; description?: string }[];
 	} | null;
 	isQuestionSubmitting?: boolean;

--- a/apps/desktop/src/renderer/components/Chat/ChatInterface/components/ChatInputFooter/components/QuestionInputOverlay/QuestionInputOverlay.tsx
+++ b/apps/desktop/src/renderer/components/Chat/ChatInterface/components/ChatInputFooter/components/QuestionInputOverlay/QuestionInputOverlay.tsx
@@ -9,6 +9,7 @@ interface QuestionInputOverlayProps {
 	question: {
 		questionId: string;
 		question: string;
+		description?: string;
 		options?: QuestionOption[];
 	};
 	isSubmitting: boolean;
@@ -63,9 +64,16 @@ export function QuestionInputOverlay({
 		<div className="flex max-h-[300px] flex-col overflow-hidden rounded-[13px] border-[0.5px] border-border bg-foreground/[0.02]">
 			{/* Question — pinned header */}
 			<div className="flex shrink-0 items-start gap-2 px-3 pt-3 pb-3">
-				<p className="flex-1 text-sm leading-snug text-foreground">
-					{question.question}
-				</p>
+				<div className="flex-1 space-y-1">
+					<p className="text-sm leading-snug text-foreground">
+						{question.question}
+					</p>
+					{question.description && (
+						<p className="text-xs leading-snug text-muted-foreground">
+							{question.description}
+						</p>
+					)}
+				</div>
 				<Tooltip>
 					<TooltipTrigger asChild>
 						<button

--- a/apps/desktop/src/renderer/components/Chat/ChatInterface/components/IssueLinkCommand/IssueLinkCommand.tsx
+++ b/apps/desktop/src/renderer/components/Chat/ChatInterface/components/IssueLinkCommand/IssueLinkCommand.tsx
@@ -1,3 +1,4 @@
+import { Checkbox } from "@superset/ui/checkbox";
 import {
 	Command,
 	CommandEmpty,
@@ -11,7 +12,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { useLiveQuery } from "@tanstack/react-db";
 import Fuse from "fuse.js";
 import type { ReactNode } from "react";
-import { useMemo, useState } from "react";
+import { useId, useMemo, useState } from "react";
 import {
 	StatusIcon,
 	type StatusType,
@@ -19,6 +20,10 @@ import {
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 
 const MAX_RESULTS = 20;
+
+function isClosedStatus(type: StatusType | undefined): boolean {
+	return type === "completed" || type === "canceled";
+}
 
 interface IssueLinkCommandProps {
 	children: ReactNode;
@@ -38,6 +43,8 @@ export function IssueLinkCommand({
 }: IssueLinkCommandProps) {
 	const [open, setOpen] = useState(false);
 	const [searchQuery, setSearchQuery] = useState("");
+	const [showClosed, setShowClosed] = useState(false);
+	const showClosedId = useId();
 	const collections = useCollections();
 
 	const { data: allTasks } = useLiveQuery(
@@ -82,21 +89,35 @@ export function IssueLinkCommand({
 
 	const taskFuse = useMemo(
 		() =>
-			new Fuse(allTasks ?? [], {
-				keys: [
-					{ name: "slug", weight: 3 },
-					{ name: "title", weight: 2 },
-				],
-				threshold: 0.4,
-				ignoreLocation: true,
-			}),
-		[allTasks],
+			new Fuse(
+				(allTasks ?? []).filter((task) => {
+					if (showClosed) return true;
+					const status = task.statusId
+						? statusMap.get(task.statusId)
+						: undefined;
+					return !isClosedStatus(status?.type);
+				}),
+				{
+					keys: [
+						{ name: "slug", weight: 3 },
+						{ name: "title", weight: 2 },
+					],
+					threshold: 0.4,
+					ignoreLocation: true,
+				},
+			),
+		[allTasks, showClosed, statusMap],
 	);
 
 	const filteredTasks = useMemo(() => {
 		if (!allTasks?.length) return [];
+		const visibleTasks = allTasks.filter((task) => {
+			if (showClosed) return true;
+			const status = task.statusId ? statusMap.get(task.statusId) : undefined;
+			return !isClosedStatus(status?.type);
+		});
 		if (!searchQuery) {
-			return [...allTasks]
+			return visibleTasks
 				.sort(
 					(a, b) =>
 						new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime(),
@@ -106,7 +127,7 @@ export function IssueLinkCommand({
 		return taskFuse
 			.search(searchQuery, { limit: MAX_RESULTS })
 			.map((r) => r.item);
-	}, [allTasks, searchQuery, taskFuse]);
+	}, [allTasks, searchQuery, showClosed, statusMap, taskFuse]);
 
 	const handleSelect = (
 		slug: string,
@@ -145,12 +166,35 @@ export function IssueLinkCommand({
 						value={searchQuery}
 						onValueChange={setSearchQuery}
 					/>
+					<div className="flex items-center gap-2 border-b px-3 py-2">
+						<Checkbox
+							id={showClosedId}
+							checked={showClosed}
+							onCheckedChange={(checked) => setShowClosed(checked === true)}
+						/>
+						<label
+							htmlFor={showClosedId}
+							className="cursor-pointer select-none text-xs text-muted-foreground"
+						>
+							Show closed
+						</label>
+					</div>
 					<CommandList className="max-h-[280px]">
 						{filteredTasks.length === 0 && (
-							<CommandEmpty>No issues found.</CommandEmpty>
+							<CommandEmpty>
+								{showClosed ? "No issues found." : "No open issues found."}
+							</CommandEmpty>
 						)}
 						{filteredTasks.length > 0 && (
-							<CommandGroup heading={searchQuery ? "Results" : "Recent issues"}>
+							<CommandGroup
+								heading={
+									searchQuery
+										? "Results"
+										: showClosed
+											? "Recent issues"
+											: "Open issues"
+								}
+							>
 								{filteredTasks.map((task) => {
 									const status = task.statusId
 										? statusMap.get(task.statusId)

--- a/apps/desktop/src/renderer/components/Chat/ChatInterface/components/ToolCallBlock/ToolCallBlock.tsx
+++ b/apps/desktop/src/renderer/components/Chat/ChatInterface/components/ToolCallBlock/ToolCallBlock.tsx
@@ -51,7 +51,6 @@ interface ToolCallBlockProps {
 	workspaceCwd?: string;
 	sessionId?: string | null;
 	organizationId?: string | null;
-	isStreaming?: boolean;
 	isInterrupted?: boolean;
 	onAnswer?: (
 		toolCallId: string,
@@ -71,7 +70,6 @@ export function ToolCallBlock({
 	workspaceCwd,
 	sessionId,
 	organizationId,
-	isStreaming,
 	isInterrupted,
 	onAnswer,
 }: ToolCallBlockProps) {

--- a/apps/desktop/src/renderer/components/Chat/ChatInterface/components/ToolCallBlock/ToolCallBlock.tsx
+++ b/apps/desktop/src/renderer/components/Chat/ChatInterface/components/ToolCallBlock/ToolCallBlock.tsx
@@ -35,6 +35,7 @@ import { ListProjectsToolCall } from "./components/ListProjectsToolCall";
 import { ListTaskStatusesToolCall } from "./components/ListTaskStatusesToolCall";
 import { ListTasksToolCall } from "./components/ListTasksToolCall";
 import { ListWorkspacesToolCall } from "./components/ListWorkspacesToolCall";
+import { RequestSandboxAccessToolCall } from "./components/RequestSandboxAccessToolCall";
 import { StartAgentSessionToolCall } from "./components/StartAgentSessionToolCall";
 import { SubagentToolCall } from "./components/SubagentToolCall";
 import { SupersetToolCall } from "./components/SupersetToolCall";
@@ -50,6 +51,8 @@ interface ToolCallBlockProps {
 	workspaceCwd?: string;
 	sessionId?: string | null;
 	organizationId?: string | null;
+	isStreaming?: boolean;
+	isInterrupted?: boolean;
 	onAnswer?: (
 		toolCallId: string,
 		answers: Record<string, string>,
@@ -68,6 +71,8 @@ export function ToolCallBlock({
 	workspaceCwd,
 	sessionId,
 	organizationId,
+	isStreaming,
+	isInterrupted,
 	onAnswer,
 }: ToolCallBlockProps) {
 	const args = getArgs(part);
@@ -592,8 +597,15 @@ export function ToolCallBlock({
 		);
 	}
 
-	if (toolName === "request_sandbox_access") {
-		return <SupersetToolCall part={part} toolName="Request sandbox access" />;
+	if (toolName === "request_access") {
+		return (
+			<RequestSandboxAccessToolCall
+				part={part}
+				args={args}
+				result={result}
+				isInterrupted={isInterrupted ?? false}
+			/>
+		);
 	}
 
 	if (toolName === "task_write") {

--- a/apps/desktop/src/renderer/components/Chat/ChatInterface/components/ToolCallBlock/components/AskUserQuestionToolCall/AskUserQuestionToolCall.tsx
+++ b/apps/desktop/src/renderer/components/Chat/ChatInterface/components/ToolCallBlock/components/AskUserQuestionToolCall/AskUserQuestionToolCall.tsx
@@ -119,6 +119,8 @@ function findAnswerForQuestion({
 	return undefined;
 }
 
+// FORK NOTE: fork uses buildQuestionMarkdown + UserQuestionTool instead of the
+// upstream ToolCallRow/ToolStatusBadge pattern; fork implementation maintained here.
 function buildQuestionMarkdown({
 	questions,
 	answers,

--- a/apps/desktop/src/renderer/components/Chat/ChatInterface/components/ToolCallBlock/components/RequestSandboxAccessToolCall/RequestSandboxAccessToolCall.tsx
+++ b/apps/desktop/src/renderer/components/Chat/ChatInterface/components/ToolCallBlock/components/RequestSandboxAccessToolCall/RequestSandboxAccessToolCall.tsx
@@ -1,0 +1,123 @@
+import { ToolCallRow } from "@superset/ui/ai-elements/tool-call-row";
+import {
+	CheckIcon,
+	CircleXIcon,
+	ClockIcon,
+	FolderLockIcon,
+	XIcon,
+} from "lucide-react";
+import type { ComponentType } from "react";
+import type { ToolPart } from "../../../../utils/tool-helpers";
+import type { ToolStatusBadgeVariant } from "../ToolStatusBadge";
+import { ToolStatusBadge } from "../ToolStatusBadge";
+
+interface RequestSandboxAccessToolCallProps {
+	part: ToolPart;
+	args: Record<string, unknown>;
+	result: Record<string, unknown>;
+	isInterrupted?: boolean;
+}
+
+type AccessStatus = "pending" | "granted" | "denied" | "cancelled" | "error";
+
+const ACCESS_STATUS_CONFIG: Record<
+	AccessStatus,
+	{
+		icon: ComponentType<{ className?: string }>;
+		label: string;
+		variant?: ToolStatusBadgeVariant;
+	}
+> = {
+	pending: { icon: ClockIcon, label: "Awaiting Response" },
+	granted: { icon: CheckIcon, label: "Access Granted" },
+	denied: { icon: XIcon, label: "Access Denied" },
+	cancelled: { icon: XIcon, label: "Cancelled" },
+	error: { icon: CircleXIcon, label: "Error", variant: "danger" },
+};
+
+function toAccessDecision(content: string): "granted" | "denied" | null {
+	if (content.startsWith("Access already granted")) return "granted";
+	if (content.startsWith("Access granted")) return "granted";
+	if (content.startsWith("Access denied")) return "denied";
+	return null;
+}
+
+function toAccessStatus(
+	part: ToolPart,
+	result: Record<string, unknown>,
+	isInterrupted: boolean,
+): AccessStatus {
+	if (
+		isInterrupted &&
+		part.state !== "output-available" &&
+		part.state !== "output-error"
+	) {
+		return "cancelled";
+	}
+	if (part.state !== "output-available" && part.state !== "output-error") {
+		return "pending";
+	}
+	if (part.state === "output-error" || result.isError === true) {
+		return "error";
+	}
+	const content =
+		(typeof result.content === "string" && result.content.trim()) ||
+		(typeof result.text === "string" && result.text.trim()) ||
+		"";
+	return toAccessDecision(content) ?? "error";
+}
+
+export function RequestSandboxAccessToolCall({
+	part,
+	args,
+	result,
+	isInterrupted = false,
+}: RequestSandboxAccessToolCallProps) {
+	const requestedPath = typeof args.path === "string" ? args.path.trim() : null;
+	const reason = typeof args.reason === "string" ? args.reason.trim() : null;
+
+	const status = toAccessStatus(part, result, isInterrupted);
+	const { icon, label, variant } = ACCESS_STATUS_CONFIG[status];
+	const statusBadge = (
+		<ToolStatusBadge icon={icon} label={label} variant={variant} />
+	);
+
+	const isPending = status === "pending";
+	const isCancelledOrError = status === "cancelled" || status === "error";
+	const hasContext = Boolean(requestedPath || reason);
+
+	return (
+		<ToolCallRow
+			icon={FolderLockIcon}
+			isPending={false}
+			isError={false}
+			title="Request Access"
+			description={statusBadge}
+		>
+			{!isPending && hasContext ? (
+				<div className="space-y-1 px-3 py-2">
+					{requestedPath ? (
+						<div className="text-xs text-muted-foreground">
+							Path: {requestedPath}
+						</div>
+					) : null}
+					{reason ? (
+						<div className="text-xs text-muted-foreground">
+							Reason: {reason}
+						</div>
+					) : null}
+					{!isCancelledOrError ? (
+						<div className="text-sm text-foreground">
+							{status === "granted" ? "Access granted" : "Access denied"}
+						</div>
+					) : (
+						<div className="flex items-center gap-1 text-sm text-destructive">
+							<CircleXIcon className="h-3 w-3 shrink-0" />
+							Aborted
+						</div>
+					)}
+				</div>
+			) : undefined}
+		</ToolCallRow>
+	);
+}

--- a/apps/desktop/src/renderer/components/Chat/ChatInterface/components/ToolCallBlock/components/RequestSandboxAccessToolCall/index.ts
+++ b/apps/desktop/src/renderer/components/Chat/ChatInterface/components/ToolCallBlock/components/RequestSandboxAccessToolCall/index.ts
@@ -1,0 +1,1 @@
+export { RequestSandboxAccessToolCall } from "./RequestSandboxAccessToolCall";

--- a/apps/desktop/src/renderer/components/Chat/ChatInterface/components/ToolCallBlock/components/ToolStatusBadge/ToolStatusBadge.tsx
+++ b/apps/desktop/src/renderer/components/Chat/ChatInterface/components/ToolCallBlock/components/ToolStatusBadge/ToolStatusBadge.tsx
@@ -1,0 +1,34 @@
+import { cn } from "@superset/ui/lib/utils";
+import type { ComponentType } from "react";
+
+const VARIANT_CLASSES = {
+	default: "",
+	success: "text-emerald-500",
+	danger: "text-destructive",
+} as const;
+
+export type ToolStatusBadgeVariant = keyof typeof VARIANT_CLASSES;
+
+interface ToolStatusBadgeProps {
+	icon: ComponentType<{ className?: string }>;
+	label: string;
+	variant?: ToolStatusBadgeVariant;
+}
+
+export function ToolStatusBadge({
+	icon: Icon,
+	label,
+	variant = "default",
+}: ToolStatusBadgeProps) {
+	return (
+		<span
+			className={cn(
+				"ml-2 flex items-center gap-1 font-medium uppercase tracking-wide",
+				VARIANT_CLASSES[variant],
+			)}
+		>
+			<Icon className="h-3 w-3 shrink-0" />
+			{label}
+		</span>
+	);
+}

--- a/apps/desktop/src/renderer/components/Chat/ChatInterface/components/ToolCallBlock/components/ToolStatusBadge/index.ts
+++ b/apps/desktop/src/renderer/components/Chat/ChatInterface/components/ToolCallBlock/components/ToolStatusBadge/index.ts
@@ -1,0 +1,2 @@
+export type { ToolStatusBadgeVariant } from "./ToolStatusBadge";
+export { ToolStatusBadge } from "./ToolStatusBadge";

--- a/apps/desktop/src/renderer/components/Chat/ChatInterface/utils/tool-helpers.test.ts
+++ b/apps/desktop/src/renderer/components/Chat/ChatInterface/utils/tool-helpers.test.ts
@@ -17,9 +17,7 @@ describe("normalizeToolName", () => {
 		expect(normalizeToolName("web_extract")).toBe("web_fetch");
 		expect(normalizeToolName("ask_user")).toBe("ask_user_question");
 		expect(normalizeToolName("ast_smart_edit")).toBe("ast_smart_edit");
-		expect(normalizeToolName("request_sandbox_access")).toBe(
-			"request_sandbox_access",
-		);
+		expect(normalizeToolName("request_sandbox_access")).toBe("request_access");
 		expect(normalizeToolName("task_write")).toBe("task_write");
 		expect(normalizeToolName("task_check")).toBe("task_check");
 		expect(normalizeToolName("submit_plan")).toBe("submit_plan");

--- a/apps/desktop/src/renderer/components/Chat/ChatInterface/utils/tool-helpers.ts
+++ b/apps/desktop/src/renderer/components/Chat/ChatInterface/utils/tool-helpers.ts
@@ -29,7 +29,8 @@ const TOOL_NAME_ALIASES: Record<string, string> = {
 
 	// Keep explicit passthroughs for newer Mastra tool names
 	ast_smart_edit: "ast_smart_edit",
-	request_sandbox_access: "request_sandbox_access",
+	request_access: "request_access",
+	request_sandbox_access: "request_access",
 	task_write: "task_write",
 	task_check: "task_check",
 	submit_plan: "submit_plan",

--- a/apps/desktop/src/renderer/components/MarkdownEditor/MarkdownEditor.tsx
+++ b/apps/desktop/src/renderer/components/MarkdownEditor/MarkdownEditor.tsx
@@ -22,6 +22,7 @@ import { OrderedList } from "@tiptap/extension-ordered-list";
 import { Paragraph } from "@tiptap/extension-paragraph";
 import Placeholder from "@tiptap/extension-placeholder";
 import { Strike } from "@tiptap/extension-strike";
+import { TableKit } from "@tiptap/extension-table";
 import TaskItem from "@tiptap/extension-task-item";
 import TaskList from "@tiptap/extension-task-list";
 import { Text } from "@tiptap/extension-text";
@@ -151,6 +152,20 @@ function getMarkdown(editor: Editor | null): string {
 	return storage?.markdown?.getMarkdown?.() ?? "";
 }
 
+function isMarkdownTable(text: string): boolean {
+	const lines = text
+		.trim()
+		.split(/\r?\n/)
+		.map((line) => line.trim())
+		.filter(Boolean);
+
+	if (lines.length < 2 || !lines[0]?.includes("|")) {
+		return false;
+	}
+
+	return /^\|?\s*:?-{3,}:?\s*(\|\s*:?-{3,}:?\s*)+\|?$/.test(lines[1]);
+}
+
 export function MarkdownEditor({
 	content,
 	onSave,
@@ -167,6 +182,7 @@ export function MarkdownEditor({
 	// Thread through a ref so the extension reads the live callback each fire.
 	const searchFilesRef = useRef(searchFiles);
 	searchFilesRef.current = searchFiles;
+	const editorRef = useRef<Editor | null>(null);
 
 	const { getUrlAction } = useInlineLinkActions();
 
@@ -242,6 +258,26 @@ export function MarkdownEditor({
 			LinearImage.configure({
 				HTMLAttributes: { class: "max-w-full h-auto rounded-md my-3" },
 			}),
+			TableKit.configure({
+				table: {
+					resizable: false,
+					cellMinWidth: 192,
+					HTMLAttributes: {
+						class: "markdown-table my-4 min-w-full border-collapse",
+					},
+				},
+				tableHeader: {
+					HTMLAttributes: {
+						class:
+							"bg-muted px-4 py-2 text-left text-sm font-semibold align-top",
+					},
+				},
+				tableCell: {
+					HTMLAttributes: {
+						class: "border-t border-border px-4 py-2 text-sm align-top",
+					},
+				},
+			}),
 			Placeholder.configure({
 				placeholder: ({ node }) => {
 					if (node.type.name === "paragraph") {
@@ -277,6 +313,22 @@ export function MarkdownEditor({
 				onModEnter?.();
 				return true;
 			},
+			handlePaste: (_, event) => {
+				const text = event.clipboardData?.getData("text/plain") ?? "";
+				const currentEditor = editorRef.current;
+				if (!currentEditor || !isMarkdownTable(text)) {
+					return false;
+				}
+
+				event.preventDefault();
+				return currentEditor.commands.insertContentAt(
+					{
+						from: currentEditor.state.selection.from,
+						to: currentEditor.state.selection.to,
+					},
+					text,
+				);
+			},
 			handleClickOn: (_view, _pos, _node, _nodePos, event) => {
 				const target = event.target as HTMLElement | null;
 				const anchor = target?.closest?.("a") as HTMLAnchorElement | null;
@@ -301,6 +353,7 @@ export function MarkdownEditor({
 			onSave?.(getMarkdown(editor));
 		},
 	});
+	editorRef.current = editor;
 
 	useEffect(() => {
 		if (!editor || editor.isFocused) return;

--- a/apps/desktop/src/renderer/components/MarkdownEditor/markdown-editor.css
+++ b/apps/desktop/src/renderer/components/MarkdownEditor/markdown-editor.css
@@ -85,3 +85,27 @@ ul[data-type="taskList"]
 		0 0 0 2px hsl(var(--background)),
 		0 0 0 4px hsl(var(--ring));
 }
+
+.markdown-table {
+	width: max-content;
+	min-width: 100%;
+	overflow: hidden;
+	border: 1px solid hsl(var(--border));
+	border-radius: 0.375rem;
+}
+
+.markdown-table th,
+.markdown-table td {
+	border: 1px solid hsl(var(--border));
+	min-width: 12rem;
+}
+
+.markdown-table th > *,
+.markdown-table td > * {
+	margin-top: 0;
+	margin-bottom: 0;
+}
+
+.markdown-table .selectedCell {
+	background-color: hsl(var(--accent) / 0.6);
+}

--- a/apps/desktop/src/renderer/components/MarkdownRenderer/components/TipTapMarkdownRenderer/createMarkdownExtensions.ts
+++ b/apps/desktop/src/renderer/components/MarkdownRenderer/components/TipTapMarkdownRenderer/createMarkdownExtensions.ts
@@ -16,10 +16,7 @@ import { ListItem } from "@tiptap/extension-list-item";
 import { OrderedList } from "@tiptap/extension-ordered-list";
 import { Paragraph } from "@tiptap/extension-paragraph";
 import { Strike } from "@tiptap/extension-strike";
-import { Table } from "@tiptap/extension-table";
-import TableCell from "@tiptap/extension-table-cell";
-import TableHeader from "@tiptap/extension-table-header";
-import TableRow from "@tiptap/extension-table-row";
+import { TableKit } from "@tiptap/extension-table";
 import TaskItem from "@tiptap/extension-task-item";
 import TaskList from "@tiptap/extension-task-list";
 import { Text } from "@tiptap/extension-text";
@@ -158,21 +155,23 @@ export function createMarkdownExtensions({
 			},
 		}),
 		SafeImage,
-		Table.configure({
-			resizable: false,
-			HTMLAttributes: {
-				class: "markdown-table my-4 min-w-full border-collapse",
+		TableKit.configure({
+			table: {
+				resizable: false,
+				cellMinWidth: 192,
+				HTMLAttributes: {
+					class: "markdown-table my-4 min-w-full border-collapse",
+				},
 			},
-		}),
-		TableRow,
-		TableHeader.configure({
-			HTMLAttributes: {
-				class: "bg-muted px-4 py-2 text-left text-sm font-semibold align-top",
+			tableHeader: {
+				HTMLAttributes: {
+					class: "bg-muted px-4 py-2 text-left text-sm font-semibold align-top",
+				},
 			},
-		}),
-		TableCell.configure({
-			HTMLAttributes: {
-				class: "border-t border-border px-4 py-2 text-sm align-top",
+			tableCell: {
+				HTMLAttributes: {
+					class: "border-t border-border px-4 py-2 text-sm align-top",
+				},
 			},
 		}),
 		Markdown.configure({

--- a/apps/desktop/src/renderer/components/NewWorkspaceModal/components/PromptGroup/components/GitHubIssueLinkCommand/GitHubIssueLinkCommand.tsx
+++ b/apps/desktop/src/renderer/components/NewWorkspaceModal/components/PromptGroup/components/GitHubIssueLinkCommand/GitHubIssueLinkCommand.tsx
@@ -1,3 +1,4 @@
+import { Checkbox } from "@superset/ui/checkbox";
 import {
 	Command,
 	CommandEmpty,
@@ -10,7 +11,7 @@ import { Popover, PopoverAnchor, PopoverContent } from "@superset/ui/popover";
 import Fuse from "fuse.js";
 import type React from "react";
 import type { RefObject } from "react";
-import { useMemo, useState } from "react";
+import { useId, useMemo, useState } from "react";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import {
 	IssueIcon,
@@ -46,9 +47,11 @@ export function GitHubIssueLinkCommand({
 	anchorRef,
 }: GitHubIssueLinkCommandProps) {
 	const [searchQuery, setSearchQuery] = useState("");
+	const [showClosed, setShowClosed] = useState(false);
+	const showClosedId = useId();
 
 	const { data: issues, isLoading } = electronTrpc.projects.listIssues.useQuery(
-		{ projectId: projectId ?? "" },
+		{ projectId: projectId ?? "", includeClosed: showClosed },
 		{ enabled: !!projectId && open },
 	);
 
@@ -122,14 +125,39 @@ export function GitHubIssueLinkCommand({
 						value={searchQuery}
 						onValueChange={setSearchQuery}
 					/>
+					<div className="flex items-center gap-2 border-b px-3 py-2">
+						<Checkbox
+							id={showClosedId}
+							checked={showClosed}
+							onCheckedChange={(checked) => setShowClosed(checked === true)}
+						/>
+						<label
+							htmlFor={showClosedId}
+							className="cursor-pointer select-none text-xs text-muted-foreground"
+						>
+							Show closed
+						</label>
+					</div>
 					<CommandList className="max-h-[280px]">
 						{searchResults.length === 0 && (
 							<CommandEmpty>
-								{isLoading ? "Loading issues..." : "No open issues found."}
+								{isLoading
+									? "Loading issues..."
+									: showClosed
+										? "No issues found."
+										: "No open issues found."}
 							</CommandEmpty>
 						)}
 						{searchResults.length > 0 && (
-							<CommandGroup heading={searchQuery ? "Results" : "Open issues"}>
+							<CommandGroup
+								heading={
+									searchQuery
+										? "Results"
+										: showClosed
+											? "Recent issues"
+											: "Open issues"
+								}
+							>
 								{searchResults.map((issue) => (
 									<CommandItem
 										key={issue.issueNumber}

--- a/apps/desktop/src/renderer/components/NewWorkspaceModal/components/PromptGroup/components/PRLinkCommand/PRLinkCommand.tsx
+++ b/apps/desktop/src/renderer/components/NewWorkspaceModal/components/PromptGroup/components/PRLinkCommand/PRLinkCommand.tsx
@@ -1,3 +1,4 @@
+import { Checkbox } from "@superset/ui/checkbox";
 import {
 	Command,
 	CommandEmpty,
@@ -9,7 +10,7 @@ import {
 import { Popover, PopoverAnchor, PopoverContent } from "@superset/ui/popover";
 import type React from "react";
 import type { RefObject } from "react";
-import { useMemo, useState } from "react";
+import { useId, useMemo, useState } from "react";
 import { useDebouncedValue } from "renderer/hooks/useDebouncedValue";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import {
@@ -62,6 +63,8 @@ export function PRLinkCommand({
 	anchorRef,
 }: PRLinkCommandProps) {
 	const [searchQuery, setSearchQuery] = useState("");
+	const [showClosed, setShowClosed] = useState(false);
+	const showClosedId = useId();
 	const debouncedQuery = useDebouncedValue(searchQuery, 300);
 	const trimmedQuery = searchQuery.trim(); // Immediate trim for UI decisions
 	const debouncedTrimmed = debouncedQuery.trim(); // Debounced trim for RPC calls
@@ -99,14 +102,18 @@ export function PRLinkCommand({
 	// Fetch recent PRs for browsing (only when no search query)
 	const { data: recentPRs, isLoading: isLoadingRecent } =
 		electronTrpc.projects.listPullRequests.useQuery(
-			{ projectId: projectId ?? "" },
+			{ projectId: projectId ?? "", includeClosed: showClosed },
 			{ enabled: !!projectId && open && !debouncedTrimmed },
 		);
 
 	// Server-side search when user types (use debounced for RPC)
 	const { data: searchResults, isLoading: isSearching } =
 		electronTrpc.projects.searchPullRequests.useQuery(
-			{ projectId: projectId ?? "", query: effectiveQuery },
+			{
+				projectId: projectId ?? "",
+				query: effectiveQuery,
+				includeClosed: showClosed,
+			},
 			{
 				enabled:
 					!!projectId && open && !!effectiveQuery && !isCrossRepositoryUrl,
@@ -164,6 +171,19 @@ export function PRLinkCommand({
 						value={searchQuery}
 						onValueChange={setSearchQuery}
 					/>
+					<div className="flex items-center gap-2 border-b px-3 py-2">
+						<Checkbox
+							id={showClosedId}
+							checked={showClosed}
+							onCheckedChange={(checked) => setShowClosed(checked === true)}
+						/>
+						<label
+							htmlFor={showClosedId}
+							className="cursor-pointer select-none text-xs text-muted-foreground"
+						>
+							Show closed
+						</label>
+					</div>
 					<CommandList className="max-h-[280px]">
 						{pullRequests.length === 0 && (
 							<CommandEmpty>
@@ -175,7 +195,9 @@ export function PRLinkCommand({
 										? `PR URL must match ${selectedRepositoryLabel}.`
 										: debouncedTrimmed
 											? "No pull requests found."
-											: "No open pull requests."}
+											: showClosed
+												? "No pull requests found."
+												: "No open pull requests."}
 							</CommandEmpty>
 						)}
 						{pullRequests.length > 0 && (
@@ -183,7 +205,9 @@ export function PRLinkCommand({
 								heading={
 									debouncedTrimmed
 										? `${pullRequests.length} result${pullRequests.length === 1 ? "" : "s"}`
-										: "Recent pull requests"
+										: showClosed
+											? "Recent pull requests"
+											: "Open pull requests"
 								}
 							>
 								{pullRequests.map((pr) => (

--- a/apps/desktop/src/renderer/lib/terminal/terminal-background-intents.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-background-intents.ts
@@ -1,0 +1,9 @@
+const backgroundTerminalIds = new Set<string>();
+
+export function markTerminalForBackground(terminalId: string): void {
+	backgroundTerminalIds.add(terminalId);
+}
+
+export function consumeTerminalBackgroundIntent(terminalId: string): boolean {
+	return backgroundTerminalIds.delete(terminalId);
+}

--- a/apps/desktop/src/renderer/lib/terminal/terminal-runtime-registry.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-runtime-registry.ts
@@ -28,6 +28,8 @@ import {
 } from "./terminal-ws-transport";
 
 interface RegistryEntry {
+	terminalId: string;
+	instanceId: string;
 	runtime: TerminalRuntime | null;
 	transport: TerminalTransport;
 	linkManager: TerminalLinkManager | null;
@@ -37,20 +39,90 @@ interface RegistryEntry {
 
 class TerminalRuntimeRegistryImpl {
 	private entries = new Map<string, RegistryEntry>();
+	private entryKeysByTerminalId = new Map<string, Set<string>>();
 
-	private getOrCreateEntry(terminalId: string): RegistryEntry {
-		let entry = this.entries.get(terminalId);
+	private getEntryKey(terminalId: string, instanceId = terminalId): string {
+		return `${terminalId}\u0000${instanceId}`;
+	}
+
+	private getOrCreateEntry(
+		terminalId: string,
+		instanceId = terminalId,
+	): RegistryEntry {
+		const key = this.getEntryKey(terminalId, instanceId);
+		let entry = this.entries.get(key);
 		if (entry) return entry;
 
 		entry = {
+			terminalId,
+			instanceId,
 			runtime: null,
 			transport: createTransport(terminalId),
 			linkManager: null,
 			pendingLinkHandlers: null,
 		};
 
-		this.entries.set(terminalId, entry);
+		this.entries.set(key, entry);
+		let keys = this.entryKeysByTerminalId.get(terminalId);
+		if (!keys) {
+			keys = new Set();
+			this.entryKeysByTerminalId.set(terminalId, keys);
+		}
+		keys.add(key);
 		return entry;
+	}
+
+	private getEntry(
+		terminalId: string,
+		instanceId?: string,
+	): RegistryEntry | null {
+		if (instanceId) {
+			return this.entries.get(this.getEntryKey(terminalId, instanceId)) ?? null;
+		}
+		return this.getPrimaryEntry(terminalId);
+	}
+
+	private getPrimaryEntry(terminalId: string): RegistryEntry | null {
+		const defaultEntry = this.entries.get(this.getEntryKey(terminalId));
+		if (defaultEntry) return defaultEntry;
+
+		const keys = this.entryKeysByTerminalId.get(terminalId);
+		const firstKey = keys?.values().next().value;
+		return firstKey ? (this.entries.get(firstKey) ?? null) : null;
+	}
+
+	private getEntries(terminalId: string): RegistryEntry[] {
+		const keys = this.entryKeysByTerminalId.get(terminalId);
+		if (!keys) return [];
+		return Array.from(keys)
+			.map((key) => this.entries.get(key))
+			.filter((entry): entry is RegistryEntry => Boolean(entry));
+	}
+
+	private deleteEntry(entry: RegistryEntry) {
+		const key = this.getEntryKey(entry.terminalId, entry.instanceId);
+		this.entries.delete(key);
+		const keys = this.entryKeysByTerminalId.get(entry.terminalId);
+		if (!keys) return;
+		keys.delete(key);
+		if (keys.size === 0) {
+			this.entryKeysByTerminalId.delete(entry.terminalId);
+		}
+	}
+
+	private serializeExistingRuntime(
+		terminalId: string,
+		excludedInstanceId: string,
+	): string | undefined {
+		for (const entry of this.getEntries(terminalId)) {
+			if (entry.instanceId === excludedInstanceId || !entry.runtime) continue;
+			try {
+				return entry.runtime.serializeAddon.serialize({ scrollback: 1000 });
+			} catch {
+				return undefined;
+			}
+		}
+		return undefined;
 	}
 
 	/**
@@ -69,8 +141,9 @@ class TerminalRuntimeRegistryImpl {
 		terminalId: string,
 		container: HTMLDivElement,
 		appearance: TerminalAppearance,
+		instanceId = terminalId,
 	) {
-		const entry = this.getOrCreateEntry(terminalId);
+		const entry = this.getOrCreateEntry(terminalId, instanceId);
 		terminalRendererDebug.info("runtime-attach", {
 			terminalId,
 			hasExistingRuntime: entry.runtime !== null,
@@ -78,7 +151,9 @@ class TerminalRuntimeRegistryImpl {
 		});
 
 		if (!entry.runtime) {
-			entry.runtime = createRuntime(terminalId, appearance);
+			entry.runtime = createRuntime(terminalId, appearance, {
+				initialBuffer: this.serializeExistingRuntime(terminalId, instanceId),
+			});
 			entry.linkManager = new TerminalLinkManager(entry.runtime.terminal);
 			if (entry.pendingLinkHandlers) {
 				entry.linkManager.setHandlers(entry.pendingLinkHandlers);
@@ -101,8 +176,8 @@ class TerminalRuntimeRegistryImpl {
 	 *
 	 * Idempotent: no-op if already connected/connecting to the same URL.
 	 */
-	connect(terminalId: string, wsUrl: string) {
-		const entry = this.entries.get(terminalId);
+	connect(terminalId: string, wsUrl: string, instanceId = terminalId) {
+		const entry = this.getEntry(terminalId, instanceId);
 		if (!entry?.runtime) return;
 		// Reset backoff only when the connection is in a stable state (open or
 		// disconnected). If the transport is in "closed" state it may be mid-way
@@ -126,8 +201,8 @@ class TerminalRuntimeRegistryImpl {
 	 * swap), and `"closed"` (previously live and mid-auto-reconnect — swap
 	 * the URL so the reconnect targets the new endpoint).
 	 */
-	reconnect(terminalId: string, wsUrl: string) {
-		const entry = this.entries.get(terminalId);
+	reconnect(terminalId: string, wsUrl: string, instanceId = terminalId) {
+		const entry = this.getEntry(terminalId, instanceId);
 		if (!entry?.runtime) return;
 		if (entry.transport.connectionState === "disconnected") return;
 		if (entry.transport.currentUrl === wsUrl) return;
@@ -138,8 +213,12 @@ class TerminalRuntimeRegistryImpl {
 	 * Set link handler callbacks for a terminal. Safe to call before or after
 	 * mount(). If the runtime already exists, link providers are re-registered.
 	 */
-	setLinkHandlers(terminalId: string, handlers: TerminalLinkHandlers) {
-		const entry = this.getOrCreateEntry(terminalId);
+	setLinkHandlers(
+		terminalId: string,
+		handlers: TerminalLinkHandlers,
+		instanceId = terminalId,
+	) {
+		const entry = this.getOrCreateEntry(terminalId, instanceId);
 		if (entry.linkManager) {
 			entry.linkManager.setHandlers(handlers);
 		} else {
@@ -152,8 +231,8 @@ class TerminalRuntimeRegistryImpl {
 	 * transport stay alive; DOM is moved off the React-controlled tree so
 	 * it survives the parent unmount without re-entering xterm.open().
 	 */
-	detach(terminalId: string) {
-		const entry = this.entries.get(terminalId);
+	detach(terminalId: string, instanceId = terminalId) {
+		const entry = this.getEntry(terminalId, instanceId);
 		if (!entry?.runtime) return;
 		terminalRendererDebug.info(
 			"runtime-detach",
@@ -170,8 +249,12 @@ class TerminalRuntimeRegistryImpl {
 		detachFromContainer(entry.runtime);
 	}
 
-	updateAppearance(terminalId: string, appearance: TerminalAppearance) {
-		const entry = this.entries.get(terminalId);
+	updateAppearance(
+		terminalId: string,
+		appearance: TerminalAppearance,
+		instanceId = terminalId,
+	) {
+		const entry = this.getEntry(terminalId, instanceId);
 		if (!entry?.runtime) return;
 
 		const prevCols = entry.runtime.terminal.cols;
@@ -185,13 +268,14 @@ class TerminalRuntimeRegistryImpl {
 		}
 	}
 
-	dispose(terminalId: string) {
-		const entry = this.entries.get(terminalId);
-		if (!entry) return;
+	private disposeEntry(
+		entry: RegistryEntry,
+		options: { clearPersistedState?: boolean } = {},
+	) {
 		terminalRendererDebug.info(
 			"runtime-dispose",
 			{
-				terminalId,
+				terminalId: entry.terminalId,
 				hasRuntime: entry.runtime !== null,
 				connectionState: entry.transport.connectionState,
 			},
@@ -200,86 +284,125 @@ class TerminalRuntimeRegistryImpl {
 				fingerprint: ["terminal.renderer", "runtime-dispose"],
 			},
 		);
-
 		entry.linkManager?.dispose();
-
-		sendDispose(entry.transport);
 		disposeTransport(entry.transport);
-		if (entry.runtime) disposeRuntime(entry.runtime);
-
-		this.entries.delete(terminalId);
+		if (entry.runtime) {
+			disposeRuntime(entry.runtime, options);
+		}
+		this.deleteEntry(entry);
 	}
 
-	getSelection(terminalId: string): string {
-		const entry = this.entries.get(terminalId);
+	/**
+	 * Release the renderer-side terminal runtime only. This detaches the xterm
+	 * view and closes the WebSocket, but it does not tell host-service to kill
+	 * the underlying PTY. Use this for pane/sidebar lifecycle cleanup.
+	 */
+	release(terminalId: string, instanceId?: string) {
+		const entries = instanceId
+			? [this.getEntry(terminalId, instanceId)].filter(
+					(entry): entry is RegistryEntry => Boolean(entry),
+				)
+			: this.getEntries(terminalId);
+		for (const entry of entries) {
+			this.disposeEntry(entry, { clearPersistedState: false });
+		}
+	}
+
+	/**
+	 * Kill the host-service terminal session and remove all renderer-side state.
+	 * This is destructive and should only be used from explicit kill actions.
+	 */
+	dispose(terminalId: string) {
+		for (const entry of this.getEntries(terminalId)) {
+			sendDispose(entry.transport);
+			this.disposeEntry(entry);
+		}
+	}
+
+	getSelection(terminalId: string, instanceId?: string): string {
+		const entry = this.getEntry(terminalId, instanceId);
 		return entry?.runtime?.terminal.getSelection() ?? "";
 	}
 
-	clear(terminalId: string): void {
-		const entry = this.entries.get(terminalId);
+	clear(terminalId: string, instanceId?: string): void {
+		const entry = this.getEntry(terminalId, instanceId);
 		entry?.runtime?.terminal.clear();
 	}
 
-	scrollToBottom(terminalId: string): void {
-		const entry = this.entries.get(terminalId);
+	scrollToBottom(terminalId: string, instanceId?: string): void {
+		const entry = this.getEntry(terminalId, instanceId);
 		entry?.runtime?.terminal.scrollToBottom();
 	}
 
-	paste(terminalId: string, text: string): void {
-		const entry = this.entries.get(terminalId);
+	paste(terminalId: string, text: string, instanceId?: string): void {
+		const entry = this.getEntry(terminalId, instanceId);
 		entry?.runtime?.terminal.paste(text);
 	}
 
 	/** Send raw input to the terminal via the WebSocket transport (bypasses xterm). */
-	writeInput(terminalId: string, data: string): void {
-		const entry = this.entries.get(terminalId);
+	writeInput(terminalId: string, data: string, instanceId?: string): void {
+		const entry = this.getEntry(terminalId, instanceId);
 		if (!entry) return;
 		sendInput(entry.transport, data);
 	}
 
-	findNext(terminalId: string, query: string): boolean {
-		const entry = this.entries.get(terminalId);
+	findNext(terminalId: string, query: string, instanceId?: string): boolean {
+		const entry = this.getEntry(terminalId, instanceId);
 		return entry?.runtime?.searchAddon?.findNext(query) ?? false;
 	}
 
-	findPrevious(terminalId: string, query: string): boolean {
-		const entry = this.entries.get(terminalId);
+	findPrevious(
+		terminalId: string,
+		query: string,
+		instanceId?: string,
+	): boolean {
+		const entry = this.getEntry(terminalId, instanceId);
 		return entry?.runtime?.searchAddon?.findPrevious(query) ?? false;
 	}
 
-	clearSearch(terminalId: string): void {
-		const entry = this.entries.get(terminalId);
+	clearSearch(terminalId: string, instanceId?: string): void {
+		const entry = this.getEntry(terminalId, instanceId);
 		entry?.runtime?.searchAddon?.clearDecorations();
 	}
 
-	getTerminal(terminalId: string) {
-		return this.entries.get(terminalId)?.runtime?.terminal ?? null;
+	getTerminal(terminalId: string, instanceId?: string) {
+		return this.getEntry(terminalId, instanceId)?.runtime?.terminal ?? null;
 	}
 
-	getSearchAddon(terminalId: string): SearchAddon | null {
-		return this.entries.get(terminalId)?.runtime?.searchAddon ?? null;
+	getSearchAddon(terminalId: string, instanceId?: string): SearchAddon | null {
+		return this.getEntry(terminalId, instanceId)?.runtime?.searchAddon ?? null;
 	}
 
-	getProgressAddon(terminalId: string): ProgressAddon | null {
-		return this.entries.get(terminalId)?.runtime?.progressAddon ?? null;
-	}
-
-	getAllTerminalIds(): Set<string> {
-		return new Set(this.entries.keys());
-	}
-
-	has(terminalId: string): boolean {
-		return this.entries.has(terminalId);
-	}
-
-	getConnectionState(terminalId: string): ConnectionState {
+	getProgressAddon(
+		terminalId: string,
+		instanceId?: string,
+	): ProgressAddon | null {
 		return (
-			this.entries.get(terminalId)?.transport.connectionState ?? "disconnected"
+			this.getEntry(terminalId, instanceId)?.runtime?.progressAddon ?? null
 		);
 	}
 
-	onStateChange(terminalId: string, listener: () => void): () => void {
-		const entry = this.getOrCreateEntry(terminalId);
+	getAllTerminalIds(): Set<string> {
+		return new Set(this.entryKeysByTerminalId.keys());
+	}
+
+	has(terminalId: string): boolean {
+		return this.entryKeysByTerminalId.has(terminalId);
+	}
+
+	getConnectionState(terminalId: string, instanceId?: string): ConnectionState {
+		return (
+			this.getEntry(terminalId, instanceId)?.transport.connectionState ??
+			"disconnected"
+		);
+	}
+
+	onStateChange(
+		terminalId: string,
+		listener: () => void,
+		instanceId = terminalId,
+	): () => void {
+		const entry = this.getOrCreateEntry(terminalId, instanceId);
 		entry.transport.stateListeners.add(listener);
 		return () => {
 			entry.transport.stateListeners.delete(listener);

--- a/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
@@ -262,6 +262,7 @@ function measureAndResize(runtime: TerminalRuntime) {
 export function createRuntime(
 	terminalId: string,
 	appearance: TerminalAppearance,
+	options: { initialBuffer?: string } = {},
 ): TerminalRuntime {
 	const savedDims = loadSavedDimensions(terminalId);
 	const cols = savedDims?.cols ?? DEFAULT_COLS;
@@ -283,7 +284,11 @@ export function createRuntime(
 	// Activate Unicode 11 widths (inside loadAddons) before restoring the buffer,
 	// else CJK/emoji/ZWJ widths get baked wrong into the replay. (#3572)
 	const addonsResult = loadAddons(terminal);
-	restoreBuffer(terminalId, terminal);
+	if (options.initialBuffer !== undefined) {
+		terminal.write(options.initialBuffer);
+	} else {
+		restoreBuffer(terminalId, terminal);
+	}
 
 	return {
 		terminalId,
@@ -395,13 +400,23 @@ export function updateRuntimeAppearance(
 	}
 }
 
-export function disposeRuntime(runtime: TerminalRuntime) {
+export function disposeRuntime(
+	runtime: TerminalRuntime,
+	options: { clearPersistedState?: boolean } = {},
+) {
+	const clearPersistedState = options.clearPersistedState ?? true;
+	if (!clearPersistedState) {
+		persistBuffer(runtime.terminalId, runtime.serializeAddon);
+		persistDimensions(runtime.terminalId, runtime.lastCols, runtime.lastRows);
+	}
 	runtime._disposeAddons?.();
 	runtime._disposeAddons = null;
 	runtime.resizeObserver?.disconnect();
 	runtime.resizeObserver = null;
 	runtime.wrapper.remove();
 	runtime.terminal.dispose();
-	clearPersistedBuffer(runtime.terminalId);
-	clearPersistedDimensions(runtime.terminalId);
+	if (clearPersistedState) {
+		clearPersistedBuffer(runtime.terminalId);
+		clearPersistedDimensions(runtime.terminalId);
+	}
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useConsumePendingLaunch/useConsumePendingLaunch.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useConsumePendingLaunch/useConsumePendingLaunch.ts
@@ -62,9 +62,6 @@ export function useConsumePendingLaunch({
 
 	useEffect(() => {
 		if (!pending) {
-			console.log("[v2-launch] useConsumePendingLaunch: no pending row yet", {
-				workspaceId,
-			});
 			return;
 		}
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/DiffPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/DiffPane.tsx
@@ -41,9 +41,10 @@ function ScrollToFile({ path }: { path: string }) {
 interface DiffPaneProps {
 	context: RendererContext<PaneViewerData>;
 	workspaceId: string;
+	onOpenFile: (path: string, openInNewTab?: boolean) => void;
 }
 
-export function DiffPane({ context, workspaceId }: DiffPaneProps) {
+export function DiffPane({ context, workspaceId, onOpenFile }: DiffPaneProps) {
 	const data = context.pane.data as DiffPaneData;
 
 	const diffStyle = useSettings((s) => s.diffStyle);
@@ -104,7 +105,8 @@ export function DiffPane({ context, workspaceId }: DiffPaneProps) {
 					onSetCollapsed={setCollapsed}
 					viewed={viewedSet.has(file.path)}
 					onSetViewed={setViewed}
-					onOpenFile={openInExternalEditor}
+					onOpenFile={onOpenFile}
+					onOpenInExternalEditor={openInExternalEditor}
 				/>
 			))}
 		</Virtualizer>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/DiffFileEntry/DiffFileEntry.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/DiffFileEntry/DiffFileEntry.tsx
@@ -35,7 +35,8 @@ interface DiffFileEntryProps {
 	onSetCollapsed: (path: string, value: boolean) => void;
 	viewed: boolean;
 	onSetViewed: (path: string, next: boolean) => void;
-	onOpenFile: (path: string) => void;
+	onOpenFile: (path: string, openInNewTab?: boolean) => void;
+	onOpenInExternalEditor: (path: string) => void;
 }
 
 export const DiffFileEntry = memo(function DiffFileEntry({
@@ -47,6 +48,7 @@ export const DiffFileEntry = memo(function DiffFileEntry({
 	viewed,
 	onSetViewed,
 	onOpenFile,
+	onOpenInExternalEditor,
 }: DiffFileEntryProps) {
 	const wrapperRef = useRef<HTMLDivElement>(null);
 	const isNear = useInView(wrapperRef, { rootMargin: "2000px 0px" });
@@ -66,15 +68,28 @@ export const DiffFileEntry = memo(function DiffFileEntry({
 		onSetViewed(file.path, next);
 		onSetCollapsed(file.path, next);
 	}, [viewed, file.path, onSetViewed, onSetCollapsed]);
-	const handleOpenFile = useCallback(() => {
+	const showDeletedFileToast = useCallback(() => {
+		toast.error("File no longer exists", {
+			description: `${file.path} was deleted in this change.`,
+		});
+	}, [file.path]);
+	const handleOpenFile = useCallback(
+		(openInNewTab?: boolean) => {
+			if (file.status === "deleted") {
+				showDeletedFileToast();
+				return;
+			}
+			onOpenFile(file.path, openInNewTab);
+		},
+		[file.status, file.path, onOpenFile, showDeletedFileToast],
+	);
+	const handleOpenInExternalEditor = useCallback(() => {
 		if (file.status === "deleted") {
-			toast.error("File no longer exists", {
-				description: `${file.path} was deleted in this change.`,
-			});
+			showDeletedFileToast();
 			return;
 		}
-		onOpenFile(file.path);
-	}, [file.status, file.path, onOpenFile]);
+		onOpenInExternalEditor(file.path);
+	}, [file.status, file.path, onOpenInExternalEditor, showDeletedFileToast]);
 	const handleShowFullDiff = useCallback(() => setShowFullDiff(true), []);
 	const handleToggleExpandUnchanged = useCallback(
 		() => setExpandUnchanged((prev) => !prev),
@@ -103,6 +118,7 @@ export const DiffFileEntry = memo(function DiffFileEntry({
 					viewed={viewed}
 					onToggleViewed={handleToggleViewed}
 					onOpenFile={handleOpenFile}
+					onOpenInExternalEditor={handleOpenInExternalEditor}
 				/>
 			</div>
 		);
@@ -134,6 +150,7 @@ export const DiffFileEntry = memo(function DiffFileEntry({
 					viewed={viewed}
 					onToggleViewed={handleToggleViewed}
 					onOpenFile={handleOpenFile}
+					onOpenInExternalEditor={handleOpenInExternalEditor}
 				/>
 			) : null}
 		</div>
@@ -148,7 +165,8 @@ interface DeferredDiffPlaceholderProps {
 	onToggleCollapsed: () => void;
 	viewed: boolean;
 	onToggleViewed: () => void;
-	onOpenFile?: () => void;
+	onOpenFile?: (openInNewTab?: boolean) => void;
+	onOpenInExternalEditor?: () => void;
 }
 
 function DeferredDiffPlaceholder({
@@ -160,6 +178,7 @@ function DeferredDiffPlaceholder({
 	viewed,
 	onToggleViewed,
 	onOpenFile,
+	onOpenInExternalEditor,
 }: DeferredDiffPlaceholderProps) {
 	const isDeleted = reason === "deleted";
 	const fullHeight = isDeleted
@@ -185,6 +204,7 @@ function DeferredDiffPlaceholder({
 				viewed={viewed}
 				onToggleViewed={onToggleViewed}
 				onOpenFile={onOpenFile}
+				onOpenInExternalEditor={onOpenInExternalEditor}
 			/>
 			{!collapsed && (
 				<div

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/DiffFileHeader/DiffFileHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/DiffFileHeader/DiffFileHeader.tsx
@@ -1,9 +1,17 @@
 import { Checkbox } from "@superset/ui/checkbox";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
-import { ChevronDown, ChevronRight, Eye, EyeOff } from "lucide-react";
+import {
+	ChevronDown,
+	ChevronRight,
+	ExternalLink,
+	Eye,
+	EyeOff,
+} from "lucide-react";
 import { useId } from "react";
 import { LuCopy, LuUndo2 } from "react-icons/lu";
 import { StatusIndicator } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/StatusIndicator";
+import { CLICK_HINT_TOOLTIP } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/utils/clickModifierLabels";
+import { getSidebarClickIntent } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/utils/getSidebarClickIntent";
 import { FileIcon } from "renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/utils";
 
 interface DiffFileHeaderProps {
@@ -17,7 +25,8 @@ interface DiffFileHeaderProps {
 	onToggleCollapsed: () => void;
 	viewed: boolean;
 	onToggleViewed: () => void;
-	onOpenFile?: () => void;
+	onOpenFile?: (openInNewTab?: boolean) => void;
+	onOpenInExternalEditor?: () => void;
 	onCopyContents?: () => void;
 	onDiscard?: () => void;
 }
@@ -34,6 +43,7 @@ export function DiffFileHeader({
 	viewed,
 	onToggleViewed,
 	onOpenFile,
+	onOpenInExternalEditor,
 	onCopyContents,
 	onDiscard,
 }: DiffFileHeaderProps) {
@@ -58,8 +68,16 @@ export function DiffFileHeader({
 				<TooltipTrigger asChild>
 					<button
 						type="button"
-						onClick={onOpenFile}
-						disabled={!onOpenFile}
+						onClick={(event) => {
+							const intent = getSidebarClickIntent(event);
+							if (intent === "openInEditor") {
+								onOpenInExternalEditor?.();
+								return;
+							}
+							onOpenFile?.(intent === "openInNewTab");
+						}}
+						disabled={!onOpenFile && !onOpenInExternalEditor}
+						aria-label="Open in file viewer"
 						className="flex min-w-0 flex-1 items-center gap-2 rounded border border-border px-2 py-1 text-left transition-colors hover:bg-accent disabled:pointer-events-none disabled:opacity-60"
 					>
 						<FileIcon fileName={path} className="size-4 shrink-0" />
@@ -82,11 +100,32 @@ export function DiffFileHeader({
 					</button>
 				</TooltipTrigger>
 				<TooltipContent side="bottom" showArrow={false}>
-					Open {path}
+					Open in file viewer. {CLICK_HINT_TOOLTIP}
 				</TooltipContent>
 			</Tooltip>
 
 			<div className="flex shrink-0 items-center gap-2">
+				<Tooltip>
+					<TooltipTrigger asChild>
+						<span className="inline-flex rounded">
+							<button
+								type="button"
+								onClick={onOpenInExternalEditor}
+								disabled={!onOpenInExternalEditor}
+								aria-label="Open in editor"
+								className="rounded p-1 text-muted-foreground/60 transition-colors hover:bg-accent hover:text-muted-foreground disabled:pointer-events-none disabled:opacity-40"
+							>
+								<ExternalLink className="size-3.5" />
+							</button>
+						</span>
+					</TooltipTrigger>
+					<TooltipContent side="bottom" showArrow={false}>
+						{onOpenInExternalEditor
+							? "Open in editor"
+							: "Open in editor unavailable"}
+					</TooltipContent>
+				</Tooltip>
+
 				<div className="flex items-center gap-1.5">
 					<Checkbox
 						id={viewedId}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/WorkspaceDiff/WorkspaceDiff.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/WorkspaceDiff/WorkspaceDiff.tsx
@@ -27,7 +27,8 @@ interface WorkspaceDiffProps {
 	onToggleCollapsed: () => void;
 	viewed: boolean;
 	onToggleViewed: () => void;
-	onOpenFile?: () => void;
+	onOpenFile?: (openInNewTab?: boolean) => void;
+	onOpenInExternalEditor?: () => void;
 }
 
 export const WorkspaceDiff = memo(function WorkspaceDiff({
@@ -45,6 +46,7 @@ export const WorkspaceDiff = memo(function WorkspaceDiff({
 	viewed,
 	onToggleViewed,
 	onOpenFile,
+	onOpenInExternalEditor,
 }: WorkspaceDiffProps) {
 	const activeTheme = useResolvedTheme();
 	const { data: fontSettings } = electronTrpc.settings.getFontSettings.useQuery(
@@ -155,6 +157,7 @@ export const WorkspaceDiff = memo(function WorkspaceDiff({
 				viewed={viewed}
 				onToggleViewed={onToggleViewed}
 				onOpenFile={onOpenFile}
+				onOpenInExternalEditor={onOpenInExternalEditor}
 				onCopyContents={handleCopyContents}
 				onDiscard={handleDiscard}
 			/>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx
@@ -74,6 +74,7 @@ export function TerminalPane({
 		() => paneData.terminalId ?? crypto.randomUUID(),
 		[paneData.terminalId],
 	);
+	const terminalInstanceId = ctx.pane.id;
 	const containerRef = useRef<HTMLDivElement | null>(null);
 	const activeTheme = useTheme();
 	const [isSearchOpen, setIsSearchOpen] = useState(false);
@@ -100,6 +101,12 @@ export function TerminalPane({
 	const ensureSession = workspaceTrpc.terminal.ensureSession.useMutation();
 	const ensureSessionRef = useRef(ensureSession);
 	ensureSessionRef.current = ensureSession;
+	const workspaceTrpcUtils = workspaceTrpc.useUtils();
+	const invalidateTerminalSessionsRef = useRef(
+		workspaceTrpcUtils.terminal.listSessions.invalidate,
+	);
+	invalidateTerminalSessionsRef.current =
+		workspaceTrpcUtils.terminal.listSessions.invalidate;
 
 	// useCallback so useSyncExternalStore doesn't re-subscribe every render —
 	// otherwise every keystroke-triggered re-render unsubscribes and
@@ -107,8 +114,12 @@ export function TerminalPane({
 	// docs ("If you don't memoize the subscribe function…").
 	const subscribe = useCallback(
 		(callback: () => void) =>
-			terminalRuntimeRegistry.onStateChange(terminalId, callback),
-		[terminalId],
+			terminalRuntimeRegistry.onStateChange(
+				terminalId,
+				callback,
+				terminalInstanceId,
+			),
+		[terminalId, terminalInstanceId],
 	);
 	const highlightedSessionId = useBrowserAutomationStore((state) =>
 		state.connectModal.isOpen ? state.connectModal.selectedSessionId : null,
@@ -117,8 +128,11 @@ export function TerminalPane({
 		highlightedSessionId === `terminal:${ctx.pane.id}`;
 	const getSnapshot = useCallback(
 		(): ConnectionState =>
-			terminalRuntimeRegistry.getConnectionState(terminalId),
-		[terminalId],
+			terminalRuntimeRegistry.getConnectionState(
+				terminalId,
+				terminalInstanceId,
+			),
+		[terminalId, terminalInstanceId],
 	);
 	const connectionState = useSyncExternalStore(subscribe, getSnapshot);
 
@@ -137,9 +151,15 @@ export function TerminalPane({
 		const container = containerRef.current;
 		if (!container) return;
 
-		terminalRuntimeRegistry.mount(terminalId, container, appearanceRef.current);
+		terminalRuntimeRegistry.mount(
+			terminalId,
+			container,
+			appearanceRef.current,
+			terminalInstanceId,
+		);
 
 		let cancelled = false;
+		const sessionWorkspaceId = workspaceIdRef.current;
 
 		// Always connect after ensureSession settles, even on error: if the
 		// session actually exists on the server (e.g. we raced another client),
@@ -149,34 +169,53 @@ export function TerminalPane({
 		ensureSessionRef.current
 			.mutateAsync({
 				terminalId,
-				workspaceId: workspaceIdRef.current,
+				workspaceId: sessionWorkspaceId,
 				themeType: initialThemeTypeRef.current,
+			})
+			.then((result) => {
+				if (result.status === "active") {
+					void invalidateTerminalSessionsRef.current({
+						workspaceId: sessionWorkspaceId,
+					});
+				}
 			})
 			.catch((err) => {
 				console.error("[TerminalPane] ensureSession failed:", err);
 			})
 			.finally(() => {
 				if (cancelled) return;
-				terminalRuntimeRegistry.connect(terminalId, websocketUrlRef.current);
+				terminalRuntimeRegistry.connect(
+					terminalId,
+					websocketUrlRef.current,
+					terminalInstanceId,
+				);
 			});
 
 		return () => {
 			cancelled = true;
-			terminalRuntimeRegistry.detach(terminalId);
+			terminalRuntimeRegistry.detach(terminalId, terminalInstanceId);
 		};
-	}, [terminalId]);
+	}, [terminalId, terminalInstanceId]);
 
 	// WS URL can change while the terminal stays mounted (token refresh, host
 	// URL re-resolution on provider remount). Reconnect only if the transport
 	// is already live — on initial mount the transport is "disconnected" and
 	// we let the ensureSession path above open it.
 	useEffect(() => {
-		terminalRuntimeRegistry.reconnect(terminalId, websocketUrl);
-	}, [terminalId, websocketUrl]);
+		terminalRuntimeRegistry.reconnect(
+			terminalId,
+			websocketUrl,
+			terminalInstanceId,
+		);
+	}, [terminalId, terminalInstanceId, websocketUrl]);
 
 	useEffect(() => {
-		terminalRuntimeRegistry.updateAppearance(terminalId, appearance);
-	}, [terminalId, appearance]);
+		terminalRuntimeRegistry.updateAppearance(
+			terminalId,
+			appearance,
+			terminalInstanceId,
+		);
+	}, [terminalId, terminalInstanceId, appearance]);
 
 	// --- Link handlers ---
 	// All filesystem operations go through the host service.
@@ -187,81 +226,84 @@ export function TerminalPane({
 	statPathRef.current = statPathMutation.mutateAsync;
 
 	useEffect(() => {
-		terminalRuntimeRegistry.setLinkHandlers(terminalId, {
-			stat: async (path) => {
-				try {
-					const result = await statPathRef.current({
-						workspaceId,
-						path,
-					});
-					if (!result) return null;
-					return {
-						isDirectory: result.isDirectory,
-						resolvedPath: result.resolvedPath,
-					};
-				} catch {
-					return null;
-				}
-			},
-			onFileLinkClick: (event, link) => {
-				// Folders are not settings-controlled: ⌘ reveals in sidebar,
-				// ⌘⇧ falls through to the external editor path, plain = hint.
-				if (link.isDirectory) {
-					if (!event.metaKey && !event.ctrlKey) {
+		terminalRuntimeRegistry.setLinkHandlers(
+			terminalId,
+			{
+				stat: async (path) => {
+					try {
+						const result = await statPathRef.current({
+							workspaceId,
+							path,
+						});
+						if (!result) return null;
+						return {
+							isDirectory: result.isDirectory,
+							resolvedPath: result.resolvedPath,
+						};
+					} catch {
+						return null;
+					}
+				},
+				onFileLinkClick: (event, link) => {
+					// Folders are not settings-controlled: ⌘ reveals in sidebar,
+					// ⌘⇧ falls through to the external editor path, plain = hint.
+					if (link.isDirectory) {
+						if (!event.metaKey && !event.ctrlKey) {
+							showHint(event.clientX, event.clientY);
+							return;
+						}
+						event.preventDefault();
+						if (event.shiftKey) {
+							openInExternalEditor(link.resolvedPath);
+						} else {
+							onRevealPath(link.resolvedPath, { isDirectory: true });
+						}
+						return;
+					}
+
+					const action = getFileAction(event);
+					if (action === null) {
 						showHint(event.clientX, event.clientY);
 						return;
 					}
 					event.preventDefault();
-					if (event.shiftKey) {
-						openInExternalEditor(link.resolvedPath);
+					if (action === "external") {
+						openInExternalEditor(link.resolvedPath, {
+							line: link.row,
+							column: link.col,
+						});
 					} else {
-						onRevealPath(link.resolvedPath, { isDirectory: true });
+						onOpenFile(link.resolvedPath);
 					}
-					return;
-				}
-
-				const action = getFileAction(event);
-				if (action === null) {
-					showHint(event.clientX, event.clientY);
-					return;
-				}
-				event.preventDefault();
-				if (action === "external") {
-					openInExternalEditor(link.resolvedPath, {
-						line: link.row,
-						column: link.col,
-					});
-				} else {
-					onOpenFile(link.resolvedPath);
-				}
+				},
+				onUrlClick: (event, url) => {
+					const action = getUrlAction(event);
+					if (action === null) {
+						showHint(event.clientX, event.clientY);
+						return;
+					}
+					event.preventDefault();
+					if (action === "external") {
+						electronTrpcClient.external.openUrl.mutate(url).catch((error) => {
+							console.error("[v2 Terminal] Failed to open URL:", url, error);
+						});
+					} else {
+						ctx.store.getState().openPane({
+							pane: {
+								kind: "browser",
+								data: { url, mode: "generic" } satisfies BrowserPaneData,
+							},
+						});
+					}
+				},
+				onLinkHover,
+				onLinkLeave,
 			},
-			onUrlClick: (event, url) => {
-				const action = getUrlAction(event);
-				if (action === null) {
-					showHint(event.clientX, event.clientY);
-					return;
-				}
-				event.preventDefault();
-				if (action === "external") {
-					electronTrpcClient.external.openUrl.mutate(url).catch((error) => {
-						console.error("[v2 Terminal] Failed to open URL:", url, error);
-					});
-				} else {
-					ctx.store.getState().openPane({
-						pane: {
-							kind: "browser",
-							// FORK NOTE: fork BrowserPaneData requires `mode`; default to
-							// "generic" for terminal-link-opened URLs.
-							data: { url, mode: "generic" } satisfies BrowserPaneData,
-						},
-					});
-				}
-			},
-			onLinkHover,
-			onLinkLeave,
-		});
+			terminalInstanceId,
+		);
 	}, [
 		terminalId,
+		terminalInstanceId,
 		workspaceId,
 		ctx.store,
 		onOpenFile,
@@ -277,7 +319,7 @@ export function TerminalPane({
 	useHotkey(
 		"CLEAR_TERMINAL",
 		() => {
-			terminalRuntimeRegistry.clear(terminalId);
+			terminalRuntimeRegistry.clear(terminalId, terminalInstanceId);
 		},
 		{ enabled: ctx.isActive },
 	);
@@ -285,7 +327,7 @@ export function TerminalPane({
 	useHotkey(
 		"SCROLL_TO_BOTTOM",
 		() => {
-			terminalRuntimeRegistry.scrollToBottom(terminalId);
+			terminalRuntimeRegistry.scrollToBottom(terminalId, terminalInstanceId);
 		},
 		{ enabled: ctx.isActive },
 	);
@@ -298,14 +340,15 @@ export function TerminalPane({
 	// connectionState in deps ensures terminal ref re-derives after connect/disconnect
 	// biome-ignore lint/correctness/useExhaustiveDependencies: connectionState is intentionally included to trigger re-derive
 	const terminal = useMemo(
-		() => terminalRuntimeRegistry.getTerminal(terminalId),
-		[terminalId, connectionState],
+		() => terminalRuntimeRegistry.getTerminal(terminalId, terminalInstanceId),
+		[terminalId, terminalInstanceId, connectionState],
 	);
 
 	// biome-ignore lint/correctness/useExhaustiveDependencies: connectionState is intentionally included to trigger re-derive
 	const searchAddon = useMemo(
-		() => terminalRuntimeRegistry.getSearchAddon(terminalId),
-		[terminalId, connectionState],
+		() =>
+			terminalRuntimeRegistry.getSearchAddon(terminalId, terminalInstanceId),
+		[terminalId, terminalInstanceId, connectionState],
 	);
 
 	const [isDropActive, setIsDropActive] = useState(false);
@@ -363,8 +406,10 @@ export function TerminalPane({
 		}
 		const text = resolveDroppedText(event.dataTransfer);
 		if (!text) return;
-		terminalRuntimeRegistry.getTerminal(terminalId)?.focus();
-		terminalRuntimeRegistry.paste(terminalId, text);
+		terminalRuntimeRegistry
+			.getTerminal(terminalId, terminalInstanceId)
+			?.focus();
+		terminalRuntimeRegistry.paste(terminalId, text, terminalInstanceId);
 	};
 
 	return (

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalHeaderExtras/TerminalHeaderExtras.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalHeaderExtras/TerminalHeaderExtras.tsx
@@ -1,0 +1,60 @@
+import type { RendererContext } from "@superset/panes";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
+import { Archive } from "lucide-react";
+import { markTerminalForBackground } from "renderer/lib/terminal/terminal-background-intents";
+import type {
+	PaneViewerData,
+	TerminalPaneData,
+} from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/types";
+
+interface TerminalHeaderExtrasProps {
+	context: RendererContext<PaneViewerData>;
+}
+
+export function TerminalHeaderExtras({ context }: TerminalHeaderExtrasProps) {
+	if (context.pane.kind !== "terminal") return null;
+
+	const data = context.pane.data as TerminalPaneData;
+
+	const handleMoveToBackground = () => {
+		// Check whether other panes sharing the same terminalId still exist.
+		// If so, only close this pane without marking the background intent —
+		// the stale intent would otherwise cause the remaining pane's eventual
+		// close to skip dispose/killSession (silent PTY leak).
+		const state = context.store.getState();
+		const duplicateExists = state.tabs.some((tab) =>
+			Object.values(tab.panes).some(
+				(pane) =>
+					pane.id !== context.pane.id &&
+					pane.kind === "terminal" &&
+					(pane.data as TerminalPaneData).terminalId === data.terminalId,
+			),
+		);
+
+		if (!duplicateExists) {
+			markTerminalForBackground(data.terminalId);
+		}
+		void context.actions.close();
+	};
+
+	return (
+		<Tooltip>
+			<TooltipTrigger asChild>
+				<button
+					type="button"
+					aria-label="Move terminal to background"
+					onClick={(event) => {
+						event.stopPropagation();
+						handleMoveToBackground();
+					}}
+					className="rounded p-1 text-muted-foreground/60 transition-colors hover:text-muted-foreground"
+				>
+					<Archive className="size-3.5" />
+				</button>
+			</TooltipTrigger>
+			<TooltipContent side="bottom" showArrow={false}>
+				Move terminal to background
+			</TooltipContent>
+		</Tooltip>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalHeaderExtras/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalHeaderExtras/index.ts
@@ -1,0 +1,1 @@
+export { TerminalHeaderExtras } from "./TerminalHeaderExtras";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalSessionDropdown/TerminalSessionDropdown.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalSessionDropdown/TerminalSessionDropdown.tsx
@@ -1,0 +1,307 @@
+import type { RendererContext } from "@superset/panes";
+import { alert } from "@superset/ui/atoms/Alert";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuLabel,
+	DropdownMenuSeparator,
+	DropdownMenuTrigger,
+} from "@superset/ui/dropdown-menu";
+import { toast } from "@superset/ui/sonner";
+import { workspaceTrpc } from "@superset/workspace-client";
+import {
+	Check,
+	ChevronDown,
+	LoaderCircle,
+	Plus,
+	TerminalSquare,
+	Trash2,
+} from "lucide-react";
+import { useMemo, useState } from "react";
+import { markTerminalForBackground } from "renderer/lib/terminal/terminal-background-intents";
+import type {
+	PaneViewerData,
+	TerminalPaneData,
+} from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/types";
+import { getRelativeTime } from "renderer/screens/main/components/WorkspacesListView/utils";
+
+interface TerminalSessionDropdownProps {
+	context: RendererContext<PaneViewerData>;
+	workspaceId: string;
+}
+
+interface VisibleTerminalSession {
+	terminalId: string;
+	workspaceId: string;
+	createdAt?: number;
+	exited: boolean;
+	exitCode: number;
+	attached: boolean;
+	pending?: boolean;
+}
+
+interface TerminalPaneLocation {
+	tabId: string;
+	paneId: string;
+	titleOverride?: string;
+}
+
+function formatCreatedAt(createdAt: number | undefined): string {
+	if (!createdAt) return "Creating";
+
+	return getRelativeTime(createdAt, { format: "compact" });
+}
+
+function getTerminalPaneLocations(
+	context: RendererContext<PaneViewerData>,
+): Map<string, TerminalPaneLocation[]> {
+	const locations = new Map<string, TerminalPaneLocation[]>();
+	for (const tab of context.store.getState().tabs) {
+		for (const pane of Object.values(tab.panes)) {
+			if (pane.id === context.pane.id || pane.kind !== "terminal") continue;
+			const data = pane.data as Partial<TerminalPaneData>;
+			if (data.terminalId) {
+				const terminalLocations = locations.get(data.terminalId) ?? [];
+				terminalLocations.push({
+					tabId: tab.id,
+					paneId: pane.id,
+					titleOverride: pane.titleOverride,
+				});
+				locations.set(data.terminalId, terminalLocations);
+			}
+		}
+	}
+	return locations;
+}
+
+export function TerminalSessionDropdown({
+	context,
+	workspaceId,
+}: TerminalSessionDropdownProps) {
+	const [isOpen, setIsOpen] = useState(false);
+	const data = context.pane.data as TerminalPaneData;
+	const { terminalId } = data;
+	const utils = workspaceTrpc.useUtils();
+	const killTerminalSession = workspaceTrpc.terminal.killSession.useMutation();
+	const sessionsQuery = workspaceTrpc.terminal.listSessions.useQuery(
+		{ workspaceId },
+		{
+			refetchInterval: isOpen ? 2_000 : false,
+			refetchOnWindowFocus: true,
+		},
+	);
+
+	const sessions = useMemo<VisibleTerminalSession[]>(() => {
+		const liveSessions = sessionsQuery.data?.sessions ?? [];
+		if (liveSessions.some((session) => session.terminalId === terminalId)) {
+			return liveSessions;
+		}
+		return [
+			{
+				terminalId,
+				workspaceId,
+				exited: false,
+				exitCode: 0,
+				attached: false,
+				pending: true,
+			},
+			...liveSessions,
+		];
+	}, [sessionsQuery.data?.sessions, terminalId, workspaceId]);
+	const renderTerminalPaneLocations = getTerminalPaneLocations(context);
+
+	const handleSelectSession = (nextTerminalId: string) => {
+		if (nextTerminalId === terminalId) {
+			setIsOpen(false);
+			return;
+		}
+
+		const state = context.store.getState();
+		const terminalPaneLocations = getTerminalPaneLocations(context);
+		const existingLocation = terminalPaneLocations.get(nextTerminalId)?.[0];
+		if ((terminalPaneLocations.get(terminalId)?.length ?? 0) === 0) {
+			markTerminalForBackground(terminalId);
+		}
+
+		state.setPaneData({
+			paneId: context.pane.id,
+			data: { terminalId: nextTerminalId } as PaneViewerData,
+		});
+		state.setPaneTitleOverride({
+			tabId: context.tab.id,
+			paneId: context.pane.id,
+			titleOverride: existingLocation?.titleOverride,
+		});
+		setIsOpen(false);
+	};
+
+	const closePanesForTerminal = (targetTerminalId: string) => {
+		const terminalPaneLocations = getTerminalPaneLocations(context);
+		for (const location of terminalPaneLocations.get(targetTerminalId) ?? []) {
+			context.store.getState().closePane({
+				tabId: location.tabId,
+				paneId: location.paneId,
+			});
+		}
+
+		if (targetTerminalId === terminalId) {
+			void context.actions.close();
+		}
+	};
+
+	const removeTerminalSession = async (targetTerminalId: string) => {
+		await killTerminalSession.mutateAsync({
+			terminalId: targetTerminalId,
+			workspaceId,
+		});
+		closePanesForTerminal(targetTerminalId);
+		await utils.terminal.listSessions.invalidate({ workspaceId });
+	};
+
+	const handleRemoveTerminal = (targetTerminalId: string) => {
+		alert({
+			title: "Remove terminal session?",
+			description:
+				"This will terminate the underlying process. Use Move terminal to background to keep it running without a pane.",
+			actions: [
+				{ label: "Cancel", variant: "outline", onClick: () => {} },
+				{
+					label: "Remove Terminal",
+					variant: "destructive",
+					onClick: () => {
+						toast.promise(removeTerminalSession(targetTerminalId), {
+							loading: "Removing terminal...",
+							success: "Terminal removed",
+							error: "Failed to remove terminal",
+						});
+					},
+				},
+			],
+		});
+	};
+
+	const handleNewTerminal = () => {
+		const state = context.store.getState();
+		const terminalPaneLocations = getTerminalPaneLocations(context);
+		if ((terminalPaneLocations.get(terminalId)?.length ?? 0) === 0) {
+			markTerminalForBackground(terminalId);
+		}
+		state.setPaneData({
+			paneId: context.pane.id,
+			data: {
+				terminalId: crypto.randomUUID(),
+			} as PaneViewerData,
+		});
+		state.setPaneTitleOverride({
+			tabId: context.tab.id,
+			paneId: context.pane.id,
+			titleOverride: undefined,
+		});
+		void utils.terminal.listSessions.invalidate({ workspaceId });
+		setIsOpen(false);
+	};
+
+	const triggerTitle = context.pane.titleOverride ?? "Terminal";
+	const currentSession = sessions.find(
+		(session) => session.terminalId === terminalId,
+	);
+	const currentCreatedAtLabel = formatCreatedAt(currentSession?.createdAt);
+
+	return (
+		<DropdownMenu open={isOpen} onOpenChange={setIsOpen}>
+			<DropdownMenuTrigger asChild>
+				<button
+					type="button"
+					aria-label="Terminal sessions"
+					className="flex min-w-0 max-w-72 items-center gap-1.5 rounded px-1.5 py-0.5 text-sm text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+					onMouseDown={(event) => event.stopPropagation()}
+					onClick={(event) => event.stopPropagation()}
+				>
+					<TerminalSquare className="size-4 shrink-0" />
+					<span className="min-w-0 truncate">{triggerTitle}</span>
+					<span className="shrink-0 text-[10px] text-muted-foreground/70">
+						{currentCreatedAtLabel}
+					</span>
+					{sessionsQuery.isFetching && isOpen ? (
+						<LoaderCircle className="size-3 shrink-0 animate-spin" />
+					) : (
+						<ChevronDown className="size-3 shrink-0" />
+					)}
+				</button>
+			</DropdownMenuTrigger>
+			<DropdownMenuContent align="start" className="w-80">
+				<DropdownMenuLabel className="text-xs">
+					Terminal Sessions
+				</DropdownMenuLabel>
+				<DropdownMenuSeparator />
+				<div className="max-h-80 overflow-y-auto">
+					{sessions.length > 0 ? (
+						sessions.map((session) => {
+							const isCurrent = session.terminalId === terminalId;
+							const location = renderTerminalPaneLocations.get(
+								session.terminalId,
+							)?.[0];
+							const createdAtLabel = formatCreatedAt(session.createdAt);
+							const status = isCurrent
+								? "Current"
+								: session.pending
+									? "Starting"
+									: session.attached
+										? "Attached"
+										: "Detached";
+							const title = isCurrent
+								? triggerTitle
+								: (location?.titleOverride ?? "Terminal");
+
+							return (
+								<DropdownMenuItem
+									key={session.terminalId}
+									className="group flex items-center gap-2"
+									onSelect={(_event) => {
+										handleSelectSession(session.terminalId);
+									}}
+								>
+									<span className="w-4 shrink-0">
+										{isCurrent && <Check className="size-3.5" />}
+									</span>
+									<span className="min-w-0 flex-1 truncate text-xs">
+										{title}
+									</span>
+									<span className="shrink-0 text-[10px] text-muted-foreground/70">
+										{createdAtLabel}
+									</span>
+									<span className="shrink-0 text-xs text-muted-foreground">
+										{status}
+									</span>
+									<button
+										type="button"
+										aria-label={`Remove terminal ${session.createdAt ? createdAtLabel : "session"}`}
+										disabled={killTerminalSession.isPending}
+										className="shrink-0 rounded p-0.5 opacity-0 transition-opacity hover:bg-destructive/10 hover:text-destructive disabled:pointer-events-none disabled:opacity-30 group-hover:opacity-100"
+										onClick={(event) => {
+											event.preventDefault();
+											event.stopPropagation();
+											handleRemoveTerminal(session.terminalId);
+										}}
+									>
+										<Trash2 className="size-3" />
+									</button>
+								</DropdownMenuItem>
+							);
+						})
+					) : (
+						<div className="px-2 py-1.5 text-xs text-muted-foreground">
+							No live sessions
+						</div>
+					)}
+				</div>
+				<DropdownMenuSeparator />
+				<DropdownMenuItem onSelect={handleNewTerminal}>
+					<Plus className="mr-1.5 size-3.5" />
+					<span className="text-xs">New Terminal</span>
+				</DropdownMenuItem>
+			</DropdownMenuContent>
+		</DropdownMenu>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalSessionDropdown/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalSessionDropdown/index.ts
@@ -1,0 +1,1 @@
+export { TerminalSessionDropdown } from "./TerminalSessionDropdown";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/usePaneRegistry.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/usePaneRegistry.tsx
@@ -4,8 +4,10 @@ import type {
 	RendererContext,
 } from "@superset/panes";
 import { alert } from "@superset/ui/atoms/Alert";
+import { toast } from "@superset/ui/sonner";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { cn } from "@superset/ui/utils";
+import { workspaceTrpc } from "@superset/workspace-client";
 import {
 	Circle,
 	GitCompareArrows,
@@ -22,6 +24,7 @@ import {
 	LuClipboard,
 	LuClipboardCopy,
 	LuEraser,
+	LuPower,
 } from "react-icons/lu";
 import { TbScan } from "react-icons/tb";
 import { useHotkeyDisplay } from "renderer/hotkeys";
@@ -47,6 +50,8 @@ import { DiffPane } from "./components/DiffPane";
 import { FilePane } from "./components/FilePane";
 import { FilePaneHeaderExtras } from "./components/FilePane/components/FilePaneHeaderExtras";
 import { TerminalPane } from "./components/TerminalPane";
+import { TerminalHeaderExtras } from "./components/TerminalPane/components/TerminalHeaderExtras";
+import { TerminalSessionDropdown } from "./components/TerminalPane/components/TerminalSessionDropdown";
 
 function getFileName(filePath: string): string {
 	// FORK NOTE: v2 desktop runs on Windows too, so split on both separators.
@@ -203,6 +208,21 @@ export function usePaneRegistry(
 ): PaneRegistry<PaneViewerData> {
 	const clearShortcut = useHotkeyDisplay("CLEAR_TERMINAL").text;
 	const scrollToBottomShortcut = useHotkeyDisplay("SCROLL_TO_BOTTOM").text;
+	const workspaceTrpcUtils = workspaceTrpc.useUtils();
+	const { mutate: killTerminalSession, isPending: isKillingTerminalSession } =
+		workspaceTrpc.terminal.killSession.useMutation({
+			onSuccess: () => {
+				toast.success("Terminal session killed");
+				void workspaceTrpcUtils.terminal.listSessions.invalidate({
+					workspaceId,
+				});
+			},
+			onError: (error) => {
+				toast.error("Failed to kill terminal session", {
+					description: error.message,
+				});
+			},
+		});
 
 	return useMemo<PaneRegistry<PaneViewerData>>(
 		() => ({
@@ -299,6 +319,12 @@ export function usePaneRegistry(
 			terminal: {
 				getIcon: () => <TerminalSquare className="size-4" />,
 				getTitle: () => "Terminal",
+				renderTitle: (ctx: RendererContext<PaneViewerData>) => (
+					<TerminalSessionDropdown context={ctx} workspaceId={workspaceId} />
+				),
+				renderHeaderExtras: (ctx: RendererContext<PaneViewerData>) => (
+					<TerminalHeaderExtras context={ctx} />
+				),
 				renderPane: (ctx: RendererContext<PaneViewerData>) => (
 					<TerminalPane
 						ctx={ctx}
@@ -316,11 +342,17 @@ export function usePaneRegistry(
 							shortcut: `${MOD_KEY}C`,
 							disabled: (ctx) => {
 								const { terminalId } = ctx.pane.data as TerminalPaneData;
-								return !terminalRuntimeRegistry.getSelection(terminalId);
+								return !terminalRuntimeRegistry.getSelection(
+									terminalId,
+									ctx.pane.id,
+								);
 							},
 							onSelect: (ctx) => {
 								const { terminalId } = ctx.pane.data as TerminalPaneData;
-								const text = terminalRuntimeRegistry.getSelection(terminalId);
+								const text = terminalRuntimeRegistry.getSelection(
+									terminalId,
+									ctx.pane.id,
+								);
 								if (text) navigator.clipboard.writeText(text);
 							},
 						},
@@ -333,7 +365,13 @@ export function usePaneRegistry(
 								const { terminalId } = ctx.pane.data as TerminalPaneData;
 								try {
 									const text = await navigator.clipboard.readText();
-									if (text) terminalRuntimeRegistry.paste(terminalId, text);
+									if (text) {
+										terminalRuntimeRegistry.paste(
+											terminalId,
+											text,
+											ctx.pane.id,
+										);
+									}
 								} catch {
 									// Clipboard access denied
 								}
@@ -348,7 +386,7 @@ export function usePaneRegistry(
 								clearShortcut !== "Unassigned" ? clearShortcut : undefined,
 							onSelect: (ctx) => {
 								const { terminalId } = ctx.pane.data as TerminalPaneData;
-								terminalRuntimeRegistry.clear(terminalId);
+								terminalRuntimeRegistry.clear(terminalId, ctx.pane.id);
 							},
 						},
 						{
@@ -361,18 +399,51 @@ export function usePaneRegistry(
 									: undefined,
 							onSelect: (ctx) => {
 								const { terminalId } = ctx.pane.data as TerminalPaneData;
-								terminalRuntimeRegistry.scrollToBottom(terminalId);
+								terminalRuntimeRegistry.scrollToBottom(terminalId, ctx.pane.id);
 							},
 						},
 						{ key: "sep-terminal-defaults", type: "separator" },
 					];
 
-					// Update close label
 					const modifiedDefaults = defaults.map((d) =>
 						d.key === "close-pane" ? { ...d, label: "Close Terminal" } : d,
 					);
 
-					return [...terminalActions, ...modifiedDefaults];
+					const killAction: ContextMenuActionConfig<PaneViewerData> = {
+						key: "kill-terminal-session",
+						label: "Kill Terminal Session",
+						icon: <LuPower />,
+						variant: "destructive",
+						disabled: isKillingTerminalSession,
+						onSelect: (ctx) => {
+							const { terminalId } = ctx.pane.data as TerminalPaneData;
+							alert({
+								title: "Kill terminal session?",
+								description:
+									"This will terminate the underlying process. Move the terminal to background to keep it running without a pane.",
+								actions: [
+									{ label: "Cancel", variant: "outline", onClick: () => {} },
+									{
+										label: "Kill Session",
+										variant: "destructive",
+										onClick: () => {
+											killTerminalSession({
+												terminalId,
+												workspaceId,
+											});
+										},
+									},
+								],
+							});
+						},
+					};
+
+					return [
+						...terminalActions,
+						...modifiedDefaults,
+						{ key: "sep-terminal-kill", type: "separator" },
+						killAction,
+					];
 				},
 			},
 			browser: {
@@ -472,6 +543,8 @@ export function usePaneRegistry(
 			workspaceId,
 			clearShortcut,
 			scrollToBottomShortcut,
+			killTerminalSession,
+			isKillingTerminalSession,
 			onOpenFile,
 			onRevealPath,
 		],

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/usePaneRegistry.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/usePaneRegistry.tsx
@@ -284,7 +284,11 @@ export function usePaneRegistry(
 				getIcon: () => <GitCompareArrows className="size-4" />,
 				getTitle: () => "Changes",
 				renderPane: (ctx: RendererContext<PaneViewerData>) => (
-					<DiffPane context={ctx} workspaceId={workspaceId} />
+					<DiffPane
+						context={ctx}
+						workspaceId={workspaceId}
+						onOpenFile={onOpenFile}
+					/>
 				),
 				renderHeaderExtras: () => <DiffViewModeToggle />,
 				contextMenuActions: (_ctx, defaults) =>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
@@ -316,7 +316,13 @@ function WorkspaceContent({
 	// right-sidebar-open width.
 	const openSidebarFilePane = useCallback(
 		(filePath: string, openInNewTab?: boolean) => {
-			recordRecentlyViewed(filePath);
+			// Defensively resolve to absolute path: git diff yields relative paths,
+			// but FilePane requires an absolute path for ensureWithinRoot checks.
+			const absoluteFilePath =
+				worktreePath && !filePath.startsWith("/")
+					? toAbsoluteWorkspacePath(worktreePath, filePath)
+					: filePath;
+			recordRecentlyViewed(absoluteFilePath);
 			const state = store.getState();
 			if (openInNewTab) {
 				state.addTab({
@@ -382,7 +388,7 @@ function WorkspaceContent({
 				splitPercentage: 100 - rightSidebarOpenViewWidth,
 			});
 		},
-		[rightSidebarOpenViewWidth, store, recordRecentlyViewed],
+		[rightSidebarOpenViewWidth, store, recordRecentlyViewed, worktreePath],
 	);
 
 	const revealPath = useCallback(

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
@@ -324,7 +324,7 @@ function WorkspaceContent({
 						{
 							kind: "file",
 							data: {
-								filePath,
+								filePath: absoluteFilePath,
 								mode: "editor",
 							} as FilePaneData,
 						},
@@ -338,7 +338,7 @@ function WorkspaceContent({
 				: null;
 			if (
 				active?.pane.kind === "file" &&
-				(active.pane.data as FilePaneData).filePath === filePath
+				(active.pane.data as FilePaneData).filePath === absoluteFilePath
 			) {
 				state.setPanePinned({ paneId: active.pane.id, pinned: true });
 				return;
@@ -355,7 +355,7 @@ function WorkspaceContent({
 				pane: {
 					kind: "file",
 					data: {
-						filePath,
+						filePath: absoluteFilePath,
 						mode: "editor",
 					} as FilePaneData,
 				},

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesList/V2WorkspacesList.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesList/V2WorkspacesList.tsx
@@ -113,6 +113,12 @@ export function V2WorkspacesList({ pinned, others }: V2WorkspacesListProps) {
 	const hasAnyMatches = pinnedCount > 0 || othersCount > 0;
 	const hasActiveFilters = searchQuery.trim() !== "" || deviceFilter !== "all";
 
+	// FORK NOTE: upstream #3714 (99db5be26) は SortableHeader を使った
+	// columnHeader 行を導入したが、fork の V2WorkspacesList は sortField /
+	// sortDirection / handleSort を保持していないためそのまま取り込めない。
+	// constants.ts の grid 列変更と V2WorkspaceRow の sidebar 操作位置変更は
+	// 取り込み済みなので、列ヘッダーは別 PR で fork 側に hook を足してから
+	// 戻す。empty 判定は fork の `!hasAnyMatches` (フィルタ込み) を維持。
 	if (!hasAnyMatches) {
 		return (
 			<Empty className="flex-1 border-0">

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesList/components/V2WorkspaceRow/V2WorkspaceRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesList/components/V2WorkspaceRow/V2WorkspaceRow.tsx
@@ -66,9 +66,13 @@ export function V2WorkspaceRow({
 	const handleRemoveFromSidebar = useCallback(
 		(event: React.MouseEvent) => {
 			event.stopPropagation();
+			if (isCurrentRoute) {
+				event.preventDefault();
+				return;
+			}
 			removeWorkspaceFromSidebar(workspace.id);
 		},
-		[removeWorkspaceFromSidebar, workspace.id],
+		[isCurrentRoute, removeWorkspaceFromSidebar, workspace.id],
 	);
 
 	const creatorLabel = workspace.isCreatedByCurrentUser
@@ -131,16 +135,47 @@ export function V2WorkspaceRow({
 					isCurrentRoute && "bg-accent/40",
 				)}
 			>
-				<span className="flex items-center justify-center">
+				<div className="flex items-center justify-center">
 					{workspace.isInSidebar ? (
-						<span
-							role="img"
-							aria-label="In your sidebar"
-							title="In your sidebar"
-							className="size-1.5 rounded-full bg-primary"
-						/>
-					) : null}
-				</span>
+						<Tooltip delayDuration={300}>
+							<TooltipTrigger asChild>
+								<Button
+									size="icon"
+									variant="ghost"
+									onClick={handleRemoveFromSidebar}
+									aria-disabled={isCurrentRoute}
+									aria-label="Remove from sidebar"
+									className={cn(
+										"size-7",
+										isCurrentRoute && "cursor-not-allowed opacity-50",
+									)}
+								>
+									<LuMinus className="size-3.5" />
+								</Button>
+							</TooltipTrigger>
+							<TooltipContent side="right">
+								{isCurrentRoute
+									? "Can't remove the current workspace"
+									: "Remove from sidebar"}
+							</TooltipContent>
+						</Tooltip>
+					) : (
+						<Tooltip delayDuration={300}>
+							<TooltipTrigger asChild>
+								<Button
+									size="icon"
+									variant="ghost"
+									onClick={handleAddToSidebar}
+									aria-label="Add to sidebar"
+									className="size-7"
+								>
+									<LuPlus className="size-3.5" />
+								</Button>
+							</TooltipTrigger>
+							<TooltipContent side="right">Add to sidebar</TooltipContent>
+						</Tooltip>
+					)}
+				</div>
 
 				<span className="flex min-w-0 items-center">
 					<span
@@ -176,45 +211,6 @@ export function V2WorkspaceRow({
 				>
 					{timeLabel} · {creatorLabel}
 				</span>
-
-				<div className="flex justify-end">
-					{workspace.isInSidebar ? (
-						<Tooltip delayDuration={300}>
-							<TooltipTrigger asChild>
-								<Button
-									size="icon"
-									variant="ghost"
-									onClick={handleRemoveFromSidebar}
-									disabled={isCurrentRoute}
-									aria-label="Remove from sidebar"
-									className="size-7 opacity-0 transition-opacity group-hover/row:opacity-100 focus-visible:opacity-100 data-[state=open]:opacity-100"
-								>
-									<LuMinus className="size-3.5" />
-								</Button>
-							</TooltipTrigger>
-							<TooltipContent side="left">
-								{isCurrentRoute
-									? "Can't remove the current workspace"
-									: "Remove from sidebar"}
-							</TooltipContent>
-						</Tooltip>
-					) : (
-						<Tooltip delayDuration={300}>
-							<TooltipTrigger asChild>
-								<Button
-									size="icon"
-									variant="ghost"
-									onClick={handleAddToSidebar}
-									aria-label="Add to sidebar"
-									className="size-7 opacity-0 transition-opacity group-hover/row:opacity-100 focus-visible:opacity-100"
-								>
-									<LuPlus className="size-3.5" />
-								</Button>
-							</TooltipTrigger>
-							<TooltipContent side="left">Add to sidebar</TooltipContent>
-						</Tooltip>
-					)}
-				</div>
 			</div>
 		</li>
 	);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesList/constants.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesList/constants.ts
@@ -1,5 +1,5 @@
 // Shared grid template used by the column header row and every workspace row
-// so the Sidebar / Name / Host / Branch / Created / Action columns align
-// across the whole view. Columns hide progressively on narrower viewports.
+// so the Sidebar action / Name / Host / Branch / Created columns align across
+// the whole view. Columns hide progressively on narrower viewports.
 export const V2_WORKSPACES_ROW_GRID =
-	"grid grid-cols-[1.25rem_minmax(0,1fr)_2.5rem] gap-4 md:grid-cols-[1.25rem_minmax(0,1fr)_12rem_2.5rem] lg:grid-cols-[1.25rem_minmax(0,1fr)_12rem_14rem_2.5rem] xl:grid-cols-[1.25rem_minmax(0,1fr)_12rem_14rem_11rem_2.5rem] items-center";
+	"grid grid-cols-[2.5rem_minmax(0,1fr)] gap-4 md:grid-cols-[2.5rem_minmax(0,1fr)_12rem] lg:grid-cols-[2.5rem_minmax(0,1fr)_12rem_14rem] xl:grid-cols-[2.5rem_minmax(0,1fr)_12rem_14rem_11rem] items-center";

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/components/GitHubIssueLinkCommand/GitHubIssueLinkCommand.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/components/GitHubIssueLinkCommand/GitHubIssueLinkCommand.tsx
@@ -1,3 +1,4 @@
+import { Checkbox } from "@superset/ui/checkbox";
 import {
 	Command,
 	CommandEmpty,
@@ -10,7 +11,7 @@ import { Popover, PopoverContent, PopoverTrigger } from "@superset/ui/popover";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { useQuery } from "@tanstack/react-query";
 import type { ReactNode } from "react";
-import { useState } from "react";
+import { useId, useState } from "react";
 import { env } from "renderer/env.renderer";
 import { useDebouncedValue } from "renderer/hooks/useDebouncedValue";
 import { getHostServiceClientByUrl } from "renderer/lib/host-service-client";
@@ -50,6 +51,8 @@ export function GitHubIssueLinkCommand({
 }: GitHubIssueLinkCommandProps) {
 	const [open, setOpen] = useState(false);
 	const [searchQuery, setSearchQuery] = useState("");
+	const [showClosed, setShowClosed] = useState(false);
+	const showClosedId = useId();
 	const debouncedQuery = useDebouncedValue(searchQuery, 300);
 	const { activeHostUrl } = useLocalHostService();
 
@@ -69,6 +72,7 @@ export function GitHubIssueLinkCommand({
 			projectId,
 			hostUrl,
 			debouncedTrimmed,
+			showClosed,
 		],
 		queryFn: async () => {
 			if (!hostUrl || !projectId) return { issues: [] };
@@ -77,6 +81,7 @@ export function GitHubIssueLinkCommand({
 				projectId,
 				query: debouncedTrimmed || undefined,
 				limit: MAX_RESULTS,
+				includeClosed: showClosed,
 			});
 		},
 		enabled: !!projectId && !!hostUrl && open,
@@ -133,6 +138,19 @@ export function GitHubIssueLinkCommand({
 						value={searchQuery}
 						onValueChange={setSearchQuery}
 					/>
+					<div className="flex items-center gap-2 border-b px-3 py-2">
+						<Checkbox
+							id={showClosedId}
+							checked={showClosed}
+							onCheckedChange={(checked) => setShowClosed(checked === true)}
+						/>
+						<label
+							htmlFor={showClosedId}
+							className="cursor-pointer select-none text-xs text-muted-foreground"
+						>
+							Show closed
+						</label>
+					</div>
 					<CommandList className="max-h-[280px]">
 						{searchResults.length === 0 && (
 							<CommandEmpty>
@@ -143,8 +161,12 @@ export function GitHubIssueLinkCommand({
 									: repoMismatch
 										? `Issue URL must match ${repoMismatch}.`
 										: debouncedTrimmed
-											? "No issues found."
-											: "No issues found."}
+											? showClosed
+												? "No issues found."
+												: "No open issues found."
+											: showClosed
+												? "No issues found."
+												: "No open issues found."}
 							</CommandEmpty>
 						)}
 						{searchResults.length > 0 && (
@@ -152,7 +174,9 @@ export function GitHubIssueLinkCommand({
 								heading={
 									debouncedTrimmed
 										? `${searchResults.length} result${searchResults.length === 1 ? "" : "s"}`
-										: "Recent issues"
+										: showClosed
+											? "Recent issues"
+											: "Open issues"
 								}
 							>
 								{searchResults.map((issue) => (

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/components/PRLinkCommand/PRLinkCommand.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/components/PRLinkCommand/PRLinkCommand.tsx
@@ -1,3 +1,4 @@
+import { Checkbox } from "@superset/ui/checkbox";
 import {
 	Command,
 	CommandEmpty,
@@ -10,7 +11,7 @@ import { Popover, PopoverContent, PopoverTrigger } from "@superset/ui/popover";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { useQuery } from "@tanstack/react-query";
 import type { ReactNode } from "react";
-import { useState } from "react";
+import { useId, useState } from "react";
 import { env } from "renderer/env.renderer";
 import { useDebouncedValue } from "renderer/hooks/useDebouncedValue";
 import { getHostServiceClientByUrl } from "renderer/lib/host-service-client";
@@ -51,6 +52,8 @@ export function PRLinkCommand({
 }: PRLinkCommandProps) {
 	const [open, setOpen] = useState(false);
 	const [searchQuery, setSearchQuery] = useState("");
+	const [showClosed, setShowClosed] = useState(false);
+	const showClosedId = useId();
 	const debouncedQuery = useDebouncedValue(searchQuery, 300);
 	const { activeHostUrl } = useLocalHostService();
 
@@ -70,6 +73,7 @@ export function PRLinkCommand({
 			projectId,
 			hostUrl,
 			debouncedTrimmed,
+			showClosed,
 		],
 		queryFn: async () => {
 			if (!hostUrl || !projectId) return { pullRequests: [] };
@@ -78,6 +82,7 @@ export function PRLinkCommand({
 				projectId,
 				query: debouncedTrimmed || undefined,
 				limit: 30,
+				includeClosed: showClosed,
 			});
 		},
 		enabled: !!projectId && !!hostUrl && open,
@@ -129,6 +134,19 @@ export function PRLinkCommand({
 						value={searchQuery}
 						onValueChange={setSearchQuery}
 					/>
+					<div className="flex items-center gap-2 border-b px-3 py-2">
+						<Checkbox
+							id={showClosedId}
+							checked={showClosed}
+							onCheckedChange={(checked) => setShowClosed(checked === true)}
+						/>
+						<label
+							htmlFor={showClosedId}
+							className="cursor-pointer select-none text-xs text-muted-foreground"
+						>
+							Show closed
+						</label>
+					</div>
 					<CommandList className="max-h-[280px]">
 						{pullRequests.length === 0 && (
 							<CommandEmpty>
@@ -139,8 +157,12 @@ export function PRLinkCommand({
 									: repoMismatch
 										? `PR URL must match ${repoMismatch}.`
 										: debouncedTrimmed
-											? "No pull requests found."
-											: "No pull requests found."}
+											? showClosed
+												? "No pull requests found."
+												: "No open pull requests found."
+											: showClosed
+												? "No pull requests found."
+												: "No open pull requests."}
 							</CommandEmpty>
 						)}
 						{pullRequests.length > 0 && (
@@ -148,7 +170,9 @@ export function PRLinkCommand({
 								heading={
 									debouncedTrimmed
 										? `${pullRequests.length} result${pullRequests.length === 1 ? "" : "s"}`
-										: "Recent PRs"
+										: showClosed
+											? "Recent PRs"
+											: "Open PRs"
 								}
 							>
 								{pullRequests.map((pr) => (

--- a/apps/desktop/src/renderer/routes/_authenticated/components/GlobalBrowserLifecycle/hooks/useGlobalBrowserLifecycle/useGlobalBrowserLifecycle.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/GlobalBrowserLifecycle/hooks/useGlobalBrowserLifecycle/useGlobalBrowserLifecycle.ts
@@ -3,6 +3,12 @@ import { useLiveQuery } from "@tanstack/react-db";
 import { useEffect, useRef } from "react";
 import { browserRuntimeRegistry } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/browserRuntimeRegistry";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
+import {
+	extractPaneLocations,
+	extractWorkspaceIds,
+	getRemovedPaneLocations,
+	type PaneLifecycleRow,
+} from "../../../utils/paneLifecycleRows";
 
 /**
  * Grace period for cross-workspace pane moves / renames before destroying.
@@ -10,20 +16,21 @@ import { useCollections } from "renderer/routes/_authenticated/providers/Collect
  */
 const DESTROY_DELAY_MS = 500;
 
-function extractBrowserPaneIds(rows: { paneLayout: unknown }[]): Set<string> {
-	const ids = new Set<string>();
-	for (const row of rows) {
-		const layout = row.paneLayout as WorkspaceState<unknown> | undefined;
-		if (!layout?.tabs) continue;
-		for (const tab of layout.tabs) {
-			for (const pane of Object.values(tab.panes)) {
-				if (pane.kind === "browser") {
-					ids.add(pane.id);
-				}
-			}
-		}
-	}
-	return ids;
+interface PendingBrowserDestruction {
+	workspaceId: string;
+	timer: ReturnType<typeof setTimeout> | null;
+}
+
+function getBrowserPaneId(
+	pane: WorkspaceState<unknown>["tabs"][number]["panes"][string],
+): string | null {
+	return pane.kind === "browser" ? pane.id : null;
+}
+
+function extractBrowserLocations(
+	rows: PaneLifecycleRow[],
+): Map<string, string> {
+	return extractPaneLocations(rows, getBrowserPaneId);
 }
 
 /**
@@ -40,8 +47,8 @@ function extractBrowserPaneIds(rows: { paneLayout: unknown }[]): Set<string> {
  */
 export function useGlobalBrowserLifecycle() {
 	const collections = useCollections();
-	const prevBrowserIdsRef = useRef<Set<string>>(new Set());
-	const pendingDestruction = useRef<Map<string, ReturnType<typeof setTimeout>>>(
+	const prevBrowserLocationsRef = useRef<Map<string, string>>(new Map());
+	const pendingDestruction = useRef<Map<string, PendingBrowserDestruction>>(
 		new Map(),
 	);
 
@@ -54,47 +61,79 @@ export function useGlobalBrowserLifecycle() {
 	);
 
 	useEffect(() => {
-		const currentBrowserIds = extractBrowserPaneIds(allWorkspaceRows);
-		const prevBrowserIds = prevBrowserIdsRef.current;
+		const rows = allWorkspaceRows as PaneLifecycleRow[];
+		const currentBrowserLocations = extractBrowserLocations(rows);
+		const currentWorkspaceIds = extractWorkspaceIds(rows);
+		const prevBrowserLocations = prevBrowserLocationsRef.current;
 
 		// Cancel any pending destruction for ids that reappeared (e.g. pane
 		// moved between workspaces, user undo, or the transient replaceState
 		// churn we were fighting in the first place).
-		for (const browserId of currentBrowserIds) {
-			const timer = pendingDestruction.current.get(browserId);
-			if (timer) {
-				clearTimeout(timer);
+		for (const browserId of currentBrowserLocations.keys()) {
+			const pending = pendingDestruction.current.get(browserId);
+			if (pending?.timer) {
+				clearTimeout(pending.timer);
+			}
+			pendingDestruction.current.delete(browserId);
+		}
+
+		// If a pane was authoritatively removed but the owner row disappeared
+		// before the grace timer fired, keep waiting until that row is present
+		// again. That avoids destroying webviews during sleep/wake while still
+		// cleaning up when the post-removal layout comes back.
+		for (const [browserId, pending] of pendingDestruction.current) {
+			if (pending.timer) continue;
+			if (currentWorkspaceIds.has(pending.workspaceId)) {
 				pendingDestruction.current.delete(browserId);
+				browserRuntimeRegistry.destroy(browserId);
 			}
 		}
 
-		for (const browserId of prevBrowserIds) {
-			if (currentBrowserIds.has(browserId)) continue;
+		const removedLocations = getRemovedPaneLocations({
+			previousLocations: prevBrowserLocations,
+			currentLocations: currentBrowserLocations,
+			currentWorkspaceIds,
+		});
+
+		for (const { id: browserId, workspaceId } of removedLocations) {
 			if (pendingDestruction.current.has(browserId)) continue;
 
 			const timer = setTimeout(() => {
-				pendingDestruction.current.delete(browserId);
-
 				const freshRows = Array.from(
 					collections.v2WorkspaceLocalState.state.values(),
-				);
-				const freshIds = extractBrowserPaneIds(freshRows);
+				) as PaneLifecycleRow[];
+				const freshLocations = extractBrowserLocations(freshRows);
+				const freshWorkspaceIds = extractWorkspaceIds(freshRows);
 
-				if (!freshIds.has(browserId)) {
+				if (freshLocations.has(browserId)) {
+					pendingDestruction.current.delete(browserId);
+					return;
+				}
+
+				if (freshWorkspaceIds.has(workspaceId)) {
+					pendingDestruction.current.delete(browserId);
 					browserRuntimeRegistry.destroy(browserId);
+					return;
+				}
+
+				const pending = pendingDestruction.current.get(browserId);
+				if (pending) {
+					pending.timer = null;
 				}
 			}, DESTROY_DELAY_MS);
 
-			pendingDestruction.current.set(browserId, timer);
+			pendingDestruction.current.set(browserId, { workspaceId, timer });
 		}
 
-		prevBrowserIdsRef.current = currentBrowserIds;
+		prevBrowserLocationsRef.current = currentBrowserLocations;
 	}, [allWorkspaceRows, collections]);
 
 	useEffect(() => {
 		return () => {
-			for (const timer of pendingDestruction.current.values()) {
-				clearTimeout(timer);
+			for (const pending of pendingDestruction.current.values()) {
+				if (pending.timer) {
+					clearTimeout(pending.timer);
+				}
 			}
 			pendingDestruction.current.clear();
 		};

--- a/apps/desktop/src/renderer/routes/_authenticated/components/GlobalTerminalLifecycle/hooks/useGlobalTerminalLifecycle/useGlobalTerminalLifecycle.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/GlobalTerminalLifecycle/hooks/useGlobalTerminalLifecycle/useGlobalTerminalLifecycle.ts
@@ -1,41 +1,124 @@
 import type { WorkspaceState } from "@superset/panes";
+import { eq } from "@tanstack/db";
 import { useLiveQuery } from "@tanstack/react-db";
-import { useEffect, useRef } from "react";
+import { useEffect, useMemo, useRef } from "react";
+import { env } from "renderer/env.renderer";
+import { getHostServiceClientByUrl } from "renderer/lib/host-service-client";
+import { consumeTerminalBackgroundIntent } from "renderer/lib/terminal/terminal-background-intents";
 import { terminalRuntimeRegistry } from "renderer/lib/terminal/terminal-runtime-registry";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
+import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
+import {
+	extractPaneLocations,
+	extractWorkspaceIds,
+	getRemovedPaneLocations,
+	type PaneLifecycleRow,
+} from "../../../utils/paneLifecycleRows";
 
-/** Grace period for cross-workspace pane moves before disposing. */
-const DISPOSE_DELAY_MS = 500;
+/** Grace period for cross-workspace pane moves before terminal cleanup. */
+const RELEASE_DELAY_MS = 500;
 
 interface TerminalPaneData {
 	terminalId: string;
 }
 
-function extractTerminalIds(rows: { paneLayout: unknown }[]): Set<string> {
-	const ids = new Set<string>();
-	for (const row of rows) {
-		const layout = row.paneLayout as WorkspaceState<unknown> | undefined;
-		if (!layout?.tabs) continue;
-		for (const tab of layout.tabs) {
-			for (const pane of Object.values(tab.panes)) {
-				if (pane.kind === "terminal") {
-					const data = pane.data as TerminalPaneData;
-					if (data.terminalId) {
-						ids.add(data.terminalId);
-					}
-				}
-			}
-		}
+interface PendingTerminalCleanup {
+	workspaceId: string;
+	timer: ReturnType<typeof setTimeout> | null;
+}
+
+interface PendingTerminalInstanceRelease {
+	terminalId: string;
+	workspaceId: string;
+	timer: ReturnType<typeof setTimeout> | null;
+}
+
+function getTerminalId(
+	pane: WorkspaceState<unknown>["tabs"][number]["panes"][string],
+): string | null {
+	if (pane.kind !== "terminal") return null;
+	if (!pane.data || typeof pane.data !== "object") return null;
+	const data = pane.data as Partial<TerminalPaneData>;
+	return typeof data.terminalId === "string" ? data.terminalId : null;
+}
+
+function getTerminalInstanceKey(
+	pane: WorkspaceState<unknown>["tabs"][number]["panes"][string],
+): string | null {
+	const terminalId = getTerminalId(pane);
+	return terminalId ? `${terminalId}\u0000${pane.id}` : null;
+}
+
+function parseTerminalInstanceKey(
+	key: string,
+): { terminalId: string; instanceId: string } | null {
+	const separatorIndex = key.indexOf("\u0000");
+	if (separatorIndex === -1) return null;
+	return {
+		terminalId: key.slice(0, separatorIndex),
+		instanceId: key.slice(separatorIndex + 1),
+	};
+}
+
+function extractTerminalLocations(
+	rows: PaneLifecycleRow[],
+): Map<string, string> {
+	return extractPaneLocations(rows, getTerminalId);
+}
+
+function extractTerminalInstanceLocations(
+	rows: PaneLifecycleRow[],
+): Map<string, string> {
+	return extractPaneLocations(rows, getTerminalInstanceKey);
+}
+
+function cleanupRemovedTerminal({
+	terminalId,
+	workspaceId,
+	hostUrlByWorkspaceId,
+}: {
+	terminalId: string;
+	workspaceId: string;
+	hostUrlByWorkspaceId: Map<string, string>;
+}) {
+	if (consumeTerminalBackgroundIntent(terminalId)) {
+		terminalRuntimeRegistry.release(terminalId);
+		return;
 	}
-	return ids;
+
+	terminalRuntimeRegistry.dispose(terminalId);
+	const hostUrl = hostUrlByWorkspaceId.get(workspaceId);
+	if (!hostUrl) {
+		console.warn(
+			"[GlobalTerminalLifecycle] Missing host URL while killing removed terminal",
+			{ terminalId, workspaceId },
+		);
+		return;
+	}
+
+	getHostServiceClientByUrl(hostUrl)
+		.terminal.killSession.mutate({ terminalId, workspaceId })
+		.catch((error) => {
+			console.warn(
+				"[GlobalTerminalLifecycle] Failed to kill removed terminal",
+				{ terminalId, workspaceId, error },
+			);
+		});
 }
 
 export function useGlobalTerminalLifecycle() {
 	const collections = useCollections();
-	const prevTerminalIdsRef = useRef<Set<string>>(new Set());
-	const pendingDisposals = useRef<Map<string, ReturnType<typeof setTimeout>>>(
+	const { machineId, activeHostUrl } = useLocalHostService();
+	const prevTerminalLocationsRef = useRef<Map<string, string>>(new Map());
+	const prevTerminalInstanceLocationsRef = useRef<Map<string, string>>(
 		new Map(),
 	);
+	const pendingCleanups = useRef<Map<string, PendingTerminalCleanup>>(
+		new Map(),
+	);
+	const pendingInstanceReleases = useRef<
+		Map<string, PendingTerminalInstanceRelease>
+	>(new Map());
 
 	const { data: allWorkspaceRows = [] } = useLiveQuery(
 		(query) =>
@@ -45,47 +128,198 @@ export function useGlobalTerminalLifecycle() {
 		[collections],
 	);
 
-	useEffect(() => {
-		const currentTerminalIds = extractTerminalIds(allWorkspaceRows);
-		const prevTerminalIds = prevTerminalIdsRef.current;
+	const { data: workspacesWithHosts = [] } = useLiveQuery(
+		(query) =>
+			query
+				.from({ v2Workspaces: collections.v2Workspaces })
+				.leftJoin({ hosts: collections.v2Hosts }, ({ v2Workspaces, hosts }) =>
+					eq(v2Workspaces.hostId, hosts.id),
+				)
+				.select(({ v2Workspaces, hosts }) => ({
+					workspaceId: v2Workspaces.id,
+					hostId: v2Workspaces.hostId,
+					hostMachineId: hosts?.machineId ?? null,
+				})),
+		[collections],
+	);
 
-		for (const terminalId of currentTerminalIds) {
-			const timer = pendingDisposals.current.get(terminalId);
-			if (timer) {
-				clearTimeout(timer);
-				pendingDisposals.current.delete(terminalId);
+	const hostUrlByWorkspaceId = useMemo(() => {
+		const urls = new Map<string, string>();
+		for (const workspace of workspacesWithHosts) {
+			if (workspace.hostMachineId === machineId) {
+				if (activeHostUrl) {
+					urls.set(workspace.workspaceId, activeHostUrl);
+				}
+				continue;
+			}
+
+			if (workspace.hostId) {
+				urls.set(
+					workspace.workspaceId,
+					`${env.RELAY_URL}/hosts/${workspace.hostId}`,
+				);
+			}
+		}
+		return urls;
+	}, [activeHostUrl, machineId, workspacesWithHosts]);
+	const hostUrlByWorkspaceIdRef = useRef(hostUrlByWorkspaceId);
+	hostUrlByWorkspaceIdRef.current = hostUrlByWorkspaceId;
+
+	useEffect(() => {
+		const rows = allWorkspaceRows as PaneLifecycleRow[];
+		const currentTerminalLocations = extractTerminalLocations(rows);
+		const currentTerminalInstanceLocations =
+			extractTerminalInstanceLocations(rows);
+		const currentWorkspaceIds = extractWorkspaceIds(rows);
+		const prevTerminalLocations = prevTerminalLocationsRef.current;
+		const prevTerminalInstanceLocations =
+			prevTerminalInstanceLocationsRef.current;
+
+		for (const terminalId of currentTerminalLocations.keys()) {
+			const pending = pendingCleanups.current.get(terminalId);
+			if (pending?.timer) {
+				clearTimeout(pending.timer);
+			}
+			pendingCleanups.current.delete(terminalId);
+		}
+
+		for (const instanceKey of currentTerminalInstanceLocations.keys()) {
+			const pending = pendingInstanceReleases.current.get(instanceKey);
+			if (pending?.timer) {
+				clearTimeout(pending.timer);
+			}
+			pendingInstanceReleases.current.delete(instanceKey);
+		}
+
+		// If a pane was authoritatively removed but the owner row disappeared
+		// before the grace timer fired, keep waiting until that row is present
+		// again. That avoids releasing active renderer state during sleep/wake
+		// while still cleaning up when the post-removal layout comes back.
+		for (const [terminalId, pending] of pendingCleanups.current) {
+			if (pending.timer) continue;
+			if (currentWorkspaceIds.has(pending.workspaceId)) {
+				pendingCleanups.current.delete(terminalId);
+				cleanupRemovedTerminal({
+					terminalId,
+					workspaceId: pending.workspaceId,
+					hostUrlByWorkspaceId: hostUrlByWorkspaceIdRef.current,
+				});
 			}
 		}
 
-		for (const terminalId of prevTerminalIds) {
-			if (currentTerminalIds.has(terminalId)) continue;
-			if (pendingDisposals.current.has(terminalId)) continue;
-
-			const timer = setTimeout(() => {
-				pendingDisposals.current.delete(terminalId);
-
-				const freshRows = Array.from(
-					collections.v2WorkspaceLocalState.state.values(),
-				);
-				const freshIds = extractTerminalIds(freshRows);
-
-				if (!freshIds.has(terminalId)) {
-					terminalRuntimeRegistry.dispose(terminalId);
+		for (const [instanceKey, pending] of pendingInstanceReleases.current) {
+			if (pending.timer) continue;
+			if (currentWorkspaceIds.has(pending.workspaceId)) {
+				pendingInstanceReleases.current.delete(instanceKey);
+				const parsed = parseTerminalInstanceKey(instanceKey);
+				if (parsed) {
+					terminalRuntimeRegistry.release(parsed.terminalId, parsed.instanceId);
 				}
-			}, DISPOSE_DELAY_MS);
-
-			pendingDisposals.current.set(terminalId, timer);
+			}
 		}
 
-		prevTerminalIdsRef.current = currentTerminalIds;
+		const removedInstanceLocations = getRemovedPaneLocations({
+			previousLocations: prevTerminalInstanceLocations,
+			currentLocations: currentTerminalInstanceLocations,
+			currentWorkspaceIds,
+		});
+
+		for (const { id: instanceKey, workspaceId } of removedInstanceLocations) {
+			if (pendingInstanceReleases.current.has(instanceKey)) continue;
+
+			const parsed = parseTerminalInstanceKey(instanceKey);
+			if (!parsed) continue;
+
+			const timer = setTimeout(() => {
+				const freshRows = Array.from(
+					collections.v2WorkspaceLocalState.state.values(),
+				) as PaneLifecycleRow[];
+				const freshInstanceLocations =
+					extractTerminalInstanceLocations(freshRows);
+				const freshWorkspaceIds = extractWorkspaceIds(freshRows);
+
+				if (freshInstanceLocations.has(instanceKey)) {
+					pendingInstanceReleases.current.delete(instanceKey);
+					return;
+				}
+
+				if (freshWorkspaceIds.has(workspaceId)) {
+					pendingInstanceReleases.current.delete(instanceKey);
+					terminalRuntimeRegistry.release(parsed.terminalId, parsed.instanceId);
+					return;
+				}
+
+				const pending = pendingInstanceReleases.current.get(instanceKey);
+				if (pending) {
+					pending.timer = null;
+				}
+			}, RELEASE_DELAY_MS);
+
+			pendingInstanceReleases.current.set(instanceKey, {
+				terminalId: parsed.terminalId,
+				workspaceId,
+				timer,
+			});
+		}
+
+		const removedLocations = getRemovedPaneLocations({
+			previousLocations: prevTerminalLocations,
+			currentLocations: currentTerminalLocations,
+			currentWorkspaceIds,
+		});
+
+		for (const { id: terminalId, workspaceId } of removedLocations) {
+			if (pendingCleanups.current.has(terminalId)) continue;
+
+			const timer = setTimeout(() => {
+				const freshRows = Array.from(
+					collections.v2WorkspaceLocalState.state.values(),
+				) as PaneLifecycleRow[];
+				const freshLocations = extractTerminalLocations(freshRows);
+				const freshWorkspaceIds = extractWorkspaceIds(freshRows);
+
+				if (freshLocations.has(terminalId)) {
+					pendingCleanups.current.delete(terminalId);
+					return;
+				}
+
+				if (freshWorkspaceIds.has(workspaceId)) {
+					pendingCleanups.current.delete(terminalId);
+					cleanupRemovedTerminal({
+						terminalId,
+						workspaceId,
+						hostUrlByWorkspaceId: hostUrlByWorkspaceIdRef.current,
+					});
+					return;
+				}
+
+				const pending = pendingCleanups.current.get(terminalId);
+				if (pending) {
+					pending.timer = null;
+				}
+			}, RELEASE_DELAY_MS);
+
+			pendingCleanups.current.set(terminalId, { workspaceId, timer });
+		}
+
+		prevTerminalLocationsRef.current = currentTerminalLocations;
+		prevTerminalInstanceLocationsRef.current = currentTerminalInstanceLocations;
 	}, [allWorkspaceRows, collections]);
 
 	useEffect(() => {
 		return () => {
-			for (const timer of pendingDisposals.current.values()) {
-				clearTimeout(timer);
+			for (const pending of pendingCleanups.current.values()) {
+				if (pending.timer) {
+					clearTimeout(pending.timer);
+				}
 			}
-			pendingDisposals.current.clear();
+			pendingCleanups.current.clear();
+			for (const pending of pendingInstanceReleases.current.values()) {
+				if (pending.timer) {
+					clearTimeout(pending.timer);
+				}
+			}
+			pendingInstanceReleases.current.clear();
 		};
 	}, []);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/components/utils/paneLifecycleRows/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/utils/paneLifecycleRows/index.ts
@@ -1,0 +1,8 @@
+export {
+	extractPaneIds,
+	extractPaneLocations,
+	extractWorkspaceIds,
+	getRemovedPaneLocations,
+	type PaneLifecycleRow,
+	type RemovedPaneLocation,
+} from "./paneLifecycleRows";

--- a/apps/desktop/src/renderer/routes/_authenticated/components/utils/paneLifecycleRows/paneLifecycleRows.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/utils/paneLifecycleRows/paneLifecycleRows.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, test } from "bun:test";
+import {
+	extractPaneIds,
+	extractPaneLocations,
+	extractWorkspaceIds,
+	getRemovedPaneLocations,
+	type PaneLifecycleRow,
+} from "./paneLifecycleRows";
+
+function row(
+	workspaceId: string,
+	panes: Record<string, unknown>,
+): PaneLifecycleRow {
+	return {
+		workspaceId,
+		paneLayout: {
+			tabs: [
+				{
+					id: `${workspaceId}-tab`,
+					title: "Tab",
+					panes,
+					layout: null,
+					activePaneId: null,
+				},
+			],
+			activeTabId: `${workspaceId}-tab`,
+		},
+	};
+}
+
+function terminalPane(id: string) {
+	return {
+		id: `pane-${id}`,
+		kind: "terminal",
+		data: { terminalId: id },
+	};
+}
+
+function terminalIdForPane(pane: {
+	kind: string;
+	data: unknown;
+}): string | null {
+	if (pane.kind !== "terminal") return null;
+	const data = pane.data as { terminalId?: unknown };
+	return typeof data.terminalId === "string" ? data.terminalId : null;
+}
+
+describe("paneLifecycleRows", () => {
+	test("extracts workspace IDs and tracked pane locations", () => {
+		const rows = [
+			row("workspace-a", {
+				"pane-term-1": terminalPane("term-1"),
+				"pane-file-1": { id: "pane-file-1", kind: "file", data: {} },
+			}),
+			row("workspace-b", {
+				"pane-term-2": terminalPane("term-2"),
+			}),
+		];
+
+		expect([...extractWorkspaceIds(rows)]).toEqual([
+			"workspace-a",
+			"workspace-b",
+		]);
+		expect([
+			...extractPaneLocations(rows, terminalIdForPane).entries(),
+		]).toEqual([
+			["term-1", "workspace-a"],
+			["term-2", "workspace-b"],
+		]);
+		expect([...extractPaneIds(rows, terminalIdForPane)]).toEqual([
+			"term-1",
+			"term-2",
+		]);
+	});
+
+	test("marks a pane removed only when its owner workspace row is present", () => {
+		const previousLocations = new Map([
+			["term-1", "workspace-a"],
+			["term-2", "workspace-b"],
+		]);
+		const currentLocations = new Map([["term-2", "workspace-b"]]);
+		const currentWorkspaceIds = new Set(["workspace-a", "workspace-b"]);
+
+		expect(
+			getRemovedPaneLocations({
+				previousLocations,
+				currentLocations,
+				currentWorkspaceIds,
+			}),
+		).toEqual([{ id: "term-1", workspaceId: "workspace-a" }]);
+	});
+
+	test("ignores panes whose owner workspace row disappeared", () => {
+		const previousLocations = new Map([
+			["term-1", "workspace-a"],
+			["term-2", "workspace-b"],
+		]);
+		const currentLocations = new Map([["term-2", "workspace-b"]]);
+		const currentWorkspaceIds = new Set(["workspace-b"]);
+
+		expect(
+			getRemovedPaneLocations({
+				previousLocations,
+				currentLocations,
+				currentWorkspaceIds,
+			}),
+		).toEqual([]);
+	});
+});

--- a/apps/desktop/src/renderer/routes/_authenticated/components/utils/paneLifecycleRows/paneLifecycleRows.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/utils/paneLifecycleRows/paneLifecycleRows.ts
@@ -1,0 +1,93 @@
+import type { Pane, WorkspaceState } from "@superset/panes";
+
+export interface PaneLifecycleRow {
+	workspaceId: unknown;
+	paneLayout: unknown;
+}
+
+export interface RemovedPaneLocation {
+	id: string;
+	workspaceId: string;
+}
+
+export function extractWorkspaceIds(rows: PaneLifecycleRow[]): Set<string> {
+	const workspaceIds = new Set<string>();
+	for (const row of rows) {
+		if (typeof row.workspaceId === "string") {
+			workspaceIds.add(row.workspaceId);
+		}
+	}
+	return workspaceIds;
+}
+
+export function extractPaneLocations(
+	rows: PaneLifecycleRow[],
+	getTrackedPaneId: (pane: Pane<unknown>) => string | null,
+): Map<string, string> {
+	const locations = new Map<string, string>();
+
+	for (const row of rows) {
+		if (typeof row.workspaceId !== "string") continue;
+
+		const layout = row.paneLayout as WorkspaceState<unknown> | undefined;
+		if (!layout?.tabs) continue;
+
+		for (const tab of layout.tabs) {
+			for (const pane of Object.values(tab.panes)) {
+				const trackedPaneId = getTrackedPaneId(pane);
+				if (trackedPaneId) {
+					locations.set(trackedPaneId, row.workspaceId);
+				}
+			}
+		}
+	}
+
+	return locations;
+}
+
+export function extractPaneIds(
+	rows: PaneLifecycleRow[],
+	getTrackedPaneId: (pane: Pane<unknown>) => string | null,
+): Set<string> {
+	const ids = new Set<string>();
+
+	for (const row of rows) {
+		const layout = row.paneLayout as WorkspaceState<unknown> | undefined;
+		if (!layout?.tabs) continue;
+
+		for (const tab of layout.tabs) {
+			for (const pane of Object.values(tab.panes)) {
+				const trackedPaneId = getTrackedPaneId(pane);
+				if (trackedPaneId) {
+					ids.add(trackedPaneId);
+				}
+			}
+		}
+	}
+
+	return ids;
+}
+
+export function getRemovedPaneLocations({
+	previousLocations,
+	currentLocations,
+	currentWorkspaceIds,
+}: {
+	previousLocations: Map<string, string>;
+	currentLocations: Map<string, string>;
+	currentWorkspaceIds: Set<string>;
+}): RemovedPaneLocation[] {
+	const removed: RemovedPaneLocation[] = [];
+
+	for (const [id, workspaceId] of previousLocations) {
+		if (currentLocations.has(id)) continue;
+		// A missing owner row means the collection snapshot is not authoritative
+		// for this pane. This happens during org/provider churn and can happen
+		// briefly after laptop sleep/wake. Intentional sidebar-row removals clean
+		// up their pane runtimes before deleting the row.
+		if (!currentWorkspaceIds.has(workspaceId)) continue;
+		removed.push({ id, workspaceId });
+	}
+
+	return removed;
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/hooks/useDashboardSidebarState/useDashboardSidebarState.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/hooks/useDashboardSidebarState/useDashboardSidebarState.ts
@@ -1,5 +1,11 @@
-import type { WorkspaceState } from "@superset/panes";
+import type { Pane, WorkspaceState } from "@superset/panes";
 import { useCallback } from "react";
+import { terminalRuntimeRegistry } from "renderer/lib/terminal/terminal-runtime-registry";
+import { browserRuntimeRegistry } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/browserRuntimeRegistry";
+import {
+	extractPaneIds,
+	type PaneLifecycleRow,
+} from "renderer/routes/_authenticated/components/utils/paneLifecycleRows";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 import type { AppCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider/collections";
 import { PROJECT_CUSTOM_COLORS } from "shared/constants/project-colors";
@@ -78,6 +84,26 @@ function ensureSidebarWorkspaceRecord(
 			activeTabId: null,
 		} satisfies WorkspaceState<unknown>,
 	});
+}
+
+function getTerminalRuntimeId(pane: Pane<unknown>): string | null {
+	if (pane.kind !== "terminal") return null;
+	if (!pane.data || typeof pane.data !== "object") return null;
+	const data = pane.data as { terminalId?: unknown };
+	return typeof data.terminalId === "string" ? data.terminalId : null;
+}
+
+function getBrowserRuntimeId(pane: Pane<unknown>): string | null {
+	return pane.kind === "browser" ? pane.id : null;
+}
+
+function cleanupWorkspacePaneRuntimes(rows: PaneLifecycleRow[]): void {
+	for (const terminalId of extractPaneIds(rows, getTerminalRuntimeId)) {
+		terminalRuntimeRegistry.release(terminalId);
+	}
+	for (const browserId of extractPaneIds(rows, getBrowserRuntimeId)) {
+		browserRuntimeRegistry.destroy(browserId);
+	}
 }
 
 export function useDashboardSidebarState() {
@@ -403,7 +429,9 @@ export function useDashboardSidebarState() {
 
 	const removeWorkspaceFromSidebar = useCallback(
 		(workspaceId: string) => {
-			if (!collections.v2WorkspaceLocalState.get(workspaceId)) return;
+			const workspace = collections.v2WorkspaceLocalState.get(workspaceId);
+			if (!workspace) return;
+			cleanupWorkspacePaneRuntimes([workspace]);
 			collections.v2WorkspaceLocalState.delete(workspaceId);
 		},
 		[collections],
@@ -411,11 +439,10 @@ export function useDashboardSidebarState() {
 
 	const removeProjectFromSidebar = useCallback(
 		(projectId: string) => {
-			const workspaceIds = Array.from(
+			const workspaceRows = Array.from(
 				collections.v2WorkspaceLocalState.state.values(),
-			)
-				.filter((item) => item.sidebarState.projectId === projectId)
-				.map((item) => item.workspaceId);
+			).filter((item) => item.sidebarState.projectId === projectId);
+			const workspaceIds = workspaceRows.map((item) => item.workspaceId);
 			const sectionIds = Array.from(
 				collections.v2SidebarSections.state.values(),
 			)
@@ -423,6 +450,7 @@ export function useDashboardSidebarState() {
 				.map((item) => item.sectionId);
 
 			if (workspaceIds.length > 0) {
+				cleanupWorkspacePaneRuntimes(workspaceRows);
 				collections.v2WorkspaceLocalState.delete(workspaceIds);
 			}
 			if (sectionIds.length > 0) {

--- a/apps/desktop/src/renderer/routes/_authenticated/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/layout.tsx
@@ -185,9 +185,9 @@ function AuthenticatedLayout() {
 	return (
 		<DndProvider manager={dragDropManager}>
 			<CollectionsProvider>
-				<GlobalTerminalLifecycle />
 				<GlobalBrowserLifecycle />
 				<LocalHostServiceProvider>
+					<GlobalTerminalLifecycle />
 					<DeletingWorkspacesProvider>
 						<WorkerPoolContextProvider
 							poolOptions={{ workerFactory: createPierreWorker, poolSize: 8 }}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/WorkspaceInitializingView/WorkspaceInitializingView.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/WorkspaceInitializingView/WorkspaceInitializingView.tsx
@@ -122,7 +122,12 @@ export function WorkspaceInitializingView({
 							<h2 className="text-lg font-medium text-foreground">
 								Setup incomplete
 							</h2>
-							<p className="text-sm text-muted-foreground">{workspaceName}</p>
+							<p
+								className="line-clamp-3 max-w-full break-words text-sm text-muted-foreground [overflow-wrap:anywhere]"
+								title={workspaceName}
+							>
+								{workspaceName}
+							</p>
 							<p className="text-xs text-muted-foreground/80 mt-2">
 								Workspace setup didn't finish. You can retry or remove it.
 							</p>
@@ -213,7 +218,12 @@ export function WorkspaceInitializingView({
 							<h2 className="text-lg font-medium text-foreground">
 								Workspace setup failed
 							</h2>
-							<p className="text-sm text-muted-foreground">{workspaceName}</p>
+							<p
+								className="line-clamp-3 max-w-full break-words text-sm text-muted-foreground [overflow-wrap:anywhere]"
+								title={workspaceName}
+							>
+								{workspaceName}
+							</p>
 							{progress?.error && (
 								<p className="text-xs text-destructive/80 mt-2 bg-destructive/5 rounded-md px-3 py-2 select-text cursor-text break-words">
 									{progress.error}

--- a/packages/chat/src/server/trpc/service.test.ts
+++ b/packages/chat/src/server/trpc/service.test.ts
@@ -20,14 +20,17 @@ mock.module("mastracode", () => ({
 
 const { ChatRuntimeService } = await import("./service");
 
-function createRuntime(): RuntimeSession {
+function createRuntime(options?: {
+	respondToQuestion?: RuntimeSession["harness"]["respondToQuestion"];
+}): RuntimeSession {
 	return {
 		sessionId: SESSION_ID,
 		cwd: CWD,
 		harness: {
 			abort: mock(() => {}),
 			respondToToolApproval: mock(async (payload: unknown) => payload),
-			respondToQuestion: mock(async (payload: unknown) => payload),
+			respondToQuestion:
+				options?.respondToQuestion ?? mock(async (payload: unknown) => payload),
 			respondToPlanApproval: mock(async (payload: unknown) => payload),
 		} as unknown as RuntimeSession["harness"],
 		mcpManager: null as RuntimeSession["mcpManager"],
@@ -39,11 +42,13 @@ function createRuntime(): RuntimeSession {
 			path: "/tmp/secret",
 			reason: "Need access",
 		},
+		answeredQuestionIds: new Set(),
+		pendingQuestionResponses: new Map(),
 	};
 }
 
-function createServiceHarness() {
-	const runtime = createRuntime();
+function createServiceHarness(options?: Parameters<typeof createRuntime>[0]) {
+	const runtime = createRuntime(options);
 	const service = new ChatRuntimeService({
 		headers: async () => ({}),
 		apiUrl: "http://localhost:3000",
@@ -133,5 +138,62 @@ describe("ChatRuntimeService control mutations", () => {
 			response: { action: "approved", feedback: "ship it" },
 		});
 		expect(runtime.pendingSandboxQuestion).toBeNull();
+	});
+
+	it("does not clear pending question state when question response fails", async () => {
+		const respondToQuestion = mock(async () => {
+			throw new Error("failed to answer");
+		}) as RuntimeSession["harness"]["respondToQuestion"];
+		const { caller, runtime } = createServiceHarness({ respondToQuestion });
+
+		await expect(
+			caller.session.question.respond({
+				sessionId: SESSION_ID,
+				cwd: CWD,
+				payload: { questionId: "sandbox-1", answer: "Yes" },
+			}),
+		).rejects.toThrow("failed to answer");
+
+		expect(runtime.answeredQuestionIds.has("sandbox-1")).toBe(false);
+		expect(runtime.pendingSandboxQuestion).toEqual({
+			questionId: "sandbox-1",
+			path: "/tmp/secret",
+			reason: "Need access",
+		});
+	});
+
+	it("deduplicates concurrent responses for the same question", async () => {
+		let resolveResponse: (value: unknown) => void = () => {};
+		const respondToQuestion = mock(
+			() =>
+				new Promise((resolve) => {
+					resolveResponse = resolve;
+				}),
+		) as RuntimeSession["harness"]["respondToQuestion"];
+		const { caller, runtime } = createServiceHarness({ respondToQuestion });
+		const payload = { questionId: "sandbox-1", answer: "Yes" };
+
+		const firstResponse = caller.session.question.respond({
+			sessionId: SESSION_ID,
+			cwd: CWD,
+			payload,
+		});
+		const secondResponse = caller.session.question.respond({
+			sessionId: SESSION_ID,
+			cwd: CWD,
+			payload,
+		});
+
+		await new Promise((resolve) => setTimeout(resolve, 0));
+
+		expect(respondToQuestion).toHaveBeenCalledTimes(1);
+		expect(runtime.answeredQuestionIds.has("sandbox-1")).toBe(true);
+		expect(runtime.pendingSandboxQuestion).toBeNull();
+
+		resolveResponse({ ok: true });
+
+		await expect(firstResponse).resolves.toEqual({ ok: true });
+		await expect(secondResponse).resolves.toEqual({ ok: true });
+		expect(runtime.pendingQuestionResponses.size).toBe(0);
 	});
 });

--- a/packages/chat/src/server/trpc/service.ts
+++ b/packages/chat/src/server/trpc/service.ts
@@ -12,6 +12,7 @@ import {
 	getRuntimeMcpOverview,
 	type LifecycleEvent,
 	onUserPromptSubmit,
+	type RuntimeQuestionResponse,
 	type RuntimeSession,
 	reloadHookConfig,
 	restartRuntimeFromUserMessage,
@@ -36,6 +37,56 @@ import {
 } from "./zod";
 
 const ENABLE_MASTRA_MCP_SERVERS = false;
+
+type RuntimeQuestionPayload = Parameters<
+	RuntimeSession["harness"]["respondToQuestion"]
+>[0];
+
+function respondToQuestionWithOptimisticState(
+	runtime: RuntimeSession,
+	payload: RuntimeQuestionPayload,
+): Promise<RuntimeQuestionResponse> {
+	const questionId = payload.questionId;
+	const pendingResponse = runtime.pendingQuestionResponses.get(questionId);
+	if (pendingResponse) return pendingResponse;
+
+	const wasAlreadyAnswered = runtime.answeredQuestionIds.has(questionId);
+	const previousSandboxQuestion = runtime.pendingSandboxQuestion;
+	const clearsSandboxQuestion =
+		previousSandboxQuestion?.questionId === questionId;
+
+	runtime.answeredQuestionIds.add(questionId);
+	if (clearsSandboxQuestion) {
+		runtime.pendingSandboxQuestion = null;
+	}
+
+	let responsePromise: Promise<RuntimeQuestionResponse>;
+	responsePromise = Promise.resolve()
+		.then(() => runtime.harness.respondToQuestion(payload))
+		.catch((error) => {
+			if (
+				runtime.pendingQuestionResponses.get(questionId) === responsePromise
+			) {
+				if (!wasAlreadyAnswered) {
+					runtime.answeredQuestionIds.delete(questionId);
+				}
+				if (clearsSandboxQuestion && runtime.pendingSandboxQuestion === null) {
+					runtime.pendingSandboxQuestion = previousSandboxQuestion;
+				}
+			}
+			throw error;
+		})
+		.finally(() => {
+			if (
+				runtime.pendingQuestionResponses.get(questionId) === responsePromise
+			) {
+				runtime.pendingQuestionResponses.delete(questionId);
+			}
+		});
+	runtime.pendingQuestionResponses.set(questionId, responsePromise);
+	return responsePromise;
+}
+
 function resolveOmModelFromAuth(): string | undefined {
 	if (process.env.GOOGLE_GENERATIVE_AI_API_KEY)
 		return "google/gemini-2.5-flash";
@@ -139,6 +190,8 @@ export class ChatRuntimeService {
 					mcpManualStatuses: new Map(),
 					lastErrorMessage: null,
 					pendingSandboxQuestion: null,
+					answeredQuestionIds: new Set(),
+					pendingQuestionResponses: new Map(),
 					cwd: runtimeCwd,
 				};
 				syncRuntimeHookSessionId(sessionRuntime);
@@ -223,22 +276,30 @@ export class ChatRuntimeService {
 							? {
 									questionId: runtime.pendingSandboxQuestion.questionId,
 									question: `Grant sandbox access to "${runtime.pendingSandboxQuestion.path}"?`,
+									description: runtime.pendingSandboxQuestion.reason,
 									options: [
 										{
 											label: "Yes",
-											description: `Allow access. Reason: ${runtime.pendingSandboxQuestion.reason}`,
+											description: "Allow access.",
 										},
-										{
-											label: "No",
-											description: "Deny access.",
-										},
+										{ label: "No", description: "Deny access." },
 									],
 								}
 							: null;
+						// Skip any pending question whose ID was already answered this turn.
+						// The harness only clears pendingQuestion on agent_end, so without this
+						// filter an answered ask_user question would permanently shadow the
+						// sandbox question that fired in the same turn.
+						const harnessPendingQuestion =
+							displayState.pendingQuestion &&
+							!runtime.answeredQuestionIds.has(
+								displayState.pendingQuestion.questionId,
+							)
+								? displayState.pendingQuestion
+								: null;
 						return {
 							...displayState,
-							pendingQuestion:
-								displayState.pendingQuestion ?? sandboxPendingQuestion,
+							pendingQuestion: harnessPendingQuestion ?? sandboxPendingQuestion,
 							errorMessage: currentMessageError ?? runtime.lastErrorMessage,
 						};
 					}),
@@ -347,13 +408,10 @@ export class ChatRuntimeService {
 								input.sessionId,
 								input.cwd,
 							);
-							if (
-								runtime.pendingSandboxQuestion?.questionId ===
-								input.payload.questionId
-							) {
-								runtime.pendingSandboxQuestion = null;
-							}
-							return runtime.harness.respondToQuestion(input.payload);
+							return respondToQuestionWithOptimisticState(
+								runtime,
+								input.payload,
+							);
 						}),
 				}),
 

--- a/packages/chat/src/server/trpc/utils/runtime/index.ts
+++ b/packages/chat/src/server/trpc/utils/runtime/index.ts
@@ -7,6 +7,7 @@ export {
 	type RuntimeHookManager,
 	type RuntimeMcpManager,
 	type RuntimeMcpServerStatus,
+	type RuntimeQuestionResponse,
 	type RuntimeSession,
 	reloadHookConfig,
 	restartRuntimeFromUserMessage,

--- a/packages/chat/src/server/trpc/utils/runtime/runtime.test.ts
+++ b/packages/chat/src/server/trpc/utils/runtime/runtime.test.ts
@@ -58,6 +58,8 @@ function createRuntimeForTest(): {
 		mcpManualStatuses: new Map(),
 		lastErrorMessage: null,
 		pendingSandboxQuestion: null,
+		answeredQuestionIds: new Set(),
+		pendingQuestionResponses: new Map(),
 		cwd: "/tmp",
 	};
 
@@ -109,6 +111,8 @@ function createRuntimeForTitleTest(options?: {
 		mcpManualStatuses: new Map(),
 		lastErrorMessage: null,
 		pendingSandboxQuestion: null,
+		answeredQuestionIds: new Set(),
+		pendingQuestionResponses: new Map(),
 		cwd: "/tmp",
 	};
 
@@ -346,6 +350,8 @@ describe("runtime message restart", () => {
 			mcpManualStatuses: new Map(),
 			lastErrorMessage: "stale error",
 			pendingSandboxQuestion: null,
+			answeredQuestionIds: new Set(),
+			pendingQuestionResponses: new Map(),
 			cwd: "/tmp",
 		};
 

--- a/packages/chat/src/server/trpc/utils/runtime/runtime.ts
+++ b/packages/chat/src/server/trpc/utils/runtime/runtime.ts
@@ -16,6 +16,9 @@ export type RuntimeMcpManager = Awaited<
 export type RuntimeHookManager = Awaited<
 	ReturnType<typeof createMastraCode>
 >["hookManager"];
+export type RuntimeQuestionResponse = Awaited<
+	ReturnType<RuntimeHarness["respondToQuestion"]>
+>;
 
 export interface RuntimeMcpServerStatus {
 	connected: boolean;
@@ -35,6 +38,8 @@ export interface RuntimeSession {
 		path: string;
 		reason: string;
 	} | null;
+	answeredQuestionIds: Set<string>;
+	pendingQuestionResponses: Map<string, Promise<RuntimeQuestionResponse>>;
 	cwd: string;
 }
 
@@ -237,6 +242,8 @@ export function subscribeToSessionEvents(
 		if (isHarnessAgentStartEvent(event)) {
 			runtime.lastErrorMessage = null;
 			runtime.pendingSandboxQuestion = null;
+			runtime.answeredQuestionIds.clear();
+			runtime.pendingQuestionResponses.clear();
 			onLifecycleEvent?.({
 				sessionId: runtime.sessionId,
 				eventType: "Start",
@@ -245,6 +252,8 @@ export function subscribeToSessionEvents(
 		}
 		if (isHarnessAgentEndEvent(event)) {
 			runtime.pendingSandboxQuestion = null;
+			runtime.answeredQuestionIds.clear();
+			runtime.pendingQuestionResponses.clear();
 			const raw = event.reason;
 			const reason = raw === "aborted" || raw === "error" ? raw : "complete";
 			if (runtime.hookManager) {

--- a/packages/host-service/src/runtime/chat/chat.ts
+++ b/packages/host-service/src/runtime/chat/chat.ts
@@ -56,12 +56,13 @@ interface PendingSandboxQuestion {
 
 interface ChatPendingQuestionOption {
 	label: string;
-	description: string;
+	description?: string;
 }
 
 interface ChatPendingQuestion {
 	questionId: string;
 	question: string;
+	description?: string;
 	options: ChatPendingQuestionOption[];
 }
 
@@ -99,6 +100,53 @@ interface RuntimeSession {
 	hookManager: RuntimeHookManager;
 	lastErrorMessage: string | null;
 	pendingSandboxQuestion: PendingSandboxQuestion | null;
+	answeredQuestionIds: Set<string>;
+	pendingQuestionResponses: Map<string, Promise<RuntimeQuestionResult>>;
+}
+
+function respondToQuestionWithOptimisticState(
+	runtime: RuntimeSession,
+	payload: ChatQuestionPayload,
+): Promise<RuntimeQuestionResult> {
+	const questionId = payload.questionId;
+	const pendingResponse = runtime.pendingQuestionResponses.get(questionId);
+	if (pendingResponse) return pendingResponse;
+
+	const wasAlreadyAnswered = runtime.answeredQuestionIds.has(questionId);
+	const previousSandboxQuestion = runtime.pendingSandboxQuestion;
+	const clearsSandboxQuestion =
+		previousSandboxQuestion?.questionId === questionId;
+
+	runtime.answeredQuestionIds.add(questionId);
+	if (clearsSandboxQuestion) {
+		runtime.pendingSandboxQuestion = null;
+	}
+
+	let responsePromise: Promise<RuntimeQuestionResult>;
+	responsePromise = Promise.resolve()
+		.then(() => runtime.harness.respondToQuestion(payload))
+		.catch((error) => {
+			if (
+				runtime.pendingQuestionResponses.get(questionId) === responsePromise
+			) {
+				if (!wasAlreadyAnswered) {
+					runtime.answeredQuestionIds.delete(questionId);
+				}
+				if (clearsSandboxQuestion && runtime.pendingSandboxQuestion === null) {
+					runtime.pendingSandboxQuestion = previousSandboxQuestion;
+				}
+			}
+			throw error;
+		})
+		.finally(() => {
+			if (
+				runtime.pendingQuestionResponses.get(questionId) === responsePromise
+			) {
+				runtime.pendingQuestionResponses.delete(questionId);
+			}
+		});
+	runtime.pendingQuestionResponses.set(questionId, responsePromise);
+	return responsePromise;
 }
 
 interface RuntimeStoredMessage {
@@ -339,11 +387,15 @@ export class ChatRuntimeManager {
 			if (isObjectRecord(event) && event.type === "agent_start") {
 				runtime.lastErrorMessage = null;
 				runtime.pendingSandboxQuestion = null;
+				runtime.answeredQuestionIds.clear();
+				runtime.pendingQuestionResponses.clear();
 				return;
 			}
 
 			if (isObjectRecord(event) && event.type === "agent_end") {
 				runtime.pendingSandboxQuestion = null;
+				runtime.answeredQuestionIds.clear();
+				runtime.pendingQuestionResponses.clear();
 			}
 		});
 	}
@@ -386,6 +438,8 @@ export class ChatRuntimeManager {
 			hookManager: runtime.hookManager,
 			lastErrorMessage: null,
 			pendingSandboxQuestion: null,
+			answeredQuestionIds: new Set(),
+			pendingQuestionResponses: new Map(),
 		};
 		this.subscribeToSessionEvents(sessionRuntime);
 		this.runtimes.set(sessionId, sessionRuntime);
@@ -438,26 +492,32 @@ export class ChatRuntimeManager {
 				? currentMessage.errorMessage.trim()
 				: null;
 
+		// Skip any pending question whose ID was already answered this turn.
+		// The harness only clears pendingQuestion on agent_end, so without this
+		// filter an answered ask_user question would permanently shadow the
+		// sandbox question that fired in the same turn.
+		const harnessPendingQuestion =
+			displayState.pendingQuestion &&
+			!runtime.answeredQuestionIds.has(displayState.pendingQuestion.questionId)
+				? displayState.pendingQuestion
+				: null;
+		const sandboxPendingQuestion = runtime.pendingSandboxQuestion
+			? {
+					questionId: runtime.pendingSandboxQuestion.questionId,
+					question: `Grant sandbox access to "${runtime.pendingSandboxQuestion.path}"?`,
+					description: runtime.pendingSandboxQuestion.reason,
+					options: [
+						{
+							label: "Yes",
+							description: "Allow access.",
+						},
+						{ label: "No", description: "Deny access." },
+					],
+				}
+			: null;
 		return {
 			...displayState,
-			pendingQuestion:
-				displayState.pendingQuestion ??
-				(runtime.pendingSandboxQuestion
-					? {
-							questionId: runtime.pendingSandboxQuestion.questionId,
-							question: `Grant sandbox access to "${runtime.pendingSandboxQuestion.path}"?`,
-							options: [
-								{
-									label: "Yes",
-									description: `Allow access. Reason: ${runtime.pendingSandboxQuestion.reason}`,
-								},
-								{
-									label: "No",
-									description: "Deny access.",
-								},
-							],
-						}
-					: null),
+			pendingQuestion: harnessPendingQuestion ?? sandboxPendingQuestion,
 			errorMessage: currentMessageError ?? runtime.lastErrorMessage,
 		};
 	}
@@ -537,13 +597,7 @@ export class ChatRuntimeManager {
 			input.workspaceId,
 		);
 
-		if (
-			runtime.pendingSandboxQuestion?.questionId === input.payload.questionId
-		) {
-			runtime.pendingSandboxQuestion = null;
-		}
-
-		return runtime.harness.respondToQuestion(input.payload);
+		return respondToQuestionWithOptimisticState(runtime, input.payload);
 	}
 
 	async respondToPlan(input: {

--- a/packages/host-service/src/runtime/teardown/teardown.ts
+++ b/packages/host-service/src/runtime/teardown/teardown.ts
@@ -106,6 +106,7 @@ export async function runTeardown({
 		workspaceId,
 		db,
 		initialCommand,
+		listed: false,
 	});
 	if ("error" in session) {
 		return {

--- a/packages/host-service/src/terminal/terminal.ts
+++ b/packages/host-service/src/terminal/terminal.ts
@@ -43,6 +43,15 @@ type TerminalServerMessage =
 	| { type: "replay"; data: string };
 
 const MAX_BUFFER_BYTES = 64 * 1024;
+const SOCKET_OPEN = 1;
+const SOCKET_CLOSING = 2;
+const SOCKET_CLOSED = 3;
+
+type TerminalSocket = {
+	send: (data: string) => void;
+	close: (code?: number, reason?: string) => void;
+	readyState: number;
+};
 
 // ---------------------------------------------------------------------------
 // OSC 133 shell readiness detection (FinalTerm semantic prompt standard).
@@ -67,17 +76,16 @@ type ShellReadyState = "pending" | "ready" | "timed_out" | "unsupported";
 
 interface TerminalSession {
 	terminalId: string;
+	workspaceId: string;
 	pty: IPty;
-	socket: {
-		send: (data: string) => void;
-		close: (code?: number, reason?: string) => void;
-		readyState: number;
-	} | null;
+	sockets: Set<TerminalSocket>;
 	buffer: string[];
 	bufferBytes: number;
+	createdAt: number;
 	exited: boolean;
 	exitCode: number;
 	exitSignal: number;
+	listed: boolean;
 
 	// Shell readiness (OSC 133)
 	shellReadyState: ShellReadyState;
@@ -90,12 +98,80 @@ interface TerminalSession {
 /** PTY lifetime is independent of socket lifetime — sockets detach/reattach freely. */
 const sessions = new Map<string, TerminalSession>();
 
+function pruneAndCountOpenSockets(session: TerminalSession): number {
+	let openSockets = 0;
+	for (const socket of session.sockets) {
+		if (socket.readyState === SOCKET_OPEN) {
+			openSockets += 1;
+		} else if (
+			socket.readyState === SOCKET_CLOSING ||
+			socket.readyState === SOCKET_CLOSED
+		) {
+			session.sockets.delete(socket);
+		}
+	}
+	return openSockets;
+}
+
+export interface TerminalSessionSummary {
+	terminalId: string;
+	workspaceId: string;
+	createdAt: number;
+	exited: boolean;
+	exitCode: number;
+	attached: boolean;
+}
+
+export function listTerminalSessions(
+	options: { workspaceId?: string; includeExited?: boolean } = {},
+): TerminalSessionSummary[] {
+	const includeExited = options.includeExited ?? true;
+
+	return Array.from(sessions.values())
+		.filter((session) => session.listed)
+		.filter(
+			(session) =>
+				options.workspaceId === undefined ||
+				session.workspaceId === options.workspaceId,
+		)
+		.filter((session) => includeExited || !session.exited)
+		.map((session) => ({
+			terminalId: session.terminalId,
+			workspaceId: session.workspaceId,
+			createdAt: session.createdAt,
+			exited: session.exited,
+			exitCode: session.exitCode,
+			attached: pruneAndCountOpenSockets(session) > 0,
+		}));
+}
+
 function sendMessage(
 	socket: { send: (data: string) => void; readyState: number },
 	message: TerminalServerMessage,
 ) {
-	if (socket.readyState !== 1) return;
+	if (socket.readyState !== SOCKET_OPEN) return;
 	socket.send(JSON.stringify(message));
+}
+
+function broadcastMessage(
+	session: TerminalSession,
+	message: TerminalServerMessage,
+): number {
+	let sent = 0;
+	for (const socket of session.sockets) {
+		if (socket.readyState !== SOCKET_OPEN) {
+			if (
+				socket.readyState === SOCKET_CLOSING ||
+				socket.readyState === SOCKET_CLOSED
+			) {
+				session.sockets.delete(socket);
+			}
+			continue;
+		}
+		sendMessage(socket, message);
+		sent += 1;
+	}
+	return sent;
 }
 
 function bufferOutput(session: TerminalSession, data: string) {
@@ -134,14 +210,13 @@ function resolveShellReady(
 		session.shellReadyTimeoutId = null;
 	}
 	// Flush held marker bytes — they weren't part of a full marker.
-	// Send directly to a connected socket so the output isn't lost; fall back
-	// to the output buffer when no client is currently attached.
+	// Broadcast to every attached socket so the output isn't lost; if no
+	// client is currently attached, fall back to the output buffer.
 	if (session.scanState.heldBytes.length > 0) {
 		const heldBytes = session.scanState.heldBytes;
 		session.scanState.heldBytes = "";
-		if (session.socket?.readyState === 1) {
-			sendMessage(session.socket, { type: "data", data: heldBytes });
-		} else {
+		const sent = broadcastMessage(session, { type: "data", data: heldBytes });
+		if (sent === 0) {
 			bufferOutput(session, heldBytes);
 		}
 	}
@@ -166,6 +241,10 @@ export function disposeSession(terminalId: string, db: HostDb) {
 			clearTimeout(session.shellReadyTimeoutId);
 			session.shellReadyTimeoutId = null;
 		}
+		for (const socket of session.sockets) {
+			socket.close(1000, "Session disposed");
+		}
+		session.sockets.clear();
 		if (!session.exited) {
 			try {
 				session.pty.kill();
@@ -221,6 +300,8 @@ interface CreateTerminalSessionOptions {
 	db: HostDb;
 	/** Command to run after the shell is ready. Queued behind shellReadyPromise. */
 	initialCommand?: string;
+	/** Hidden sessions are process-internal and should not appear in user pickers. */
+	listed?: boolean;
 }
 
 export function createTerminalSessionInternal({
@@ -229,9 +310,11 @@ export function createTerminalSessionInternal({
 	themeType,
 	db,
 	initialCommand,
+	listed = true,
 }: CreateTerminalSessionOptions): TerminalSession | { error: string } {
 	const existing = sessions.get(terminalId);
 	if (existing) {
+		if (listed) existing.listed = true;
 		return existing;
 	}
 
@@ -292,15 +375,18 @@ export function createTerminalSessionInternal({
 		};
 	}
 
+	const createdAt = Date.now();
+
 	db.insert(terminalSessions)
 		.values({
 			id: terminalId,
 			originWorkspaceId: workspaceId,
 			status: "active",
+			createdAt,
 		})
 		.onConflictDoUpdate({
 			target: terminalSessions.id,
-			set: { status: "active", endedAt: null },
+			set: { status: "active", createdAt, endedAt: null },
 		})
 		.run();
 
@@ -318,13 +404,16 @@ export function createTerminalSessionInternal({
 
 	const session: TerminalSession = {
 		terminalId,
+		workspaceId,
 		pty,
-		socket: null,
+		sockets: new Set(),
 		buffer: [],
 		bufferBytes: 0,
+		createdAt,
 		exited: false,
 		exitCode: 0,
 		exitSignal: 0,
+		listed,
 		shellReadyState: shellSupportsReady ? "pending" : "unsupported",
 		shellReadyResolve,
 		shellReadyPromise,
@@ -353,9 +442,7 @@ export function createTerminalSessionInternal({
 		}
 		if (data.length === 0) return;
 
-		if (session.socket?.readyState === 1) {
-			sendMessage(session.socket, { type: "data", data });
-		} else {
+		if (broadcastMessage(session, { type: "data", data }) === 0) {
 			bufferOutput(session, data);
 		}
 	});
@@ -370,13 +457,11 @@ export function createTerminalSessionInternal({
 			.where(eq(terminalSessions.id, terminalId))
 			.run();
 
-		if (session.socket?.readyState === 1) {
-			sendMessage(session.socket, {
-				type: "exit",
-				exitCode: session.exitCode,
-				signal: session.exitSignal,
-			});
-		}
+		broadcastMessage(session, {
+			type: "exit",
+			exitCode: session.exitCode,
+			signal: session.exitSignal,
+		});
 	});
 
 	if (initialCommand) {
@@ -441,13 +526,10 @@ export function registerWorkspaceTerminalRoute({
 
 	// REST list — enumerate live terminal sessions
 	app.get("/terminal/sessions", (c) => {
-		const result = Array.from(sessions.values()).map((s) => ({
-			terminalId: s.terminalId,
-			exited: s.exited,
-			exitCode: s.exitCode,
-			attached: s.socket !== null,
-		}));
-		return c.json({ sessions: result });
+		const workspaceId = c.req.query("workspaceId") || undefined;
+		return c.json({
+			sessions: listTerminalSessions({ workspaceId, includeExited: true }),
+		});
 	});
 
 	app.get(
@@ -491,7 +573,7 @@ export function registerWorkspaceTerminalRoute({
 							return;
 						}
 
-						result.socket = ws;
+						result.sockets.add(ws);
 
 						db.update(terminalSessions)
 							.set({ lastAttachedAt: Date.now() })
@@ -500,10 +582,7 @@ export function registerWorkspaceTerminalRoute({
 						return;
 					}
 
-					if (existing.socket && existing.socket !== ws) {
-						existing.socket.close(4000, "Displaced by new connection");
-					}
-					existing.socket = ws;
+					existing.sockets.add(ws);
 
 					db.update(terminalSessions)
 						.set({ lastAttachedAt: Date.now() })
@@ -522,18 +601,16 @@ export function registerWorkspaceTerminalRoute({
 
 				onMessage: (event, ws) => {
 					const session = sessions.get(terminalId ?? "");
-					if (!session || session.socket !== ws) return;
+					if (!session || !session.sockets.has(ws)) return;
 
 					let message: TerminalClientMessage;
 					try {
 						message = JSON.parse(String(event.data)) as TerminalClientMessage;
 					} catch {
-						if (session.socket) {
-							sendMessage(session.socket, {
-								type: "error",
-								message: "Invalid terminal message payload",
-							});
-						}
+						sendMessage(ws, {
+							type: "error",
+							message: "Invalid terminal message payload",
+						});
 						return;
 					}
 
@@ -558,16 +635,12 @@ export function registerWorkspaceTerminalRoute({
 
 				onClose: (_event, ws) => {
 					const session = sessions.get(terminalId ?? "");
-					if (session?.socket === ws) {
-						session.socket = null;
-					}
+					session?.sockets.delete(ws);
 				},
 
 				onError: (_event, ws) => {
 					const session = sessions.get(terminalId ?? "");
-					if (session?.socket === ws) {
-						session.socket = null;
-					}
+					session?.sockets.delete(ws);
 				},
 			};
 		}),

--- a/packages/host-service/src/trpc/router/terminal/terminal.ts
+++ b/packages/host-service/src/trpc/router/terminal/terminal.ts
@@ -1,6 +1,11 @@
+import { TRPCError } from "@trpc/server";
+import { eq } from "drizzle-orm";
 import { z } from "zod";
+import { terminalSessions, workspaces } from "../../../db/schema";
 import {
 	createTerminalSessionInternal,
+	disposeSession,
+	listTerminalSessions,
 	parseThemeType,
 } from "../../../terminal/terminal";
 import { protectedProcedure, router } from "../../index";
@@ -33,5 +38,59 @@ export const terminalRouter = router({
 			}
 
 			return { terminalId: result.terminalId, status: "active" as const };
+		}),
+
+	listSessions: protectedProcedure
+		.input(
+			z.object({
+				workspaceId: z.string(),
+			}),
+		)
+		.query(({ input }) => ({
+			sessions: listTerminalSessions({
+				workspaceId: input.workspaceId,
+				includeExited: false,
+			}),
+		})),
+
+	killSession: protectedProcedure
+		.input(
+			z.object({
+				terminalId: z.string(),
+				workspaceId: z.string(),
+			}),
+		)
+		.mutation(({ ctx, input }) => {
+			const workspace = ctx.db.query.workspaces
+				.findFirst({ where: eq(workspaces.id, input.workspaceId) })
+				.sync();
+
+			if (!workspace) {
+				throw new TRPCError({
+					code: "NOT_FOUND",
+					message: "Workspace not found",
+				});
+			}
+
+			const session = ctx.db.query.terminalSessions
+				.findFirst({ where: eq(terminalSessions.id, input.terminalId) })
+				.sync();
+
+			if (!session) {
+				throw new TRPCError({
+					code: "NOT_FOUND",
+					message: "Terminal session not found",
+				});
+			}
+
+			if (session.originWorkspaceId !== input.workspaceId) {
+				throw new TRPCError({
+					code: "FORBIDDEN",
+					message: "Terminal session does not belong to this workspace",
+				});
+			}
+
+			disposeSession(input.terminalId, ctx.db);
+			return { terminalId: input.terminalId, status: "disposed" as const };
 		}),
 });

--- a/packages/host-service/src/trpc/router/workspace-creation/procedures/search-github-issues.ts
+++ b/packages/host-service/src/trpc/router/workspace-creation/procedures/search-github-issues.ts
@@ -32,8 +32,11 @@ export const searchGitHubIssues = protectedProcedure
 					repo: repo.name,
 					issue_number: issueNumber,
 				});
-				// issues.get returns PRs too — filter them out
+				// issues.get returns PRs too - filter them out
 				if (issue.pull_request) {
+					return { issues: [] };
+				}
+				if (!input.includeClosed && issue.state !== "open") {
 					return { issues: [] };
 				}
 				return {
@@ -49,8 +52,9 @@ export const searchGitHubIssues = protectedProcedure
 				};
 			}
 
+			const stateFilter = input.includeClosed ? "" : " is:open";
 			const query =
-				`repo:${repo.owner}/${repo.name} is:issue ${effectiveQuery}`.trim();
+				`repo:${repo.owner}/${repo.name} is:issue${stateFilter} ${effectiveQuery}`.trim();
 			const { data } = await octokit.search.issuesAndPullRequests({
 				q: query,
 				per_page: limit,

--- a/packages/host-service/src/trpc/router/workspace-creation/procedures/search-pull-requests.ts
+++ b/packages/host-service/src/trpc/router/workspace-creation/procedures/search-pull-requests.ts
@@ -3,6 +3,14 @@ import { normalizeGitHubQuery } from "../normalize-github-query";
 import { githubSearchInputSchema } from "../schemas";
 import { resolveGithubRepo } from "../shared/project-helpers";
 
+function normalizePullRequestState(
+	state: string,
+	mergedAt: string | null | undefined,
+): "open" | "closed" | "merged" {
+	if (mergedAt) return "merged";
+	return state.toLowerCase() === "closed" ? "closed" : "open";
+}
+
 export const searchPullRequests = protectedProcedure
 	.input(githubSearchInputSchema)
 	.query(async ({ ctx, input }) => {
@@ -32,13 +40,17 @@ export const searchPullRequests = protectedProcedure
 					repo: repo.name,
 					pull_number: prNumber,
 				});
+				const state = normalizePullRequestState(pr.state, pr.merged_at);
+				if (!input.includeClosed && state !== "open") {
+					return { pullRequests: [] };
+				}
 				return {
 					pullRequests: [
 						{
 							prNumber: pr.number,
 							title: pr.title,
 							url: pr.html_url,
-							state: pr.state,
+							state,
 							isDraft: pr.draft ?? false,
 							authorLogin: pr.user?.login ?? null,
 						},
@@ -46,8 +58,9 @@ export const searchPullRequests = protectedProcedure
 				};
 			}
 
+			const stateFilter = input.includeClosed ? "" : " is:open";
 			const query =
-				`repo:${repo.owner}/${repo.name} is:pr ${effectiveQuery}`.trim();
+				`repo:${repo.owner}/${repo.name} is:pr${stateFilter} ${effectiveQuery}`.trim();
 			const { data } = await octokit.search.issuesAndPullRequests({
 				q: query,
 				per_page: limit,
@@ -57,14 +70,20 @@ export const searchPullRequests = protectedProcedure
 			return {
 				pullRequests: data.items
 					.filter((item) => item.pull_request)
-					.map((item) => ({
-						prNumber: item.number,
-						title: item.title,
-						url: item.html_url,
-						state: item.state,
-						isDraft: item.draft ?? false,
-						authorLogin: item.user?.login ?? null,
-					})),
+					.map((item) => {
+						const state = normalizePullRequestState(
+							item.state,
+							item.pull_request?.merged_at,
+						);
+						return {
+							prNumber: item.number,
+							title: item.title,
+							url: item.html_url,
+							state,
+							isDraft: item.draft ?? false,
+							authorLogin: item.user?.login ?? null,
+						};
+					}),
 			};
 		} catch (err) {
 			console.warn("[workspaceCreation.searchPullRequests] failed", err);

--- a/packages/host-service/src/trpc/router/workspace-creation/schemas.ts
+++ b/packages/host-service/src/trpc/router/workspace-creation/schemas.ts
@@ -112,6 +112,7 @@ export const githubSearchInputSchema = z.object({
 	projectId: z.string(),
 	query: z.string().optional(),
 	limit: z.number().min(1).max(100).optional(),
+	includeClosed: z.boolean().optional(),
 });
 
 export const githubIssueContentInputSchema = z.object({

--- a/packages/ui/src/components/ai-elements/braille-spinner.tsx
+++ b/packages/ui/src/components/ai-elements/braille-spinner.tsx
@@ -1,0 +1,29 @@
+import { useEffect, useState } from "react";
+import { cn } from "../../lib/utils";
+
+const FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+const INTERVAL = 80;
+
+export function BrailleSpinner({ className }: { className?: string }) {
+	const [frame, setFrame] = useState(0);
+
+	useEffect(() => {
+		const id = setInterval(
+			() => setFrame((f) => (f + 1) % FRAMES.length),
+			INTERVAL,
+		);
+		return () => clearInterval(id);
+	}, []);
+
+	return (
+		<span
+			aria-hidden="true"
+			className={cn(
+				"text-base font-mono select-none text-amber-500",
+				className,
+			)}
+		>
+			{FRAMES[frame]}
+		</span>
+	);
+}

--- a/packages/ui/src/components/ai-elements/tool-call-row.tsx
+++ b/packages/ui/src/components/ai-elements/tool-call-row.tsx
@@ -1,0 +1,173 @@
+"use client";
+
+import {
+	ChevronDownIcon,
+	ChevronRightIcon,
+	TriangleAlertIcon,
+	XCircleIcon,
+} from "lucide-react";
+import type { ComponentType, ReactNode } from "react";
+import { useState } from "react";
+import { cn } from "../../lib/utils";
+import {
+	Collapsible,
+	CollapsibleContent,
+	CollapsibleTrigger,
+} from "../ui/collapsible";
+import {
+	Tooltip,
+	TooltipContent,
+	TooltipProvider,
+	TooltipTrigger,
+} from "../ui/tooltip";
+import { BrailleSpinner } from "./braille-spinner";
+
+export type ToolCallRowProps = {
+	/** Icon shown in the header (replaced by chevron on hover when expandable). */
+	icon: ComponentType<{ className?: string }>;
+	/**
+	 * Header title. A plain string is wrapped in a ShimmerLabel that pulses while
+	 * `isPending` is true. Any other ReactNode is rendered as-is (useful when the
+	 * title contains interactive elements like clickable file paths).
+	 */
+	title: ReactNode;
+	/** Optional muted text rendered after the title, truncated when too long. */
+	description?: ReactNode;
+	/** When true the title shimmers and the default status shows a spinner. */
+	isPending?: boolean;
+	/** When true the default status shows an X icon. */
+	isError?: boolean;
+	/** When true shows an outlined amber warning triangle inline after the description with a "Not configured" tooltip. */
+	isNotConfigured?: boolean;
+	/**
+	 * Overrides the default status slot (X on error, nothing otherwise).
+	 * Pass `null` to render nothing. Omit (undefined) to use the default.
+	 */
+	statusNode?: ReactNode;
+	/**
+	 * Extra element placed outside (after) the CollapsibleTrigger button — useful
+	 * for action buttons that must not toggle expansion when clicked (e.g. "Open
+	 * in pane").
+	 */
+	headerExtra?: ReactNode;
+	/** Expandable content rendered inside the collapsible area with the left border. */
+	children?: ReactNode;
+	className?: string;
+};
+
+/**
+ * Shared collapsible row used by every tool call type.
+ *
+ * Provides a consistent layout:
+ *   [icon/chevron]  [title]  [description ...]  |  [status]  [headerExtra?]
+ *   └── collapsible content with left border ─────────────────────────────┘
+ */
+export function ToolCallRow({
+	icon: Icon,
+	title,
+	description,
+	isPending = false,
+	isError = false,
+	isNotConfigured = false,
+	statusNode,
+	headerExtra,
+	children,
+	className,
+}: ToolCallRowProps) {
+	const [isOpen, setIsOpen] = useState(false);
+	const [isHovered, setIsHovered] = useState(false);
+	const hasDetails = children != null && children !== false;
+
+	const defaultStatus = isError ? (
+		<XCircleIcon className="h-3 w-3 text-red-500" />
+	) : null;
+
+	const resolvedDescription =
+		description ??
+		(isError ? (
+			<span className="ml-2 flex items-center gap-1 font-medium uppercase tracking-wide text-red-500">
+				<XCircleIcon className="h-3 w-3 shrink-0" />
+				Error
+			</span>
+		) : null);
+
+	const titleContent =
+		typeof title === "string" ? (
+			<span className="shrink-0 text-xs text-foreground">{title}</span>
+		) : (
+			title
+		);
+
+	return (
+		<Collapsible
+			className={cn("-mx-1 rounded-md font-mono", className)}
+			onOpenChange={(open) => hasDetails && setIsOpen(open)}
+			open={hasDetails ? isOpen : false}
+		>
+			<div className="flex items-center">
+				<CollapsibleTrigger asChild>
+					<button
+						className={cn(
+							"flex h-7 min-w-0 flex-1 items-center justify-between rounded-md px-1 text-left outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50",
+							hasDetails
+								? "cursor-pointer transition-colors duration-150 hover:bg-muted/30"
+								: "cursor-text",
+						)}
+						data-tool-trigger
+						disabled={!hasDetails}
+						onMouseEnter={() => setIsHovered(true)}
+						onMouseLeave={() => setIsHovered(false)}
+						type="button"
+					>
+						<div className="flex min-w-0 flex-1 items-center gap-1.5 text-xs">
+							{isHovered && hasDetails ? (
+								isOpen ? (
+									<ChevronDownIcon className="h-3 w-3 shrink-0 text-muted-foreground" />
+								) : (
+									<ChevronRightIcon className="h-3 w-3 shrink-0 text-muted-foreground" />
+								)
+							) : isPending ? (
+								<span className="flex h-3 w-3 shrink-0 items-center justify-center overflow-hidden">
+									<BrailleSpinner />
+								</span>
+							) : (
+								<Icon className="h-3 w-3 shrink-0 text-muted-foreground" />
+							)}
+							{titleContent}
+							{(resolvedDescription != null || isNotConfigured) && !isOpen && (
+								<span className="flex min-w-0 items-center gap-1 text-xs text-muted-foreground">
+									{resolvedDescription != null && (
+										<span className="min-w-0 truncate">
+											{resolvedDescription}
+										</span>
+									)}
+									{isNotConfigured && (
+										<TooltipProvider>
+											<Tooltip>
+												<TooltipTrigger asChild>
+													<span className="flex shrink-0 items-center">
+														<TriangleAlertIcon className="h-3 w-3 text-amber-500" />
+													</span>
+												</TooltipTrigger>
+												<TooltipContent>Not configured</TooltipContent>
+											</Tooltip>
+										</TooltipProvider>
+									)}
+								</span>
+							)}
+						</div>
+						<div className="ml-2 flex shrink-0 items-center text-muted-foreground">
+							{statusNode !== undefined ? statusNode : defaultStatus}
+						</div>
+					</button>
+				</CollapsibleTrigger>
+				{headerExtra}
+			</div>
+			{hasDetails && (
+				<CollapsibleContent className="outline-none">
+					<div className="ml-2.5 border-l border-border">{children}</div>
+				</CollapsibleContent>
+			)}
+		</Collapsible>
+	);
+}


### PR DESCRIPTION
## Summary

upstream (`superset-sh/superset`) main `eae600874` まで 10 commits ahead だったうち、**fork 固有領域に大きく触れない 8 commits** を本 PR で取り込む。残り 2 件 (v2 notification hooks / v2 terminal hotkeys) は fork の AudioScheduler/Aivis や terminal suggestion 拡張との統合作業が必要なため別 PR に分離。

ベース: fork main `d6296a39b` (vibrancy fix 系まで)
取り込み先: `upstream/batch-2026-04-25` → main

## 取り込み内容

| upstream | fork SHA | 概要 |
|---|---|---|
| `5aab22a22` | `cdb52f9dd` | fix closed picker filters (#3702) — Issue/PR picker に Show closed checkbox + GitHub 検索の `is:open` 条件化 |
| `99db5be26` | `f07960630` | [codex] simplify workspace controls (#3714) — sidebar add/remove を行頭列に移動、constants.ts の grid 列調整 |
| `186078ae1` | `09d6b5785` | fix(chat): prevent ask_user question from shadowing sandbox access prompt (#3662) — `request_sandbox_access` を `request_access` として正規化、専用 ToolCall UI 追加 |
| `47893c21d` | `6a8c4aeaa` | fix desktop workspace creation title clamp (#3718) — 1 ファイル軽微 |
| `09323ff56` | `817ed8dee` | Add diff pane file viewer action (#3715) — Diff pane ヘッダーに「file viewer で開く」「外部 editor で開く」追加 |
| `a5891c68d` | `0764d0310` | remove pending launch log (#3721) — 3 行 console.log 削除 |
| `c83de0c16` | `e67a8855d` | Add Tiptap table support (#3719) — MarkdownEditor / TipTapMarkdownRenderer に TableKit |
| `486b62114` | `b71fbbb97` | [codex] Fix v2 terminal lifecycle after sleep (#3711) — terminal runtime / pane lifecycle の sleep 復帰補強 |

## 別 PR 送り (本 PR では取り込まない)

- `e07aef637 feat(desktop): play v2 notification hooks client-side (#3675)` — fork の AudioScheduler/Aivis (PR #405) との統合確認が必要
- `eae600874 [codex] Port v2 terminal hotkeys to v1 (#3724)` — fork の terminal suggestion handler を新 `terminalKeyboardHandler.ts` へ移植する手作業が必要

## Fork 側のコンフリクト解決

### `99db5be26` (#3714) — `V2WorkspacesList.tsx`

upstream は `SortableHeader` を使った `columnHeader` 行を導入したが、fork の `V2WorkspacesList` は `sortField` / `sortDirection` / `handleSort` hook を持たないためそのまま取り込めない。**`constants.ts` の grid 列変更と `V2WorkspaceRow` の sidebar 操作位置変更は取り込み済み**、列ヘッダーは fork 側に hook を足してから戻す方針で別 PR 化。`empty` 判定は fork の `!hasAnyMatches` (フィルタ込み) を維持。FORK NOTE コメント追加。

### `186078ae1` (#3662) — `AskUserQuestionToolCall.tsx`, `service.ts`, `ToolCallBlock.tsx`

fork は AskUserQuestion 表示に `buildQuestionMarkdown` + `UserQuestionTool` という独自実装を採用済み。upstream の専用 UI コンポーネント化は素直に取り込まず、fork 表示を維持しつつ `RequestSandboxAccessToolCall` 経路は新規取り込み。`ToolCallBlock.tsx` には `isInterrupted` props を追加して `RequestSandboxAccessToolCall` に propagate。

### `817ed8dee` (#3715) — `page.tsx`

upstream は `openFilePane` 内で `worktreePath` と `filePath` を結合して `absoluteFilePath` を計算してから pane を開く。fork の `openSidebarFilePane` には対応する変換ロジックがないため、3 箇所の `absoluteFilePath` 参照を `filePath` に戻し。サイドバー path 絶対化は別 PR で fork 側にも導入予定。

### `b71fbbb97` (#3711) — `terminal-runtime-registry.ts`, `TerminalPane.tsx`, `terminal.ts`, `page.tsx`, `tool-call-row.tsx`, `braille-spinner.tsx`, `ToolCallBlock.tsx`

複数 fork integration:
- `terminal-runtime-registry.ts`: `mount` に `instanceId` 引数追加 + fork debug log 維持、`disposeEntry` private 化を取り込み
- `TerminalPane.tsx`: `terminalInstanceId = ctx.pane.id` 追加、リンクオープン時 `mode: "generic"` を `BrowserPaneData` に補完
- `terminal.ts`: 旧 fork の `session.socket?.readyState` を upstream の `broadcastMessage` パターンに置き換え (multi-socket session 対応)
- `packages/ui/src/components/ai-elements/tool-call-row.tsx` + `braille-spinner.tsx`: upstream で新規追加された依存ファイルを fork の packages/ui に追加
- `ToolCallBlock.tsx`: agent が衝突解消で誤って追加した `isStreaming` props を削除 (upstream は `isInterrupted` のみを追加)

## Fork 固有機能ヘルスチェック

| 項目 | 状況 |
|---|---|
| 19 tRPC procedures (`workspaces.githubExtended`) | 全件健在 |
| AudioScheduler / Aivis TTS (`apps/desktop/src/main/lib/notifications/`) | 健在 |
| TERMINAL_OPTIONS, SUPERSET_WORKSPACE_NAME | 健在 |
| MainWindowEffects, INCEPTION_AUTH_PROVIDER_ID, v1MigrationState | 健在 |
| TiptapPromptEditor | 健在 (Tiptap table 取り込みも干渉なし) |
| electron-builder.ts: dmg.size="4g", fileAssociations | 健在 |
| Service Status Dashboard / Windows support / DnD scratch / Worktree auto-sync / Linux daemon systemd | 健在 |

## drizzle migration

10 commits すべて `packages/db/drizzle/` / `packages/local-db/drizzle/` への変更なし → idx 衝突 / migration ファイル競合なし。

## Codex 事前調査・最終レビュー

- 事前調査: `/tmp/upstream-batch-2026-04-25/codex-preanalysis.md` — 全 commit `git apply --check --3way` clean 判定 (実際は cherry-pick で 3 件 conflict 発生、本 PR で fork 寄り解消)
- 最終レビュー: 別途 background で実行中 (PR 作成と並行)

## Test plan

- [x] `bun install --frozen --ignore-scripts` — clean
- [x] `bun run lint` — exit 0 (rg not found warning は無視)
- [x] `bunx turbo typecheck --filter=@superset/desktop --filter=@superset/host-service --filter=@superset/chat` — 3/3 pass
- [ ] PR CI (Build / Lint / Typecheck / Test / Sherif / CodeRabbit) — push 後に追跡
- [ ] 動作確認:
  - [ ] Issue/PR picker で Show closed トグルが効く
  - [ ] v2 workspace list の sidebar 操作が行頭列で動く
  - [ ] chat の `request_access` (旧 `request_sandbox_access`) UI 表示
  - [ ] workspace creation 失敗画面の長いタイトルが clamp される
  - [ ] Diff pane のファイルヘッダーから file viewer / 外部 editor が開ける
  - [ ] Tiptap table paste / render が動作 (TiptapPromptEditor 干渉なし)
  - [ ] Sleep 復帰後の terminal lifecycle (cold/warm 両方)

## 次の PR

- `e07aef637` + `eae600874` を AudioScheduler/Aivis 統合 + terminal suggestion handler 移植して取り込む follow-up PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * GitHub IssueおよびPRで「closed」フィルター機能を追加し、オープン・クローズド状態の切り替え表示に対応
  * マークダウンエディタにテーブル挿入機能を実装
  * ターミナルセッション管理機能を追加し、複数セッションの切り替えと管理に対応
  * ターミナルをバックグラウンドに移動する機能を追加

* **改善**
  * チャット質問に説明フィールドを追加し、詳細情報の表示に対応
  * ターミナル複数インスタンス対応の強化
  * ファイルオープン機能の柔軟性向上（外部エディタでの開き方を追加）

<!-- end of auto-generated comment: release notes by coderabbit.ai -->