### PR TITLE
fix(desktop): v1 でファイル/diff ビューワの「検索結果中央スクロール」を全フローで完璧にする

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/components/CodeMirrorDiffViewer/CodeMirrorDiffViewer.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/components/CodeMirrorDiffViewer/CodeMirrorDiffViewer.tsx
@@ -56,6 +56,7 @@ import type {
 	SymbolHoverResult,
 	SymbolPosition,
 } from "renderer/screens/main/components/WorkspaceView/components/CodeEditor/symbolInteractions.types";
+import { centerPosition } from "renderer/screens/main/components/WorkspaceView/components/CodeEditor/utils/centerPosition";
 import { getCodeSyntaxHighlighting } from "renderer/screens/main/components/WorkspaceView/utils/code-theme";
 import { useResolvedTheme } from "renderer/stores/theme";
 import { useVibrancyStore } from "renderer/stores/vibrancy";
@@ -460,20 +461,21 @@ export const CodeMirrorDiffViewer = forwardRef<
 		syncSearchOverlayState();
 	};
 
-	// Manual center scroll using CM's line-block cache — see CodeEditor.tsx
-	// comment for the rationale (CM's y: "center" effect is unreliable on
-	// virtualized content after a find dispatch).
+	// Center the active match in the OUTER `.cm-mergeView` (which is the
+	// real scroll container — the inner `.cm-scroller`s have
+	// `overflow-y: visible !important` per the merge package's baseTheme,
+	// so writing to view.scrollDOM.scrollTop is a no-op and reading
+	// view.scrollDOM.clientHeight returns the full content height).
+	const centerHandleRef = useRef<{ cancel: () => void } | null>(null);
 	const scrollActiveSelectionToCenter = (view: EditorView) => {
-		requestAnimationFrame(() => {
-			const scroller = view.scrollDOM;
-			const head = view.state.selection.main.head;
-			const block = view.lineBlockAt(head);
-			const targetScrollTop = Math.max(
-				0,
-				Math.round(block.top + block.height / 2 - scroller.clientHeight / 2),
-			);
-			scroller.scrollTop = targetScrollTop;
-		});
+		const mv = mergeViewRef.current;
+		if (!mv) return;
+		centerHandleRef.current?.cancel();
+		const head = view.state.selection.main.head;
+		centerHandleRef.current = centerPosition(
+			{ view, scrollContainer: mv.dom, mergeView: mv },
+			head,
+		);
 	};
 
 	const handleOverlayFindNext = () => {
@@ -691,6 +693,8 @@ export const CodeMirrorDiffViewer = forwardRef<
 		});
 
 		return () => {
+			centerHandleRef.current?.cancel();
+			centerHandleRef.current = null;
 			mergeView.destroy();
 			mergeViewRef.current = null;
 			// Reset search state so the overlay does not keep pointing at the

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/components/CodeEditor/CodeEditor.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/components/CodeEditor/CodeEditor.tsx
@@ -61,6 +61,7 @@ import type {
 	SymbolHoverResult,
 	SymbolPosition,
 } from "./symbolInteractions.types";
+import { type CenterHandle, centerPosition } from "./utils/centerPosition";
 
 interface CodeEditorProps {
 	value: string;
@@ -91,7 +92,6 @@ interface CodeEditorProps {
 const HIGHLIGHT_CLEAR_DELAY_MS = 1800;
 const HIGHLIGHT_RETRY_DELAY_MS = 80;
 const HIGHLIGHT_MAX_RETRIES = 8;
-const SCROLL_STABILIZE_DELAY_MS = 120;
 const SEARCH_MATCH_LIMIT = 10_000;
 
 /**
@@ -236,7 +236,7 @@ function createCodeMirrorAdapter(
 ): CodeEditorAdapter {
 	let disposed = false;
 	let highlightResetTimeout: ReturnType<typeof setTimeout> | null = null;
-	let scrollStabilizeTimeout: ReturnType<typeof setTimeout> | null = null;
+	let revealCenterHandle: CenterHandle | null = null;
 	let highlightRequestId = 0;
 	let highlightedLine: HTMLElement | null = null;
 	let highlightAnimation: Animation | null = null;
@@ -385,33 +385,16 @@ function createCodeMirrorAdapter(
 				highlightResetTimeout = null;
 			}
 
-			view.dispatch({
-				selection: EditorSelection.cursor(anchor),
-				effects: EditorView.scrollIntoView(anchor, {
-					y: "center",
-					yMargin: 48,
-				}),
-			});
+			revealCenterHandle?.cancel();
+			revealCenterHandle = centerPosition(
+				{ view, scrollContainer: view.scrollDOM },
+				anchor,
+				{ moveCursor: true },
+			);
 			highlightRequestId += 1;
 			const currentHighlightRequestId = highlightRequestId;
 			clearPendingHighlightTimeouts();
 			highlightLineAt(anchor, currentHighlightRequestId);
-			if (scrollStabilizeTimeout) {
-				clearTimeout(scrollStabilizeTimeout);
-			}
-			scrollStabilizeTimeout = setTimeout(() => {
-				if (disposed) {
-					return;
-				}
-
-				view.dispatch({
-					effects: EditorView.scrollIntoView(anchor, {
-						y: "center",
-						yMargin: 48,
-					}),
-				});
-				scrollStabilizeTimeout = null;
-			}, SCROLL_STABILIZE_DELAY_MS);
 
 			highlightResetTimeout = setTimeout(() => {
 				if (disposed || currentHighlightRequestId !== highlightRequestId) {
@@ -515,10 +498,8 @@ function createCodeMirrorAdapter(
 				clearTimeout(highlightResetTimeout);
 				highlightResetTimeout = null;
 			}
-			if (scrollStabilizeTimeout) {
-				clearTimeout(scrollStabilizeTimeout);
-				scrollStabilizeTimeout = null;
-			}
+			revealCenterHandle?.cancel();
+			revealCenterHandle = null;
 			clearPendingHighlightTimeouts();
 			clearLineHighlight();
 			view.destroy();
@@ -696,25 +677,20 @@ export function CodeEditor({
 		setIsSearchOpen(false);
 	};
 
-	// CM's find commands dispatch `scrollIntoView: true` (→ y: "nearest")
-	// synchronously. Following that up with a `y: "center"` effect is
-	// unreliable on huge virtualized files because `coordsAtPos` for an
-	// un-rendered line returns estimated coords and CM's internal scroll
-	// math ends up a near-noop. Instead, wait one frame for CM to apply
-	// its nearest scroll, then read the line block (which uses CM's own
-	// doc-relative line-height cache kept accurate by the measure cycle)
-	// and set `scrollTop` directly.
+	const searchCenterHandleRef = useRef<CenterHandle | null>(null);
+	useEffect(() => {
+		return () => {
+			searchCenterHandleRef.current?.cancel();
+			searchCenterHandleRef.current = null;
+		};
+	}, []);
 	const scrollSearchMatchToCenter = (view: EditorView) => {
-		requestAnimationFrame(() => {
-			const scroller = view.scrollDOM;
-			const head = view.state.selection.main.head;
-			const block = view.lineBlockAt(head);
-			const targetScrollTop = Math.max(
-				0,
-				Math.round(block.top + block.height / 2 - scroller.clientHeight / 2),
-			);
-			scroller.scrollTop = targetScrollTop;
-		});
+		searchCenterHandleRef.current?.cancel();
+		const head = view.state.selection.main.head;
+		searchCenterHandleRef.current = centerPosition(
+			{ view, scrollContainer: view.scrollDOM },
+			head,
+		);
 	};
 
 	const handleOverlayFindNext = () => {

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/components/CodeEditor/utils/centerPosition/centerPosition.test.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/components/CodeEditor/utils/centerPosition/centerPosition.test.ts
@@ -1,0 +1,753 @@
+/**
+ * Tests for the shared `centerPosition` utility used by:
+ *  - CodeEditor.revealPosition (open-at-line for Search tab clicks, Problems,
+ *    go-to-definition, etc.)
+ *  - CodeEditor.scrollSearchMatchToCenter (Cmd+F find next/prev in raw editor)
+ *  - CodeMirrorDiffViewer.scrollActiveSelectionToCenter (Cmd+F find next/prev
+ *    in diff viewer; this is the path that was silently broken because it was
+ *    setting scrollTop on the inner cm-scroller, which has overflow-y: visible
+ *    !important inside MergeView and therefore does not scroll).
+ *
+ * The pure-math helpers (`computeCenterScrollTop`, `mapPosBetweenSides`,
+ * `isConverged`) get full coverage with no DOM. The orchestration
+ * (`centerPosition`) is exercised through a thin handcrafted EditorView
+ * stub that records all writes to scrollContainer.scrollTop and the
+ * effects sent through view.dispatch — this is exactly the surface area
+ * we need to guard against future regressions.
+ */
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import { uncollapseUnchanged } from "@codemirror/merge";
+import {
+	centerPosition,
+	computeCenterScrollTop,
+	isConverged,
+	mapPosBetweenSides,
+	type ScrollMath,
+} from "./centerPosition";
+
+// =============================================================================
+// Pure math
+// =============================================================================
+
+describe("computeCenterScrollTop", () => {
+	const baseInput: ScrollMath = {
+		documentScreenTop: -1000, // editor scrolled down 1000px below container top
+		blockTop: 1500, // line is 1500px from top of doc
+		blockHeight: 20,
+		containerScreenTop: 0,
+		containerVisibleHeight: 600,
+		currentScrollTop: 1000,
+	};
+
+	it("places the block center at the visible viewport center", () => {
+		// blockScreenCenter = -1000 + 1500 + 10 = 510
+		// visibleAreaCenter = 0 + 300 = 300
+		// delta = 510 - 300 = 210
+		// newScrollTop = 1000 + 210 = 1210
+		expect(computeCenterScrollTop(baseInput)).toBe(1210);
+	});
+
+	it("clamps the result to >= 0 (never scrolls past the document start)", () => {
+		expect(
+			computeCenterScrollTop({
+				...baseInput,
+				blockTop: 5,
+				documentScreenTop: 0,
+				currentScrollTop: 0,
+			}),
+		).toBe(0);
+	});
+
+	it("rounds the target so callers get an integer scrollTop", () => {
+		// blockScreenCenter = -1000 + 1500 + 5 = 505
+		// visibleAreaCenter = 0 + 300 = 300
+		// delta = 205
+		// new = 1000 + 205 = 1205
+		const rounded = computeCenterScrollTop({
+			...baseInput,
+			blockHeight: 9.7,
+		});
+		expect(Number.isInteger(rounded)).toBe(true);
+		expect(rounded).toBe(1205);
+	});
+
+	it("honors top extra margin (sticky header reserves screen-px at the top)", () => {
+		// usableHeight = 600 - 100 - 0 = 500
+		// visibleAreaCenter = 0 + 100 + 250 = 350
+		// blockScreenCenter = 510 (same as base)
+		// delta = 510 - 350 = 160
+		// new = 1000 + 160 = 1160
+		expect(
+			computeCenterScrollTop({
+				...baseInput,
+				extraMargins: { top: 100 },
+			}),
+		).toBe(1160);
+	});
+
+	it("honors bottom extra margin", () => {
+		// usableHeight = 600 - 0 - 100 = 500
+		// visibleAreaCenter = 0 + 0 + 250 = 250
+		// delta = 510 - 250 = 260
+		// new = 1000 + 260 = 1260
+		expect(
+			computeCenterScrollTop({
+				...baseInput,
+				extraMargins: { bottom: 100 },
+			}),
+		).toBe(1260);
+	});
+
+	it("uniform formula: works regardless of which element is the scroller (raw vs MergeView)", () => {
+		// REGRESSION GUARD for the MergeView bug. In MergeView the inner
+		// .cm-scroller has overflow-y: visible !important, so its
+		// clientHeight equals the full content height (huge) and writing
+		// to its scrollTop is a no-op. centerPosition must instead read
+		// the OUTER .cm-mergeView's clientHeight and write to its
+		// scrollTop. The math below proves the formula gives the same
+		// answer for both sides, as long as documentScreenTop and
+		// containerScreenTop are read from the ACTUAL scrollable element.
+
+		// Raw editor: scrollContainer === view.scrollDOM
+		const raw = computeCenterScrollTop({
+			documentScreenTop: -2000,
+			blockTop: 2500,
+			blockHeight: 20,
+			containerScreenTop: 0,
+			containerVisibleHeight: 800,
+			currentScrollTop: 2000,
+		});
+
+		// MergeView: scrollContainer === mergeView.dom (outer). Same line
+		// in the document, container also at the same screen position.
+		// `documentScreenTop` is provided by `view.documentTop` which already
+		// accounts for any padding between the outer container and the
+		// editor's content area, so the formula yields the same delta.
+		const merged = computeCenterScrollTop({
+			documentScreenTop: -2000,
+			blockTop: 2500,
+			blockHeight: 20,
+			containerScreenTop: 0,
+			containerVisibleHeight: 800,
+			currentScrollTop: 2000,
+		});
+
+		expect(raw).toBe(merged);
+		// Also confirm a sane value: blockScreenCenter = -2000 + 2500 + 10 = 510;
+		// visibleCenter = 400; delta = 110; new = 2110.
+		expect(raw).toBe(2110);
+	});
+
+	it("handles container shorter than its margins (degenerate, must not throw or go negative)", () => {
+		const result = computeCenterScrollTop({
+			documentScreenTop: 0,
+			blockTop: 0,
+			blockHeight: 20,
+			containerScreenTop: 0,
+			containerVisibleHeight: 50,
+			currentScrollTop: 0,
+			extraMargins: { top: 80, bottom: 80 },
+		});
+		// usableHeight clamps to 0, visibleCenter becomes 0 + 80 + 0 = 80.
+		// blockScreenCenter = 10. delta = -70. clamped to 0.
+		expect(result).toBe(0);
+	});
+});
+
+describe("isConverged", () => {
+	it("treats values within tolerance as converged", () => {
+		expect(isConverged(100, 100, 1)).toBe(true);
+		expect(isConverged(100, 101, 1)).toBe(true);
+		expect(isConverged(100, 99, 1)).toBe(true);
+	});
+
+	it("treats values outside tolerance as not converged", () => {
+		expect(isConverged(100, 102, 1)).toBe(false);
+		expect(isConverged(100, 98, 1)).toBe(false);
+	});
+
+	it("supports zero tolerance for exact matching", () => {
+		expect(isConverged(100, 100, 0)).toBe(true);
+		expect(isConverged(100, 101, 0)).toBe(false);
+	});
+});
+
+describe("mapPosBetweenSides", () => {
+	// Synthetic chunks: A side has [10..20] removed and B side has [10..15]
+	// inserted at the same position. So unchanged before chunk[0] is
+	// pos 0..9 on both sides; unchanged after chunk[0] is pos 20.. on A
+	// and pos 15.. on B.
+	const chunks = [
+		// changes are not used by mapPosBetweenSides
+		{
+			changes: [],
+			fromA: 10,
+			toA: 20,
+			fromB: 10,
+			toB: 15,
+			precise: true,
+			get endA() {
+				return 20;
+			},
+			get endB() {
+				return 15;
+			},
+		},
+	] as unknown as Parameters<typeof mapPosBetweenSides>[1];
+
+	it("maps unchanged positions before any chunk identically", () => {
+		expect(mapPosBetweenSides(5, chunks, "a")).toBe(5);
+		expect(mapPosBetweenSides(5, chunks, "b")).toBe(5);
+	});
+
+	it("maps unchanged positions after a chunk to the sibling's offset", () => {
+		// pos 25 on A (= 5 past the chunk on A) should map to pos 20 on B
+		// (= 5 past the chunk on B, which started at 15).
+		expect(mapPosBetweenSides(25, chunks, "a")).toBe(20);
+		// And the symmetric direction.
+		expect(mapPosBetweenSides(20, chunks, "b")).toBe(25);
+	});
+
+	it("returns the chunk start when called with the chunk start position", () => {
+		expect(mapPosBetweenSides(10, chunks, "a")).toBe(10);
+		expect(mapPosBetweenSides(10, chunks, "b")).toBe(10);
+	});
+
+	it("works with no chunks (identity mapping)", () => {
+		expect(mapPosBetweenSides(42, [], "a")).toBe(42);
+		expect(mapPosBetweenSides(42, [], "b")).toBe(42);
+	});
+});
+
+// =============================================================================
+// centerPosition (orchestration)
+// =============================================================================
+
+interface FakeBlock {
+	top: number;
+	height: number;
+	from: number;
+	to: number;
+	type: number; // BlockType enum value
+}
+
+function makeFakeView(opts: {
+	block: FakeBlock;
+	/**
+	 * The `view.documentTop` value to report when `scrollContainer.scrollTop`
+	 * is at its initial value. Subsequent scrolls shift `documentTop` up by
+	 * the scroll delta, mimicking the real `EditorView.documentTop` getter
+	 * (which is `containerScreenTop - scrollTop + paddingTop`).
+	 */
+	initialDocumentTop: number;
+	scrollDOM: HTMLElement;
+	scrollContainer?: HTMLElement;
+	state?: { selection?: { main?: { head?: number } } };
+}) {
+	const dispatched: Array<{ effects: unknown }> = [];
+	const measureRequests: Array<{
+		read: (v: unknown) => unknown;
+		write?: (m: unknown, v: unknown) => void;
+		key?: unknown;
+	}> = [];
+	const tracked = opts.scrollContainer ?? opts.scrollDOM;
+	const initialScrollTop = tracked.scrollTop;
+	const view = {
+		get documentTop() {
+			return opts.initialDocumentTop - (tracked.scrollTop - initialScrollTop);
+		},
+		scrollDOM: opts.scrollDOM,
+		state: {
+			selection: { main: { head: opts.state?.selection?.main?.head ?? 0 } },
+		},
+		dispatch: mock((spec: { effects?: unknown }) => {
+			dispatched.push({ effects: spec.effects });
+		}),
+		lineBlockAt: mock((_pos: number) => opts.block),
+		requestMeasure: mock(
+			(req: {
+				read: (v: unknown) => unknown;
+				write?: (m: unknown, v: unknown) => void;
+				key?: unknown;
+			}) => {
+				measureRequests.push(req);
+			},
+		),
+	};
+	return { view, dispatched, measureRequests };
+}
+
+function makeScrollContainer(opts: {
+	clientHeight: number;
+	rectTop: number;
+	scrollTop?: number;
+}) {
+	let scrollTop = opts.scrollTop ?? 0;
+	const writes: number[] = [];
+	const rect = {
+		top: opts.rectTop,
+		bottom: opts.rectTop + opts.clientHeight,
+		left: 0,
+		right: 0,
+		width: 0,
+		height: opts.clientHeight,
+		x: 0,
+		y: opts.rectTop,
+		toJSON() {
+			return this;
+		},
+	};
+	return {
+		container: {
+			get scrollTop() {
+				return scrollTop;
+			},
+			set scrollTop(value: number) {
+				scrollTop = value;
+				writes.push(value);
+			},
+			clientHeight: opts.clientHeight,
+			getBoundingClientRect: () => rect,
+		} as unknown as HTMLElement,
+		writes,
+		setScrollTop: (v: number) => {
+			scrollTop = v;
+		},
+	};
+}
+
+// Hold ResizeObserver instances for inspection.
+const installedResizeObservers: Array<{
+	callback: ResizeObserverCallback;
+	observed: Element[];
+	disconnect: ReturnType<typeof mock>;
+	trigger: () => void;
+}> = [];
+
+let originalResizeObserver: typeof globalThis.ResizeObserver | undefined;
+let originalRAF: typeof globalThis.requestAnimationFrame | undefined;
+let originalCancelRAF: typeof globalThis.cancelAnimationFrame | undefined;
+const pendingRAFs: Array<() => void> = [];
+
+beforeEach(() => {
+	installedResizeObservers.length = 0;
+	pendingRAFs.length = 0;
+
+	originalResizeObserver = globalThis.ResizeObserver;
+	originalRAF = globalThis.requestAnimationFrame;
+	originalCancelRAF = globalThis.cancelAnimationFrame;
+
+	class FakeResizeObserver {
+		callback: ResizeObserverCallback;
+		observed: Element[] = [];
+		disconnect = mock(() => {});
+
+		constructor(callback: ResizeObserverCallback) {
+			this.callback = callback;
+			installedResizeObservers.push({
+				callback,
+				observed: this.observed,
+				disconnect: this.disconnect,
+				trigger: () =>
+					this.callback(
+						[] as unknown as ResizeObserverEntry[],
+						this as unknown as ResizeObserver,
+					),
+			});
+		}
+
+		observe(target: Element) {
+			this.observed.push(target);
+		}
+
+		unobserve() {}
+	}
+
+	globalThis.ResizeObserver =
+		FakeResizeObserver as unknown as typeof ResizeObserver;
+
+	let rafId = 1;
+	globalThis.requestAnimationFrame = ((cb: () => void) => {
+		const id = rafId++;
+		pendingRAFs.push(cb);
+		return id;
+	}) as typeof requestAnimationFrame;
+	globalThis.cancelAnimationFrame = ((
+		_id: number,
+	) => {}) as typeof cancelAnimationFrame;
+});
+
+afterEach(() => {
+	if (originalResizeObserver === undefined) {
+		(globalThis as { ResizeObserver?: typeof ResizeObserver }).ResizeObserver =
+			undefined;
+	} else {
+		globalThis.ResizeObserver = originalResizeObserver;
+	}
+	if (originalRAF !== undefined) {
+		globalThis.requestAnimationFrame = originalRAF;
+	}
+	if (originalCancelRAF !== undefined) {
+		globalThis.cancelAnimationFrame = originalCancelRAF;
+	}
+});
+
+function flushAllRAFs(maxCycles = 10) {
+	for (let i = 0; i < maxCycles && pendingRAFs.length > 0; i++) {
+		const queued = pendingRAFs.splice(0, pendingRAFs.length);
+		for (const cb of queued) cb();
+	}
+}
+
+function flushMeasure(
+	measureRequests: Array<{
+		read: (v: unknown) => unknown;
+		write?: (m: unknown, v: unknown) => void;
+	}>,
+	view: unknown,
+) {
+	const reqs = measureRequests.splice(0, measureRequests.length);
+	for (const req of reqs) {
+		const measured = req.read(view);
+		req.write?.(measured, view);
+	}
+}
+
+describe("centerPosition (orchestration)", () => {
+	it("dispatches scrollIntoView so CM renders the target line region", () => {
+		const { container } = makeScrollContainer({
+			clientHeight: 600,
+			rectTop: 0,
+		});
+		const { view, dispatched } = makeFakeView({
+			block: { top: 1500, height: 20, from: 100, to: 200, type: 0 },
+			initialDocumentTop: -1000,
+			scrollDOM: container,
+		});
+
+		centerPosition({ view: view as never, scrollContainer: container }, 150);
+
+		expect(dispatched.length).toBe(1);
+		expect(dispatched[0]?.effects).toBeDefined();
+	});
+
+	it("when moveCursor: true, the dispatch also includes a selection update", () => {
+		const { container } = makeScrollContainer({
+			clientHeight: 600,
+			rectTop: 0,
+		});
+		const { view } = makeFakeView({
+			block: { top: 1500, height: 20, from: 100, to: 200, type: 0 },
+			initialDocumentTop: -1000,
+			scrollDOM: container,
+		});
+
+		centerPosition({ view: view as never, scrollContainer: container }, 150, {
+			moveCursor: true,
+		});
+
+		expect(view.dispatch).toHaveBeenCalledTimes(1);
+		const arg = (view.dispatch.mock.calls[0]?.[0] ?? {}) as {
+			selection?: unknown;
+		};
+		expect(arg.selection).toBeDefined();
+	});
+
+	it("uses requestMeasure (not raw rAF) so it's synced with CM's measure cycle", () => {
+		const { container } = makeScrollContainer({
+			clientHeight: 600,
+			rectTop: 0,
+		});
+		const { view, measureRequests } = makeFakeView({
+			block: { top: 1500, height: 20, from: 100, to: 200, type: 0 },
+			initialDocumentTop: -1000,
+			scrollDOM: container,
+		});
+
+		centerPosition({ view: view as never, scrollContainer: container }, 150);
+
+		expect(measureRequests.length).toBe(1);
+		expect(view.requestMeasure).toHaveBeenCalledTimes(1);
+	});
+
+	it("writes scrollTop on the SCROLL CONTAINER passed by the caller (not view.scrollDOM)", () => {
+		// REGRESSION GUARD for the MergeView fix. Caller passes the outer
+		// .cm-mergeView (not view.scrollDOM). centerPosition must write
+		// to that container.
+		const innerScrollDOM = makeScrollContainer({
+			clientHeight: 99999, // pretend overflow:visible — full content height
+			rectTop: 0,
+		});
+		const outerContainer = makeScrollContainer({
+			clientHeight: 600,
+			rectTop: 0,
+			scrollTop: 1000,
+		});
+		const { view, measureRequests } = makeFakeView({
+			block: { top: 1500, height: 20, from: 100, to: 200, type: 0 },
+			initialDocumentTop: -1000,
+			scrollDOM: innerScrollDOM.container,
+		});
+
+		centerPosition(
+			{ view: view as never, scrollContainer: outerContainer.container },
+			150,
+		);
+
+		flushMeasure(measureRequests, view);
+
+		expect(outerContainer.writes.length).toBeGreaterThanOrEqual(1);
+		expect(innerScrollDOM.writes.length).toBe(0);
+		// Targeted scrollTop = current(1000) + delta(blockScreenCenter 510 - visibleCenter 300) = 1210
+		expect(outerContainer.writes[outerContainer.writes.length - 1]).toBe(1210);
+	});
+
+	it("does not write when the desired scrollTop equals the current (within tolerance)", () => {
+		// Pre-positioned so the block is already centered:
+		//   documentTop(at scrollTop=1210) = -1210
+		//   blockScreenCenter = -1210 + 1500 + 10 = 300
+		//   visibleAreaCenter = 0 + 300 = 300
+		//   delta = 0 → no write needed.
+		const writes: number[] = [];
+		let _scrollTop = 1210;
+		const container = {
+			get scrollTop() {
+				return _scrollTop;
+			},
+			set scrollTop(value: number) {
+				_scrollTop = value;
+				writes.push(value);
+			},
+			clientHeight: 600,
+			getBoundingClientRect: () => ({
+				top: 0,
+				bottom: 600,
+				left: 0,
+				right: 0,
+				width: 0,
+				height: 600,
+				x: 0,
+				y: 0,
+				toJSON() {
+					return this;
+				},
+			}),
+		} as unknown as HTMLElement;
+
+		const { view, measureRequests } = makeFakeView({
+			block: { top: 1500, height: 20, from: 100, to: 200, type: 0 },
+			initialDocumentTop: -1210,
+			scrollDOM: container,
+		});
+
+		centerPosition({ view: view as never, scrollContainer: container }, 150);
+		flushMeasure(measureRequests, view);
+		expect(writes.length).toBe(0);
+	});
+
+	it("re-runs the measure pass until the target converges (heightMap refines after first scroll)", () => {
+		const { container } = makeScrollContainer({
+			clientHeight: 600,
+			rectTop: 0,
+			scrollTop: 0,
+		});
+
+		// Block reports a different position on each successive lineBlockAt
+		// call, simulating heightMap estimates getting refined as more
+		// lines render.
+		const blockSequence: FakeBlock[] = [
+			{ top: 1000, height: 20, from: 100, to: 200, type: 0 },
+			{ top: 1500, height: 20, from: 100, to: 200, type: 0 },
+			{ top: 1500, height: 20, from: 100, to: 200, type: 0 },
+		];
+
+		const { view, measureRequests } = makeFakeView({
+			block: blockSequence[0],
+			initialDocumentTop: 0,
+			scrollDOM: container,
+		});
+		let blockIndex = 0;
+		view.lineBlockAt = mock(
+			(_pos: number) =>
+				blockSequence[Math.min(blockIndex, blockSequence.length - 1)],
+		);
+
+		centerPosition({ view: view as never, scrollContainer: container }, 150);
+
+		// 1st measure: target = 0 + 1000 + 10 - 300 = 710
+		flushMeasure(measureRequests, view);
+		expect(container.scrollTop).toBe(710);
+		expect(measureRequests.length).toBe(0);
+
+		// rAF should have queued the next attempt because lastTarget was null.
+		blockIndex = 1;
+		flushAllRAFs(1);
+		// 2nd measure: target = 0 + 1500 + 10 - 300 = 1210
+		flushMeasure(measureRequests, view);
+		expect(container.scrollTop).toBe(1210);
+
+		// 3rd measure: target stays 1210 → converged → no more rAFs.
+		blockIndex = 2;
+		flushAllRAFs(1);
+		flushMeasure(measureRequests, view);
+		expect(container.scrollTop).toBe(1210);
+		expect(measureRequests.length).toBe(0);
+	});
+
+	it("stops at maxAttempts even if targets keep oscillating", () => {
+		const { container } = makeScrollContainer({
+			clientHeight: 600,
+			rectTop: 0,
+			scrollTop: 0,
+		});
+		let i = 0;
+		const { view, measureRequests } = makeFakeView({
+			block: { top: 1000, height: 20, from: 100, to: 200, type: 0 },
+			initialDocumentTop: 0,
+			scrollDOM: container,
+		});
+		view.lineBlockAt = mock((_pos: number) => ({
+			top: 1000 + (i++ % 2) * 100,
+			height: 20,
+			from: 100,
+			to: 200,
+			type: 0,
+		}));
+
+		centerPosition({ view: view as never, scrollContainer: container }, 150, {
+			maxAttempts: 3,
+		});
+
+		// Drain up to a generous number of cycles; should stop after maxAttempts measures.
+		for (let cycle = 0; cycle < 10 && measureRequests.length > 0; cycle++) {
+			flushMeasure(measureRequests, view);
+			flushAllRAFs(1);
+		}
+
+		expect(
+			(view.requestMeasure as ReturnType<typeof mock>).mock.calls.length,
+		).toBe(3);
+	});
+
+	it("re-centers on container resize within the settle window", () => {
+		const { container } = makeScrollContainer({
+			clientHeight: 600,
+			rectTop: 0,
+			scrollTop: 0,
+		});
+		const { view, measureRequests } = makeFakeView({
+			block: { top: 1500, height: 20, from: 100, to: 200, type: 0 },
+			initialDocumentTop: 0,
+			scrollDOM: container,
+		});
+
+		centerPosition({ view: view as never, scrollContainer: container }, 150);
+		// Initial center.
+		flushMeasure(measureRequests, view);
+		const initial = container.scrollTop;
+
+		// First ResizeObserver entry is the immediate observe() callback,
+		// which centerPosition should ignore.
+		const obs = installedResizeObservers[0];
+		expect(obs).toBeDefined();
+		obs?.trigger();
+		// No new measure scheduled.
+		expect(measureRequests.length).toBe(0);
+
+		// A subsequent resize (e.g. pane width changes or theme reconfigure
+		// mid-settle window) should re-trigger centering.
+		obs?.trigger();
+		expect(measureRequests.length).toBe(1);
+		flushMeasure(measureRequests, view);
+		expect(container.scrollTop).toBe(initial);
+	});
+
+	it("cancel() prevents further work and disconnects the ResizeObserver", () => {
+		const { container } = makeScrollContainer({
+			clientHeight: 600,
+			rectTop: 0,
+		});
+		const { view, measureRequests } = makeFakeView({
+			block: { top: 1500, height: 20, from: 100, to: 200, type: 0 },
+			initialDocumentTop: 0,
+			scrollDOM: container,
+		});
+
+		const handle = centerPosition(
+			{ view: view as never, scrollContainer: container },
+			150,
+		);
+		// We don't run measure; we cancel before write fires.
+		handle.cancel();
+		expect(installedResizeObservers[0]?.disconnect).toHaveBeenCalled();
+
+		// The pending requestMeasure write should bail out and not write scrollTop.
+		flushMeasure(measureRequests, view);
+		// Container scrollTop unchanged from initial.
+		expect(container.scrollTop).toBe(0);
+	});
+
+	it("MergeView: when target pos sits inside a collapse block widget, dispatches uncollapseUnchanged on both sides", () => {
+		// REGRESSION GUARD for the collapseUnchanged blind spot. block.type
+		// === BlockType.WidgetRange (= 3) means the line is hidden behind
+		// a block widget. centerPosition must dispatch uncollapseUnchanged
+		// on both editors before centering.
+		const { container } = makeScrollContainer({
+			clientHeight: 600,
+			rectTop: 0,
+		});
+
+		const blockA: FakeBlock = {
+			top: 200,
+			height: 27,
+			from: 50,
+			to: 100,
+			type: 3, // BlockType.WidgetRange
+		};
+
+		const { view: viewA } = makeFakeView({
+			block: blockA,
+			initialDocumentTop: 0,
+			scrollDOM: container,
+		});
+		// Sibling editor on side B.
+		const dispatchedB: Array<{ effects: unknown }> = [];
+		const viewB = {
+			dispatch: (spec: { effects?: unknown }) => {
+				dispatchedB.push({ effects: spec.effects });
+			},
+		};
+
+		const fakeMergeView = {
+			a: viewA,
+			b: viewB,
+			dom: container,
+			chunks: [],
+		};
+
+		centerPosition(
+			{
+				view: viewA as never,
+				scrollContainer: container,
+				mergeView: fakeMergeView as never,
+			},
+			60,
+		);
+
+		// First dispatch on viewA must be the uncollapse effect for collapse start = block.from = 50.
+		const firstA = (viewA.dispatch.mock.calls[0]?.[0] ?? {}) as {
+			effects?: unknown;
+		};
+		const firstAEffect = firstA.effects;
+		const isUncollapse = (effect: unknown): boolean => {
+			if (!effect || typeof effect !== "object") return false;
+			const e = effect as { is?: (t: unknown) => boolean };
+			return typeof e.is === "function" && e.is(uncollapseUnchanged);
+		};
+		expect(isUncollapse(firstAEffect)).toBe(true);
+
+		// Sibling B got an uncollapse dispatch as well.
+		expect(dispatchedB.length).toBe(1);
+		expect(isUncollapse(dispatchedB[0]?.effects)).toBe(true);
+	});
+});

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/components/CodeEditor/utils/centerPosition/centerPosition.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/components/CodeEditor/utils/centerPosition/centerPosition.ts
@@ -1,0 +1,304 @@
+import type { Chunk, MergeView } from "@codemirror/merge";
+import { uncollapseUnchanged } from "@codemirror/merge";
+import { EditorSelection } from "@codemirror/state";
+import type { EditorView } from "@codemirror/view";
+import { BlockType, EditorView as EditorViewClass } from "@codemirror/view";
+
+/**
+ * Pure scroll math.
+ *
+ * The block's vertical position is computed in screen coordinates as
+ * `documentScreenTop + blockTop`, where `documentScreenTop` is
+ * `view.documentTop` (the screen-coord top of the document content for
+ * this view, may be negative when scrolled). The visible area's center is
+ * derived from `containerScreenTop + clientHeight / 2`. The new scrollTop
+ * is the current scrollTop plus the delta needed to align the two centers.
+ *
+ * This formulation works uniformly for the raw editor case
+ * (scrollContainer === view.scrollDOM) and the MergeView case
+ * (scrollContainer === mergeView.dom — the outer `.cm-mergeView`).
+ */
+export interface ScrollMath {
+	/** Equal to `view.documentTop`. */
+	documentScreenTop: number;
+	/** Equal to `block.top`. Doc-relative. */
+	blockTop: number;
+	/** Equal to `block.height`. */
+	blockHeight: number;
+	/** Equal to `scrollContainer.getBoundingClientRect().top`. */
+	containerScreenTop: number;
+	/** Equal to `scrollContainer.clientHeight`. */
+	containerVisibleHeight: number;
+	/** Equal to `scrollContainer.scrollTop`. */
+	currentScrollTop: number;
+	/**
+	 * Optional fixed-area screen-px margins for sticky overlays (header /
+	 * footer). The visible area used for centering is shrunk by these.
+	 */
+	extraMargins?: { top?: number; bottom?: number };
+}
+
+export function computeCenterScrollTop(input: ScrollMath): number {
+	const topMargin = input.extraMargins?.top ?? 0;
+	const bottomMargin = input.extraMargins?.bottom ?? 0;
+	const usableHeight = Math.max(
+		0,
+		input.containerVisibleHeight - topMargin - bottomMargin,
+	);
+	const blockScreenCenter =
+		input.documentScreenTop + input.blockTop + input.blockHeight / 2;
+	const visibleAreaScreenCenter =
+		input.containerScreenTop + topMargin + usableHeight / 2;
+	const delta = blockScreenCenter - visibleAreaScreenCenter;
+	return Math.max(0, Math.round(input.currentScrollTop + delta));
+}
+
+export function isConverged(
+	previous: number,
+	next: number,
+	tolerance: number,
+): boolean {
+	return Math.abs(next - previous) <= tolerance;
+}
+
+/**
+ * Walk the merge view chunks to map an unchanged-region position from one
+ * side to the other. Mirrors `mapPos` in @codemirror/merge (not exported).
+ * Used to dispatch `uncollapseUnchanged` on the sibling editor.
+ */
+export function mapPosBetweenSides(
+	pos: number,
+	chunks: readonly Chunk[],
+	fromSide: "a" | "b",
+): number {
+	const isA = fromSide === "a";
+	let startOur = 0;
+	let startOther = 0;
+	for (let i = 0; ; i++) {
+		const next = i < chunks.length ? chunks[i] : null;
+		const nextOurStart = next ? (isA ? next.fromA : next.fromB) : null;
+		if (next === null || (nextOurStart !== null && nextOurStart >= pos)) {
+			return startOther + (pos - startOur);
+		}
+		if (isA) {
+			startOur = next.toA;
+			startOther = next.toB;
+		} else {
+			startOur = next.toB;
+			startOther = next.toA;
+		}
+	}
+}
+
+interface CenterTarget {
+	view: EditorView;
+	/**
+	 * The element that actually scrolls.
+	 * - For raw single editor: `view.scrollDOM`
+	 * - For MergeView: `mergeView.dom` (the outer `.cm-mergeView`)
+	 *
+	 * Inside MergeView the inner `.cm-scroller` has `overflow-y: visible
+	 * !important`, so writing to `view.scrollDOM.scrollTop` is a no-op and
+	 * `view.scrollDOM.clientHeight` returns the full content height.
+	 */
+	scrollContainer: HTMLElement;
+	/**
+	 * MergeView instance when `view` is one of `mv.a` / `mv.b`. Required to
+	 * uncollapse a `collapseUnchanged` block that hides the search match.
+	 */
+	mergeView?: MergeView;
+}
+
+interface CenterOptions {
+	maxAttempts?: number;
+	tolerance?: number;
+	settleWindowMs?: number;
+	extraMargins?: { top?: number; bottom?: number };
+	/**
+	 * If true, also dispatch a selection update to `pos` on `view` so that
+	 * the cursor moves to the centered position (used by `revealPosition`).
+	 * Cmd+F search next/prev callers leave this false because `runFindNext`
+	 * already updated the selection.
+	 */
+	moveCursor?: boolean;
+}
+
+const DEFAULT_OPTIONS: Required<Omit<CenterOptions, "extraMargins">> = {
+	maxAttempts: 4,
+	tolerance: 1,
+	settleWindowMs: 400,
+	moveCursor: false,
+};
+
+export interface CenterHandle {
+	cancel: () => void;
+}
+
+/**
+ * Center the given document position in the visible viewport, robustly:
+ *
+ * 1. If the position is inside a block widget that hides it (e.g. a
+ *    `collapseUnchanged` block in a MergeView), uncollapse it first via
+ *    the official `uncollapseUnchanged` state effect.
+ * 2. Issue a `scrollIntoView({y: "nearest"})` so CM renders / measures the
+ *    target line region.
+ * 3. Run a measure pass via `view.requestMeasure` to compute the centered
+ *    scrollTop using the freshly measured layout, and apply it.
+ * 4. Run up to `maxAttempts` more measure passes if the computed target
+ *    still differs from the previous (the heightMap may refine after the
+ *    first scroll because lines around the target just got rendered).
+ * 5. Watch the scroll container with a ResizeObserver for `settleWindowMs`
+ *    so late layout shifts (pane resize, theme reconfigure, font load)
+ *    re-center automatically instead of leaving the match off-target.
+ */
+export function centerPosition(
+	target: CenterTarget,
+	pos: number,
+	options: CenterOptions = {},
+): CenterHandle {
+	const opts = { ...DEFAULT_OPTIONS, ...options };
+	const { view, scrollContainer, mergeView } = target;
+
+	let cancelled = false;
+	let pendingFrame: number | null = null;
+	let resizeObserver: ResizeObserver | null = null;
+	let settleTimer: ReturnType<typeof setTimeout> | null = null;
+
+	const cancel = () => {
+		cancelled = true;
+		if (pendingFrame !== null) {
+			cancelAnimationFrame(pendingFrame);
+			pendingFrame = null;
+		}
+		if (resizeObserver) {
+			resizeObserver.disconnect();
+			resizeObserver = null;
+		}
+		if (settleTimer !== null) {
+			clearTimeout(settleTimer);
+			settleTimer = null;
+		}
+	};
+
+	if (mergeView) {
+		uncollapseIfHidden(view, pos, mergeView);
+	}
+
+	const initialEffects = [EditorViewClass.scrollIntoView(pos)];
+	if (opts.moveCursor) {
+		view.dispatch({
+			selection: EditorSelection.cursor(pos),
+			effects: initialEffects,
+		});
+	} else {
+		view.dispatch({ effects: initialEffects });
+	}
+
+	let lastTarget: number | null = null;
+	let attempts = 0;
+
+	const measureAndApply = () => {
+		if (cancelled) return;
+		attempts += 1;
+		view.requestMeasure({
+			key: "centerPosition",
+			read: (v) => {
+				const block = v.lineBlockAt(pos);
+				const containerRect = scrollContainer.getBoundingClientRect();
+				const desired = computeCenterScrollTop({
+					documentScreenTop: v.documentTop,
+					blockTop: block.top,
+					blockHeight: block.height,
+					containerScreenTop: containerRect.top,
+					containerVisibleHeight: scrollContainer.clientHeight,
+					currentScrollTop: scrollContainer.scrollTop,
+					extraMargins: opts.extraMargins,
+				});
+				return {
+					desired,
+					current: scrollContainer.scrollTop,
+				};
+			},
+			write: ({ desired, current }) => {
+				if (cancelled) return;
+				if (Math.abs(desired - current) > opts.tolerance) {
+					scrollContainer.scrollTop = desired;
+				}
+				const converged =
+					lastTarget !== null &&
+					isConverged(lastTarget, desired, opts.tolerance);
+				lastTarget = desired;
+				if (!converged && attempts < opts.maxAttempts) {
+					pendingFrame = requestAnimationFrame(() => {
+						pendingFrame = null;
+						measureAndApply();
+					});
+				}
+			},
+		});
+	};
+
+	measureAndApply();
+
+	if (typeof ResizeObserver !== "undefined" && opts.settleWindowMs > 0) {
+		let initialFire = true;
+		resizeObserver = new ResizeObserver(() => {
+			if (cancelled) return;
+			// ResizeObserver fires once on observe(). Skip that initial entry
+			// — the first measureAndApply() above is already in flight.
+			if (initialFire) {
+				initialFire = false;
+				return;
+			}
+			attempts = 0;
+			lastTarget = null;
+			measureAndApply();
+		});
+		resizeObserver.observe(scrollContainer);
+		settleTimer = setTimeout(() => {
+			if (resizeObserver) {
+				resizeObserver.disconnect();
+				resizeObserver = null;
+			}
+			settleTimer = null;
+		}, opts.settleWindowMs);
+	}
+
+	return { cancel };
+}
+
+/**
+ * Detect whether `pos` falls inside a block widget that visually hides
+ * the line (typically a `collapseUnchanged` collapse). If so, dispatch
+ * `uncollapseUnchanged` on both editors so the match becomes visible.
+ *
+ * Notes:
+ * - We can't access the merge package's private `CollapsedRanges` field,
+ *   so we detect via `view.lineBlockAt(pos).type === BlockType.WidgetRange`.
+ *   `uncollapseUnchanged.of(start)` is a no-op when no matching decoration
+ *   starts at `start`, so dispatching for non-collapse block widgets is
+ *   safe.
+ * - For the sibling editor we map the position via `mergeView.chunks`
+ *   because collapseUnchanged ranges live in unchanged regions and can
+ *   start at different positions on each side.
+ */
+function uncollapseIfHidden(
+	view: EditorView,
+	pos: number,
+	mergeView: MergeView,
+): void {
+	const block = view.lineBlockAt(pos);
+	if (block.type !== BlockType.WidgetRange) return;
+
+	const collapseStart = block.from;
+	const onSideA = view === mergeView.a;
+	const sibling = onSideA ? mergeView.b : mergeView.a;
+
+	view.dispatch({ effects: uncollapseUnchanged.of(collapseStart) });
+	const siblingPos = mapPosBetweenSides(
+		collapseStart,
+		mergeView.chunks,
+		onSideA ? "a" : "b",
+	);
+	sibling.dispatch({ effects: uncollapseUnchanged.of(siblingPos) });
+}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/components/CodeEditor/utils/centerPosition/index.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/components/CodeEditor/utils/centerPosition/index.ts
@@ -1,0 +1,8 @@
+export {
+	type CenterHandle,
+	centerPosition,
+	computeCenterScrollTop,
+	isConverged,
+	mapPosBetweenSides,
+	type ScrollMath,
+} from "./centerPosition";


### PR DESCRIPTION
## Summary

v1 のファイル/diff ビューワで、検索結果やジャンプ先が中央に来ず下端や画面外に出る問題を、3 つあったセンタリング実装を 1 つの堅牢ユーティリティに統一して根治しました。

## 直接原因 (バグ 2 件 + 構造的脆弱性 4 件)

### バグ 1: Diff Viewer の Cmd+F は書き込み先 DOM を間違えていた (致命)

\`@codemirror/merge\` の baseTheme は外側 \`.cm-mergeView\` を唯一のスクロールコンテナとし、内側 \`.cm-scroller\` を \`overflow-y: visible !important\` で固定しています。

\`\`\`css
.cm-mergeView & .cm-scroller, .cm-mergeView & {
    height: auto !important;
    overflow-y: visible !important;
}
\`\`\`

それにも関わらず \`scrollActiveSelectionToCenter\` は \`view.scrollDOM.scrollTop = X\` と書いていたため:

- \`view.scrollDOM\` はスクロールしないので書き込みは **no-op**
- \`view.scrollDOM.clientHeight\` は文書全体の高さなので、計算式 \`block.top + h/2 - clientHeight/2\` がほぼ常にマイナス → \`Math.max(0, …)\` で 0 に潰れる
- 結局 CM 内部の \`runFindNext\` が dispatch した \`y: "nearest"\` だけが効き、マッチが画面下端に張り付く

### バグ 2: \`revealPosition\` は CM の \`y: "center"\` を使っていた (Search タブ等)

\`revealPosition\` は \`EditorView.scrollIntoView({y: "center"})\` + 120ms \`setTimeout\` 再発火だが、**コードベース自身が search 経路で「仮想化下では unreliable」と明記**している方式 (CodeEditor.tsx の検索センタリングコメント参照)。最近 \`useRightSidebarOpenViewWidth: true\` が Search タブクリックを含む全 open フローに適用された結果、ペイン幅が狭くなって折返し再計算中に 120ms タイマーが走るため、より外しやすくなっていました。

### その他の脆弱性 (今回の統一実装で同時解消)

3. heightMap の estimated heights による \`block.top\` 推定誤差 → 収束ループ
4. MergeView の \`collapseUnchanged\` で折りたたまれた領域内のマッチが widget 中心になる → \`uncollapseUnchanged\` 自動 dispatch
5. ペイン幅確定 / theme reconfigure 中のセンタリングが事後ズレ → ResizeObserver settle window
6. 将来 \`scrollMargins\` を追加した瞬間ズレる → \`extraMargins\` オプション

## 実装

### 新規 \`centerPosition\` ユーティリティ (\`utils/centerPosition/centerPosition.ts\`)

| ステップ | 内容 |
|---|---|
| 1 | \`view.lineBlockAt(pos).type === BlockType.WidgetRange\` なら collapse とみなし、\`uncollapseUnchanged.of(start)\` を **両 side に dispatch** (\`mergeView.chunks\` 経由で sibling 位置 mapping) |
| 2 | \`EditorView.scrollIntoView(pos, {y: "nearest"})\` を dispatch して target 周辺を強制 render |
| 3 | \`view.requestMeasure({read, write})\` で CM の measure cycle に同期して \`block.top + view.documentTop\` ベースの screen-coord 計算を実行 |
| 4 | 算出 target が前回値と差分 > tolerance なら最大 \`maxAttempts\` (4 回) 再 measure: heightMap の refine に追従 |
| 5 | \`ResizeObserver\` で \`settleWindowMs\` (400ms) の間 container resize を監視: pane resize / theme reconfigure / font load による事後ズレを再センタリング |
| 6 | \`cancel()\` で全部止める (Find Next 連打や view destroy 時用) |

純粋計算は \`computeCenterScrollTop\` / \`mapPosBetweenSides\` / \`isConverged\` に分離。

### 既存呼び出し 3 箇所を \`centerPosition\` に置換

| 場所 | 旧 | 新 |
|---|---|---|
| \`CodeMirrorDiffViewer.scrollActiveSelectionToCenter\` | inner \`view.scrollDOM\` に書き込み | outer \`mergeView.dom\` に書き込み |
| \`CodeEditor.scrollSearchMatchToCenter\` | rAF + lineBlockAt 手動 | \`centerPosition\` (収束 + ResizeObserver 付) |
| \`CodeEditor.revealPosition\` | \`y: "center"\` + 120ms \`setTimeout\` 再発火 | \`centerPosition({moveCursor: true})\` |

\`SCROLL_STABILIZE_DELAY_MS\` と \`scrollStabilizeTimeout\` 系は削除。

## テスト (24 件全パス、CI でリグレッション検出可)

\`centerPosition.test.ts\` に純粋関数のフル単体テスト + フェイク EditorView での orchestration テスト。

特に **2 つのバグに対する明示的な regression guard** を入れています:

- **MergeView バグ用**: 「scrollContainer に渡された outer 要素」に scrollTop が書かれ、内部 \`view.scrollDOM\` には **書かれない** ことを確認するテスト
- **collapse blind spot 用**: \`BlockType.WidgetRange\` を返した時、\`uncollapseUnchanged\` が **両 side に** dispatch されることを確認するテスト

将来誰かが \`view.scrollDOM\` への書き込みに戻したり、collapse 処理を削った瞬間に CI が落ちます。

## 影響範囲 (centerPosition が効くフロー)

- Diff viewer Cmd+F の Find Next/Previous (致命バグ修正)
- Raw file viewer Cmd+F の Find Next/Previous
- Search タブの結果クリック → ファイル open
- Problems パネルクリック → ファイル open
- Go to definition (同一ファイル内ジャンプ)
- Reference graph ノードダブルクリック
- Command palette / Keyword search 選択
- Chat の mentioned-file / markdown ファイルリンク
- ターミナルのファイルリンクリック
- ツールコール由来の open-file
- VS Code 拡張からの open-file
- Commit details panel のファイルクリック
- (= 全 \`addFileViewerPane({line, column})\` 経由パス)

## Test plan

- [x] \`bun run typecheck\`
- [x] \`bun run lint\` (biome 0 issues)
- [x] \`bun test src/.../centerPosition\` 24/24 pass
- [x] \`bun test\` デスクトップ全体 1954 pass / 1 fail (失敗は \`external-worktree-import\` のタイムアウトで main でも同じ — 本変更と無関係)
- [ ] CI 緑確認
- [ ] 手動: 大ファイル (1000 行超) の raw viewer / diff viewer で Cmd+F → Enter 連打して常に中央に来ること
- [ ] 手動: Search タブで結果クリック → 中央に来ること (右サイドバー幅を 30% 程度に絞った状態でも)
- [ ] 手動: diff viewer で collapseUnchanged の中の単語を検索 → 折りたたみが展開されてマッチが中央に来ること