### PR TITLE
fix(desktop): v1 検索タブの replace 後に結果を自動リフレッシュ

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/SearchView/SearchView.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/SearchView/SearchView.tsx
@@ -258,7 +258,7 @@ export function SearchView({
 		[project],
 	);
 
-	const { searchResults, isFetching, hasQuery, validationError } =
+	const { searchResults, isFetching, hasQuery, validationError, refresh } =
 		useContentSearch({
 			workspaceId,
 			query,
@@ -471,6 +471,7 @@ export function SearchView({
 				}
 
 				void utils.filesystem.searchContent.invalidate();
+				refresh();
 			} catch (error) {
 				toast.error(
 					error instanceof Error ? error.message : "Failed to replace matches.",
@@ -484,6 +485,7 @@ export function SearchView({
 			isRegex,
 			multiline,
 			query,
+			refresh,
 			replacement,
 			replaceMutation,
 			utils.filesystem.searchContent,
@@ -560,6 +562,7 @@ export function SearchView({
 					absolutePath: lineMatch.absolutePath,
 				});
 				void utils.filesystem.searchContent.invalidate();
+				refresh();
 				toast.success(
 					`Replaced ${lineMatch.matches.length} match${lineMatch.matches.length === 1 ? "" : "es"} on line ${lineMatch.line}.`,
 				);
@@ -576,6 +579,7 @@ export function SearchView({
 			isRegex,
 			multiline,
 			query,
+			refresh,
 			replacement,
 			utils,
 			validationError,

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/SearchView/hooks/useContentSearch/useContentSearch.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/SearchView/hooks/useContentSearch/useContentSearch.ts
@@ -63,6 +63,14 @@ export function useContentSearch({
 	// hits as ripgrep finds them (VSCode-style streaming).
 	const [searchResults, setSearchResults] = useState<SearchContentResult[]>([]);
 	const [isStreaming, setIsStreaming] = useState(false);
+	// Bumped by `refresh()` to force a resubscribe after external mutations
+	// (e.g. replace-in-file). Mixing it into `subscriptionKey` resets local
+	// state, and into `scopeId` changes the subscription input identity so
+	// trpc tears down the old stream and starts a fresh ripgrep run.
+	const [refreshEpoch, setRefreshEpoch] = useState(0);
+	const refresh = useCallback(() => {
+		setRefreshEpoch((current) => current + 1);
+	}, []);
 
 	// We keep the "idle timeout after last event" and "reset-on-query-change"
 	// bookkeeping in refs so biome's exhaustive-deps autofix can't strip them
@@ -92,6 +100,7 @@ export function useContentSearch({
 		String(caseSensitive),
 		String(wholeWord),
 		String(multiline),
+		String(refreshEpoch),
 	].join("\u0000");
 
 	const subscriptionInput = useMemo(
@@ -106,7 +115,7 @@ export function useContentSearch({
 			caseSensitive,
 			wholeWord,
 			multiline,
-			scopeId: "search-tab",
+			scopeId: `search-tab:${refreshEpoch}`,
 		}),
 		[
 			workspaceId,
@@ -118,6 +127,7 @@ export function useContentSearch({
 			caseSensitive,
 			wholeWord,
 			multiline,
+			refreshEpoch,
 		],
 	);
 
@@ -194,5 +204,6 @@ export function useContentSearch({
 		isFetching: validationError === null && (isStreaming || isDebouncing),
 		hasQuery: trimmedQuery.length > 0,
 		validationError,
+		refresh,
 	};
 }


### PR DESCRIPTION
## 概要

v1 ワークスペースの検索タブ（右サイドバー Search）で replace を実行した後、置換済みの行・ファイルが結果ツリーに残り続ける問題を修正。VS Code の挙動に合わせて、replace 後にマッチしなくなったエントリが自動で消えるようにした。

## 背景

- 検索結果は `useContentSearch` 内の `searchContentStream` 購読で取得しており、ローカル state にマッチを蓄積している。
- 置換後の `utils.filesystem.searchContent.invalidate()` は別 procedure（query 版）への invalidate で、購読中のストリームには無効。
- 結果として「Replace All」「Replace in file」「インライン Replace match」のいずれを実行しても古いヒットが残り、インライン replace では既に置換済みの行に対して "out of date" トーストが出ることもあった。

## 変更内容

### `useContentSearch`
- `refreshEpoch` state と `refresh()` を追加。
- epoch を `subscriptionKey`（ローカル state リセット用）と `subscriptionInput.scopeId`（trpc 購読の input 識別子）に混ぜることで、`refresh()` 呼び出しで購読が貼り直され、新しい ripgrep ストリームが走る。
- 戻り値に `refresh` を expose。

### `SearchView`
- `runReplace`（Replace All / Replace in file）成功後に `refresh()`。
- `replaceLineMatch`（行単位インライン replace）成功後に `refresh()`。

## 影響範囲

- v1 検索タブ（右サイドバー Search）の Replace 動作のみ。検索 / フィルタ / ファイル一覧などには影響なし。
- ユーザーがクエリを編集した時のリセットロジック（既存の `subscriptionKey` 変更検知）はそのまま機能。

## Test plan

- [ ] v1 ワークスペースで「Replace All」実行後、置換対象だったファイルが結果から消えることを確認
- [ ] 「Replace in file」（ファイル行ホバー時のアイコン）実行後、そのファイルが結果から消えることを確認
- [ ] インライン Replace match（行のホバーアクション）実行後、その行が結果から消えることを確認
- [ ] 置換語が検索クエリ自体にマッチする場合（例: case-insensitive で大文字小文字違いに replace）に、新しいヒットが正しく再ストリームされることを確認
- [ ] 大量ヒットでのちらつきが許容範囲か確認