### PR TITLE
feat(desktop): Markdown プレビューで raw HTML (details/div/br/img) を描画する

### DIFF
--- a/apps/desktop/src/renderer/components/MarkdownRenderer/components/TipTapMarkdownRenderer/createMarkdownExtensions.ts
+++ b/apps/desktop/src/renderer/components/MarkdownRenderer/components/TipTapMarkdownRenderer/createMarkdownExtensions.ts
@@ -32,11 +32,19 @@ import { Details, Div, Span, Summary } from "./extensions/htmlBlockNodes";
 import { sanitizeUrl } from "./extensions/safeUrl";
 
 const lowlight = createLowlight(common);
-// Raw HTML in markdown is rendered through ProseMirror. XSS is mitigated by
-// schema-level safety: tags without an Extension (script/iframe/style/...) and
-// attributes without addAttributes (on*, srcset, ...) are dropped during parse.
-// SafeImage and SafeLink below additionally strip javascript:, vbscript:, and
-// data:text/html schemes from src/href.
+// Raw HTML in markdown is rendered through ProseMirror **only in read-only
+// mode** (file preview, comment rendering, etc.). Editable mode keeps html:false
+// to avoid silently dropping unknown tags (e.g. <iframe>, <video>) on save:
+// in editable mode the editor parses → user edits → serializer writes back, so
+// any tag the schema doesn't know would be permanently stripped from the
+// underlying markdown file. With html:false, tiptap-markdown's parser leaves
+// such tags as literal text and the serializer round-trips them unchanged.
+//
+// XSS in read-only mode is mitigated by:
+//  1) ProseMirror schema — tags without an Extension (script/iframe/style/...)
+//     and attributes without addAttributes (on*, srcset, ...) are dropped on parse.
+//  2) SafeImage / SafeLink strip javascript:, vbscript:, and data:text/html
+//     schemes from src/href.
 const ENABLE_RAW_MARKDOWN_HTML = true;
 
 const SafeImage = Image.extend({
@@ -215,7 +223,7 @@ export function createMarkdownExtensions({
 			},
 		}),
 		Markdown.configure({
-			html: ENABLE_RAW_MARKDOWN_HTML,
+			html: !editable && ENABLE_RAW_MARKDOWN_HTML,
 			transformPastedText: true,
 			transformCopiedText: true,
 		}),

--- a/apps/desktop/src/renderer/components/MarkdownRenderer/components/TipTapMarkdownRenderer/createMarkdownExtensions.ts
+++ b/apps/desktop/src/renderer/components/MarkdownRenderer/components/TipTapMarkdownRenderer/createMarkdownExtensions.ts
@@ -28,13 +28,49 @@ import { Markdown } from "tiptap-markdown";
 import { EditableCodeBlockView } from "./components/EditableCodeBlockView";
 import { ReadOnlyCodeBlockView } from "./components/ReadOnlyCodeBlockView";
 import { ReadOnlySafeImageView } from "./components/ReadOnlySafeImageView";
+import { Details, Div, Span, Summary } from "./extensions/htmlBlockNodes";
+import { sanitizeUrl } from "./extensions/safeUrl";
 
 const lowlight = createLowlight(common);
-const ENABLE_RAW_MARKDOWN_HTML = false;
+// Raw HTML in markdown is rendered through ProseMirror. XSS is mitigated by
+// schema-level safety: tags without an Extension (script/iframe/style/...) and
+// attributes without addAttributes (on*, srcset, ...) are dropped during parse.
+// SafeImage and SafeLink below additionally strip javascript:, vbscript:, and
+// data:text/html schemes from src/href.
+const ENABLE_RAW_MARKDOWN_HTML = true;
 
 const SafeImage = Image.extend({
 	addNodeView() {
 		return ReactNodeViewRenderer(ReadOnlySafeImageView);
+	},
+	addAttributes() {
+		return {
+			...this.parent?.(),
+			src: {
+				default: null,
+				parseHTML: (element) => sanitizeUrl(element.getAttribute("src")),
+				renderHTML: (attributes) => {
+					const src = attributes.src as string | null | undefined;
+					return src ? { src } : {};
+				},
+			},
+		};
+	},
+});
+
+const SafeLink = Link.extend({
+	addAttributes() {
+		return {
+			...this.parent?.(),
+			href: {
+				default: null,
+				parseHTML: (element) => sanitizeUrl(element.getAttribute("href")),
+				renderHTML: (attributes) => {
+					const href = attributes.href as string | null | undefined;
+					return href ? { href } : {};
+				},
+			},
+		};
 	},
 });
 
@@ -145,7 +181,7 @@ export function createMarkdownExtensions({
 		HorizontalRule,
 		HardBreak,
 		History,
-		Link.configure({
+		SafeLink.configure({
 			openOnClick: !editable,
 			HTMLAttributes: {
 				class:
@@ -155,6 +191,10 @@ export function createMarkdownExtensions({
 			},
 		}),
 		SafeImage,
+		Details,
+		Summary,
+		Div,
+		Span,
 		TableKit.configure({
 			table: {
 				resizable: false,
@@ -175,7 +215,6 @@ export function createMarkdownExtensions({
 			},
 		}),
 		Markdown.configure({
-			// Keep raw HTML disabled until the TipTap path has an explicit sanitizer.
 			html: ENABLE_RAW_MARKDOWN_HTML,
 			transformPastedText: true,
 			transformCopiedText: true,

--- a/apps/desktop/src/renderer/components/MarkdownRenderer/components/TipTapMarkdownRenderer/extensions/htmlBlockNodes.ts
+++ b/apps/desktop/src/renderer/components/MarkdownRenderer/components/TipTapMarkdownRenderer/extensions/htmlBlockNodes.ts
@@ -1,0 +1,99 @@
+import { mergeAttributes, Node } from "@tiptap/core";
+
+const COMMON_BLOCK_ATTRS = {
+	align: { default: null as string | null },
+	class: { default: null as string | null },
+	style: { default: null as string | null },
+	id: { default: null as string | null },
+};
+
+const COMMON_INLINE_ATTRS = {
+	class: { default: null as string | null },
+	style: { default: null as string | null },
+	id: { default: null as string | null },
+};
+
+export const Details = Node.create({
+	name: "details",
+	group: "block",
+	content: "block+",
+	defining: true,
+
+	addAttributes() {
+		return {
+			...COMMON_BLOCK_ATTRS,
+			open: {
+				default: null as "" | null,
+				parseHTML: (element: HTMLElement) =>
+					element.hasAttribute("open") ? "" : null,
+				renderHTML: (attrs: Record<string, unknown>) =>
+					attrs.open === null ? {} : { open: "" },
+			},
+		};
+	},
+
+	parseHTML() {
+		return [{ tag: "details" }];
+	},
+
+	renderHTML({ HTMLAttributes }) {
+		return ["details", mergeAttributes(HTMLAttributes), 0];
+	},
+});
+
+export const Summary = Node.create({
+	name: "summary",
+	group: "block",
+	content: "inline*",
+	defining: true,
+
+	addAttributes() {
+		return COMMON_INLINE_ATTRS;
+	},
+
+	parseHTML() {
+		return [{ tag: "summary" }];
+	},
+
+	renderHTML({ HTMLAttributes }) {
+		return ["summary", mergeAttributes(HTMLAttributes), 0];
+	},
+});
+
+export const Div = Node.create({
+	name: "div",
+	group: "block",
+	content: "block+",
+	defining: true,
+
+	addAttributes() {
+		return COMMON_BLOCK_ATTRS;
+	},
+
+	parseHTML() {
+		return [{ tag: "div" }];
+	},
+
+	renderHTML({ HTMLAttributes }) {
+		return ["div", mergeAttributes(HTMLAttributes), 0];
+	},
+});
+
+export const Span = Node.create({
+	name: "span",
+	inline: true,
+	group: "inline",
+	content: "inline*",
+
+	addAttributes() {
+		return COMMON_INLINE_ATTRS;
+	},
+
+	parseHTML() {
+		return [{ tag: "span" }];
+	},
+
+	renderHTML({ HTMLAttributes }) {
+		return ["span", mergeAttributes(HTMLAttributes), 0];
+	},
+});

--- a/apps/desktop/src/renderer/components/MarkdownRenderer/components/TipTapMarkdownRenderer/extensions/safeUrl.test.ts
+++ b/apps/desktop/src/renderer/components/MarkdownRenderer/components/TipTapMarkdownRenderer/extensions/safeUrl.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "bun:test";
+import { isSafeUrl, sanitizeUrl } from "./safeUrl";
+
+describe("isSafeUrl", () => {
+	it("allows null/undefined/empty (no href present)", () => {
+		expect(isSafeUrl(null)).toBe(true);
+		expect(isSafeUrl(undefined)).toBe(true);
+		expect(isSafeUrl("")).toBe(true);
+	});
+
+	it("allows http(s) urls", () => {
+		expect(isSafeUrl("https://example.com")).toBe(true);
+		expect(isSafeUrl("http://example.com")).toBe(true);
+	});
+
+	it("allows mailto, ftp, tel, data:image", () => {
+		expect(isSafeUrl("mailto:user@example.com")).toBe(true);
+		expect(isSafeUrl("ftp://example.com")).toBe(true);
+		expect(isSafeUrl("tel:+15551234567")).toBe(true);
+		expect(isSafeUrl("data:image/png;base64,AAAA")).toBe(true);
+	});
+
+	it("allows relative urls and fragments", () => {
+		expect(isSafeUrl("/path/to/file")).toBe(true);
+		expect(isSafeUrl("./relative")).toBe(true);
+		expect(isSafeUrl("#anchor")).toBe(true);
+		expect(isSafeUrl("?query=1")).toBe(true);
+		expect(isSafeUrl("file.html")).toBe(true);
+	});
+
+	it("blocks javascript: scheme (case-insensitive, with whitespace)", () => {
+		expect(isSafeUrl("javascript:alert(1)")).toBe(false);
+		expect(isSafeUrl("JavaScript:alert(1)")).toBe(false);
+		expect(isSafeUrl("  javascript:alert(1)")).toBe(false);
+		expect(isSafeUrl("\tjavascript:alert(1)")).toBe(false);
+	});
+
+	it("blocks vbscript: scheme", () => {
+		expect(isSafeUrl("vbscript:msgbox(1)")).toBe(false);
+		expect(isSafeUrl("VBScript:msgbox(1)")).toBe(false);
+	});
+
+	it("blocks data:text/html (HTML smuggled in data URI)", () => {
+		expect(isSafeUrl("data:text/html,<script>alert(1)</script>")).toBe(false);
+		expect(isSafeUrl("Data:Text/Html,<script>")).toBe(false);
+	});
+});
+
+describe("sanitizeUrl", () => {
+	it("returns the url when safe", () => {
+		expect(sanitizeUrl("https://example.com")).toBe("https://example.com");
+		expect(sanitizeUrl("/relative")).toBe("/relative");
+	});
+
+	it("returns null when unsafe", () => {
+		expect(sanitizeUrl("javascript:alert(1)")).toBe(null);
+		expect(sanitizeUrl("vbscript:x")).toBe(null);
+		expect(sanitizeUrl("data:text/html,evil")).toBe(null);
+	});
+
+	it("returns null for null input, preserves empty string for empty input", () => {
+		expect(sanitizeUrl(null)).toBe(null);
+		expect(sanitizeUrl(undefined)).toBe(null);
+		// Empty string is technically "safe" but downstream renderHTML drops it.
+		expect(sanitizeUrl("")).toBe("");
+	});
+});

--- a/apps/desktop/src/renderer/components/MarkdownRenderer/components/TipTapMarkdownRenderer/extensions/safeUrl.ts
+++ b/apps/desktop/src/renderer/components/MarkdownRenderer/components/TipTapMarkdownRenderer/extensions/safeUrl.ts
@@ -1,0 +1,15 @@
+const DANGEROUS_SCHEME = /^\s*(javascript|vbscript|data:text\/html)/i;
+
+export function isSafeUrl(href: string | null | undefined): boolean {
+	if (href === null || href === undefined || href === "") {
+		return true;
+	}
+	return !DANGEROUS_SCHEME.test(href);
+}
+
+export function sanitizeUrl(href: string | null | undefined): string | null {
+	if (href === null || href === undefined) {
+		return null;
+	}
+	return isSafeUrl(href) ? href : null;
+}


### PR DESCRIPTION
## Summary

Files プレビュー / メモタブ / `MarkdownPreviewView` で使う `TipTapMarkdownRenderer` は `tiptap-markdown` の `html: false` を入れていたため、`<details>` / `<div align="center">` / `<br />` / `<img>` / `<summary>` といった raw HTML がそのまま画面に漏れていた (例: README.md を Files で開くと全部 `<div>...</div>` の文字列がそのまま表示)。

ProseMirror schema による暗黙の排除 + URL scheme 検証で XSS を抑えつつ、raw HTML を有効化する。

### 修正内容

- **Tiptap Custom Node を追加** (`extensions/htmlBlockNodes.ts`)
  - `Details` / `Summary` / `Div` / `Span` を schema に登録
  - 共通許可属性は `id`/`class`/`style`/`align` のみ。`on*` などは addAttributes に無いため自動排除
  - `Details` のみ `open` 属性をサポート
- **SafeImage / SafeLink を導入** (`createMarkdownExtensions.ts`)
  - 既存 Image / Link を extend し、`src` / `href` の `parseHTML` で URL を sanitize
  - `javascript:`, `vbscript:`, `data:text/html` は `null` に置換 (大文字小文字・先頭空白も検出)
- **`ENABLE_RAW_MARKDOWN_HTML = true`** に切替

### XSS 対策の二段防衛

1. **ProseMirror schema による排除**
   - `<script>` / `<iframe>` / `<style>` などは Extension 未登録 → parse 時に破棄
   - `on*` (onerror, onclick, ...) は addAttributes に無い → 同上
2. **URL scheme 検証** (SafeImage / SafeLink)
   - `<a href="javascript:alert(1)">` → href が `null` になりリンクとして機能しない
   - `<img src="javascript:...">` も同様
   - `data:image/png;base64,...` のような安全な data: URL は通す

### 設計の選択

`sanitize-html` で **markdown 入力を直接サニタイズ** する案も検証したが、

- `if (x < 5)` → `if (x &lt; 5)` のようにテキスト中の `<` がエンティティ化される
- fenced code block 内の `const a = <Component />;` の JSX タグが消される

など markdown を破壊するため却下した。schema レベルでの安全性 + URL バリデーションで完結させる方が「ズレない」。

react-markdown 版に差し替える案も、Tiptap と HTML 出力構造が異なる (list の wrapping、code block の class 命名など) ためズレが出る懸念があり不採用。

## Test plan

- [x] `bun test` (10/10 pass) — `safeUrl` の許可/拒否ケースを網羅
- [x] `bun run typecheck --filter=@superset/desktop` 通過
- [x] `bun run lint` 通過
- [ ] dev で `README.md` を Files プレビューで開き、`<details>` `<div>` `<br />` `<img>` などが正しく描画されること、既存の見出し/リスト/コードブロック/テーブルがズレないことを目視確認
- [ ] メモタブで `<details>` を書き込んで保存→再表示できること
- [ ] `<a href="javascript:alert(1)">` `<img src="javascript:..."/>` `<script>` を含む md で alert が出ないこと