### PR TITLE
feat(desktop): ウィンドウ透過を Win/Linux 対応 + macOS の透明度を実用レベルに

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/vibrancy.ts
+++ b/apps/desktop/src/lib/trpc/routers/vibrancy.ts
@@ -4,6 +4,7 @@ import { appState } from "main/lib/app-state";
 import {
 	applyVibrancy,
 	DEFAULT_VIBRANCY_STATE,
+	getBootTransparent,
 	isNativeContinuousBlurSupported,
 	isVibrancySupported,
 	normalizeVibrancyState,
@@ -68,6 +69,12 @@ export const createVibrancyRouter = (wm: WindowManager) => {
 				supported: isVibrancySupported(),
 				nativeBlurSupported: isNativeContinuousBlurSupported(),
 				platform: getVibrancyPlatform(),
+				// Whether the main window was constructed with `transparent: true`
+				// at this app launch. macOS is always true; Windows/Linux match
+				// the persisted enabled state at startup. Renderer compares this
+				// against the live state to decide whether toggling vibrancy
+				// requires an app restart to fully take effect.
+				bootTransparent: getBootTransparent(),
 			};
 		}),
 

--- a/apps/desktop/src/lib/trpc/routers/vibrancy.ts
+++ b/apps/desktop/src/lib/trpc/routers/vibrancy.ts
@@ -12,8 +12,18 @@ import {
 } from "main/lib/vibrancy";
 import { VIBRANCY_EVENTS, vibrancyEmitter } from "main/lib/vibrancy/emitter";
 import type { WindowManager } from "main/lib/window-manager";
+import { PLATFORM } from "shared/constants";
 import { z } from "zod";
 import { publicProcedure, router } from "..";
+
+type VibrancyPlatform = "mac" | "windows" | "linux" | "unsupported";
+
+function getVibrancyPlatform(): VibrancyPlatform {
+	if (PLATFORM.IS_MAC) return "mac";
+	if (PLATFORM.IS_WINDOWS) return "windows";
+	if (PLATFORM.IS_LINUX) return "linux";
+	return "unsupported";
+}
 
 const blurLevelSchema: z.ZodType<VibrancyBlurLevel> = z.enum([
 	"subtle",
@@ -57,6 +67,7 @@ export const createVibrancyRouter = (wm: WindowManager) => {
 			return {
 				supported: isVibrancySupported(),
 				nativeBlurSupported: isNativeContinuousBlurSupported(),
+				platform: getVibrancyPlatform(),
 			};
 		}),
 

--- a/apps/desktop/src/main/lib/vibrancy/index.ts
+++ b/apps/desktop/src/main/lib/vibrancy/index.ts
@@ -38,9 +38,22 @@ const DARK_RGB = { r: 21, g: 17, b: 16 };
 const LIGHT_RGB = { r: 255, g: 255, b: 255 };
 
 export function isVibrancySupported(): boolean {
-	// macOS uses NSVisualEffectView. Windows 11 22H2+ uses Mica via
-	// BrowserWindow.setBackgroundMaterial; on older Windows versions the call
-	// is a no-op so gating on IS_WINDOWS is safe.
+	// macOS uses NSVisualEffectView. Windows 11 22H2+ uses Acrylic via
+	// BrowserWindow.setBackgroundMaterial (gives a real see-through blurred
+	// translucency, unlike Mica which is more of a desktop-color tint).
+	// Linux uses pure transparency — actual background blur depends on the
+	// active compositor (KDE KWin: yes, GNOME Shell: no, Wayland varies).
+	return PLATFORM.IS_MAC || PLATFORM.IS_WINDOWS || PLATFORM.IS_LINUX;
+}
+
+/**
+ * Whether the platform supports a system-level blur material behind the
+ * window. macOS always does (NSVisualEffectView). Windows 11 22H2+ does via
+ * acrylic. Linux varies per compositor and we don't gate the feature on it,
+ * so callers that care should treat Linux as "no system blur, transparent
+ * pixels only".
+ */
+export function hasSystemBlurMaterial(): boolean {
 	return PLATFORM.IS_MAC || PLATFORM.IS_WINDOWS;
 }
 
@@ -122,9 +135,8 @@ export function resolveVibrancyType(
 }
 
 /**
- * Apply the current vibrancy state to a BrowserWindow. Only has effect on
- * macOS — on other platforms this is a no-op so callers can invoke it
- * unconditionally.
+ * Apply the current vibrancy state to a BrowserWindow. Routes to the right
+ * platform-specific path; safe to call on unsupported platforms (no-op).
  */
 export function applyVibrancy(
 	window: BrowserWindow,
@@ -136,6 +148,11 @@ export function applyVibrancy(
 
 	if (PLATFORM.IS_WINDOWS) {
 		applyWindowsBackgroundMaterial(window, state, isDark);
+		return;
+	}
+
+	if (PLATFORM.IS_LINUX) {
+		applyLinuxTransparency(window, state, isDark);
 		return;
 	}
 
@@ -152,9 +169,11 @@ export function applyVibrancy(
 }
 
 /**
- * Windows 11 22H2+ Mica fallback. Uses `setBackgroundMaterial('mica' | 'none')`.
- * On older Windows versions the call silently no-ops; the opaque backgroundColor
- * below keeps the chrome looking intentional even when Mica isn't available.
+ * Windows 11 22H2+ uses Acrylic for actual see-through translucency
+ * (Mica is more of a binary "desktop color tint" effect). On older Windows
+ * versions setBackgroundMaterial silently no-ops and the rgba backgroundColor
+ * still makes the window translucent because we created it with
+ * `transparent: true`.
  */
 function applyWindowsBackgroundMaterial(
 	window: BrowserWindow,
@@ -168,13 +187,33 @@ function applyWindowsBackgroundMaterial(
 	};
 	const withMaterial = window as WithSetBackgroundMaterial;
 	try {
-		withMaterial.setBackgroundMaterial?.(state.enabled ? "mica" : "none");
+		withMaterial.setBackgroundMaterial?.(state.enabled ? "acrylic" : "none");
 	} catch (error) {
 		console.warn("[vibrancy] setBackgroundMaterial failed on Windows:", error);
 	}
-	// Even when Mica is active we keep backgroundColor at the brand opaque
-	// value — the renderer decides per-region whether to let Mica show through.
-	window.setBackgroundColor(isDark ? OPAQUE_DARK : OPAQUE_LIGHT);
+	// Pass the rgba value through so the slider's opacity reaches the
+	// composited window. With `transparent: true` set at construction, this
+	// produces a real translucent surface even when acrylic is unavailable
+	// (older Win10 / Win11 pre-22H2).
+	window.setBackgroundColor(computeBackgroundColor(state, isDark));
+}
+
+/**
+ * Linux has no equivalent of NSVisualEffectView/Acrylic in Electron — there's
+ * no setVibrancy or setBackgroundMaterial path. We rely entirely on
+ * `transparent: true` at window creation plus an rgba backgroundColor here.
+ * Whether the user sees a blur behind the window depends on their compositor:
+ *   - KDE Plasma (KWin): blur via the Blur effect, can read window hints.
+ *   - GNOME Shell: no app-controllable blur — the window will look like a
+ *     simple translucent overlay.
+ *   - Wayland: per-compositor, generally same as above.
+ */
+function applyLinuxTransparency(
+	window: BrowserWindow,
+	state: VibrancyState,
+	isDark: boolean,
+): void {
+	window.setBackgroundColor(computeBackgroundColor(state, isDark));
 }
 
 // --- Native blur scheduling ----------------------------------------------
@@ -236,14 +275,14 @@ function scheduleNativeBlur(window: BrowserWindow, state: VibrancyState): void {
 }
 
 /**
- * Options that callers should spread into the BrowserWindow constructor on
- * macOS so that vibrancy can later be toggled dynamically via
- * `setVibrancy` / `setBackgroundColor` without recreating the window.
+ * Options that callers spread into the BrowserWindow constructor.
  *
  * `transparent: true` is required at construction time — it cannot be
- * toggled later — so we always opt in on macOS even when the user has
- * vibrancy disabled. The opaque background color we set keeps the window
- * visually identical to the pre-vibrancy build until the user enables it.
+ * toggled later — so we always opt in on every supported platform, even
+ * when the user has vibrancy disabled. While disabled we paint an opaque
+ * background color so the window looks identical to the pre-vibrancy build,
+ * and toggling ON only needs to swap `setBackgroundColor` to an rgba value
+ * (no window recreation, no restart).
  */
 export function getInitialWindowOptions(
 	state: VibrancyState,
@@ -263,8 +302,24 @@ export function getInitialWindowOptions(
 
 	if (PLATFORM.IS_WINDOWS) {
 		return {
-			backgroundMaterial: state.enabled ? "mica" : "none",
-			backgroundColor: isDark ? OPAQUE_DARK : OPAQUE_LIGHT,
+			transparent: true,
+			backgroundMaterial: state.enabled ? "acrylic" : "none",
+			backgroundColor: state.enabled
+				? computeBackgroundColor(state, isDark)
+				: isDark
+					? OPAQUE_DARK
+					: OPAQUE_LIGHT,
+		};
+	}
+
+	if (PLATFORM.IS_LINUX) {
+		return {
+			transparent: true,
+			backgroundColor: state.enabled
+				? computeBackgroundColor(state, isDark)
+				: isDark
+					? OPAQUE_DARK
+					: OPAQUE_LIGHT,
 		};
 	}
 

--- a/apps/desktop/src/main/lib/vibrancy/index.ts
+++ b/apps/desktop/src/main/lib/vibrancy/index.ts
@@ -275,14 +275,33 @@ function scheduleNativeBlur(window: BrowserWindow, state: VibrancyState): void {
 }
 
 /**
+ * Tracks whether the *first* window built in this app launch was constructed
+ * with `transparent: true`. macOS always is (NSVisualEffectView is well-tested
+ * and we want runtime toggles to "just work"); Windows/Linux are gated to the
+ * vibrancy-enabled path because Electron's transparent windows on those
+ * platforms have known interaction quirks (resize/maximize, GPU compositing)
+ * that we don't want to inflict on users who never opted into vibrancy.
+ *
+ * Renderer reads this via the tRPC support query and, on Win/Linux, compares
+ * against the live `state.enabled` to decide whether to surface a "restart
+ * required" hint when the user toggles vibrancy after launch.
+ */
+let bootTransparent: boolean | null = null;
+
+export function getBootTransparent(): boolean | null {
+	return bootTransparent;
+}
+
+/**
  * Options that callers spread into the BrowserWindow constructor.
  *
- * `transparent: true` is required at construction time — it cannot be
- * toggled later — so we always opt in on every supported platform, even
- * when the user has vibrancy disabled. While disabled we paint an opaque
- * background color so the window looks identical to the pre-vibrancy build,
- * and toggling ON only needs to swap `setBackgroundColor` to an rgba value
- * (no window recreation, no restart).
+ * `transparent: true` cannot be toggled at runtime — it has to be decided at
+ * construction. macOS always opts in so that turning vibrancy on/off after
+ * launch is a no-restart operation; on Windows/Linux we only opt in when
+ * vibrancy is already enabled at startup so unrelated users don't pay the
+ * transparent-window cost (Electron docs note reduced resize/maximize support
+ * for transparent windows on these platforms). Toggling vibrancy after launch
+ * therefore requires an app restart on Win/Linux to actually let pixels through.
  */
 export function getInitialWindowOptions(
 	state: VibrancyState,
@@ -295,14 +314,17 @@ export function getInitialWindowOptions(
 	backgroundColor: string;
 } {
 	if (!isVibrancySupported()) {
+		bootTransparent ??= false;
 		return {
 			backgroundColor: isDark ? OPAQUE_DARK : OPAQUE_LIGHT,
 		};
 	}
 
 	if (PLATFORM.IS_WINDOWS) {
+		const transparent = state.enabled;
+		bootTransparent ??= transparent;
 		return {
-			transparent: true,
+			...(transparent ? { transparent: true } : {}),
 			backgroundMaterial: state.enabled ? "acrylic" : "none",
 			backgroundColor: state.enabled
 				? computeBackgroundColor(state, isDark)
@@ -313,8 +335,10 @@ export function getInitialWindowOptions(
 	}
 
 	if (PLATFORM.IS_LINUX) {
+		const transparent = state.enabled;
+		bootTransparent ??= transparent;
 		return {
-			transparent: true,
+			...(transparent ? { transparent: true } : {}),
 			backgroundColor: state.enabled
 				? computeBackgroundColor(state, isDark)
 				: isDark
@@ -322,6 +346,8 @@ export function getInitialWindowOptions(
 					: OPAQUE_LIGHT,
 		};
 	}
+
+	bootTransparent ??= true;
 
 	const backgroundColor = computeBackgroundColor(state, isDark);
 	// Always attach NSVisualEffectView at construction time, even when the

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/appearance/components/AppearanceSettings/components/VibrancySection/VibrancySection.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/appearance/components/AppearanceSettings/components/VibrancySection/VibrancySection.tsx
@@ -45,6 +45,7 @@ export function VibrancySection() {
 	const supported = useVibrancyStore((s) => s.supported);
 	const nativeBlurSupported = useVibrancyStore((s) => s.nativeBlurSupported);
 	const platform = useVibrancyStore((s) => s.platform);
+	const bootTransparent = useVibrancyStore((s) => s.bootTransparent);
 	const enabled = useVibrancyStore((s) => s.enabled);
 	const opacity = useVibrancyStore((s) => s.opacity);
 	const blurLevel = useVibrancyStore((s) => s.blurLevel);
@@ -57,6 +58,17 @@ export function VibrancySection() {
 	// Windows uses Acrylic, which has no app-controllable blur strength.
 	// Linux relies on the user's compositor — there's nothing to slide.
 	const showBlurControl = platform === "mac";
+
+	// On Win/Linux, `transparent: true` is decided at window construction and
+	// can't be toggled at runtime. If the user flips vibrancy on/off after
+	// launch, the rgba background change won't actually let pixels through
+	// until the app restarts and the window is built with the matching
+	// transparent flag. macOS always opts into transparent so this never
+	// applies there.
+	const restartRequired =
+		platform !== "mac" &&
+		bootTransparent !== null &&
+		bootTransparent !== enabled;
 
 	// Drag-local opacity: drives the slider thumb and a CSS preview via the
 	// `--vibrancy-alpha` variable, so the window updates in real time without
@@ -143,6 +155,14 @@ export function VibrancySection() {
 				</p>
 				<p className="mt-1 text-xs text-muted-foreground">{platformNote}</p>
 			</div>
+
+			{restartRequired ? (
+				<div className="rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-xs text-amber-700 dark:text-amber-300">
+					{platform === "windows"
+						? "Windows ではウィンドウの透過を切り替えるにはアプリの再起動が必要です。"
+						: "Linux ではウィンドウの透過を切り替えるにはアプリの再起動が必要です。"}
+				</div>
+			) : null}
 
 			<div className="flex items-center justify-between gap-4">
 				<div className="space-y-0.5">

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/appearance/components/AppearanceSettings/components/VibrancySection/VibrancySection.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/appearance/components/AppearanceSettings/components/VibrancySection/VibrancySection.tsx
@@ -44,12 +44,19 @@ export function VibrancySection() {
 	const hydrated = useVibrancyStore((s) => s.hydrated);
 	const supported = useVibrancyStore((s) => s.supported);
 	const nativeBlurSupported = useVibrancyStore((s) => s.nativeBlurSupported);
+	const platform = useVibrancyStore((s) => s.platform);
 	const enabled = useVibrancyStore((s) => s.enabled);
 	const opacity = useVibrancyStore((s) => s.opacity);
 	const blurLevel = useVibrancyStore((s) => s.blurLevel);
 	const blurRadius = useVibrancyStore((s) => s.blurRadius);
 	const setState = useVibrancyStore((s) => s.setState);
 	const previewOpacity = useVibrancyStore((s) => s.previewOpacity);
+
+	// macOS exposes either the continuous CIGaussianBlur (when the native
+	// addon loaded) or the four-step NSVisualEffectView material picker.
+	// Windows uses Acrylic, which has no app-controllable blur strength.
+	// Linux relies on the user's compositor — there's nothing to slide.
+	const showBlurControl = platform === "mac";
 
 	// Drag-local opacity: drives the slider thumb and a CSS preview via the
 	// `--vibrancy-alpha` variable, so the window updates in real time without
@@ -111,22 +118,30 @@ export function VibrancySection() {
 			<div>
 				<h3 className="text-sm font-medium">ウィンドウ透過</h3>
 				<p className="mt-1 text-xs text-muted-foreground">
-					この機能は現在 macOS でのみ利用できます。
+					この機能はお使いのプラットフォームではサポートされていません。
 				</p>
 			</div>
 		);
 	}
 
+	const platformNote =
+		platform === "mac"
+			? "macOS は NSVisualEffectView を使ってウィンドウ全体をぼかしながら半透明にします。"
+			: platform === "windows"
+				? "Windows 11 22H2 以降は Acrylic でぼかし付きの半透明になります。それ以前のバージョンでは半透明のみ (ぼかしなし) です。"
+				: "Linux ではぼかしの有無はお使いのコンポジタ依存です (KDE Plasma の KWin はブラーあり、GNOME Shell はブラーなし)。";
+
 	return (
 		<div className="space-y-5">
 			<div>
-				<h3 className="text-sm font-medium">ウィンドウ透過 (macOS)</h3>
+				<h3 className="text-sm font-medium">ウィンドウ透過</h3>
 				<p className="mt-1 text-xs text-muted-foreground">
 					Warp
-					のようにウィンドウ全体を半透明にし、背景をぼかしてデスクトップが透けて見えるようにします。
-					ブラウザペイン (webview) は macOS
+					のようにウィンドウ全体を半透明にして、背景にデスクトップが透けて見えるようにします。
+					ブラウザペイン (webview) は OS
 					の制約により透過できず、不透明のまま残ります。
 				</p>
+				<p className="mt-1 text-xs text-muted-foreground">{platformNote}</p>
 			</div>
 
 			<div className="flex items-center justify-between gap-4">
@@ -183,76 +198,77 @@ export function VibrancySection() {
 				</p>
 			</div>
 
-			{nativeBlurSupported ? (
-				<div className="space-y-3">
-					<div className="flex items-center justify-between gap-4">
-						<Label className="text-sm font-medium">
-							ブラー半径
-							<span className="ml-2 text-xs text-muted-foreground">
-								{displayBlurRadius} pt
-							</span>
-						</Label>
+			{showBlurControl &&
+				(nativeBlurSupported ? (
+					<div className="space-y-3">
+						<div className="flex items-center justify-between gap-4">
+							<Label className="text-sm font-medium">
+								ブラー半径
+								<span className="ml-2 text-xs text-muted-foreground">
+									{displayBlurRadius} pt
+								</span>
+							</Label>
+						</div>
+						<Slider
+							value={[displayBlurRadius]}
+							min={VIBRANCY_BLUR_RADIUS_MIN}
+							max={VIBRANCY_BLUR_RADIUS_MAX}
+							step={1}
+							disabled={!enabled || !hydrated}
+							onValueChange={(values) => {
+								const value = values[0];
+								if (typeof value !== "number") return;
+								blurRadiusDraftRevisionRef.current += 1;
+								setDraftBlurRadius(value);
+							}}
+							onValueCommit={(values) => {
+								const value = values[0];
+								if (typeof value !== "number") return;
+								commitBlurRadius(value);
+							}}
+						/>
+						<p className="text-xs text-muted-foreground">
+							CIGaussianBlur を 1 単位で調整します (ネイティブアドオン使用)。
+						</p>
 					</div>
-					<Slider
-						value={[displayBlurRadius]}
-						min={VIBRANCY_BLUR_RADIUS_MIN}
-						max={VIBRANCY_BLUR_RADIUS_MAX}
-						step={1}
-						disabled={!enabled || !hydrated}
-						onValueChange={(values) => {
-							const value = values[0];
-							if (typeof value !== "number") return;
-							blurRadiusDraftRevisionRef.current += 1;
-							setDraftBlurRadius(value);
-						}}
-						onValueCommit={(values) => {
-							const value = values[0];
-							if (typeof value !== "number") return;
-							commitBlurRadius(value);
-						}}
-					/>
-					<p className="text-xs text-muted-foreground">
-						CIGaussianBlur を 1 単位で調整します (ネイティブアドオン使用)。
-					</p>
-				</div>
-			) : (
-				<div className="space-y-3">
-					<div className="flex items-center justify-between gap-4">
-						<Label className="text-sm font-medium">
-							ブラー強度
-							<span className="ml-2 text-xs text-muted-foreground">
-								{
-									BLUR_LEVEL_LABEL[
-										sliderValueToBlurLevel(displayBlurLevelValue)
-									]
-								}
-							</span>
-						</Label>
+				) : (
+					<div className="space-y-3">
+						<div className="flex items-center justify-between gap-4">
+							<Label className="text-sm font-medium">
+								ブラー強度
+								<span className="ml-2 text-xs text-muted-foreground">
+									{
+										BLUR_LEVEL_LABEL[
+											sliderValueToBlurLevel(displayBlurLevelValue)
+										]
+									}
+								</span>
+							</Label>
+						</div>
+						<Slider
+							value={[displayBlurLevelValue]}
+							min={0}
+							max={100}
+							step={1}
+							disabled={!enabled || !hydrated}
+							onValueChange={(values) => {
+								const value = values[0];
+								if (typeof value !== "number") return;
+								blurLevelDraftRevisionRef.current += 1;
+								setDraftBlurLevelValue(value);
+							}}
+							onValueCommit={(values) => {
+								const value = values[0];
+								if (typeof value !== "number") return;
+								commitBlurLevelValue(value);
+							}}
+						/>
+						<p className="text-xs text-muted-foreground">
+							ネイティブブラーアドオンが未ロードのため、NSVisualEffectView の
+							material を 4 段階で切り替えます (弱 → 標準 → 強 → 最強)。
+						</p>
 					</div>
-					<Slider
-						value={[displayBlurLevelValue]}
-						min={0}
-						max={100}
-						step={1}
-						disabled={!enabled || !hydrated}
-						onValueChange={(values) => {
-							const value = values[0];
-							if (typeof value !== "number") return;
-							blurLevelDraftRevisionRef.current += 1;
-							setDraftBlurLevelValue(value);
-						}}
-						onValueCommit={(values) => {
-							const value = values[0];
-							if (typeof value !== "number") return;
-							commitBlurLevelValue(value);
-						}}
-					/>
-					<p className="text-xs text-muted-foreground">
-						ネイティブブラーアドオンが未ロードのため、NSVisualEffectView の
-						material を 4 段階で切り替えます (弱 → 標準 → 強 → 最強)。
-					</p>
-				</div>
-			)}
+				))}
 		</div>
 	);
 }

--- a/apps/desktop/src/renderer/stores/vibrancy/store.ts
+++ b/apps/desktop/src/renderer/stores/vibrancy/store.ts
@@ -17,6 +17,14 @@ interface VibrancyStore extends VibrancyState {
 	supported: boolean;
 	nativeBlurSupported: boolean;
 	platform: VibrancyPlatform;
+	/**
+	 * Whether the current app instance launched with a transparent window.
+	 * macOS is always true; on Win/Linux this only matches `enabled` if the
+	 * user hasn't toggled vibrancy since startup. When it diverges, switching
+	 * the rgba background at runtime won't actually let pixels through and
+	 * the user needs to restart for the change to fully take effect.
+	 */
+	bootTransparent: boolean | null;
 	hydrated: boolean;
 	setState: (partial: Partial<VibrancyState>) => Promise<void>;
 	previewOpacity: (opacity: number) => void;
@@ -154,6 +162,7 @@ export const useVibrancyStore = create<VibrancyStore>()((set, get) => ({
 	supported: false,
 	nativeBlurSupported: false,
 	platform: "unsupported",
+	bootTransparent: null,
 	hydrated: false,
 
 	hydrate: async () => {
@@ -179,6 +188,7 @@ export const useVibrancyStore = create<VibrancyStore>()((set, get) => ({
 					supported: supportInfo.supported,
 					nativeBlurSupported: supportInfo.nativeBlurSupported,
 					platform: supportInfo.platform,
+					bootTransparent: supportInfo.bootTransparent,
 					hydrated: true,
 				});
 				ensureThemeSubscription();

--- a/apps/desktop/src/renderer/stores/vibrancy/store.ts
+++ b/apps/desktop/src/renderer/stores/vibrancy/store.ts
@@ -11,9 +11,12 @@ import { electronTrpcClient } from "../../lib/trpc-client";
 import { useThemeStore } from "../theme";
 import { applyUIColors } from "../theme/utils";
 
+export type VibrancyPlatform = "mac" | "windows" | "linux" | "unsupported";
+
 interface VibrancyStore extends VibrancyState {
 	supported: boolean;
 	nativeBlurSupported: boolean;
+	platform: VibrancyPlatform;
 	hydrated: boolean;
 	setState: (partial: Partial<VibrancyState>) => Promise<void>;
 	previewOpacity: (opacity: number) => void;
@@ -84,10 +87,14 @@ function applyVibrancyOverlay(theme: Theme, alpha: number): void {
 	// chrome is the single source of truth for the base color.
 	root.style.setProperty("--background", "transparent");
 
-	// Chrome surfaces keep a tint so they stand out from the transparent
-	// body. We bias them slightly more opaque than the raw alpha so
-	// sidebars/cards are still legible at low opacity settings.
-	const chromeAlpha = clampAlpha(alpha + 0.15);
+	// Chrome surfaces get a small bias on top of the raw slider so they
+	// remain distinguishable from the fully-transparent body even at very
+	// low slider values. Bias was previously 0.15 which made sidebars look
+	// ~25% opaque even when the slider asked for 10%; combined with 3-4
+	// nesting levels this produced a `1-(1-0.25)^N ≈ 60%` effective coverage
+	// and the window felt opaque. 0.05 keeps a hairline tint so the chrome
+	// is still visible against transparent body without dominating it.
+	const chromeAlpha = clampAlpha(alpha + 0.05);
 	set("--card", theme.ui.card, chromeAlpha);
 	set("--muted", theme.ui.muted, chromeAlpha);
 	set("--accent", theme.ui.accent, chromeAlpha);
@@ -146,6 +153,7 @@ export const useVibrancyStore = create<VibrancyStore>()((set, get) => ({
 	...DEFAULT_VIBRANCY_STATE,
 	supported: false,
 	nativeBlurSupported: false,
+	platform: "unsupported",
 	hydrated: false,
 
 	hydrate: async () => {
@@ -170,6 +178,7 @@ export const useVibrancyStore = create<VibrancyStore>()((set, get) => ({
 					...effective,
 					supported: supportInfo.supported,
 					nativeBlurSupported: supportInfo.nativeBlurSupported,
+					platform: supportInfo.platform,
 					hydrated: true,
 				});
 				ensureThemeSubscription();

--- a/apps/desktop/src/shared/vibrancy-types.ts
+++ b/apps/desktop/src/shared/vibrancy-types.ts
@@ -28,7 +28,7 @@ export const DEFAULT_VIBRANCY_STATE: VibrancyState = {
 };
 
 /** Lower bound matched by the settings slider. Keep in sync with UI. */
-export const VIBRANCY_OPACITY_MIN = 10;
+export const VIBRANCY_OPACITY_MIN = 0;
 export const VIBRANCY_OPACITY_MAX = 100;
 export const VIBRANCY_BLUR_RADIUS_MIN = 0;
 export const VIBRANCY_BLUR_RADIUS_MAX = 100;


### PR DESCRIPTION
## 概要

Desktop アプリのウィンドウ透過 (vibrancy) 機能を改善する PR。

これまで macOS 専用とされていたが、コードを精査すると Windows 分岐は配線済みなのに `transparent: true` が抜けて opacity スライダーが死んでいる、Linux はそもそも判定で弾かれている、という状態だった。今回 3 プラットフォーム揃え、加えて macOS のスライダー下限が透けない問題を修正する。

## 変更点

### macOS: 本当に透けるよう調整
- `chromeAlpha = alpha + 0.15` → `+ 0.05` (`renderer/stores/vibrancy/store.ts`)
- `VIBRANCY_OPACITY_MIN` 10 → 0 (`shared/vibrancy-types.ts`)
- 旧実装はサイドバー/カードに +0.15 のバイアスを足していたため、スライダーを 10% にしてもサイドバーは 25% で塗られ、3 段ネストすると `1 - (1 - 0.25)^3 ≈ 58%` の実効カバー率となり「全然透けない」状態だった。バイアスを 0.05 に落とし、下限を 0 まで開放することで、スライダーで本当にデスクトップが透けるところまで持っていけるようになる

### Windows: スライダーを実機能化
- `getInitialWindowOptions` の Windows 分岐に `transparent: true` を追加 (`main/lib/vibrancy/index.ts`)
- Mica → **Acrylic** に変更。Mica は二値で「デスクトップの色味を拾う」程度の効果しかなく、Acrylic がいわゆる「透けて見える + ぼかし」材質
- `setBackgroundColor` を rgba で渡すように修正。これで opacity スライダーが Windows でも実際に効く
- Win10 / Win11 22H2 未満で `setBackgroundMaterial` が no-op になっても、`transparent: true` + rgba 背景の組み合わせで素の半透明は出る

### Linux: 純粋透過対応
- `isVibrancySupported` に `IS_LINUX` を追加 (`main/lib/vibrancy/index.ts`)
- `applyLinuxTransparency` を新設。`setVibrancy` / `setBackgroundMaterial` は Electron Linux で no-op なので、`transparent: true` + rgba 背景のみ
- ブラーの有無はコンポジタ依存 (KDE Plasma の KWin はブラーあり、GNOME Shell はブラーなし)。設定 UI でその旨を明記

### 設定 UI のプラットフォーム別化
- 見出しから "(macOS)" を撤回 (`VibrancySection.tsx`)
- tRPC `getSupported` に `platform: 'mac' | 'windows' | 'linux' | 'unsupported'` フィールドを追加し、ストア経由で UI に伝搬
- ブラー強度スライダー (CIGaussianBlur / NSVisualEffectView material 4 段切替) は macOS 専用の API なので、Windows / Linux では非表示
- 各プラットフォームの挙動を説明する注記を追加

## 影響範囲

- macOS: 既存ユーザーがスライダー 10% で開いていた場合、視覚的に**もっと透ける**ようになる (体感上の挙動変化)。ただし読みやすさを欲しい人は値を上げれば従来同等に戻せる
- Windows: これまで設定 UI を開いてもスライダーを動かしてもほぼ何も起きなかった機能が、Win11 22H2+ で Acrylic、それ以前で素の半透明として動作する
- Linux: これまで「サポート対象外」と表示されていたユーザーに UI が出るようになる
- macOS の `reapplyVibrancyOnReshow` (`PLATFORM.IS_MAC` でガードされた dock-restore 用フック) は非 macOS ではそもそも要らないので変更なし
- ブラウザペイン (webview) は OS 制約で不透明のまま、これは従来通り

## 動作確認

- `bun run typecheck` ✅
- `bun run lint` ✅
- macOS: ローカルで `apps/desktop` の dev 起動 → スライダー 0% → 100% を流して透明度の連続的な変化 / chrome の読みやすさを確認推奨
- Windows: 実機 (Win11 22H2+ / Win11 < 22H2 / Win10) での確認が望ましい。`titleBarOverlay` × `transparent: true` の組み合わせはまれに描画不整合の報告があるので、最小化/最大化/閉じるボタンの表示確認
- Linux: KWin (KDE) と Mutter (GNOME) でそれぞれ確認推奨。GNOME ではブラーなしの素通しになる

## Test plan

- [ ] macOS: vibrancy ON → opacity 0% で背景デスクトップが見える
- [ ] macOS: opacity 100% で従来同等の不透明な見た目
- [ ] macOS: ブラー半径 / ブラー強度スライダーが従来通り動作
- [ ] Windows 11 22H2+: vibrancy ON で Acrylic が効き、opacity スライダーが反映される
- [ ] Windows 旧版: スライダー連動の素の半透明 (ブラーなし) になる
- [ ] Linux KDE: 半透明 + コンポジタブラー
- [ ] Linux GNOME: 半透明のみ (ブラーなし) で、注記が UI に出る
- [ ] vibrancy OFF: 従来同等の不透明なウィンドウ
- [ ] tearoff window でも同じ vibrancy が効く