### PR TITLE
fix(desktop): 壊れた Service Status プリセットを修正＋ヘッダーアイコン縮小

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/service-status.ts
+++ b/apps/desktop/src/lib/trpc/routers/service-status.ts
@@ -25,6 +25,9 @@ const formatSchema = z.enum([
 	"gcp-incidents",
 	"aws-health",
 	"azure-rss",
+	"status-io",
+	"slack-v2",
+	"instatus-summary",
 ]);
 
 // 2KB max iconValue — fits URLs, simple-icon slugs, and filesystem paths, and

--- a/apps/desktop/src/main/lib/service-status/definitions-store.ts
+++ b/apps/desktop/src/main/lib/service-status/definitions-store.ts
@@ -54,6 +54,9 @@ const KNOWN_FORMATS = new Set<ServiceStatusFormat>([
 	"gcp-incidents",
 	"aws-health",
 	"azure-rss",
+	"status-io",
+	"slack-v2",
+	"instatus-summary",
 ]);
 
 /**

--- a/apps/desktop/src/main/lib/service-status/parsers/index.ts
+++ b/apps/desktop/src/main/lib/service-status/parsers/index.ts
@@ -2,6 +2,9 @@ import type { ServiceStatusFormat } from "shared/service-status-types";
 import { fetchAwsHealth } from "./aws-health";
 import { fetchAzureRss } from "./azure-rss";
 import { fetchGcpIncidents } from "./gcp-incidents";
+import { fetchInstatusSummary } from "./instatus-summary";
+import { fetchSlackV2 } from "./slack-v2";
+import { fetchStatusIo } from "./status-io";
 import { fetchStatuspageV2 } from "./statuspage-v2";
 import type { ParsedStatus } from "./types";
 
@@ -29,6 +32,12 @@ export function fetchStatusPayload(
 			return fetchAwsHealth(apiUrl);
 		case "azure-rss":
 			return fetchAzureRss(apiUrl);
+		case "status-io":
+			return fetchStatusIo(apiUrl);
+		case "slack-v2":
+			return fetchSlackV2(apiUrl);
+		case "instatus-summary":
+			return fetchInstatusSummary(apiUrl);
 		default: {
 			// TypeScript exhaustiveness check; a runtime hit here means someone
 			// added a new ServiceStatusFormat without wiring in an adapter.

--- a/apps/desktop/src/main/lib/service-status/parsers/instatus-summary.ts
+++ b/apps/desktop/src/main/lib/service-status/parsers/instatus-summary.ts
@@ -1,0 +1,53 @@
+import { fetchJson } from "./net-helpers";
+import type { ParsedStatus } from "./types";
+
+/**
+ * Instatus pages publish a tiny summary at `<page>/summary.json`:
+ *
+ *   { "page": { "name": "...", "url": "...", "status": "UP" | "HASISSUES" | "UNDERMAINTENANCE" } }
+ *
+ * Reference: https://instatus.com/help/api
+ *
+ * Used by Perplexity (and a growing number of providers migrating from
+ * Atlassian Statuspage). We prefer summary.json over components.json because
+ * it's a single-property response and avoids needing to aggregate per-component
+ * statuses ourselves.
+ */
+
+interface InstatusSummary {
+	page?: {
+		name?: string;
+		url?: string;
+		status?: string;
+	};
+}
+
+export async function fetchInstatusSummary(
+	apiUrl: string,
+): Promise<ParsedStatus> {
+	const json = await fetchJson<InstatusSummary>(apiUrl);
+	const status = (json.page?.status ?? "").toUpperCase();
+	const name = json.page?.name?.trim() || "";
+
+	switch (status) {
+		case "UP":
+			return { indicator: "none", description: "全システム正常" };
+		case "HASISSUES":
+			return {
+				indicator: "major",
+				description: name ? `${name} で障害発生中` : "障害発生中",
+			};
+		case "UNDERMAINTENANCE":
+			return {
+				indicator: "maintenance",
+				description: "メンテナンス中",
+			};
+		default:
+			return {
+				indicator: null,
+				description: status
+					? `Instatus ステータス: ${status}`
+					: "ステータス不明",
+			};
+	}
+}

--- a/apps/desktop/src/main/lib/service-status/parsers/slack-v2.ts
+++ b/apps/desktop/src/main/lib/service-status/parsers/slack-v2.ts
@@ -1,0 +1,93 @@
+import { fetchJson } from "./net-helpers";
+import type { ParsedStatus } from "./types";
+
+/**
+ * Slack publishes a custom status payload at slack-status.com/api/v2.0.0/current:
+ *
+ *   {
+ *     "status": "ok" | "active",
+ *     "active_incidents": [
+ *       { id, title, type, status, services, ... }
+ *     ]
+ *   }
+ *
+ * `type` per incident is one of "incident" | "outage" | "notice" | "maintenance"
+ * (observed values; no public schema). We pick the worst type across the
+ * active incidents and map it onto the Statuspage indicator scale so the rest
+ * of the app doesn't need a Slack-specific code path.
+ */
+
+type SlackIncidentType = "incident" | "outage" | "notice" | "maintenance";
+
+interface SlackIncident {
+	id?: number;
+	title?: string;
+	type?: SlackIncidentType | string;
+	status?: string;
+	services?: string[];
+}
+
+interface SlackStatusResponse {
+	status?: string;
+	active_incidents?: SlackIncident[];
+}
+
+const SEVERITY_RANK: Record<string, number> = {
+	notice: 1,
+	maintenance: 2,
+	incident: 3,
+	outage: 4,
+};
+
+export async function fetchSlackV2(apiUrl: string): Promise<ParsedStatus> {
+	const json = await fetchJson<SlackStatusResponse>(apiUrl);
+	const status = (json.status ?? "").toLowerCase();
+	const incidents = Array.isArray(json.active_incidents)
+		? json.active_incidents
+		: [];
+
+	if (status === "ok" && incidents.length === 0) {
+		return { indicator: "none", description: "全システム正常" };
+	}
+
+	if (incidents.length === 0) {
+		// status !== "ok" but no incident details — surface the bare status.
+		return {
+			indicator: null,
+			description: status ? `Slack ステータス: ${status}` : "ステータス不明",
+		};
+	}
+
+	const worst = incidents.reduce((best, incident) => {
+		const bestRank = SEVERITY_RANK[(best.type ?? "").toLowerCase()] ?? 0;
+		const currentRank = SEVERITY_RANK[(incident.type ?? "").toLowerCase()] ?? 0;
+		return currentRank > bestRank ? incident : best;
+	}, incidents[0]);
+
+	const worstType = (worst.type ?? "").toLowerCase();
+	let indicator: ParsedStatus["indicator"];
+	switch (worstType) {
+		case "outage":
+			indicator = "critical";
+			break;
+		case "incident":
+			indicator = "major";
+			break;
+		case "maintenance":
+			indicator = "maintenance";
+			break;
+		case "notice":
+			indicator = "minor";
+			break;
+		default:
+			indicator = "minor";
+	}
+
+	const title = worst.title?.trim() || "進行中のインシデントあり";
+	const description =
+		incidents.length > 1
+			? `${title} (他 ${incidents.length - 1} 件)`.slice(0, 180)
+			: title.slice(0, 180);
+
+	return { indicator, description };
+}

--- a/apps/desktop/src/main/lib/service-status/parsers/status-io.ts
+++ b/apps/desktop/src/main/lib/service-status/parsers/status-io.ts
@@ -1,0 +1,75 @@
+import { fetchJson } from "./net-helpers";
+import type { ParsedStatus } from "./types";
+
+/**
+ * status.io (api.status.io/1.0/status/<page_id>) shape:
+ *
+ *   { result: { status_overall: { status_code: number, status: string } } }
+ *
+ * status_code values per https://kb.status.io/developers/status-codes/:
+ *   100 — Operational
+ *   200 — Planned Maintenance
+ *   300 — Degraded Performance
+ *   400 — Partial Service Disruption
+ *   500 — Service Disruption
+ *   600 — Security Event
+ *
+ * Used by GitLab and Docker Hub which moved off Atlassian Statuspage.
+ */
+
+interface StatusIoResponse {
+	result?: {
+		status_overall?: {
+			status_code?: number;
+			status?: string;
+		};
+	};
+}
+
+export async function fetchStatusIo(apiUrl: string): Promise<ParsedStatus> {
+	const json = await fetchJson<StatusIoResponse>(apiUrl);
+	const overall = json.result?.status_overall;
+	const code = overall?.status_code;
+	const status = overall?.status?.trim() || "";
+
+	if (typeof code !== "number") {
+		return {
+			indicator: null,
+			description: "status.io レスポンスの形式が想定と違います",
+		};
+	}
+
+	let indicator: ParsedStatus["indicator"];
+	let fallbackLabel: string;
+	switch (code) {
+		case 100:
+			indicator = "none";
+			fallbackLabel = "全システム正常";
+			break;
+		case 200:
+			indicator = "maintenance";
+			fallbackLabel = "メンテナンス中";
+			break;
+		case 300:
+			indicator = "minor";
+			fallbackLabel = "パフォーマンス低下";
+			break;
+		case 400:
+			indicator = "major";
+			fallbackLabel = "一部機能で障害発生";
+			break;
+		case 500:
+			indicator = "critical";
+			fallbackLabel = "サービス停止中";
+			break;
+		case 600:
+			indicator = "critical";
+			fallbackLabel = "セキュリティ事象";
+			break;
+		default:
+			indicator = null;
+			fallbackLabel = "ステータス不明";
+	}
+
+	return { indicator, description: status || fallbackLabel };
+}

--- a/apps/desktop/src/renderer/lib/service-status/service-presets.ts
+++ b/apps/desktop/src/renderer/lib/service-status/service-presets.ts
@@ -164,23 +164,14 @@ export const SERVICE_PRESETS: readonly ServicePreset[] = [
 		slug: "perplexity",
 		label: "Perplexity",
 		category: "ai",
+		// Perplexity migrated to Instatus; the legacy /api/v2/status.json path
+		// 404s but summary.json gives us the page-level status.
 		statusUrl: "https://status.perplexity.com/",
-		apiUrl: "https://status.perplexity.com/api/v2/status.json",
-		format: "statuspage-v2",
+		apiUrl: "https://status.perplexity.com/summary.json",
+		format: "instatus-summary",
 		iconType: "simple-icon",
 		iconValue: "perplexity",
 	},
-	{
-		slug: "huggingface",
-		label: "Hugging Face",
-		category: "ai",
-		statusUrl: "https://status.huggingface.co/",
-		apiUrl: "https://status.huggingface.co/api/v2/status.json",
-		format: "statuspage-v2",
-		iconType: "simple-icon",
-		iconValue: "huggingface",
-	},
-
 	// --- Dev Infra --------------------------------------------------------
 	{
 		slug: "github",
@@ -196,9 +187,11 @@ export const SERVICE_PRESETS: readonly ServicePreset[] = [
 		slug: "gitlab",
 		label: "GitLab",
 		category: "dev-infra",
+		// GitLab status page is hosted on status.io, not Atlassian Statuspage.
+		// API responds at api.status.io/1.0/status/<page_id>.
 		statusUrl: "https://status.gitlab.com/",
-		apiUrl: "https://status.gitlab.com/api/v2/status.json",
-		format: "statuspage-v2",
+		apiUrl: "https://api.status.io/1.0/status/5b36dc6502d06804c08349f7",
+		format: "status-io",
 		iconType: "simple-icon",
 		iconValue: "gitlab",
 	},
@@ -226,9 +219,10 @@ export const SERVICE_PRESETS: readonly ServicePreset[] = [
 		slug: "docker-hub",
 		label: "Docker Hub",
 		category: "dev-infra",
-		statusUrl: "https://status.docker.com/",
-		apiUrl: "https://status.docker.com/api/v2/status.json",
-		format: "statuspage-v2",
+		// Docker Hub uses status.io (same backend as GitLab).
+		statusUrl: "https://www.dockerstatus.com/",
+		apiUrl: "https://api.status.io/1.0/status/533c6539221ae15e3f000031",
+		format: "status-io",
 		iconType: "simple-icon",
 		iconValue: "docker",
 	},
@@ -295,16 +289,6 @@ export const SERVICE_PRESETS: readonly ServicePreset[] = [
 		iconValue: "netlify",
 	},
 	{
-		slug: "fastly",
-		label: "Fastly",
-		category: "hosting",
-		statusUrl: "https://status.fastly.com/",
-		apiUrl: "https://status.fastly.com/api/v2/status.json",
-		format: "statuspage-v2",
-		iconType: "simple-icon",
-		iconValue: "fastly",
-	},
-	{
 		slug: "digitalocean",
 		label: "DigitalOcean",
 		category: "hosting",
@@ -319,9 +303,10 @@ export const SERVICE_PRESETS: readonly ServicePreset[] = [
 		slug: "slack",
 		label: "Slack",
 		category: "communication",
-		statusUrl: "https://status.slack.com/",
-		apiUrl: "https://status.slack.com/api/v2/status.json",
-		format: "statuspage-v2",
+		// Slack moved off Atlassian Statuspage to a custom feed at slack-status.com.
+		statusUrl: "https://slack-status.com/",
+		apiUrl: "https://slack-status.com/api/v2.0.0/current",
+		format: "slack-v2",
 		iconType: "simple-icon",
 		iconValue: "slack",
 	},
@@ -361,8 +346,10 @@ export const SERVICE_PRESETS: readonly ServicePreset[] = [
 		slug: "linear",
 		label: "Linear",
 		category: "productivity",
-		statusUrl: "https://status.linear.app/",
-		apiUrl: "https://status.linear.app/api/v2/status.json",
+		// Linear moved its statuspage off status.linear.app (now a custom HTML
+		// page) onto linearstatus.com which keeps the statuspage v2 schema.
+		statusUrl: "https://linearstatus.com/",
+		apiUrl: "https://linearstatus.com/api/v2/status.json",
 		format: "statuspage-v2",
 		iconType: "simple-icon",
 		iconValue: "linear",
@@ -381,8 +368,10 @@ export const SERVICE_PRESETS: readonly ServicePreset[] = [
 		slug: "notion",
 		label: "Notion",
 		category: "productivity",
-		statusUrl: "https://status.notion.so/",
-		apiUrl: "https://status.notion.so/api/v2/status.json",
+		// Notion's status.notion.so now serves a custom HTML page; the actual
+		// statuspage v2 feed lives on www.notion-status.com.
+		statusUrl: "https://www.notion-status.com/",
+		apiUrl: "https://www.notion-status.com/api/v2/status.json",
 		format: "statuspage-v2",
 		iconType: "simple-icon",
 		iconValue: "notion",
@@ -403,8 +392,10 @@ export const SERVICE_PRESETS: readonly ServicePreset[] = [
 		slug: "stripe",
 		label: "Stripe",
 		category: "payment",
-		statusUrl: "https://status.stripe.com/",
-		apiUrl: "https://status.stripe.com/api/v2/status.json",
+		// Stripe migrated from status.stripe.com to www.stripestatus.com (2024).
+		// Old host returns 404 for /api/v2/*.
+		statusUrl: "https://www.stripestatus.com/",
+		apiUrl: "https://www.stripestatus.com/api/v2/status.json",
 		format: "statuspage-v2",
 		iconType: "simple-icon",
 		iconValue: "stripe",

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/ServiceStatusIndicators/ServiceStatusIndicators.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/ServiceStatusIndicators/ServiceStatusIndicators.tsx
@@ -40,14 +40,14 @@ function ServiceStatusIndicator({
 				<button
 					type="button"
 					aria-label={`${snapshot.label} status: ${levelLabel}`}
-					className="no-drag relative flex items-center justify-center size-7 rounded-md text-foreground/80 hover:text-foreground hover:bg-accent/60 transition-colors"
+					className="no-drag relative flex items-center justify-center size-[25px] rounded-md text-foreground/80 hover:text-foreground hover:bg-accent/60 transition-colors"
 				>
 					<ServiceStatusIcon
 						source={snapshot}
-						className="size-[15px] shrink-0"
+						className="size-[13px] shrink-0"
 					/>
 					<span
-						className={`absolute -bottom-0.5 -right-0.5 size-2 rounded-full ring-2 ring-background ${dotClass}`}
+						className={`absolute -bottom-px -right-px size-1.5 rounded-full ring-[1.5px] ring-background ${dotClass}`}
 					/>
 				</button>
 			</PopoverTrigger>

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/service-status/components/ServiceStatusSettings/components/ServiceDefinitionDialog/ServiceDefinitionDialog.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/service-status/components/ServiceStatusSettings/components/ServiceDefinitionDialog/ServiceDefinitionDialog.tsx
@@ -51,6 +51,9 @@ const formatSchema = z.enum([
 	"gcp-incidents",
 	"aws-health",
 	"azure-rss",
+	"status-io",
+	"slack-v2",
+	"instatus-summary",
 ]);
 
 const formSchema = z
@@ -387,6 +390,15 @@ export function ServiceDefinitionDialog({
 											</SelectItem>
 											<SelectItem value="aws-health">AWS data.json</SelectItem>
 											<SelectItem value="azure-rss">Azure RSS feed</SelectItem>
+											<SelectItem value="status-io">
+												status.io (GitLab / Docker Hub)
+											</SelectItem>
+											<SelectItem value="slack-v2">
+												Slack v2.0.0 (slack-status.com)
+											</SelectItem>
+											<SelectItem value="instatus-summary">
+												Instatus summary.json
+											</SelectItem>
 										</SelectContent>
 									</Select>
 									<p className="text-xs text-muted-foreground">

--- a/apps/desktop/src/shared/service-status-types.ts
+++ b/apps/desktop/src/shared/service-status-types.ts
@@ -32,8 +32,16 @@ export type ServiceStatusIconType =
 /**
  * API response shape the poller should assume for a definition. The default
  * `statuspage-v2` covers the most common case (Claude, GitHub, Stripe, …);
- * the other three are dedicated adapters for the Big 3 cloud providers which
- * publish incidents in incompatible formats.
+ * the other adapters cover providers that have moved off Atlassian Statuspage
+ * onto custom or third-party status backends.
+ *
+ *   - `statuspage-v2`     — Atlassian Statuspage `/api/v2/status.json`
+ *   - `gcp-incidents`     — `status.cloud.google.com/incidents.json`
+ *   - `aws-health`        — `status.aws.amazon.com/data.json`
+ *   - `azure-rss`         — Azure / Microsoft status RSS 2.0 feed
+ *   - `status-io`         — `api.status.io/1.0/status/<page_id>` (GitLab, Docker Hub)
+ *   - `slack-v2`          — `slack-status.com/api/v2.0.0/current`
+ *   - `instatus-summary`  — Instatus `<page>/summary.json` (Perplexity et al.)
  *
  * Mirrored from `@superset/local-db`; keep in sync manually (see note above
  * for `ServiceStatusIconType`).
@@ -42,7 +50,10 @@ export type ServiceStatusFormat =
 	| "statuspage-v2"
 	| "gcp-incidents"
 	| "aws-health"
-	| "azure-rss";
+	| "azure-rss"
+	| "status-io"
+	| "slack-v2"
+	| "instatus-summary";
 
 export interface ServiceStatusDefinition {
 	id: ServiceStatusId;

--- a/packages/local-db/src/schema/service-status-definitions.ts
+++ b/packages/local-db/src/schema/service-status-definitions.ts
@@ -23,16 +23,22 @@ export type ServiceStatusIconType =
  * to `statuspage-v2` for backward compatibility with rows that predate the
  * multi-format adapter.
  *
- *   - `statuspage-v2`  — Statuspage.io `/api/v2/status.json` (Claude, GitHub, Stripe, …)
- *   - `gcp-incidents`  — `status.cloud.google.com/incidents.json`
- *   - `aws-health`     — `status.aws.amazon.com/data.json`
- *   - `azure-rss`      — Azure / Microsoft status RSS 2.0 feed
+ *   - `statuspage-v2`     — Atlassian Statuspage `/api/v2/status.json`
+ *   - `gcp-incidents`     — `status.cloud.google.com/incidents.json`
+ *   - `aws-health`        — `status.aws.amazon.com/data.json`
+ *   - `azure-rss`         — Azure / Microsoft status RSS 2.0 feed
+ *   - `status-io`         — `api.status.io/1.0/status/<page_id>` (GitLab, Docker Hub)
+ *   - `slack-v2`          — `slack-status.com/api/v2.0.0/current`
+ *   - `instatus-summary`  — Instatus `<page>/summary.json` (Perplexity et al.)
  */
 export type ServiceStatusFormat =
 	| "statuspage-v2"
 	| "gcp-incidents"
 	| "aws-health"
-	| "azure-rss";
+	| "azure-rss"
+	| "status-io"
+	| "slack-v2"
+	| "instatus-summary";
 
 /**
  * User-configurable list of external status pages to poll.


### PR DESCRIPTION
## Summary

PR #407 で導入された Service Status プリセット 36 件のうち、**9 件が現在 404 / 403 / HTML を返す壊れた状態**だったので、まとめて修正する。同時に TopBar の表示密度を上げるためインジケーターを少し小さくする。

## 背景

各プロバイダの実 HTTP 検証 (curl) と公開ドキュメント調査の結果、壊れていたのは以下:

| 種別 | プリセット | 旧 API URL | 状態 |
|---|---|---|---|
| URL 移行 | stripe | `status.stripe.com/api/v2/status.json` | 404 |
| URL 移行 | linear | `status.linear.app/api/v2/status.json` | HTML (200) |
| URL 移行 | notion | `status.notion.so/api/v2/status.json` | HTML (200) |
| 別 backend へ移行 | gitlab | `status.gitlab.com/api/v2/status.json` | 404 |
| 別 backend へ移行 | docker-hub | `status.docker.com/api/v2/status.json` | HTML (200) |
| 別 backend へ移行 | slack | `status.slack.com/api/v2/status.json` | 404 |
| 別 backend へ移行 | perplexity | `status.perplexity.com/api/v2/status.json` | 404 |
| 取得不能 | fastly | `status.fastly.com/api/v2/status.json` | 403 (Bot 検知) |
| 取得不能 | huggingface | `status.huggingface.co/api/v2/status.json` | HTML (BetterStack) |

## 変更内容

### A. URL 差し替えのみ (Statuspage v2 互換のまま別ホストへ移動)

| slug | 旧 | 新 |
|---|---|---|
| stripe | `status.stripe.com` | `www.stripestatus.com` |
| linear | `status.linear.app` | `linearstatus.com` |
| notion | `status.notion.so` | `www.notion-status.com` |

3 件とも Statuspage v2 互換のままなので format 変更不要。

### B. 新パーサ 3 種を追加して救済

`ServiceStatusFormat` に 3 つの値を追加し、対応するアダプタを `apps/desktop/src/main/lib/service-status/parsers/` に新規作成:

| format | 適用プリセット | API スキーマ |
|---|---|---|
| `status-io` | gitlab, docker-hub | `{ result: { status_overall: { status_code, status } } }` (status_code 100/200/300/400/500/600 を indicator にマッピング) |
| `slack-v2` | slack | `{ status: \"ok\"\|\"active\", active_incidents: [{ type: \"incident\"\|\"outage\"\|... }] }` |
| `instatus-summary` | perplexity | `{ page: { status: \"UP\"\|\"HASISSUES\"\|\"UNDERMAINTENANCE\" } }` |

### C. 取得不可プリセットを削除

- `fastly` — StatusCast (Azure Front Door) で `/api/v2/*` も RSS も 403 / 302→`/errors/404`、認証なしでは取得経路なし
- `huggingface` — BetterStack 移行で「現在ステータス」の機械可読 API が無い (RSS は incident 履歴のみ)

### D. TopBar インジケーターのサイズ調整

\`ServiceStatusIndicators.tsx\`:

| 要素 | 旧 | 新 |
|---|---|---|
| button | 28×28 (\`size-7\`) | **25×25** (\`size-[25px]\`) |
| icon | 15px (\`size-[15px]\`) | **13px** (\`size-[13px]\`) |
| dot | 8px (\`size-2\`) | **6px** (\`size-1.5\`) |
| ring | 2px (\`ring-2\`) | **1.5px** (\`ring-[1.5px]\`) |

dot のオフセットは \`-bottom-px -right-px\` (1px) に縮小、6px に対して半分外にはみ出す自然な見た目を維持。

## 影響範囲

- **既存 DB 行**: format 列は \`text\` カラムで $type だけが narrow を担うので、追加した値は既存スキーマと SQL レベルで互換 (drizzle migration 不要)
- **未知の format 値**: \`definitions-store.ts\` の \`narrowFormat\` が statuspage-v2 にフォールバックするため、古いビルドで作成された行が壊れることはない
- **ユーザーが手動で \"プリセットから追加\" していた壊れた行**: 自動修正はしない。Settings → Service Status から手で削除/再追加してもらう (UPDATE migration を打つほどのリスクはないと判断)

## 同期した箇所

format 値を増やしたので以下を一斉更新:

- \`packages/local-db/src/schema/service-status-definitions.ts\` の型
- \`apps/desktop/src/shared/service-status-types.ts\` の型
- \`apps/desktop/src/main/lib/service-status/definitions-store.ts\` の \`KNOWN_FORMATS\` Set
- \`apps/desktop/src/main/lib/service-status/parsers/index.ts\` の dispatch
- \`apps/desktop/src/lib/trpc/routers/service-status.ts\` の \`formatSchema\` (zod)
- \`apps/desktop/src/renderer/routes/.../ServiceDefinitionDialog.tsx\` の \`formatSchema\` + Select UI

\`validateApiUrl\` (接続確認ボタン) は **statuspage-v2 専用のまま** にしてある。他フォーマットは \"確認なしで保存→ポーリング結果で判定\" の挙動になるが、Dialog の注釈にもその旨が明記されていて変更不要。

## Test plan

- [ ] Settings → Service Status の \"プリセットから追加\" で stripe / linear / notion を追加 → TopBar が正常 (緑) で表示される
- [ ] 同じく gitlab / docker-hub を追加 → status.io から取得して状態が表示される
- [ ] slack を追加 → \`{status:\"ok\"}\` レスポンスが \"全システム正常\" として表示される
- [ ] perplexity を追加 → Instatus summary.json から \"UP\" を読み取り operational として表示される
- [ ] fastly / huggingface がプリセット選択 Dialog から消えていることを確認
- [ ] Dialog の format Select に \"status.io\" / \"Slack v2.0.0\" / \"Instatus summary.json\" の 3 項目が追加されている
- [ ] TopBar のインジケーターが少し小さくなり (28→25)、列幅も短くなることを目視確認
- [ ] \`bun run typecheck\` が service-status 系で 0 エラー (CodeMirror 二重バージョン由来の既存エラーは無関係)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 3つの新しいサービスステータス形式（status.io、Slack v2、Instatus）をサポート
  * 複数のサービスプリセットを最新のステータスページエンドポイントに更新（Perplexity、GitLab、Docker Hub、Slack、Linear、Notion、Stripe）
  * 廃止されたサービスプリセット（HuggingFace、Fastly）を削除

* **スタイル**
  * サービスステータスインジケータボタンのサイズを調整

<!-- end of auto-generated comment: release notes by coderabbit.ai -->