### PR TITLE
upstream/2026-04-26 PR2: 単一ファイル競合 UI 系 3 commits 取り込み

### DIFF
--- a/apps/desktop/docs/OPTIMISTIC_ELECTRIC_UPDATES.md
+++ b/apps/desktop/docs/OPTIMISTIC_ELECTRIC_UPDATES.md
@@ -1,0 +1,111 @@
+# Optimistic Electric Updates
+
+Desktop uses TanStack DB collections backed by Electric shapes for task and workspace data. The default write model is **optimistic online**, not offline-first.
+
+## Decision
+
+Use TanStack DB collection mutations for routine server-backed writes that already have stable local identity:
+
+1. The UI calls `collection.insert`, `collection.update`, or `collection.delete`.
+2. TanStack DB applies optimistic state immediately.
+3. The collection handler persists through our API.
+4. The API returns the PostgreSQL `txid` from the same database transaction as the write.
+5. Electric streams that transaction back to the client.
+6. TanStack DB drops the optimistic overlay or rolls it back if persistence fails.
+
+This matches the documented TanStack DB mutation lifecycle and Electric collection txid strategy:
+
+- TanStack DB mutations: https://tanstack.com/db/latest/docs/guides/mutations
+- Electric collection txid matching: https://tanstack.com/db/latest/docs/collections/electric-collection
+
+## Scope
+
+Optimistic online is the right default for task edits, status changes, assignment changes, priority changes, title/description edits, and soft deletes. These are simple, single-record writes where immediate feedback matters and rollback is acceptable if the server rejects the write.
+
+New task creation can remain server-confirmed while it relies on server-generated slugs, default status seeding, and navigation to the canonical record. Move creation to optimistic insert only after the client can provide all stable identity and routing fields up front.
+
+Do not treat this as offline-first. If the API call cannot run, the transaction should fail, TanStack DB should roll back the optimistic state, and the UI should show a failure toast. We are not adding a durable outbox, replay queue, conflict resolver, or persisted collection state in this pass.
+
+## Desktop Collection Matrix
+
+Desktop currently has three write categories.
+
+### Server-backed Electric writes
+
+These collections have Electric mutation handlers in `CollectionsProvider/collections.ts`:
+
+| Collection | Handlers | Current write surface | Behavior |
+| --- | --- | --- | --- |
+| `tasks` | insert, update, delete | `useOptimisticCollectionActions().tasks` for update/delete; create dialog still uses `task.createFromUi` directly | Optimistic for task edits/deletes; collection handlers return `{ txid }`. |
+| `v2Projects` | update | `useOptimisticCollectionActions().v2Projects` for rename/repository updates | Optimistic for project row edits; create/delete remain API-confirmed. |
+| `v2Workspaces` | update | `useOptimisticCollectionActions().v2Workspaces` for rename-style updates | Optimistic for workspace row edits; create/delete remain host-service sagas. |
+| `chatSessions` | delete | `useOptimisticCollectionActions().chatSessions` for chat session deletion | Optimistic delete; create remains server-confirmed because the chat runtime coordinates session creation. |
+| `agentCommands` | update | `useCommandWatcher` | Background optimistic update; caller awaits `tx.isPersisted.promise` and retries on failure. |
+
+### Read-only Electric collections
+
+These are Electric-backed in the renderer but have no collection mutation handlers and no direct renderer `collection.insert/update/delete` calls:
+
+- `organizations`
+- `taskStatuses`
+- `projects`
+- `v2Hosts`
+- `v2Clients`
+- `v2UsersHosts`
+- `workspaces`
+- `members`
+- `users`
+- `invitations`
+- `integrationConnections`
+- `subscriptions`
+- `apiKeys`
+- `sessionHosts`
+- `githubRepositories`
+- `githubPullRequests`
+- `automations`
+- `automationRuns`
+
+Workspace create/delete flows do not use `collections.v2Workspaces.insert/delete`. They go through host-service or tRPC APIs and then Electric streams the confirmed row back:
+
+- workspace create/checkout/adopt writes a local `pendingWorkspaces` row, then the pending page calls host-service
+- workspace delete calls host-service `workspaceCleanup.destroy`; the sidebar hides the row through `DeletingWorkspacesProvider` while the saga runs
+
+Workspace rename does use `collections.v2Workspaces.update` via `useOptimisticCollectionActions().v2Workspaces`, backed by `v2Workspace.update` returning `{ txid }` from the same Postgres transaction.
+
+### LocalStorage collections
+
+These are client-local TanStack DB collections. They are synchronous local persistence, not Electric/Postgres optimistic writes:
+
+- `v2SidebarProjects` — sidebar project order/collapse/default app
+- `v2WorkspaceLocalState` — sidebar placement, pane layout, viewed files, changes tab
+- `v2SidebarSections` — user-created sidebar sections and ordering
+- `v2TerminalPresets` — local terminal presets
+- `pendingWorkspaces` — durable local bus for workspace creation progress and launch handoff
+- `v2UserPreferences` — local v2 preferences such as link behavior and delete-branch default
+
+LocalStorage mutations can still throw for schema/storage errors, but they do not have remote persistence confirmation or Electric rollback semantics.
+
+## Implementation Contract
+
+Collection handlers must return `{ txid }` for server-backed Electric writes. The txid must come from `pg_current_xact_id()` inside the same transaction that performs the mutation. A txid captured before or after the write can leave `tx.isPersisted.promise` waiting for a transaction that Electric will never stream.
+
+Feature code should not scatter direct server-backed collection mutations. Use `useOptimisticCollectionActions` and the relevant grouped action surface, such as `.tasks`, `.v2Workspaces`, `.v2Projects`, or `.chatSessions`, so every call site gets the same behavior:
+
+- apply the optimistic collection mutation immediately
+- attach a rejection handler to `tx.isPersisted.promise`
+- show a user-visible error when persistence fails
+- let TanStack DB own rollback
+
+Use `{ optimistic: false }` only for exceptional flows where the UI must wait for server confirmation before revealing the result, such as a workflow that depends on a server-generated identifier or a multi-step server-side effect.
+
+## Offline-First Boundary
+
+Offline-first needs more than optimistic state. It needs durable local persistence, queued transactions, replay ordering, idempotency, and conflict handling. If we decide to support offline task writes later, design it as a separate feature with:
+
+- a durable transaction queue
+- client-generated stable IDs for created records
+- idempotent API mutations
+- explicit conflict policy per write type
+- UI for pending and failed replays
+
+Until then, Electric is our read/sync confirmation path and the API remains the write authority.

--- a/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
@@ -19,6 +19,7 @@ const STORAGE_KEY_PREFIX = "terminal-buffer:";
 const DIMS_KEY_PREFIX = "terminal-dims:";
 const DEFAULT_COLS = 120;
 const DEFAULT_ROWS = 32;
+const RESIZE_DEBOUNCE_MS = 75;
 
 // xterm's _keyDown calls stopPropagation after processing, so any chord we
 // want the host (react-hotkeys-hook, Electron menu accelerators) or the shell
@@ -85,6 +86,7 @@ export interface TerminalRuntime {
 	wrapper: HTMLDivElement;
 	container: HTMLDivElement | null;
 	resizeObserver: ResizeObserver | null;
+	_disposeResizeObserver: (() => void) | null;
 	lastCols: number;
 	lastRows: number;
 	_disposeAddons: (() => void) | null;
@@ -211,11 +213,70 @@ function getParkingContainer(): HTMLDivElement {
 	return el;
 }
 
-function measureAndResize(runtime: TerminalRuntime) {
-	if (!hostIsVisible(runtime.container)) return;
+function measureAndResize(runtime: TerminalRuntime): boolean {
+	if (!hostIsVisible(runtime.container)) return false;
+	const { terminal } = runtime;
+	const buffer = terminal.buffer.active;
+	const wasPinnedToBottom = buffer.viewportY >= buffer.baseY;
+	const savedViewportY = buffer.viewportY;
+	const prevCols = terminal.cols;
+	const prevRows = terminal.rows;
+
 	runtime.fitAddon.fit();
-	runtime.lastCols = runtime.terminal.cols;
-	runtime.lastRows = runtime.terminal.rows;
+	runtime.lastCols = terminal.cols;
+	runtime.lastRows = terminal.rows;
+
+	if (wasPinnedToBottom) {
+		terminal.scrollToBottom();
+	} else {
+		const targetY = Math.min(savedViewportY, terminal.buffer.active.baseY);
+		if (terminal.buffer.active.viewportY !== targetY) {
+			terminal.scrollToLine(targetY);
+		}
+	}
+
+	terminal.refresh(0, Math.max(0, terminal.rows - 1));
+
+	return terminal.cols !== prevCols || terminal.rows !== prevRows;
+}
+
+function createResizeScheduler(
+	runtime: TerminalRuntime,
+	onResize?: () => void,
+): {
+	observe: ResizeObserverCallback;
+	dispose: () => void;
+} {
+	let timeoutId: ReturnType<typeof setTimeout> | null = null;
+
+	const dispose = () => {
+		if (timeoutId !== null) {
+			clearTimeout(timeoutId);
+			timeoutId = null;
+		}
+	};
+
+	const run = () => {
+		timeoutId = null;
+		const changed = measureAndResize(runtime);
+		if (changed) onResize?.();
+	};
+
+	const observe: ResizeObserverCallback = (entries) => {
+		if (
+			entries.some(
+				(entry) =>
+					entry.contentRect.width <= 0 || entry.contentRect.height <= 0,
+			)
+		) {
+			dispose();
+			return;
+		}
+		dispose();
+		timeoutId = setTimeout(run, RESIZE_DEBOUNCE_MS);
+	};
+
+	return { observe, dispose };
 }
 
 export function createRuntime(
@@ -259,6 +320,7 @@ export function createRuntime(
 		wrapper,
 		container: null,
 		resizeObserver: null,
+		_disposeResizeObserver: null,
 		lastCols: cols,
 		lastRows: rows,
 		_disposeAddons: addonsResult.dispose,
@@ -287,9 +349,10 @@ export function attachToContainer(
 		containerWidth: container.clientWidth,
 		containerHeight: container.clientHeight,
 	});
-	measureAndResize(runtime);
+	if (measureAndResize(runtime)) onResize?.();
 
 	// Renderer may have skipped frames while the wrapper was detached.
+	// (refresh is now handled inside measureAndResize)
 	terminalRendererDebug.info(
 		"runtime-refresh",
 		{
@@ -301,15 +364,15 @@ export function attachToContainer(
 			fingerprint: ["terminal.renderer", "runtime-refresh"],
 		},
 	);
-	runtime.terminal.refresh(0, runtime.terminal.rows - 1);
 
+	runtime._disposeResizeObserver?.();
+	runtime._disposeResizeObserver = null;
 	runtime.resizeObserver?.disconnect();
-	const observer = new ResizeObserver(() => {
-		measureAndResize(runtime);
-		onResize?.();
-	});
+	const scheduler = createResizeScheduler(runtime, onResize);
+	const observer = new ResizeObserver(scheduler.observe);
 	observer.observe(container);
 	runtime.resizeObserver = observer;
+	runtime._disposeResizeObserver = scheduler.dispose;
 
 	runtime.terminal.focus();
 }
@@ -329,6 +392,8 @@ export function detachFromContainer(runtime: TerminalRuntime) {
 			fingerprint: ["terminal.renderer", "runtime-detach-from-container"],
 		},
 	);
+	runtime._disposeResizeObserver?.();
+	runtime._disposeResizeObserver = null;
 	runtime.resizeObserver?.disconnect();
 	runtime.resizeObserver = null;
 	// Park instead of .remove() so xterm survives the React unmount —
@@ -341,7 +406,7 @@ export function updateRuntimeAppearance(
 	runtime: TerminalRuntime,
 	appearance: TerminalAppearance,
 ) {
-	const { terminal, fitAddon } = runtime;
+	const { terminal } = runtime;
 	terminal.options.theme = appearance.theme;
 
 	const fontChanged =
@@ -352,9 +417,7 @@ export function updateRuntimeAppearance(
 		terminal.options.fontFamily = appearance.fontFamily;
 		terminal.options.fontSize = appearance.fontSize;
 		if (hostIsVisible(runtime.container)) {
-			fitAddon.fit();
-			runtime.lastCols = terminal.cols;
-			runtime.lastRows = terminal.rows;
+			measureAndResize(runtime);
 		}
 	}
 }
@@ -370,6 +433,8 @@ export function disposeRuntime(
 	}
 	runtime._disposeAddons?.();
 	runtime._disposeAddons = null;
+	runtime._disposeResizeObserver?.();
+	runtime._disposeResizeObserver = null;
 	runtime.resizeObserver?.disconnect();
 	runtime.resizeObserver = null;
 	runtime.wrapper.remove();

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarProjectSection/hooks/useDashboardSidebarProjectSectionActions/useDashboardSidebarProjectSectionActions.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarProjectSection/hooks/useDashboardSidebarProjectSectionActions/useDashboardSidebarProjectSectionActions.ts
@@ -2,8 +2,8 @@ import { alert } from "@superset/ui/atoms/Alert";
 import { toast } from "@superset/ui/sonner";
 import { useNavigate } from "@tanstack/react-router";
 import { useState } from "react";
-import { apiTrpcClient } from "renderer/lib/api-trpc-client";
 import { useDashboardSidebarState } from "renderer/routes/_authenticated/hooks/useDashboardSidebarState";
+import { useOptimisticCollectionActions } from "renderer/routes/_authenticated/hooks/useOptimisticCollectionActions";
 import { useOpenNewWorkspaceModal } from "renderer/stores/new-workspace-modal";
 import type { DashboardSidebarProject } from "../../../../types";
 
@@ -16,6 +16,7 @@ export function useDashboardSidebarProjectSectionActions({
 }: UseDashboardSidebarProjectSectionActionsOptions) {
 	const openModal = useOpenNewWorkspaceModal();
 	const navigate = useNavigate();
+	const { v2Projects: projectActions } = useOptimisticCollectionActions();
 	const {
 		createSection,
 		deleteSection,
@@ -37,20 +38,11 @@ export function useDashboardSidebarProjectSectionActions({
 		setRenameValue(project.name);
 	};
 
-	const submitRename = async () => {
+	const submitRename = () => {
 		setIsRenaming(false);
 		const trimmed = renameValue.trim();
 		if (!trimmed || trimmed === project.name) return;
-		try {
-			await apiTrpcClient.v2Project.update.mutate({
-				id: project.id,
-				name: trimmed,
-			});
-		} catch (error) {
-			toast.error(
-				`Failed to rename: ${error instanceof Error ? error.message : "Unknown error"}`,
-			);
-		}
+		projectActions.renameProject(project.id, trimmed);
 	};
 
 	const handleOpenInFinder = () => {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarCollapsedWorkspaceButton/DashboardSidebarCollapsedWorkspaceButton.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarCollapsedWorkspaceButton/DashboardSidebarCollapsedWorkspaceButton.tsx
@@ -35,8 +35,8 @@ export const DashboardSidebarCollapsedWorkspaceButton = forwardRef<
 				ref={ref}
 				className={cn(
 					"relative flex items-center justify-center size-8 rounded-md",
-					"hover:bg-muted/50 transition-colors cursor-pointer",
-					isActive && "bg-muted",
+					"transition-colors cursor-pointer",
+					isActive ? "bg-muted hover:bg-muted" : "hover:bg-muted/50",
 					className,
 				)}
 				{...props}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/DashboardSidebarExpandedWorkspaceRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/DashboardSidebarExpandedWorkspaceRow.tsx
@@ -120,7 +120,10 @@ export const DashboardSidebarExpandedWorkspaceRow = forwardRef<
 				onDoubleClick={onDoubleClick}
 				className={cn(
 					"relative flex w-full items-center pl-3 pr-2 text-left text-sm",
-					onClick && "cursor-pointer hover:bg-muted/50",
+					onClick &&
+						(isActive
+							? "cursor-pointer hover:bg-muted"
+							: "cursor-pointer hover:bg-muted/50"),
 					"group",
 					"py-1.5",
 					isActive && "bg-muted",

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/hooks/useDashboardSidebarWorkspaceItemActions/useDashboardSidebarWorkspaceItemActions.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/hooks/useDashboardSidebarWorkspaceItemActions/useDashboardSidebarWorkspaceItemActions.ts
@@ -2,13 +2,13 @@ import { toast } from "@superset/ui/sonner";
 import { useMatchRoute, useNavigate } from "@tanstack/react-router";
 import { useState } from "react";
 import { useCopyToClipboard } from "renderer/hooks/useCopyToClipboard";
-import { apiTrpcClient } from "renderer/lib/api-trpc-client";
 import { getHostServiceClientByUrl } from "renderer/lib/host-service-client";
 import { electronTrpcClient } from "renderer/lib/trpc-client";
 import { getDeleteFocusTargetWorkspaceId } from "renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/utils/getDeleteFocusTargetWorkspaceId";
 import { getFlattenedV2WorkspaceIds } from "renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/utils/getFlattenedV2WorkspaceIds";
 import { navigateToV2Workspace } from "renderer/routes/_authenticated/_dashboard/utils/workspace-navigation";
 import { useDashboardSidebarState } from "renderer/routes/_authenticated/hooks/useDashboardSidebarState";
+import { useOptimisticCollectionActions } from "renderer/routes/_authenticated/hooks/useOptimisticCollectionActions";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
 
@@ -30,6 +30,7 @@ export function useDashboardSidebarWorkspaceItemActions({
 	const collections = useCollections();
 	const { activeHostUrl } = useLocalHostService();
 	const { copyToClipboard } = useCopyToClipboard();
+	const { v2Workspaces: workspaceActions } = useOptimisticCollectionActions();
 	const { createSection, moveWorkspaceToSection, removeWorkspaceFromSidebar } =
 		useDashboardSidebarState();
 
@@ -61,20 +62,11 @@ export function useDashboardSidebarWorkspaceItemActions({
 		setRenameValue(workspaceName);
 	};
 
-	const submitRename = async () => {
+	const submitRename = () => {
 		setIsRenaming(false);
 		const trimmed = renameValue.trim();
 		if (!trimmed || trimmed === workspaceName) return;
-		try {
-			await apiTrpcClient.v2Workspace.update.mutate({
-				id: workspaceId,
-				name: trimmed,
-			});
-		} catch (error) {
-			toast.error(
-				`Failed to rename: ${error instanceof Error ? error.message : "Unknown error"}`,
-			);
-		}
+		workspaceActions.renameWorkspace(workspaceId, trimmed);
 	};
 
 	/**

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/$taskId/components/PropertiesSidebar/components/AssigneeProperty/AssigneeProperty.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/$taskId/components/PropertiesSidebar/components/AssigneeProperty/AssigneeProperty.tsx
@@ -8,6 +8,7 @@ import {
 import { useLiveQuery } from "@tanstack/react-db";
 import { useMemo, useState } from "react";
 import { HiOutlineUserCircle } from "react-icons/hi2";
+import { useOptimisticCollectionActions } from "renderer/routes/_authenticated/hooks/useOptimisticCollectionActions";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 import type { TaskWithStatus } from "../../../../../components/TasksView/hooks/useTasksTable";
 
@@ -17,6 +18,7 @@ interface AssigneePropertyProps {
 
 export function AssigneeProperty({ task }: AssigneePropertyProps) {
 	const collections = useCollections();
+	const { tasks: taskActions } = useOptimisticCollectionActions();
 	const [open, setOpen] = useState(false);
 
 	const { data: allUsers } = useLiveQuery(
@@ -32,14 +34,10 @@ export function AssigneeProperty({ task }: AssigneePropertyProps) {
 			return;
 		}
 
-		setOpen(false);
-
-		collections.tasks.update(task.id, (draft) => {
-			draft.assigneeId = userId;
-			draft.assigneeExternalId = null;
-			draft.assigneeDisplayName = null;
-			draft.assigneeAvatarUrl = null;
-		});
+		const transaction = taskActions.updateAssignee(task.id, userId);
+		if (transaction) {
+			setOpen(false);
+		}
 	};
 
 	return (

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/$taskId/components/PropertiesSidebar/components/PriorityProperty/PriorityProperty.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/$taskId/components/PropertiesSidebar/components/PriorityProperty/PriorityProperty.tsx
@@ -6,7 +6,7 @@ import {
 	DropdownMenuTrigger,
 } from "@superset/ui/dropdown-menu";
 import { useState } from "react";
-import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
+import { useOptimisticCollectionActions } from "renderer/routes/_authenticated/hooks/useOptimisticCollectionActions";
 import { PriorityIcon } from "../../../../../components/TasksView/components/shared/PriorityIcon";
 import type { TaskWithStatus } from "../../../../../components/TasksView/hooks/useTasksTable";
 import { ALL_PRIORITIES } from "../../../../../components/TasksView/utils/sorting";
@@ -24,7 +24,7 @@ interface PriorityPropertyProps {
 }
 
 export function PriorityProperty({ task }: PriorityPropertyProps) {
-	const collections = useCollections();
+	const { tasks: taskActions } = useOptimisticCollectionActions();
 	const [open, setOpen] = useState(false);
 
 	const currentPriority = task.priority;
@@ -36,13 +36,9 @@ export function PriorityProperty({ task }: PriorityPropertyProps) {
 			return;
 		}
 
-		try {
-			collections.tasks.update(task.id, (draft) => {
-				draft.priority = newPriority;
-			});
+		const transaction = taskActions.updatePriority(task.id, newPriority);
+		if (transaction) {
 			setOpen(false);
-		} catch (error) {
-			console.error("[PriorityProperty] Failed to update priority:", error);
 		}
 	};
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/$taskId/components/PropertiesSidebar/components/StatusProperty/StatusProperty.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/$taskId/components/PropertiesSidebar/components/StatusProperty/StatusProperty.tsx
@@ -7,6 +7,7 @@ import {
 } from "@superset/ui/dropdown-menu";
 import { useLiveQuery } from "@tanstack/react-db";
 import { useMemo, useState } from "react";
+import { useOptimisticCollectionActions } from "renderer/routes/_authenticated/hooks/useOptimisticCollectionActions";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 import {
 	StatusIcon,
@@ -22,6 +23,7 @@ interface StatusPropertyProps {
 
 export function StatusProperty({ task }: StatusPropertyProps) {
 	const collections = useCollections();
+	const { tasks: taskActions } = useOptimisticCollectionActions();
 	const [open, setOpen] = useState(false);
 
 	const { data: allStatuses } = useLiveQuery(
@@ -42,13 +44,9 @@ export function StatusProperty({ task }: StatusPropertyProps) {
 			return;
 		}
 
-		try {
-			collections.tasks.update(task.id, (draft) => {
-				draft.statusId = newStatus.id;
-			});
+		const transaction = taskActions.updateStatus(task.id, newStatus.id);
+		if (transaction) {
 			setOpen(false);
-		} catch (error) {
-			console.error("[StatusProperty] Failed to update status:", error);
 		}
 	};
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/$taskId/components/TaskActionMenu/TaskActionMenu.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/$taskId/components/TaskActionMenu/TaskActionMenu.tsx
@@ -13,7 +13,7 @@ import {
 	HiOutlineTrash,
 } from "react-icons/hi2";
 import { useCopyToClipboard } from "renderer/hooks/useCopyToClipboard";
-import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
+import { useOptimisticCollectionActions } from "renderer/routes/_authenticated/hooks/useOptimisticCollectionActions";
 import type { TaskWithStatus } from "../../../components/TasksView/hooks/useTasksTable";
 
 interface TaskActionMenuProps {
@@ -22,7 +22,7 @@ interface TaskActionMenuProps {
 }
 
 export function TaskActionMenu({ task, onDelete }: TaskActionMenuProps) {
-	const collections = useCollections();
+	const { tasks: taskActions } = useOptimisticCollectionActions();
 	const [open, setOpen] = useState(false);
 
 	const { copyToClipboard } = useCopyToClipboard();
@@ -37,13 +37,11 @@ export function TaskActionMenu({ task, onDelete }: TaskActionMenuProps) {
 		setOpen(false);
 	};
 
-	const handleDelete = async () => {
-		try {
-			await collections.tasks.delete(task.id);
+	const handleDelete = () => {
+		const transaction = taskActions.deleteTask(task.id);
+		if (transaction) {
 			setOpen(false);
 			onDelete?.();
-		} catch (error) {
-			console.error("[TaskActionMenu] Failed to delete task:", error);
 		}
 	};
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/$taskId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/$taskId/page.tsx
@@ -12,6 +12,7 @@ import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { useMemo } from "react";
 import { MarkdownEditor } from "renderer/components/MarkdownEditor";
 import { apiTrpcClient } from "renderer/lib/api-trpc-client";
+import { useOptimisticCollectionActions } from "renderer/routes/_authenticated/hooks/useOptimisticCollectionActions";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 import { Route as TasksLayoutRoute } from "../layout";
 import { ActivitySection } from "./components/ActivitySection";
@@ -37,6 +38,7 @@ function TaskDetailPage() {
 	const { tab, assignee, search } = TasksLayoutRoute.useSearch();
 	const navigate = useNavigate();
 	const collections = useCollections();
+	const { tasks: taskActions } = useOptimisticCollectionActions();
 	const isUuidTaskId =
 		/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
 			taskId,
@@ -108,16 +110,12 @@ function TaskDetailPage() {
 
 	const handleSaveTitle = (title: string) => {
 		if (!task) return;
-		collections.tasks.update(task.id, (draft) => {
-			draft.title = title;
-		});
+		taskActions.updateTitle(task.id, title);
 	};
 
 	const handleSaveDescription = (markdown: string) => {
 		if (!task) return;
-		collections.tasks.update(task.id, (draft) => {
-			draft.description = markdown;
-		});
+		taskActions.updateDescription(task.id, markdown);
 	};
 
 	const handleDelete = () => {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/components/TasksBoardView/TasksBoardView.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/components/TasksBoardView/TasksBoardView.tsx
@@ -12,7 +12,7 @@ import {
 import { sortableKeyboardCoordinates } from "@dnd-kit/sortable";
 import type { SelectTaskStatus } from "@superset/db/schema";
 import { useCallback, useMemo, useState } from "react";
-import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
+import { useOptimisticCollectionActions } from "renderer/routes/_authenticated/hooks/useOptimisticCollectionActions";
 import type { TaskWithStatus } from "../../hooks/useTasksData";
 import { compareStatusesForDropdown } from "../../utils/sorting";
 import { KanbanCard } from "./components/KanbanCard";
@@ -29,7 +29,7 @@ export function TasksBoardView({
 	allStatuses,
 	onTaskClick,
 }: TasksBoardViewProps) {
-	const collections = useCollections();
+	const { tasks: taskActions } = useOptimisticCollectionActions();
 	const [activeTask, setActiveTask] = useState<TaskWithStatus | null>(null);
 
 	const sensors = useSensors(
@@ -95,11 +95,9 @@ export function TasksBoardView({
 			const task = data.find((t) => t.id === taskId);
 			if (!task || task.statusId === targetStatusId) return;
 
-			collections.tasks.update(taskId, (draft) => {
-				draft.statusId = targetStatusId;
-			});
+			taskActions.updateStatus(taskId, targetStatusId);
 		},
-		[data, collections],
+		[data, taskActions],
 	);
 
 	const handleDragCancel = useCallback(() => {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/components/TasksTableView/TasksTableView.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/components/TasksTableView/TasksTableView.test.ts
@@ -11,12 +11,13 @@ function readComponent(relativePath: string): string {
 }
 
 describe("Tasks table delete wiring", () => {
-	test("TaskContextMenu deletes tasks through the collections API", () => {
+	test("TaskContextMenu deletes tasks through optimistic task actions", () => {
 		const source = readComponent(
 			"components/TaskContextMenu/TaskContextMenu.tsx",
 		);
 
-		expect(source).toContain("collections.tasks.delete(task.id)");
+		expect(source).toContain("useOptimisticCollectionActions");
+		expect(source).toContain("taskActions.deleteTask(task.id)");
 		expect(source).toContain("onSelect={handleDelete}");
 	});
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/components/TasksTableView/components/TaskContextMenu/TaskContextMenu.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/components/TasksTableView/components/TaskContextMenu/TaskContextMenu.tsx
@@ -17,6 +17,7 @@ import {
 	HiOutlineUserCircle,
 } from "react-icons/hi2";
 import { useCopyToClipboard } from "renderer/hooks/useCopyToClipboard";
+import { useOptimisticCollectionActions } from "renderer/routes/_authenticated/hooks/useOptimisticCollectionActions";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 import type { TaskWithStatus } from "../../../../hooks/useTasksTable";
 import { compareStatusesForDropdown } from "../../../../utils/sorting";
@@ -38,6 +39,7 @@ export function TaskContextMenu({
 	onDelete,
 }: TaskContextMenuProps) {
 	const collections = useCollections();
+	const { tasks: taskActions } = useOptimisticCollectionActions();
 
 	const { data: allStatuses } = useLiveQuery(
 		(q) => q.from({ taskStatuses: collections.taskStatuses }),
@@ -57,36 +59,15 @@ export function TaskContextMenu({
 	const users = useMemo(() => allUsers || [], [allUsers]);
 
 	const handleStatusChange = (status: SelectTaskStatus) => {
-		try {
-			collections.tasks.update(task.id, (draft) => {
-				draft.statusId = status.id;
-			});
-		} catch (error) {
-			console.error("[TaskContextMenu] Failed to update status:", error);
-		}
+		taskActions.updateStatus(task.id, status.id);
 	};
 
 	const handleAssigneeChange = (userId: string | null) => {
-		try {
-			collections.tasks.update(task.id, (draft) => {
-				draft.assigneeId = userId;
-				draft.assigneeExternalId = null;
-				draft.assigneeDisplayName = null;
-				draft.assigneeAvatarUrl = null;
-			});
-		} catch (error) {
-			console.error("[TaskContextMenu] Failed to update assignee:", error);
-		}
+		taskActions.updateAssignee(task.id, userId);
 	};
 
 	const handlePriorityChange = (priority: typeof task.priority) => {
-		try {
-			collections.tasks.update(task.id, (draft) => {
-				draft.priority = priority;
-			});
-		} catch (error) {
-			console.error("[TaskContextMenu] Failed to update priority:", error);
-		}
+		taskActions.updatePriority(task.id, priority);
 	};
 
 	const { copyToClipboard } = useCopyToClipboard();
@@ -100,11 +81,9 @@ export function TaskContextMenu({
 	};
 
 	const handleDelete = () => {
-		try {
-			collections.tasks.delete(task.id);
+		const transaction = taskActions.deleteTask(task.id);
+		if (transaction) {
 			onDelete?.();
-		} catch (error) {
-			console.error("[TaskContextMenu] Failed to delete task:", error);
 		}
 	};
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/hooks/useTasksTable/components/AssigneeCell/AssigneeCell.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/hooks/useTasksTable/components/AssigneeCell/AssigneeCell.tsx
@@ -9,6 +9,7 @@ import { useLiveQuery } from "@tanstack/react-db";
 import type { CellContext } from "@tanstack/react-table";
 import { useMemo, useState } from "react";
 import { HiOutlineUserCircle } from "react-icons/hi2";
+import { useOptimisticCollectionActions } from "renderer/routes/_authenticated/hooks/useOptimisticCollectionActions";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 import type { TaskWithStatus } from "../../useTasksTable";
 
@@ -18,6 +19,7 @@ interface AssigneeCellProps {
 
 export function AssigneeCell({ info }: AssigneeCellProps) {
 	const collections = useCollections();
+	const { tasks: taskActions } = useOptimisticCollectionActions();
 	const [open, setOpen] = useState(false);
 
 	const task = info.row.original;
@@ -36,14 +38,10 @@ export function AssigneeCell({ info }: AssigneeCellProps) {
 			return;
 		}
 
-		setOpen(false);
-
-		collections.tasks.update(task.id, (draft) => {
-			draft.assigneeId = userId;
-			draft.assigneeExternalId = null;
-			draft.assigneeDisplayName = null;
-			draft.assigneeAvatarUrl = null;
-		});
+		const transaction = taskActions.updateAssignee(task.id, userId);
+		if (transaction) {
+			setOpen(false);
+		}
 	};
 
 	return (

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/hooks/useTasksTable/components/PriorityCell/PriorityCell.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/hooks/useTasksTable/components/PriorityCell/PriorityCell.tsx
@@ -7,7 +7,7 @@ import {
 } from "@superset/ui/dropdown-menu";
 import type { CellContext } from "@tanstack/react-table";
 import { useState } from "react";
-import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
+import { useOptimisticCollectionActions } from "renderer/routes/_authenticated/hooks/useOptimisticCollectionActions";
 import { PriorityIcon } from "../../../../components/shared/PriorityIcon";
 import { ALL_PRIORITIES } from "../../../../utils/sorting";
 import type { TaskWithStatus } from "../../useTasksTable";
@@ -25,7 +25,7 @@ const PRIORITY_LABELS: Record<TaskPriority, string> = {
 };
 
 export function PriorityCell({ info }: PriorityCellProps) {
-	const collections = useCollections();
+	const { tasks: taskActions } = useOptimisticCollectionActions();
 	const [open, setOpen] = useState(false);
 
 	const task = info.row.original;
@@ -38,13 +38,9 @@ export function PriorityCell({ info }: PriorityCellProps) {
 			return;
 		}
 
-		try {
-			collections.tasks.update(task.id, (draft) => {
-				draft.priority = newPriority;
-			});
+		const transaction = taskActions.updatePriority(task.id, newPriority);
+		if (transaction) {
 			setOpen(false);
-		} catch (error) {
-			console.error("[PriorityCell] Failed to update priority:", error);
 		}
 	};
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/hooks/useTasksTable/components/StatusCell/StatusCell.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/hooks/useTasksTable/components/StatusCell/StatusCell.tsx
@@ -7,6 +7,7 @@ import {
 } from "@superset/ui/dropdown-menu";
 import { useLiveQuery } from "@tanstack/react-db";
 import { useMemo, useState } from "react";
+import { useOptimisticCollectionActions } from "renderer/routes/_authenticated/hooks/useOptimisticCollectionActions";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 import {
 	StatusIcon,
@@ -22,6 +23,7 @@ interface StatusCellProps {
 
 export function StatusCell({ taskWithStatus }: StatusCellProps) {
 	const collections = useCollections();
+	const { tasks: taskActions } = useOptimisticCollectionActions();
 	const [open, setOpen] = useState(false);
 
 	const { data: allStatuses } = useLiveQuery(
@@ -42,13 +44,12 @@ export function StatusCell({ taskWithStatus }: StatusCellProps) {
 			return;
 		}
 
-		try {
-			collections.tasks.update(taskWithStatus.id, (draft) => {
-				draft.statusId = newStatus.id;
-			});
+		const transaction = taskActions.updateStatus(
+			taskWithStatus.id,
+			newStatus.id,
+		);
+		if (transaction) {
 			setOpen(false);
-		} catch (error) {
-			console.error("[StatusCell] Failed to update status:", error);
 		}
 	};
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/V2PresetsBar/V2PresetsBar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/V2PresetsBar/V2PresetsBar.tsx
@@ -1,8 +1,3 @@
-import {
-	AGENT_PRESET_COMMANDS,
-	AGENT_PRESET_DESCRIPTIONS,
-	AGENT_TYPES,
-} from "@superset/shared/agent-command";
 import { Button } from "@superset/ui/button";
 import {
 	DropdownMenu,
@@ -13,9 +8,9 @@ import {
 } from "@superset/ui/dropdown-menu";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { useNavigate } from "@tanstack/react-router";
+import { Eye, EyeOff, Settings } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { HiMiniCog6Tooth, HiMiniCommandLine } from "react-icons/hi2";
-import { LuCirclePlus, LuPin } from "react-icons/lu";
+import { HiMiniCommandLine } from "react-icons/hi2";
 import {
 	getPresetIcon,
 	useIsDarkTheme,
@@ -34,7 +29,7 @@ interface V2PresetsBarProps {
 
 // Co-located to keep v2 self-contained. Mirrors the v1 array in
 // renderer/hotkeys/registry.ts; order matches the registry OPEN_PRESET_{n}
-// definitions so PRESET_HOTKEY_IDS[i] targets the i-th pinned preset.
+// definitions so PRESET_HOTKEY_IDS[i] targets the i-th visible preset.
 const PRESET_HOTKEY_IDS: HotkeyId[] = [
 	"OPEN_PRESET_1",
 	"OPEN_PRESET_2",
@@ -47,24 +42,9 @@ const PRESET_HOTKEY_IDS: HotkeyId[] = [
 	"OPEN_PRESET_9",
 ];
 
-interface PresetTemplate {
-	name: string;
-	description: string;
-	cwd: string;
-	commands: string[];
-}
-
-const QUICK_ADD_PRESET_TEMPLATES: PresetTemplate[] = AGENT_TYPES.map(
-	(agent) => ({
-		name: agent,
-		description: AGENT_PRESET_DESCRIPTIONS[agent],
-		cwd: "",
-		commands: AGENT_PRESET_COMMANDS[agent],
-	}),
-);
-
-function isPresetPinnedToBar(pinnedToBar: boolean | undefined): boolean {
-	// Backward-compatibility rule mirroring v1: undefined defaults to pinned.
+function isPresetVisibleInBar(pinnedToBar: boolean | undefined): boolean {
+	// The persisted field is legacy "pinned" wording; the v2 UI treats it as
+	// show/hide visibility. Undefined defaults to visible for compatibility.
 	return pinnedToBar !== false;
 }
 
@@ -73,11 +53,11 @@ function areStringArraysEqual(left: string[], right: string[]): boolean {
 	return left.every((value, index) => value === right[index]);
 }
 
-function getPinnedPresetOrder(
+function getVisiblePresetOrder(
 	presets: ReadonlyArray<{ id: string; pinnedToBar?: boolean }>,
 ): string[] {
 	return presets.flatMap((preset) =>
-		isPresetPinnedToBar(preset.pinnedToBar) ? [preset.id] : [],
+		isPresetVisibleInBar(preset.pinnedToBar) ? [preset.id] : [],
 	);
 }
 
@@ -90,96 +70,56 @@ export function V2PresetsBar({
 	const collections = useCollections();
 	useMigrateV1PresetsToV2();
 
-	const [localPinnedPresetIds, setLocalPinnedPresetIds] = useState<string[]>(
-		() => getPinnedPresetOrder(matchedPresets),
+	const [localVisiblePresetIds, setLocalVisiblePresetIds] = useState<string[]>(
+		() => getVisiblePresetOrder(matchedPresets),
 	);
 
 	useEffect(() => {
-		const serverPinnedPresetIds = getPinnedPresetOrder(matchedPresets);
-		setLocalPinnedPresetIds((current) =>
-			areStringArraysEqual(current, serverPinnedPresetIds)
+		const serverVisiblePresetIds = getVisiblePresetOrder(matchedPresets);
+		setLocalVisiblePresetIds((current) =>
+			areStringArraysEqual(current, serverVisiblePresetIds)
 				? current
-				: serverPinnedPresetIds,
+				: serverVisiblePresetIds,
 		);
 	}, [matchedPresets]);
 
-	const presetsByName = useMemo(() => {
-		const map = new Map<string, V2TerminalPresetRow[]>();
-		for (const preset of matchedPresets) {
-			const existing = map.get(preset.name);
-			if (existing) {
-				existing.push(preset);
-				continue;
-			}
-			map.set(preset.name, [preset]);
-		}
-		return map;
-	}, [matchedPresets]);
-
-	const pinnedPresets = useMemo(() => {
+	const visiblePresets = useMemo(() => {
 		const presetById = new Map(
 			matchedPresets.map((preset, index) => [preset.id, { preset, index }]),
 		);
-		const orderedPinnedPresets: Array<{
+		const orderedVisiblePresets: Array<{
 			preset: V2TerminalPresetRow;
 			index: number;
 		}> = [];
 		const seenIds = new Set<string>();
 
-		for (const presetId of localPinnedPresetIds) {
+		for (const presetId of localVisiblePresetIds) {
 			const item = presetById.get(presetId);
 			if (!item) continue;
-			if (!isPresetPinnedToBar(item.preset.pinnedToBar)) continue;
-			orderedPinnedPresets.push(item);
+			if (!isPresetVisibleInBar(item.preset.pinnedToBar)) continue;
+			orderedVisiblePresets.push(item);
 			seenIds.add(presetId);
 		}
 
 		for (const [index, preset] of matchedPresets.entries()) {
-			if (!isPresetPinnedToBar(preset.pinnedToBar)) continue;
+			if (!isPresetVisibleInBar(preset.pinnedToBar)) continue;
 			if (seenIds.has(preset.id)) continue;
-			orderedPinnedPresets.push({ preset, index });
+			orderedVisiblePresets.push({ preset, index });
 		}
 
-		return orderedPinnedPresets;
-	}, [matchedPresets, localPinnedPresetIds]);
+		return orderedVisiblePresets;
+	}, [matchedPresets, localVisiblePresetIds]);
 
-	const presetIndexById = useMemo(
-		() => new Map(matchedPresets.map((preset, index) => [preset.id, index])),
-		[matchedPresets],
+	const visiblePresetIndexById = useMemo(
+		() =>
+			new Map(
+				visiblePresets.map(({ preset }, visibleIndex) => [
+					preset.id,
+					visibleIndex,
+				]),
+			),
+		[visiblePresets],
 	);
-
-	const managedPresets = useMemo(() => {
-		const templateNames = new Set(
-			QUICK_ADD_PRESET_TEMPLATES.map((t) => t.name),
-		);
-		const primaryTemplatePresetIds = new Set(
-			QUICK_ADD_PRESET_TEMPLATES.flatMap((template) => {
-				const match = presetsByName.get(template.name)?.[0];
-				return match ? [match.id] : [];
-			}),
-		);
-		const fromTemplates = QUICK_ADD_PRESET_TEMPLATES.map((template) => ({
-			key: `template:${template.name}`,
-			name: template.name,
-			preset: presetsByName.get(template.name)?.[0],
-			template,
-			iconName: template.name,
-		}));
-		const customExisting = matchedPresets
-			.filter(
-				(preset) =>
-					!templateNames.has(preset.name) ||
-					!primaryTemplatePresetIds.has(preset.id),
-			)
-			.map((preset) => ({
-				key: `preset:${preset.id}`,
-				name: preset.name || "default",
-				preset: preset as V2TerminalPresetRow | undefined,
-				template: null as PresetTemplate | null,
-				iconName: preset.name,
-			}));
-		return [...fromTemplates, ...customExisting];
-	}, [matchedPresets, presetsByName]);
 
 	const handleEditPreset = useCallback(
 		(presetId: string) => {
@@ -191,9 +131,9 @@ export function V2PresetsBar({
 		[navigate],
 	);
 
-	const handleLocalPinnedReorder = useCallback(
+	const handleLocalVisibleReorder = useCallback(
 		(fromIndex: number, toIndex: number) => {
-			setLocalPinnedPresetIds((current) => {
+			setLocalVisiblePresetIds((current) => {
 				if (
 					fromIndex < 0 ||
 					fromIndex >= current.length ||
@@ -211,63 +151,45 @@ export function V2PresetsBar({
 		[],
 	);
 
-	const handlePersistPinnedReorder = useCallback(
-		(presetId: string, targetPinnedIndex: number) => {
-			const reorderedPinnedPresetIds = [...localPinnedPresetIds];
-			const currentPinnedIndex = reorderedPinnedPresetIds.indexOf(presetId);
-			if (currentPinnedIndex === -1) return;
-			const [moved] = reorderedPinnedPresetIds.splice(currentPinnedIndex, 1);
-			reorderedPinnedPresetIds.splice(targetPinnedIndex, 0, moved);
+	const handlePersistVisibleReorder = useCallback(
+		(presetId: string, targetVisibleIndex: number) => {
+			const reorderedVisiblePresetIds = [...localVisiblePresetIds];
+			const currentVisibleIndex = reorderedVisiblePresetIds.indexOf(presetId);
+			if (currentVisibleIndex === -1) return;
+			const [moved] = reorderedVisiblePresetIds.splice(currentVisibleIndex, 1);
+			reorderedVisiblePresetIds.splice(targetVisibleIndex, 0, moved);
 
-			const pinnedSet = new Set(reorderedPinnedPresetIds);
-			const unpinned = matchedPresets
-				.filter((preset) => !pinnedSet.has(preset.id))
+			const visibleSet = new Set(reorderedVisiblePresetIds);
+			const hidden = matchedPresets
+				.filter((preset) => !visibleSet.has(preset.id))
 				.map((preset) => preset.id);
-			const finalOrder = [...reorderedPinnedPresetIds, ...unpinned];
+			const finalOrder = [...reorderedVisiblePresetIds, ...hidden];
+			const currentTabOrderById = new Map(
+				matchedPresets.map((preset) => [preset.id, preset.tabOrder]),
+			);
 
 			for (const [index, id] of finalOrder.entries()) {
+				if (currentTabOrderById.get(id) === index) continue;
 				collections.v2TerminalPresets.update(id, (draft) => {
 					draft.tabOrder = index;
 				});
 			}
 		},
-		[collections.v2TerminalPresets, localPinnedPresetIds, matchedPresets],
+		[collections.v2TerminalPresets, localVisiblePresetIds, matchedPresets],
 	);
 
-	const handleTogglePinned = useCallback(
-		(presetId: string, nextPinned: boolean) => {
+	const handleTogglePresetVisibility = useCallback(
+		(presetId: string, nextVisible: boolean) => {
 			collections.v2TerminalPresets.update(presetId, (draft) => {
-				draft.pinnedToBar = nextPinned;
+				draft.pinnedToBar = nextVisible;
 			});
 		},
 		[collections.v2TerminalPresets],
 	);
 
-	const handleCreateFromTemplate = useCallback(
-		(template: PresetTemplate) => {
-			const maxTabOrder = matchedPresets.reduce(
-				(max, preset) => Math.max(max, preset.tabOrder),
-				-1,
-			);
-			collections.v2TerminalPresets.insert({
-				id: crypto.randomUUID(),
-				name: template.name,
-				description: template.description,
-				cwd: template.cwd,
-				commands: template.commands,
-				projectIds: null,
-				pinnedToBar: true,
-				executionMode: "new-tab",
-				tabOrder: maxTabOrder + 1,
-				createdAt: new Date(),
-			});
-		},
-		[collections.v2TerminalPresets, matchedPresets],
-	);
-
 	return (
 		<div
-			className="flex items-center h-8 border-b border-border bg-background px-2 gap-0.5 overflow-x-auto shrink-0"
+			className="flex h-8 min-w-0 shrink-0 items-center gap-0.5 overflow-x-auto overflow-y-hidden border-b border-border bg-background px-2"
 			style={{ scrollbarWidth: "none" }}
 		>
 			<DropdownMenu>
@@ -275,7 +197,7 @@ export function V2PresetsBar({
 					<TooltipTrigger asChild>
 						<DropdownMenuTrigger asChild>
 							<Button variant="ghost" size="icon" className="size-6 shrink-0">
-								<HiMiniCog6Tooth className="size-3.5" />
+								<Settings className="size-3.5" />
 							</Button>
 						</DropdownMenuTrigger>
 					</TooltipTrigger>
@@ -283,32 +205,22 @@ export function V2PresetsBar({
 						Manage Presets
 					</TooltipContent>
 				</Tooltip>
-				<DropdownMenuContent align="start" className="w-56">
-					{managedPresets.map((item) => {
-						const icon = getPresetIcon(item.iconName, isDark);
-						const isPinned = item.preset
-							? isPresetPinnedToBar(item.preset.pinnedToBar)
-							: false;
-						const hasPreset = !!item.preset;
-						const presetIndex = item.preset
-							? presetIndexById.get(item.preset.id)
-							: undefined;
+				<DropdownMenuContent align="end" className="w-56">
+					{matchedPresets.map((preset) => {
+						const icon = getPresetIcon(preset.name, isDark);
+						const isVisible = isPresetVisibleInBar(preset.pinnedToBar);
+						const visibleIndex = visiblePresetIndexById.get(preset.id);
 						const hotkeyId =
-							typeof presetIndex === "number"
-								? PRESET_HOTKEY_IDS[presetIndex]
+							typeof visibleIndex === "number"
+								? PRESET_HOTKEY_IDS[visibleIndex]
 								: undefined;
 						return (
 							<DropdownMenuItem
-								key={item.key}
+								key={preset.id}
 								className="gap-2"
 								onSelect={(event) => {
 									event.preventDefault();
-									if (hasPreset && item.preset) {
-										handleTogglePinned(item.preset.id, !isPinned);
-										return;
-									}
-									if (!item.template) return;
-									handleCreateFromTemplate(item.template);
+									handleTogglePresetVisibility(preset.id, !isVisible);
 								}}
 							>
 								{icon ? (
@@ -316,19 +228,17 @@ export function V2PresetsBar({
 								) : (
 									<HiMiniCommandLine className="size-4" />
 								)}
-								<span className="truncate">{item.name || "default"}</span>
+								<span className="min-w-0 flex-1 truncate">
+									{preset.name || "default"}
+								</span>
 								<div className="ml-auto flex items-center gap-2">
-									{hotkeyId ? <HotkeyMenuShortcut hotkeyId={hotkeyId} /> : null}
-									{hasPreset ? (
-										<LuPin
-											className={`size-3.5 ${
-												isPinned
-													? "text-foreground"
-													: "text-muted-foreground/60"
-											}`}
-										/>
+									{isVisible && hotkeyId ? (
+										<HotkeyMenuShortcut hotkeyId={hotkeyId} />
+									) : null}
+									{isVisible ? (
+										<Eye className="size-3.5 text-foreground" />
 									) : (
-										<LuCirclePlus className="size-3.5 text-muted-foreground" />
+										<EyeOff className="size-3.5 text-muted-foreground/60" />
 									)}
 								</div>
 							</DropdownMenuItem>
@@ -339,25 +249,24 @@ export function V2PresetsBar({
 						className="gap-2"
 						onClick={() => navigate({ to: "/settings/terminal" })}
 					>
-						<HiMiniCog6Tooth className="size-4" />
+						<Settings className="size-4" />
 						<span>Manage Presets</span>
 					</DropdownMenuItem>
 				</DropdownMenuContent>
 			</DropdownMenu>
-			<div className="h-4 w-px bg-border mx-1 shrink-0" />
-			{pinnedPresets.map(({ preset, index }, pinnedIndex) => {
-				const hotkeyId = PRESET_HOTKEY_IDS[index];
+			{visiblePresets.map(({ preset }, visibleIndex) => {
+				const hotkeyId = PRESET_HOTKEY_IDS[visibleIndex];
 				return (
 					<V2PresetBarItem
 						key={preset.id}
 						preset={preset}
-						pinnedIndex={pinnedIndex}
+						visibleIndex={visibleIndex}
 						hotkeyId={hotkeyId}
 						isDark={isDark}
 						onExecutePreset={executePreset}
 						onEdit={(presetToEdit) => handleEditPreset(presetToEdit.id)}
-						onLocalReorder={handleLocalPinnedReorder}
-						onPersistReorder={handlePersistPinnedReorder}
+						onLocalReorder={handleLocalVisibleReorder}
+						onPersistReorder={handlePersistVisibleReorder}
 					/>
 				);
 			})}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/V2PresetsBar/components/V2PresetBarItem/V2PresetBarItem.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/V2PresetsBar/components/V2PresetBarItem/V2PresetBarItem.tsx
@@ -19,18 +19,18 @@ const V2_PRESET_BAR_ITEM_TYPE = "V2_PRESET_BAR_ITEM";
 
 interface V2PresetBarItemProps {
 	preset: V2TerminalPresetRow;
-	pinnedIndex: number;
+	visibleIndex: number;
 	hotkeyId?: HotkeyId;
 	isDark: boolean;
 	onExecutePreset: (preset: V2TerminalPresetRow) => void;
 	onEdit: (preset: V2TerminalPresetRow) => void;
 	onLocalReorder: (fromIndex: number, toIndex: number) => void;
-	onPersistReorder: (presetId: string, targetPinnedIndex: number) => void;
+	onPersistReorder: (presetId: string, targetVisibleIndex: number) => void;
 }
 
 export function V2PresetBarItem({
 	preset,
-	pinnedIndex,
+	visibleIndex,
 	hotkeyId,
 	isDark,
 	onExecutePreset,
@@ -47,22 +47,22 @@ export function V2PresetBarItem({
 			type: V2_PRESET_BAR_ITEM_TYPE,
 			item: {
 				id: preset.id,
-				index: pinnedIndex,
-				originalIndex: pinnedIndex,
+				index: visibleIndex,
+				originalIndex: visibleIndex,
 			},
 			collect: (monitor) => ({
 				isDragging: monitor.isDragging(),
 			}),
 		}),
-		[preset.id, pinnedIndex],
+		[preset.id, visibleIndex],
 	);
 
 	const [, drop] = useDrop({
 		accept: V2_PRESET_BAR_ITEM_TYPE,
 		hover: (item: { id: string; index: number; originalIndex: number }) => {
-			if (item.index !== pinnedIndex) {
-				onLocalReorder(item.index, pinnedIndex);
-				item.index = pinnedIndex;
+			if (item.index !== visibleIndex) {
+				onLocalReorder(item.index, visibleIndex);
+				item.index = visibleIndex;
 			}
 		},
 		drop: (item: { id: string; index: number; originalIndex: number }) => {
@@ -89,15 +89,19 @@ export function V2PresetBarItem({
 							<Button
 								variant="ghost"
 								size="sm"
-								className="h-6 px-2 gap-1.5 text-xs shrink-0"
+								className="h-6 max-w-36 min-w-0 shrink-0 gap-1.5 px-2 text-xs"
 								onClick={() => onExecutePreset(preset)}
 							>
 								{icon ? (
-									<img src={icon} alt="" className="size-3.5 object-contain" />
+									<img
+										src={icon}
+										alt=""
+										className="size-3.5 shrink-0 object-contain"
+									/>
 								) : (
-									<HiMiniCommandLine className="size-3.5" />
+									<HiMiniCommandLine className="size-3.5 shrink-0" />
 								)}
-								<span className="truncate max-w-[120px]">
+								<span className="min-w-0 truncate">
 									{preset.name || "default"}
 								</span>
 							</Button>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/BrowserPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/BrowserPane.tsx
@@ -164,7 +164,7 @@ export function BrowserPaneToolbar({ ctx }: BrowserPaneToolbarProps) {
 	const PaneHeaderActions = ctx.components.PaneHeaderActions;
 
 	return (
-		<div className="flex h-full w-full items-center justify-between min-w-0">
+		<div className="flex h-full w-full min-w-0 items-center justify-between">
 			<BrowserToolbar
 				currentUrl={state.currentUrl}
 				pageTitle={state.pageTitle}
@@ -176,7 +176,7 @@ export function BrowserPaneToolbar({ ctx }: BrowserPaneToolbarProps) {
 				onReload={handleReload}
 				onNavigate={handleNavigate}
 			/>
-			<div className="flex items-center shrink-0 pr-1">
+			<div className="flex shrink-0 items-center pr-1">
 				<div className="mx-1.5 h-3.5 w-px bg-muted-foreground/60" />
 				<Tooltip>
 					<TooltipTrigger asChild>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/components/BrowserToolbar/BrowserToolbar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/components/BrowserToolbar/BrowserToolbar.tsx
@@ -107,8 +107,8 @@ export function BrowserToolbar({
 	);
 
 	return (
-		<div className="flex h-full flex-1 min-w-0 items-center px-2">
-			<div className="flex items-center gap-0.5 shrink-0">
+		<div className="flex h-full min-w-0 flex-1 items-center px-2">
+			<div className="flex shrink-0 items-center gap-0.5">
 				<Tooltip>
 					<TooltipTrigger asChild>
 						<button
@@ -158,8 +158,8 @@ export function BrowserToolbar({
 					</TooltipContent>
 				</Tooltip>
 			</div>
-			<div className="mx-1.5 h-3.5 w-px bg-muted-foreground/60" />
-			<div className="relative flex flex-1 min-w-0 items-center">
+			<div className="mx-1.5 h-3.5 w-px shrink-0 bg-muted-foreground/60" />
+			<div className="relative flex min-w-0 flex-1 items-center">
 				{isEditing ? (
 					<form
 						onSubmit={handleSubmit}
@@ -181,20 +181,21 @@ export function BrowserToolbar({
 				) : (
 					<button
 						type="button"
+						title={isBlank ? undefined : url}
 						onClick={enterEditMode}
-						className="group flex w-full min-w-0 items-baseline rounded-sm border border-transparent px-2 py-0.5 text-left text-xs"
+						className="group flex w-full min-w-0 items-center rounded-sm border border-transparent px-2 py-0.5 text-left text-xs"
 					>
 						{isBlank ? (
-							<span className="text-muted-foreground/40">
+							<span className="min-w-0 truncate text-muted-foreground/40">
 								Enter URL or search...
 							</span>
 						) : (
 							<>
-								<span className="min-w-0 truncate text-muted-foreground/60 transition-colors group-hover:text-foreground">
+								<span className="min-w-0 shrink truncate text-muted-foreground/60 transition-colors group-hover:text-foreground">
 									{url}
 								</span>
 								{pageTitle && (
-									<span className="min-w-0 ml-1 truncate text-muted-foreground/40 transition-opacity group-hover:opacity-0">
+									<span className="ml-1 min-w-0 flex-1 truncate text-muted-foreground/40 transition-opacity group-hover:opacity-0">
 										/ {pageTitle}
 									</span>
 								)}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatPane/ChatPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatPane/ChatPane.tsx
@@ -32,7 +32,7 @@ export function ChatPane({
 
 	return (
 		<div className="flex h-full w-full min-h-0 flex-col">
-			<div className="border-b border-border px-4 py-3">
+			<div className="flex h-8 shrink-0 items-center border-b border-border px-2">
 				<SessionSelector
 					currentSessionId={sessionId}
 					sessions={sessionItems}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatPane/components/SessionSelector/SessionSelector.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatPane/components/SessionSelector/SessionSelector.tsx
@@ -115,9 +115,10 @@ export function SessionSelector({
 			<DropdownMenuTrigger asChild>
 				<button
 					type="button"
+					title={currentTitle}
 					className="flex min-w-0 flex-1 items-center gap-1 rounded px-1.5 py-0.5 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
 				>
-					<HiMiniChevronDown className="size-3" />
+					<HiMiniChevronDown className="size-3 shrink-0" />
 					<span className="min-w-0 flex-1 truncate text-left">
 						{currentTitle}
 					</span>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatPane/hooks/useWorkspaceChatController/useWorkspaceChatController.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatPane/hooks/useWorkspaceChatController/useWorkspaceChatController.ts
@@ -9,6 +9,7 @@ import {
 	resolveDesktopChatOrganizationId,
 } from "renderer/lib/dev-chat";
 import { posthog } from "renderer/lib/posthog";
+import { useOptimisticCollectionActions } from "renderer/routes/_authenticated/hooks/useOptimisticCollectionActions";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 
 interface SessionSelectorItem {
@@ -53,16 +54,6 @@ async function createSessionRecord(input: {
 	}
 }
 
-async function deleteSessionRecord(sessionId: string): Promise<void> {
-	if (isDesktopChatDevMode()) return;
-	const result = await apiTrpcClient.chat.deleteSession.mutate({
-		sessionId,
-	});
-	if (!result.deleted) {
-		throw new Error(`Failed to delete session ${sessionId}`);
-	}
-}
-
 export function useWorkspaceChatController({
 	sessionId,
 	onSessionIdChange,
@@ -77,6 +68,7 @@ export function useWorkspaceChatController({
 		session?.session?.activeOrganizationId,
 	);
 	const collections = useCollections();
+	const { chatSessions: chatSessionActions } = useOptimisticCollectionActions();
 
 	const { data: workspace } = workspaceTrpc.workspace.get.useQuery(
 		{ id: workspaceId },
@@ -109,7 +101,11 @@ export function useWorkspaceChatController({
 
 	const handleDeleteSession = useCallback(
 		async (sessionIdToDelete: string) => {
-			await deleteSessionRecord(sessionIdToDelete);
+			const transaction = chatSessionActions.deleteSession(sessionIdToDelete);
+			if (!transaction && !isDesktopChatDevMode()) {
+				throw new Error("Failed to delete chat session");
+			}
+
 			posthog.capture("chat_session_deleted", {
 				workspace_id: workspaceId,
 				session_id: sessionIdToDelete,
@@ -119,7 +115,13 @@ export function useWorkspaceChatController({
 				onSessionIdChange(null);
 			}
 		},
-		[onSessionIdChange, organizationId, sessionId, workspaceId],
+		[
+			chatSessionActions,
+			onSessionIdChange,
+			organizationId,
+			sessionId,
+			workspaceId,
+		],
 	);
 
 	const getOrCreateSession = useCallback(async (): Promise<string> => {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/DiffFileHeader/DiffFileHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/DiffFileHeader/DiffFileHeader.tsx
@@ -50,17 +50,17 @@ export function DiffFileHeader({
 	const viewedId = useId();
 
 	return (
-		<div className="flex items-center justify-between gap-2 px-3 py-2">
+		<div className="@container/diff-file-header flex min-w-0 flex-wrap items-center justify-between gap-1 px-2 py-1.5">
 			<button
 				type="button"
 				onClick={onToggleCollapsed}
 				aria-label={collapsed ? "Expand file" : "Collapse file"}
-				className="rounded p-0.5 text-muted-foreground/60 transition-colors hover:bg-accent hover:text-muted-foreground"
+				className="shrink-0 rounded p-0.5 text-muted-foreground/60 transition-colors hover:bg-accent hover:text-muted-foreground"
 			>
 				{collapsed ? (
-					<ChevronRight className="size-4" />
+					<ChevronRight className="size-3.5" />
 				) : (
-					<ChevronDown className="size-4" />
+					<ChevronDown className="size-3.5" />
 				)}
 			</button>
 			<StatusIndicator status={status} />
@@ -78,13 +78,13 @@ export function DiffFileHeader({
 						}}
 						disabled={!onOpenFile && !onOpenInExternalEditor}
 						aria-label="Open in file viewer"
-						className="flex min-w-0 flex-1 items-center gap-2 rounded border border-border px-2 py-1 text-left transition-colors hover:bg-accent disabled:pointer-events-none disabled:opacity-60"
+						className="flex h-6 min-w-20 flex-[1_1_10rem] items-center gap-1.5 rounded border border-border px-1.5 py-0.5 text-left transition-colors hover:bg-accent disabled:pointer-events-none disabled:opacity-60"
 					>
-						<FileIcon fileName={path} className="size-4 shrink-0" />
-						<span className="truncate font-mono text-xs text-foreground">
+						<FileIcon fileName={path} className="size-3.5 shrink-0" />
+						<span className="min-w-0 flex-1 truncate font-mono text-xs text-foreground">
 							{path}
 						</span>
-						<span className="ml-1 shrink-0 font-mono text-[11px] text-muted-foreground">
+						<span className="hidden shrink-0 font-mono text-[10px] text-muted-foreground @min-[300px]/diff-file-header:inline">
 							{additions > 0 && (
 								<span className="text-green-700 dark:text-green-400">
 									+{additions}
@@ -99,12 +99,21 @@ export function DiffFileHeader({
 						</span>
 					</button>
 				</TooltipTrigger>
-				<TooltipContent side="bottom" showArrow={false}>
-					Open in file viewer. {CLICK_HINT_TOOLTIP}
+				<TooltipContent
+					side="bottom"
+					showArrow={false}
+					className="max-w-[80vw]"
+				>
+					<div className="space-y-1">
+						<div>Open in file viewer. {CLICK_HINT_TOOLTIP}</div>
+						<div className="break-all font-mono text-[10px] text-muted-foreground">
+							{path}
+						</div>
+					</div>
 				</TooltipContent>
 			</Tooltip>
 
-			<div className="flex shrink-0 items-center gap-2">
+			<div className="ml-auto flex shrink-0 items-center gap-1">
 				<Tooltip>
 					<TooltipTrigger asChild>
 						<span className="inline-flex rounded">
@@ -113,7 +122,7 @@ export function DiffFileHeader({
 								onClick={onOpenInExternalEditor}
 								disabled={!onOpenInExternalEditor}
 								aria-label="Open in editor"
-								className="rounded p-1 text-muted-foreground/60 transition-colors hover:bg-accent hover:text-muted-foreground disabled:pointer-events-none disabled:opacity-40"
+								className="rounded p-0.5 text-muted-foreground/60 transition-colors hover:bg-accent hover:text-muted-foreground disabled:pointer-events-none disabled:opacity-40"
 							>
 								<ExternalLink className="size-3.5" />
 							</button>
@@ -126,16 +135,16 @@ export function DiffFileHeader({
 					</TooltipContent>
 				</Tooltip>
 
-				<div className="flex items-center gap-1.5">
+				<div className="flex items-center gap-1">
 					<Checkbox
 						id={viewedId}
 						checked={viewed}
 						onCheckedChange={() => onToggleViewed()}
-						className="size-3.5 border-muted-foreground/50"
+						className="size-3 border-muted-foreground/50"
 					/>
 					<label
 						htmlFor={viewedId}
-						className="cursor-pointer select-none text-[11px] text-muted-foreground"
+						className="hidden cursor-pointer select-none text-[10px] text-muted-foreground @min-[380px]/diff-file-header:inline"
 					>
 						Viewed
 					</label>
@@ -150,7 +159,7 @@ export function DiffFileHeader({
 							aria-label={
 								expandUnchanged ? "Hide unchanged regions" : "Show all lines"
 							}
-							className="rounded p-1 text-muted-foreground/60 transition-colors hover:bg-accent hover:text-muted-foreground disabled:pointer-events-none disabled:opacity-40"
+							className="rounded p-0.5 text-muted-foreground/60 transition-colors hover:bg-accent hover:text-muted-foreground disabled:pointer-events-none disabled:opacity-40"
 						>
 							{expandUnchanged ? (
 								<EyeOff className="size-3.5" />
@@ -171,7 +180,7 @@ export function DiffFileHeader({
 							onClick={onCopyContents}
 							disabled={!onCopyContents}
 							aria-label="Copy file contents"
-							className="rounded p-1 text-muted-foreground/60 transition-colors hover:bg-accent hover:text-muted-foreground disabled:pointer-events-none disabled:opacity-40"
+							className="rounded p-0.5 text-muted-foreground/60 transition-colors hover:bg-accent hover:text-muted-foreground disabled:pointer-events-none disabled:opacity-40"
 						>
 							<LuCopy className="size-3.5" />
 						</button>
@@ -188,7 +197,7 @@ export function DiffFileHeader({
 							onClick={onDiscard}
 							disabled={!onDiscard}
 							aria-label="Discard changes"
-							className="rounded p-1 text-muted-foreground/60 transition-colors hover:bg-accent hover:text-destructive disabled:pointer-events-none disabled:opacity-40"
+							className="rounded p-0.5 text-muted-foreground/60 transition-colors hover:bg-accent hover:text-destructive disabled:pointer-events-none disabled:opacity-40"
 						>
 							<LuUndo2 className="size-3.5" />
 						</button>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/FilePane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/FilePane.tsx
@@ -1,6 +1,7 @@
 import type { RendererContext } from "@superset/panes";
 import { alert } from "@superset/ui/atoms/Alert";
 import { useCallback, useEffect } from "react";
+import { getBaseName } from "renderer/lib/pathBasename";
 import {
 	deriveMemoDisplayName,
 	getTrustedMemoRootPath,
@@ -88,7 +89,7 @@ function FilePaneContent({ context, workspaceId }: FilePaneProps) {
 	const hasConflict = document.conflict !== null;
 	useEffect(() => {
 		if (!hasConflict) return;
-		const name = filePath.split(/[/\\]/).pop();
+		const name = getBaseName(filePath);
 		alert({
 			title: `Do you want to save the changes you made to ${name}?`,
 			description: "Your changes will be lost if you don't save them.",

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/components/FilePaneHeaderExtras/FilePaneHeaderExtras.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/components/FilePaneHeaderExtras/FilePaneHeaderExtras.tsx
@@ -72,7 +72,7 @@ function FilePaneHeaderExtrasInner({
 	}, [filePath, openInExternalEditor]);
 
 	return (
-		<div className="flex items-center gap-1">
+		<div className="flex min-w-0 items-center gap-1">
 			{shouldShowToggle && activeView && (
 				<FileViewToggle
 					views={orderForToggle(views)}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/components/FileViewToggle/FileViewToggle.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/components/FileViewToggle/FileViewToggle.tsx
@@ -15,22 +15,27 @@ export function FileViewToggle({
 	onChange,
 }: FileViewToggleProps) {
 	return (
-		<div className="inline-flex items-center gap-0.5 rounded bg-muted p-0.5 text-xs">
-			{views.map((view) => (
-				<button
-					key={view.id}
-					type="button"
-					className={cn(
-						"rounded px-2 py-0.5 transition-colors",
-						view.id === activeViewId
-							? "bg-background text-foreground shadow-sm"
-							: "text-muted-foreground hover:text-foreground",
-					)}
-					onClick={() => onChange(view.id)}
-				>
-					{resolveViewLabel(view, filePath)}
-				</button>
-			))}
+		<div className="inline-flex h-5 min-w-0 items-center gap-0.5 rounded-md bg-muted/50 p-0.5">
+			{views.map((view) => {
+				const label = resolveViewLabel(view, filePath);
+
+				return (
+					<button
+						key={view.id}
+						type="button"
+						title={label}
+						className={cn(
+							"flex h-4 min-w-0 max-w-20 items-center rounded px-1.5 text-[10px] leading-none transition-colors",
+							view.id === activeViewId
+								? "bg-background text-foreground shadow-sm"
+								: "text-muted-foreground hover:text-foreground",
+						)}
+						onClick={() => onChange(view.id)}
+					>
+						<span className="min-w-0 truncate">{label}</span>
+					</button>
+				);
+			})}
 		</div>
 	);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/registry/views/ImageView/ImageView.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/registry/views/ImageView/ImageView.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { getBaseName } from "renderer/lib/pathBasename";
 import { getImageMimeType } from "shared/file-types";
 import type { ViewProps } from "../../types";
 
@@ -34,7 +35,7 @@ export function ImageView({ document, filePath }: ViewProps) {
 			>
 				<img
 					src={objectUrl}
-					alt={filePath.split("/").pop() ?? ""}
+					alt={getBaseName(filePath)}
 					className="block max-h-full max-w-full object-contain"
 					draggable={false}
 				/>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalSessionDropdown/TerminalSessionDropdown.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalSessionDropdown/TerminalSessionDropdown.tsx
@@ -214,13 +214,14 @@ export function TerminalSessionDropdown({
 				<button
 					type="button"
 					aria-label="Terminal sessions"
-					className="flex min-w-0 max-w-72 items-center gap-1.5 rounded px-1.5 py-0.5 text-sm text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+					title={triggerTitle}
+					className="@container/terminal-session flex min-w-0 max-w-full flex-1 items-center gap-1.5 rounded px-1.5 py-0.5 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
 					onMouseDown={(event) => event.stopPropagation()}
 					onClick={(event) => event.stopPropagation()}
 				>
-					<TerminalSquare className="size-4 shrink-0" />
+					<TerminalSquare className="size-3.5 shrink-0" />
 					<span className="min-w-0 truncate">{triggerTitle}</span>
-					<span className="shrink-0 text-[10px] text-muted-foreground/70">
+					<span className="hidden shrink-0 text-[10px] text-muted-foreground/70 @min-[160px]/terminal-session:inline">
 						{currentCreatedAtLabel}
 					</span>
 					{sessionsQuery.isFetching && isOpen ? (

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/usePaneRegistry.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/usePaneRegistry.tsx
@@ -119,8 +119,13 @@ function FilePaneTabTitleStatic({
 			)}
 			title={filePath}
 		>
-			<FileIcon fileName={getFileName(filePath)} className="size-3.5 shrink-0" />
-			<span className={cn("min-w-0 truncate", !pinned && "italic")}>{name}</span>
+			<FileIcon
+				fileName={getFileName(filePath)}
+				className="size-3.5 shrink-0"
+			/>
+			<span className={cn("min-w-0 truncate", !pinned && "italic")}>
+				{name}
+			</span>
 		</div>
 	);
 }
@@ -154,7 +159,10 @@ function FilePaneTabTitleWithDocument({
 			)}
 			title={filePath}
 		>
-			<FileIcon fileName={getFileName(filePath)} className="size-3.5 shrink-0" />
+			<FileIcon
+				fileName={getFileName(filePath)}
+				className="size-3.5 shrink-0"
+			/>
 			<span className={cn("min-w-0 truncate", !pinned && "italic")}>
 				{name}
 			</span>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/usePaneRegistry.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/usePaneRegistry.tsx
@@ -28,6 +28,7 @@ import {
 } from "react-icons/lu";
 import { TbScan } from "react-icons/tb";
 import { useHotkeyDisplay } from "renderer/hotkeys";
+import { getBaseName } from "renderer/lib/pathBasename";
 import { terminalRuntimeRegistry } from "renderer/lib/terminal/terminal-runtime-registry";
 import { FileIcon } from "renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/utils";
 import { useSettings } from "renderer/stores/settings";
@@ -56,18 +57,21 @@ import { TerminalHeaderExtras } from "./components/TerminalPane/components/Termi
 import { TerminalSessionDropdown } from "./components/TerminalPane/components/TerminalSessionDropdown";
 
 function getFileName(filePath: string): string {
-	// FORK NOTE: v2 desktop runs on Windows too, so split on both separators.
-	return filePath.split(/[/\\]/).pop() || filePath;
+	// FORK NOTE: v2 desktop runs on Windows too. getBaseName splits on both
+	// "/" and "\\" so this stays platform-correct.
+	return getBaseName(filePath);
 }
 
 function FilePaneTabTitle({
 	filePath,
 	displayName,
+	isActive,
 	pinned,
 	workspaceId,
 }: {
 	filePath: string;
 	displayName?: string;
+	isActive: boolean;
 	pinned: boolean;
 	workspaceId: string;
 }) {
@@ -79,6 +83,7 @@ function FilePaneTabTitle({
 			<FilePaneTabTitleStatic
 				filePath={filePath}
 				displayName={displayName}
+				isActive={isActive}
 				pinned={pinned}
 			/>
 		);
@@ -87,6 +92,7 @@ function FilePaneTabTitle({
 		<FilePaneTabTitleWithDocument
 			filePath={filePath}
 			displayName={displayName}
+			isActive={isActive}
 			pinned={pinned}
 			workspaceId={workspaceId}
 		/>
@@ -96,17 +102,25 @@ function FilePaneTabTitle({
 function FilePaneTabTitleStatic({
 	filePath,
 	displayName,
+	isActive,
 	pinned,
 }: {
 	filePath: string;
 	displayName?: string;
+	isActive: boolean;
 	pinned: boolean;
 }) {
 	const name = displayName ?? getFileName(filePath);
 	return (
-		<div className="flex items-center space-x-2">
-			<FileIcon fileName={getFileName(filePath)} className="size-4 shrink-0" />
-			<span className={pinned ? undefined : "italic"}>{name}</span>
+		<div
+			className={cn(
+				"flex min-w-0 items-center gap-1.5 text-xs transition-colors duration-150",
+				isActive ? "text-foreground" : "text-muted-foreground",
+			)}
+			title={filePath}
+		>
+			<FileIcon fileName={getFileName(filePath)} className="size-3.5 shrink-0" />
+			<span className={cn("min-w-0 truncate", !pinned && "italic")}>{name}</span>
 		</div>
 	);
 }
@@ -114,11 +128,13 @@ function FilePaneTabTitleStatic({
 function FilePaneTabTitleWithDocument({
 	filePath,
 	displayName,
+	isActive,
 	pinned,
 	workspaceId,
 }: {
 	filePath: string;
 	displayName?: string;
+	isActive: boolean;
 	pinned: boolean;
 	workspaceId: string;
 }) {
@@ -131,9 +147,17 @@ function FilePaneTabTitleWithDocument({
 	// the basename for everything else.
 	const name = displayName ?? getFileName(filePath);
 	return (
-		<div className="flex items-center space-x-2">
-			<FileIcon fileName={getFileName(filePath)} className="size-4 shrink-0" />
-			<span className={pinned ? undefined : "italic"}>{name}</span>
+		<div
+			className={cn(
+				"flex min-w-0 items-center gap-1.5 text-xs transition-colors duration-150",
+				isActive ? "text-foreground" : "text-muted-foreground",
+			)}
+			title={filePath}
+		>
+			<FileIcon fileName={getFileName(filePath)} className="size-3.5 shrink-0" />
+			<span className={cn("min-w-0 truncate", !pinned && "italic")}>
+				{name}
+			</span>
 			{document.dirty && (
 				<Circle className="size-2 shrink-0 fill-current text-muted-foreground" />
 			)}
@@ -151,7 +175,7 @@ function DiffViewModeToggle() {
 
 	const buttonClass = (active: boolean) =>
 		cn(
-			"flex size-6 items-center justify-center transition-colors",
+			"flex size-5 items-center justify-center transition-colors",
 			active
 				? "bg-secondary text-foreground"
 				: "text-muted-foreground hover:text-foreground",
@@ -192,7 +216,7 @@ function DiffViewModeToggle() {
 				</TooltipContent>
 			</Tooltip>
 			<div
-				className="mx-1.5 h-4 w-px bg-muted-foreground/30"
+				className="mx-1 h-3.5 w-px bg-muted-foreground/30"
 				aria-hidden="true"
 			/>
 		</div>
@@ -244,6 +268,7 @@ export function usePaneRegistry(
 						<FilePaneTabTitle
 							filePath={data.filePath}
 							displayName={data.displayName}
+							isActive={ctx.isActive}
 							pinned={Boolean(ctx.pane.pinned)}
 							workspaceId={workspaceId}
 						/>
@@ -261,7 +286,7 @@ export function usePaneRegistry(
 					const data = pane.data as FilePaneData;
 					const doc = getDocument(workspaceId, data.filePath);
 					if (!doc?.dirty) return true;
-					const name = data.filePath.split(/[/\\]/).pop();
+					const name = getFileName(data.filePath);
 					return new Promise<boolean>((resolve) => {
 						alert({
 							title: `Do you want to save the changes you made to ${name}?`,
@@ -303,7 +328,7 @@ export function usePaneRegistry(
 					),
 			},
 			diff: {
-				getIcon: () => <GitCompareArrows className="size-4" />,
+				getIcon: () => <GitCompareArrows className="size-3.5" />,
 				getTitle: () => "Changes",
 				renderPane: (ctx: RendererContext<PaneViewerData>) => (
 					<DiffPane
@@ -319,16 +344,16 @@ export function usePaneRegistry(
 					),
 			},
 			terminal: {
-				getIcon: () => <TerminalSquare className="size-4" />,
+				getIcon: () => <TerminalSquare className="size-3.5" />,
 				getTitle: () => "Terminal",
 				renderTitle: (ctx: RendererContext<PaneViewerData>) => (
-					<>
+					<div className="flex min-w-0 flex-1 items-center gap-1.5">
 						<TerminalSessionDropdown context={ctx} workspaceId={workspaceId} />
 						<V2NotificationStatusIndicator
 							workspaceId={workspaceId}
 							sources={getV2NotificationSourcesForPane(ctx.pane)}
 						/>
-					</>
+					</div>
 				),
 				renderHeaderExtras: (ctx: RendererContext<PaneViewerData>) => (
 					<TerminalHeaderExtras context={ctx} />
@@ -455,7 +480,7 @@ export function usePaneRegistry(
 				},
 			},
 			browser: {
-				getIcon: () => <Globe className="size-4" />,
+				getIcon: () => <Globe className="size-3.5" />,
 				getTitle: (pane) => {
 					const data = pane.data as BrowserPaneData;
 					if (data.pageTitle) return data.pageTitle;
@@ -483,14 +508,14 @@ export function usePaneRegistry(
 					),
 			},
 			chat: {
-				getIcon: () => <MessageSquare className="size-4" />,
+				getIcon: () => <MessageSquare className="size-3.5" />,
 				getTitle: () => "Chat",
 				renderTitle: (ctx: RendererContext<PaneViewerData>) => (
-					<>
-						<MessageSquare className="size-4 shrink-0" />
+					<div className="flex min-w-0 flex-1 items-center gap-1.5">
+						<MessageSquare className="size-3.5 shrink-0" />
 						<span
 							className={cn(
-								"truncate text-sm transition-colors duration-150",
+								"min-w-0 flex-1 truncate text-xs transition-colors duration-150",
 								ctx.isActive ? "text-foreground" : "text-muted-foreground",
 							)}
 						>
@@ -500,7 +525,7 @@ export function usePaneRegistry(
 							workspaceId={workspaceId}
 							sources={getV2NotificationSourcesForPane(ctx.pane)}
 						/>
-					</>
+					</div>
 				),
 				// Disabled until ChatServiceProvider is wired above v2 panes —
 				// TiptapPromptEditor needs its tRPC context.
@@ -518,10 +543,14 @@ export function usePaneRegistry(
 				getIcon: (ctx: RendererContext<PaneViewerData>) => {
 					const data = ctx.pane.data as CommentPaneData;
 					if (!data.avatarUrl) {
-						return <MessageSquare className="size-4" />;
+						return <MessageSquare className="size-3.5" />;
 					}
 					return (
-						<img src={data.avatarUrl} alt="" className="size-4 rounded-full" />
+						<img
+							src={data.avatarUrl}
+							alt=""
+							className="size-3.5 rounded-full"
+						/>
 					);
 				},
 				getTitle: (pane) => {
@@ -539,10 +568,10 @@ export function usePaneRegistry(
 							href={data.url}
 							target="_blank"
 							rel="noopener noreferrer"
-							className="flex items-center gap-0.5 text-muted-foreground hover:text-foreground"
+							className="flex shrink-0 items-center gap-0.5 rounded p-0.5 text-muted-foreground/60 transition-colors hover:text-muted-foreground"
 							aria-label="View on GitHub"
 						>
-							<FaGithub className="size-4" />
+							<FaGithub className="size-3.5" />
 							<LuArrowUpRight className="size-3" />
 						</a>
 					);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useWorkspaceHotkeys/useWorkspaceHotkeys.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useWorkspaceHotkeys/useWorkspaceHotkeys.ts
@@ -4,7 +4,7 @@ import {
 	type PaneRegistry,
 	type WorkspaceStore,
 } from "@superset/panes";
-import { useCallback, useRef } from "react";
+import { useCallback, useMemo, useRef } from "react";
 import { useHotkey } from "renderer/hotkeys";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 import type { V2TerminalPresetRow } from "renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal";
@@ -31,6 +31,10 @@ export function useWorkspaceHotkeys({
 	paneRegistry: PaneRegistry<PaneViewerData>;
 }) {
 	const collections = useCollections();
+	const visiblePresets = useMemo(
+		() => matchedPresets.filter((preset) => preset.pinnedToBar !== false),
+		[matchedPresets],
+	);
 
 	useHotkey("TOGGLE_SIDEBAR", () => {
 		if (!collections.v2WorkspaceLocalState.get(workspaceId)) return;
@@ -289,10 +293,10 @@ export function useWorkspaceHotkeys({
 
 	const openPresetByIndex = useCallback(
 		(index: number) => {
-			const preset = matchedPresets[index];
+			const preset = visiblePresets[index];
 			if (preset) executePreset(preset);
 		},
-		[matchedPresets, executePreset],
+		[visiblePresets, executePreset],
 	);
 
 	useHotkey("OPEN_PRESET_1", () => openPresetByIndex(0));

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
@@ -26,6 +26,7 @@ import {
 	dispatchBrowserShortcutEvent,
 } from "renderer/lib/browser-shortcut-events";
 import { electronTrpc } from "renderer/lib/electron-trpc";
+import { getBaseName } from "renderer/lib/pathBasename";
 import { createWorkspaceMemo } from "renderer/lib/workspace-memos";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 import {
@@ -709,8 +710,11 @@ function WorkspaceContent({
 
 	return (
 		<FileDocumentStoreProvider workspaceId={workspaceId}>
-			<ResizablePanelGroup direction="horizontal" className="flex-1">
-				<ResizablePanel defaultSize={80} minSize={30}>
+			<ResizablePanelGroup
+				direction="horizontal"
+				className="min-h-0 min-w-0 flex-1 overflow-auto"
+			>
+				<ResizablePanel className="min-w-[320px]" defaultSize={80} minSize={30}>
 					<div
 						className="flex min-h-0 min-w-0 h-full flex-col overflow-hidden"
 						data-workspace-id={workspaceId}
@@ -760,7 +764,7 @@ function WorkspaceContent({
 									return getDocument(workspaceId, filePath)?.dirty === true;
 								});
 								const dirtyFileNames = dirtyPanes.map((p) =>
-									(p.data as FilePaneData).filePath.split(/[/\\]/).pop(),
+									getBaseName((p.data as FilePaneData).filePath),
 								);
 								if (dirtyPanes.length === 0) return true;
 								const title =
@@ -819,7 +823,12 @@ function WorkspaceContent({
 				{sidebarOpen && (
 					<>
 						<ResizableHandle />
-						<ResizablePanel defaultSize={20} minSize={15} maxSize={40}>
+						<ResizablePanel
+							className="min-w-[220px]"
+							defaultSize={20}
+							minSize={15}
+							maxSize={40}
+						>
 							<WorkspaceSidebar
 								workspaceId={workspaceId}
 								workspaceName={workspaceName}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesList/components/V2WorkspaceRow/V2WorkspaceRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesList/components/V2WorkspaceRow/V2WorkspaceRow.tsx
@@ -130,9 +130,11 @@ export function V2WorkspaceRow({
 				className={cn(
 					V2_WORKSPACES_ROW_GRID,
 					"group/row relative min-w-0 px-6 py-2 text-sm outline-none",
-					"cursor-pointer transition-colors hover:bg-accent/50",
-					"focus-visible:bg-accent/50 focus-visible:ring-2 focus-visible:ring-ring/40 focus-visible:ring-inset",
-					isCurrentRoute && "bg-accent/40",
+					"cursor-pointer transition-colors",
+					"focus-visible:ring-2 focus-visible:ring-ring/40 focus-visible:ring-inset",
+					isCurrentRoute
+						? "bg-muted hover:bg-muted focus-visible:bg-muted"
+						: "hover:bg-accent/50 focus-visible:bg-accent/50",
 				)}
 			>
 				<div className="flex items-center justify-center">

--- a/apps/desktop/src/renderer/routes/_authenticated/hooks/useOptimisticCollectionActions/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/hooks/useOptimisticCollectionActions/index.ts
@@ -1,0 +1,4 @@
+export {
+	type PersistableTransaction,
+	useOptimisticCollectionActions,
+} from "./useOptimisticCollectionActions";

--- a/apps/desktop/src/renderer/routes/_authenticated/hooks/useOptimisticCollectionActions/useOptimisticCollectionActions.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/hooks/useOptimisticCollectionActions/useOptimisticCollectionActions.ts
@@ -1,0 +1,202 @@
+import type { TaskPriority } from "@superset/db/enums";
+import { toast } from "@superset/ui/sonner";
+import { useCallback, useMemo } from "react";
+import { isDesktopChatDevMode } from "renderer/lib/dev-chat";
+import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
+
+export type PersistableTransaction = {
+	isPersisted: {
+		promise: Promise<unknown>;
+	};
+};
+
+interface V2ProjectPatch {
+	name?: string;
+	slug?: string;
+	repoCloneUrl?: string | null;
+	githubRepositoryId?: string | null;
+}
+
+interface V2WorkspacePatch {
+	name?: string;
+	branch?: string;
+	hostId?: string;
+}
+
+function getErrorMessage(error: unknown): string {
+	if (error instanceof Error && error.message.trim()) {
+		return error.message;
+	}
+
+	if (typeof error === "string" && error.trim()) {
+		return error;
+	}
+
+	return "The local change was rolled back.";
+}
+
+function useOptimisticMutationRunner() {
+	const reportFailure = useCallback(
+		(scope: string, title: string, error: unknown) => {
+			console.error(`[${scope}] ${title}:`, error);
+			toast.error(title, {
+				description: getErrorMessage(error),
+			});
+		},
+		[],
+	);
+
+	return useCallback(
+		(
+			scope: string,
+			failureTitle: string,
+			mutation: () => PersistableTransaction,
+		): PersistableTransaction | null => {
+			try {
+				const transaction = mutation();
+
+				void transaction.isPersisted.promise.catch((error) => {
+					reportFailure(scope, failureTitle, error);
+				});
+
+				return transaction;
+			} catch (error) {
+				reportFailure(scope, failureTitle, error);
+				return null;
+			}
+		},
+		[reportFailure],
+	);
+}
+
+export function useOptimisticCollectionActions() {
+	const collections = useCollections();
+	const runMutation = useOptimisticMutationRunner();
+
+	return useMemo(() => {
+		const runTaskMutation = (
+			failureTitle: string,
+			mutation: () => PersistableTransaction,
+		) => runMutation("optimistic.tasks", failureTitle, mutation);
+
+		const runProjectMutation = (
+			failureTitle: string,
+			mutation: () => PersistableTransaction,
+		) => runMutation("optimistic.v2Projects", failureTitle, mutation);
+
+		const runWorkspaceMutation = (
+			failureTitle: string,
+			mutation: () => PersistableTransaction,
+		) => runMutation("optimistic.v2Workspaces", failureTitle, mutation);
+
+		const runChatSessionMutation = (
+			failureTitle: string,
+			mutation: () => PersistableTransaction,
+		) => runMutation("optimistic.chatSessions", failureTitle, mutation);
+
+		return {
+			tasks: {
+				updateTitle: (taskId: string, title: string) =>
+					runTaskMutation("Failed to update task title", () =>
+						collections.tasks.update(taskId, (draft) => {
+							draft.title = title;
+						}),
+					),
+				updateDescription: (taskId: string, description: string) =>
+					runTaskMutation("Failed to update task description", () =>
+						collections.tasks.update(taskId, (draft) => {
+							draft.description = description;
+						}),
+					),
+				updateStatus: (taskId: string, statusId: string) =>
+					runTaskMutation("Failed to update task status", () =>
+						collections.tasks.update(taskId, (draft) => {
+							draft.statusId = statusId;
+						}),
+					),
+				updatePriority: (taskId: string, priority: TaskPriority) =>
+					runTaskMutation("Failed to update task priority", () =>
+						collections.tasks.update(taskId, (draft) => {
+							draft.priority = priority;
+						}),
+					),
+				updateAssignee: (taskId: string, assigneeId: string | null) =>
+					runTaskMutation("Failed to update task assignee", () =>
+						collections.tasks.update(taskId, (draft) => {
+							draft.assigneeId = assigneeId;
+							draft.assigneeExternalId = null;
+							draft.assigneeDisplayName = null;
+							draft.assigneeAvatarUrl = null;
+						}),
+					),
+				deleteTask: (taskId: string) =>
+					runTaskMutation("Failed to delete task", () =>
+						collections.tasks.delete(taskId),
+					),
+			},
+			v2Projects: {
+				updateProject: (projectId: string, patch: V2ProjectPatch) =>
+					runProjectMutation("Failed to update project", () =>
+						collections.v2Projects.update(projectId, (draft) => {
+							if (patch.name !== undefined) {
+								draft.name = patch.name;
+							}
+							if (patch.slug !== undefined) {
+								draft.slug = patch.slug;
+							}
+							if (patch.repoCloneUrl !== undefined) {
+								draft.repoCloneUrl = patch.repoCloneUrl;
+							}
+							if (patch.githubRepositoryId !== undefined) {
+								draft.githubRepositoryId = patch.githubRepositoryId;
+							}
+						}),
+					),
+				renameProject: (projectId: string, name: string) =>
+					runProjectMutation("Failed to rename project", () =>
+						collections.v2Projects.update(projectId, (draft) => {
+							draft.name = name;
+						}),
+					),
+				updateRepository: (projectId: string, repoCloneUrl: string | null) =>
+					runProjectMutation("Failed to update project repository", () =>
+						collections.v2Projects.update(projectId, (draft) => {
+							draft.repoCloneUrl = repoCloneUrl;
+							draft.githubRepositoryId = null;
+						}),
+					),
+			},
+			v2Workspaces: {
+				updateWorkspace: (workspaceId: string, patch: V2WorkspacePatch) =>
+					runWorkspaceMutation("Failed to update workspace", () =>
+						collections.v2Workspaces.update(workspaceId, (draft) => {
+							if (patch.name !== undefined) {
+								draft.name = patch.name;
+							}
+							if (patch.branch !== undefined) {
+								draft.branch = patch.branch;
+							}
+							if (patch.hostId !== undefined) {
+								draft.hostId = patch.hostId;
+							}
+						}),
+					),
+				renameWorkspace: (workspaceId: string, name: string) =>
+					runWorkspaceMutation("Failed to rename workspace", () =>
+						collections.v2Workspaces.update(workspaceId, (draft) => {
+							draft.name = name;
+						}),
+					),
+			},
+			chatSessions: {
+				deleteSession: (sessionId: string) => {
+					if (isDesktopChatDevMode()) return null;
+
+					return runChatSessionMutation("Failed to delete chat session", () =>
+						collections.chatSessions.delete(sessionId),
+					);
+				},
+			},
+		};
+	}, [collections, runMutation]);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/collections.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/collections.ts
@@ -271,6 +271,22 @@ function createOrgCollections(organizationId: string): OrgCollections {
 				columnMapper,
 			},
 			getKey: (item) => item.id,
+			onUpdate: async ({ transaction }) => {
+				const { original, changes } = transaction.mutations[0];
+				const githubRepositoryId =
+					changes.githubRepositoryId === null &&
+					changes.repoCloneUrl !== undefined
+						? undefined
+						: changes.githubRepositoryId;
+				const result = await apiClient.v2Project.update.mutate({
+					id: original.id,
+					name: changes.name,
+					slug: changes.slug,
+					repoCloneUrl: changes.repoCloneUrl,
+					githubRepositoryId,
+				});
+				return { txid: result.txid };
+			},
 		}),
 	);
 
@@ -335,6 +351,17 @@ function createOrgCollections(organizationId: string): OrgCollections {
 				columnMapper,
 			},
 			getKey: (item) => item.id,
+			onUpdate: async ({ transaction }) => {
+				const { original, changes } = transaction.mutations[0];
+				const { branch, hostId, name } = changes;
+				const result = await apiClient.v2Workspace.update.mutate({
+					id: original.id,
+					branch,
+					hostId,
+					name,
+				});
+				return { txid: result.txid };
+			},
 		}),
 	);
 
@@ -487,6 +514,16 @@ function createOrgCollections(organizationId: string): OrgCollections {
 				columnMapper,
 			},
 			getKey: (item) => item.id,
+			onDelete: async ({ transaction }) => {
+				const item = transaction.mutations[0].original;
+				const result = await apiClient.chat.deleteSession.mutate({
+					sessionId: item.id,
+				});
+				if (!result.deleted) {
+					throw new Error("Chat session was not deleted");
+				}
+				return { txid: result.txid };
+			},
 		}),
 	);
 

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/PresetRow/PresetRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/PresetRow/PresetRow.tsx
@@ -1,8 +1,9 @@
 import { normalizeExecutionMode } from "@superset/local-db";
 import { Badge } from "@superset/ui/badge";
+import { Eye, EyeOff } from "lucide-react";
 import { useEffect, useRef } from "react";
 import { useDrag, useDrop } from "react-dnd";
-import { LuGripVertical, LuPin } from "react-icons/lu";
+import { LuGripVertical } from "react-icons/lu";
 import type { TerminalPreset } from "renderer/routes/_authenticated/settings/presets/types";
 import {
 	getPresetProjectTargetLabel,
@@ -19,7 +20,7 @@ interface PresetRowProps {
 	onEdit: (presetId: string) => void;
 	onLocalReorder: (fromIndex: number, toIndex: number) => void;
 	onPersistReorder: (presetId: string, targetIndex: number) => void;
-	onTogglePin: (presetId: string, pinned: boolean) => void;
+	onToggleVisibility: (presetId: string, visible: boolean) => void;
 }
 
 export function PresetRow({
@@ -30,7 +31,7 @@ export function PresetRow({
 	onEdit,
 	onLocalReorder,
 	onPersistReorder,
-	onTogglePin,
+	onToggleVisibility,
 }: PresetRowProps) {
 	const rowRef = useRef<HTMLDivElement>(null);
 	const dragHandleRef = useRef<HTMLDivElement>(null);
@@ -68,6 +69,7 @@ export function PresetRow({
 
 	const isWorkspaceCreation = !!preset.applyOnWorkspaceCreated;
 	const isNewTab = !!preset.applyOnNewTab;
+	const isVisibleInBar = preset.pinnedToBar !== false;
 	const modeValue = normalizeExecutionMode(preset.executionMode);
 	const modeLabel =
 		modeValue === "new-tab"
@@ -163,22 +165,17 @@ export function PresetRow({
 					className="p-1 rounded hover:bg-accent/50 transition-colors"
 					onClick={(e) => {
 						e.stopPropagation();
-						const isPinned = preset.pinnedToBar !== false;
-						onTogglePin(preset.id, !isPinned);
+						onToggleVisibility(preset.id, !isVisibleInBar);
 					}}
-					title={preset.pinnedToBar !== false ? "Unpin from bar" : "Pin to bar"}
-					aria-label={
-						preset.pinnedToBar !== false ? "Unpin from bar" : "Pin to bar"
-					}
-					aria-pressed={preset.pinnedToBar !== false}
+					title={isVisibleInBar ? "Hide from bar" : "Show in bar"}
+					aria-label={isVisibleInBar ? "Hide from bar" : "Show in bar"}
+					aria-pressed={isVisibleInBar}
 				>
-					<LuPin
-						className={`size-3.5 ${
-							preset.pinnedToBar !== false
-								? "text-foreground"
-								: "text-muted-foreground/40"
-						}`}
-					/>
+					{isVisibleInBar ? (
+						<Eye className="size-3.5 text-foreground" />
+					) : (
+						<EyeOff className="size-3.5 text-muted-foreground/40" />
+					)}
 				</button>
 			</div>
 		</div>

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/PresetsSection/PresetsSection.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/PresetsSection/PresetsSection.tsx
@@ -312,11 +312,11 @@ export function PresetsSection({
 		[setPresetAutoApply],
 	);
 
-	const handleTogglePin = useCallback(
-		(presetId: string, pinned: boolean) => {
+	const handleToggleVisibility = useCallback(
+		(presetId: string, visible: boolean) => {
 			updatePreset.mutate({
 				id: presetId,
-				patch: { pinnedToBar: pinned },
+				patch: { pinnedToBar: visible },
 			});
 		},
 		[updatePreset],
@@ -485,7 +485,7 @@ export function PresetsSection({
 						onEdit={setEditingPreset}
 						onLocalReorder={handleLocalReorder}
 						onPersistReorder={handlePersistReorder}
-						onTogglePin={handleTogglePin}
+						onToggleVisibility={handleToggleVisibility}
 					/>
 					<p className="text-xs text-muted-foreground">
 						Click a preset row to edit details.

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/PresetsSection/components/PresetsTable/PresetsTable.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/PresetsSection/components/PresetsTable/PresetsTable.tsx
@@ -11,7 +11,7 @@ interface PresetsTableProps {
 	onEdit: (presetId: string) => void;
 	onLocalReorder: (fromIndex: number, toIndex: number) => void;
 	onPersistReorder: (presetId: string, targetIndex: number) => void;
-	onTogglePin: (presetId: string, pinned: boolean) => void;
+	onToggleVisibility: (presetId: string, visible: boolean) => void;
 }
 
 export function PresetsTable({
@@ -22,7 +22,7 @@ export function PresetsTable({
 	onEdit,
 	onLocalReorder,
 	onPersistReorder,
-	onTogglePin,
+	onToggleVisibility,
 }: PresetsTableProps) {
 	return (
 		<div className="rounded-lg border border-border overflow-hidden">
@@ -33,7 +33,7 @@ export function PresetsTable({
 				<div className="w-40 shrink-0">Applies to</div>
 				<div className="w-32 shrink-0">Mode</div>
 				<div className="w-36 shrink-0">Auto-run</div>
-				<div className="w-16 shrink-0 text-center">Pinned</div>
+				<div className="w-16 shrink-0 text-center">Visibility</div>
 			</div>
 
 			<div
@@ -55,7 +55,7 @@ export function PresetsTable({
 							onEdit={onEdit}
 							onLocalReorder={onLocalReorder}
 							onPersistReorder={onPersistReorder}
-							onTogglePin={onTogglePin}
+							onToggleVisibility={onToggleVisibility}
 						/>
 					))
 				) : (

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/V2PresetsSection/V2PresetsSection.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/V2PresetsSection/V2PresetsSection.tsx
@@ -393,9 +393,9 @@ export function V2PresetsSection({
 		[updateV2Preset],
 	);
 
-	const handleTogglePin = useCallback(
-		(presetId: string, pinned: boolean) => {
-			updateV2Preset(presetId, { pinnedToBar: pinned });
+	const handleToggleVisibility = useCallback(
+		(presetId: string, visible: boolean) => {
+			updateV2Preset(presetId, { pinnedToBar: visible });
 		},
 		[updateV2Preset],
 	);
@@ -557,7 +557,7 @@ export function V2PresetsSection({
 						onEdit={setEditingPreset}
 						onLocalReorder={handleLocalReorder}
 						onPersistReorder={handlePersistReorder}
-						onTogglePin={handleTogglePin}
+						onToggleVisibility={handleToggleVisibility}
 					/>
 					<p className="text-xs text-muted-foreground">
 						Click a preset row to edit details.

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/v2-project/$projectId/components/V2ProjectSettings/components/RepositorySection/RepositorySection.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/v2-project/$projectId/components/V2ProjectSettings/components/RepositorySection/RepositorySection.tsx
@@ -1,8 +1,7 @@
 import { Button } from "@superset/ui/button";
 import { Input } from "@superset/ui/input";
-import { toast } from "@superset/ui/sonner";
 import { useEffect, useRef, useState } from "react";
-import { apiTrpcClient } from "renderer/lib/api-trpc-client";
+import { useOptimisticCollectionActions } from "renderer/routes/_authenticated/hooks/useOptimisticCollectionActions";
 
 interface RepositorySectionProps {
 	projectId: string;
@@ -13,9 +12,9 @@ export function RepositorySection({
 	projectId,
 	currentRepoCloneUrl,
 }: RepositorySectionProps) {
+	const { v2Projects: projectActions } = useOptimisticCollectionActions();
 	const [isEditing, setIsEditing] = useState(false);
 	const [value, setValue] = useState(currentRepoCloneUrl ?? "");
-	const [isSaving, setIsSaving] = useState(false);
 	const inputRef = useRef<HTMLInputElement>(null);
 
 	useEffect(() => {
@@ -32,25 +31,18 @@ export function RepositorySection({
 		setIsEditing(false);
 	};
 
-	const save = async () => {
-		if (isSaving) return;
+	const save = () => {
 		const trimmed = value.trim();
 		if (trimmed === (currentRepoCloneUrl ?? "")) {
 			setIsEditing(false);
 			return;
 		}
-		setIsSaving(true);
-		try {
-			await apiTrpcClient.v2Project.update.mutate({
-				id: projectId,
-				repoCloneUrl: trimmed === "" ? null : trimmed,
-			});
-			toast.success("Repository updated");
+		const transaction = projectActions.updateRepository(
+			projectId,
+			trimmed === "" ? null : trimmed,
+		);
+		if (transaction) {
 			setIsEditing(false);
-		} catch (err) {
-			toast.error(err instanceof Error ? err.message : "Failed to update");
-		} finally {
-			setIsSaving(false);
 		}
 	};
 
@@ -67,7 +59,7 @@ export function RepositorySection({
 						onKeyDown={(e) => {
 							if (e.key === "Enter") {
 								e.preventDefault();
-								void save();
+								save();
 							} else if (e.key === "Escape") {
 								e.preventDefault();
 								cancelEdit();
@@ -79,12 +71,11 @@ export function RepositorySection({
 						variant="outline"
 						size="sm"
 						onClick={cancelEdit}
-						disabled={isSaving}
 					>
 						Cancel
 					</Button>
-					<Button type="button" size="sm" onClick={save} disabled={isSaving}>
-						{isSaving ? "Saving…" : "Save"}
+					<Button type="button" size="sm" onClick={save}>
+						Save
 					</Button>
 				</>
 			) : (

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/CollapsedWorkspaceItem.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/CollapsedWorkspaceItem.tsx
@@ -77,8 +77,8 @@ export function CollapsedWorkspaceItem({
 			onMouseEnter={onMouseEnter}
 			className={cn(
 				"relative flex items-center justify-center size-8 rounded-md",
-				"hover:bg-muted/50 transition-colors",
-				isActive && "bg-muted",
+				"transition-colors",
+				isActive ? "bg-muted hover:bg-muted" : "hover:bg-muted/50",
 			)}
 		>
 			<WorkspaceIcon

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceListItem.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceListItem.tsx
@@ -310,7 +310,8 @@ export function WorkspaceListItem({
 			onDoubleClick={isBranchWorkspace ? undefined : rename.startRename}
 			className={cn(
 				"flex w-full pl-3 pr-2 text-sm",
-				"hover:bg-muted/50 transition-colors text-left cursor-pointer",
+				"transition-colors text-left cursor-pointer",
+				isActive ? "hover:bg-muted" : "hover:bg-muted/50",
 				"group relative",
 				showBranchSubtitle ? "py-1.5" : "py-2 items-center",
 				isActive && "bg-muted",

--- a/packages/panes/src/react/components/Workspace/components/Tab/Tab.tsx
+++ b/packages/panes/src/react/components/Workspace/components/Tab/Tab.tsx
@@ -18,6 +18,7 @@ import type {
 	RendererContext,
 } from "../../../../types";
 import { Pane } from "./components/Pane";
+import { PANE_MIN_SIZE_CLASS_NAME } from "./constants";
 
 interface TabProps<TData> {
 	store: StoreApi<WorkspaceStore<TData>>;
@@ -55,6 +56,7 @@ function SplitView<TData>({
 	return (
 		<ResizablePanelGroup
 			ref={groupRef}
+			className="min-h-full min-w-full overflow-auto"
 			direction={node.direction}
 			onLayout={(sizes) => {
 				if (sizes[0] != null) {
@@ -70,7 +72,10 @@ function SplitView<TData>({
 				groupRef.current?.setLayout([50, 50]);
 			}}
 		>
-			<ResizablePanel defaultSize={firstSize}>
+			<ResizablePanel
+				className={PANE_MIN_SIZE_CLASS_NAME}
+				defaultSize={firstSize}
+			>
 				<LayoutNodeView
 					store={store}
 					tab={tab}
@@ -83,7 +88,10 @@ function SplitView<TData>({
 				/>
 			</ResizablePanel>
 			<ResizableHandle />
-			<ResizablePanel defaultSize={secondSize}>
+			<ResizablePanel
+				className={PANE_MIN_SIZE_CLASS_NAME}
+				defaultSize={secondSize}
+			>
 				<LayoutNodeView
 					store={store}
 					tab={tab}
@@ -165,7 +173,7 @@ export function Tab<TData>({
 	}
 
 	return (
-		<div className="flex h-full w-full min-h-0 min-w-0 overflow-hidden">
+		<div className="flex h-full w-full min-h-0 min-w-0 flex-1 overflow-auto">
 			<LayoutNodeView
 				store={store}
 				tab={tab}

--- a/packages/panes/src/react/components/Workspace/components/Tab/components/Pane/Pane.tsx
+++ b/packages/panes/src/react/components/Workspace/components/Tab/components/Pane/Pane.tsx
@@ -14,6 +14,7 @@ import type {
 	RendererContext,
 } from "../../../../../../types";
 import { PaneHeaderActions } from "../../../../../PaneHeaderActions";
+import { PANE_MIN_SIZE_CLASS_NAME } from "../../constants";
 import { DropZoneOverlay } from "./components/DropZoneOverlay";
 import { PaneContent } from "./components/PaneContent";
 import { PaneContextMenu } from "./components/PaneContextMenu";
@@ -225,7 +226,7 @@ export function Pane<TData>({
 			{/* biome-ignore lint/a11y/noStaticElementInteractions: clicking anywhere in a pane focuses it (standard IDE behavior) */}
 			<div
 				ref={setRefs}
-				className="relative flex h-full w-full flex-col overflow-hidden"
+				className={`relative flex h-full w-full ${PANE_MIN_SIZE_CLASS_NAME} flex-col overflow-hidden`}
 				onMouseDown={context.actions.focus}
 			>
 				<PaneHeader

--- a/packages/panes/src/react/components/Workspace/components/Tab/components/Pane/components/PaneHeader/PaneHeader.tsx
+++ b/packages/panes/src/react/components/Workspace/components/Tab/components/Pane/components/PaneHeader/PaneHeader.tsx
@@ -58,7 +58,7 @@ export function PaneHeader({
 			ref={setRef}
 			className={cn(
 				"flex h-7 shrink-0 items-center transition-[background-color] duration-150 cursor-grab",
-				isActive ? "bg-secondary" : "bg-tertiary",
+				isActive ? "bg-muted" : "bg-transparent",
 				isDragging && "opacity-30",
 			)}
 			onClick={(e) => {

--- a/packages/panes/src/react/components/Workspace/components/Tab/components/Pane/components/PaneHeader/components/DefaultHeaderContent/DefaultHeaderContent.tsx
+++ b/packages/panes/src/react/components/Workspace/components/Tab/components/Pane/components/PaneHeader/components/DefaultHeaderContent/DefaultHeaderContent.tsx
@@ -19,16 +19,17 @@ export function DefaultHeaderContent({
 	actionsContent,
 }: DefaultHeaderContentProps) {
 	return (
-		<div className="flex h-full w-full items-center justify-between px-3">
-			<div className="flex min-w-0 items-center gap-2">
+		<div className="flex h-full w-full min-w-0 items-center gap-2 px-3">
+			<div className="flex min-w-0 flex-1 items-center gap-2">
 				{titleContent ?? (
 					<>
 						{icon && <span className="shrink-0">{icon}</span>}
 						<span
 							className={cn(
-								"truncate text-sm transition-colors duration-150",
+								"truncate text-xs transition-colors duration-150",
 								isActive ? "text-foreground" : "text-muted-foreground",
 							)}
+							title={typeof title === "string" ? title : undefined}
 						>
 							{title}
 						</span>

--- a/packages/panes/src/react/components/Workspace/components/Tab/constants.ts
+++ b/packages/panes/src/react/components/Workspace/components/Tab/constants.ts
@@ -1,0 +1,1 @@
+export const PANE_MIN_SIZE_CLASS_NAME = "min-h-[160px] min-w-[260px]";

--- a/packages/panes/src/react/components/Workspace/components/TabBar/components/TabItem/TabItem.tsx
+++ b/packages/panes/src/react/components/Workspace/components/TabBar/components/TabItem/TabItem.tsx
@@ -110,7 +110,10 @@ export function TabItem<TData>({
 				<div
 					ref={setRef}
 					className={cn(
-						"group relative flex h-full w-full items-center border-r border-border",
+						"group relative flex h-full w-full items-center border-r border-border transition-colors",
+						isActive
+							? "bg-muted text-foreground"
+							: "text-muted-foreground/70 hover:bg-tertiary/20 hover:text-muted-foreground",
 						isPaneOver && "bg-primary/5",
 						isDragging && "opacity-30",
 					)}
@@ -119,7 +122,7 @@ export function TabItem<TData>({
 					{isEditing ? (
 						<div className="flex h-full w-full shrink-0 items-center px-2">
 							<TabRenameInput
-								className="text-sm w-full min-w-0 rounded border border-border bg-background px-1 py-0.5 text-foreground outline-none focus:ring-1 focus:ring-ring"
+								className="w-full min-w-0 rounded border border-border bg-background px-1 py-0.5 text-xs text-foreground outline-none focus:ring-1 focus:ring-ring"
 								maxLength={64}
 								onCancel={stopEditing}
 								onChange={setEditValue}
@@ -135,12 +138,7 @@ export function TabItem<TData>({
 							>
 								<TooltipTrigger asChild>
 									<button
-										className={cn(
-											"flex h-full w-full shrink-0 items-center gap-2 pl-3 pr-8 text-left text-sm transition-all",
-											isActive
-												? "bg-border/30 text-foreground"
-												: "text-muted-foreground/70 hover:bg-tertiary/20 hover:text-muted-foreground",
-										)}
+										className="flex h-full min-w-0 flex-1 items-center gap-1.5 pl-3 pr-1 text-left text-xs transition-colors"
 										onAuxClick={(event) => {
 											if (event.button === 1) {
 												event.preventDefault();
@@ -151,20 +149,25 @@ export function TabItem<TData>({
 										onDoubleClick={startEditing}
 										type="button"
 									>
-										{icon}
-										<span className="flex-1 truncate">{title}</span>
-										{accessory}
+										{icon && <span className="shrink-0">{icon}</span>}
+										<span className="min-w-0 flex-1 truncate">{title}</span>
+										{accessory && (
+											<span className="shrink-0 leading-none">{accessory}</span>
+										)}
 									</button>
 								</TooltipTrigger>
 								<TooltipContent side="bottom" showArrow={false}>
 									{title}
 								</TooltipContent>
 							</Tooltip>
-							<div className="absolute right-1 top-1/2 hidden -translate-y-1/2 items-center gap-0.5 group-hover:flex">
+							<div className="flex h-full w-7 shrink-0 items-center justify-center opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100">
 								<Tooltip delayDuration={500}>
 									<TooltipTrigger asChild>
 										<Button
-											className="size-6 cursor-pointer hover:bg-muted"
+											className={cn(
+												"size-5 cursor-pointer text-current",
+												isActive ? "hover:bg-foreground/10" : "hover:bg-muted",
+											)}
 											onClick={(event) => {
 												event.stopPropagation();
 												onClose();

--- a/packages/trpc/src/router/chat/chat.ts
+++ b/packages/trpc/src/router/chat/chat.ts
@@ -1,5 +1,6 @@
-import { db } from "@superset/db/client";
+import { db, dbWs } from "@superset/db/client";
 import { chatSessions } from "@superset/db/schema";
+import { getCurrentTxid } from "@superset/db/utils";
 import type { TRPCRouterRecord } from "@trpc/server";
 import { TRPCError } from "@trpc/server";
 import { and, eq } from "drizzle-orm";
@@ -140,18 +141,25 @@ export const chatRouter = {
 				});
 			}
 
-			const [deleted] = await db
-				.delete(chatSessions)
-				.where(
-					and(
-						eq(chatSessions.id, input.sessionId),
-						eq(chatSessions.organizationId, organizationId),
-						eq(chatSessions.createdBy, ctx.session.user.id),
-					),
-				)
-				.returning({ id: chatSessions.id });
+			const result = await dbWs.transaction(async (tx) => {
+				const [deleted] = await tx
+					.delete(chatSessions)
+					.where(
+						and(
+							eq(chatSessions.id, input.sessionId),
+							eq(chatSessions.organizationId, organizationId),
+							eq(chatSessions.createdBy, ctx.session.user.id),
+						),
+					)
+					.returning({ id: chatSessions.id });
 
-			return { deleted: !!deleted };
+				const txid = await getCurrentTxid(tx);
+
+				return { deleted, txid };
+			});
+			const { deleted, txid } = result;
+
+			return { deleted: !!deleted, txid };
 		}),
 
 	uploadAttachment: protectedProcedure

--- a/packages/trpc/src/router/v2-project/v2-project.ts
+++ b/packages/trpc/src/router/v2-project/v2-project.ts
@@ -4,6 +4,7 @@ import {
 	organizations,
 	v2Projects,
 } from "@superset/db/schema";
+import { getCurrentTxid } from "@superset/db/utils";
 import { parseGitHubRemote } from "@superset/shared/github-remote";
 import type { TRPCRouterRecord } from "@trpc/server";
 import { TRPCError } from "@trpc/server";
@@ -300,7 +301,7 @@ export const v2ProjectRouter = {
 				id: z.string().uuid(),
 				name: z.string().min(1).optional(),
 				slug: z.string().min(1).optional(),
-				githubRepositoryId: z.string().uuid().optional(),
+				githubRepositoryId: z.string().uuid().nullable().optional(),
 				repoCloneUrl: z.string().min(1).nullable().optional(),
 			}),
 		)
@@ -361,18 +362,25 @@ export const v2ProjectRouter = {
 					message: "No fields to update",
 				});
 			}
-			const [updated] = await dbWs
-				.update(v2Projects)
-				.set(data)
-				.where(eq(v2Projects.id, project.id))
-				.returning();
+			const result = await dbWs.transaction(async (tx) => {
+				const [updated] = await tx
+					.update(v2Projects)
+					.set(data)
+					.where(eq(v2Projects.id, project.id))
+					.returning();
+
+				const txid = await getCurrentTxid(tx);
+
+				return { updated, txid };
+			});
+			const { updated, txid } = result;
 			if (!updated) {
 				throw new TRPCError({
 					code: "NOT_FOUND",
 					message: "Project not found",
 				});
 			}
-			return updated;
+			return { ...updated, txid };
 		}),
 
 	delete: protectedProcedure

--- a/packages/trpc/src/router/v2-workspace/v2-workspace.ts
+++ b/packages/trpc/src/router/v2-workspace/v2-workspace.ts
@@ -1,5 +1,6 @@
 import { dbWs } from "@superset/db/client";
 import { v2Hosts, v2Projects, v2Workspaces } from "@superset/db/schema";
+import { getCurrentTxid } from "@superset/db/utils";
 import type { TRPCRouterRecord } from "@trpc/server";
 import { TRPCError } from "@trpc/server";
 import { and, eq } from "drizzle-orm";
@@ -170,18 +171,25 @@ export const v2WorkspaceRouter = {
 					message: "No fields to update",
 				});
 			}
-			const [updated] = await dbWs
-				.update(v2Workspaces)
-				.set(data)
-				.where(eq(v2Workspaces.id, workspace.id))
-				.returning();
+			const result = await dbWs.transaction(async (tx) => {
+				const [updated] = await tx
+					.update(v2Workspaces)
+					.set(data)
+					.where(eq(v2Workspaces.id, workspace.id))
+					.returning();
+
+				const txid = await getCurrentTxid(tx);
+
+				return { updated, txid };
+			});
+			const { updated, txid } = result;
 			if (!updated) {
 				throw new TRPCError({
 					code: "NOT_FOUND",
 					message: "Workspace not found",
 				});
 			}
-			return updated;
+			return { ...updated, txid };
 		}),
 
 	// JWT-authed rename endpoint called from host-service's AI rename flow.

--- a/plans/20260425-v2-terminal-rendering-divergences.md
+++ b/plans/20260425-v2-terminal-rendering-divergences.md
@@ -1,0 +1,240 @@
+# V2 Terminal Rendering Divergences vs VS Code / Hyper / Tabby
+
+Compares our v2 xterm.js setup against three reference Electron+xterm terminals
+and lists divergences that can plausibly cause rendering bugs (flicker, blurry
+text, cell drift, ghost glyphs, scroll jumps, GPU atlas issues).
+
+**Amended validation:** This document was reviewed against the current repo on
+2026-04-25. The points below now distinguish confirmed issues from weaker
+hypotheses and from items already handled by xterm internals.
+
+**Our code (shared by v2 via `terminal-runtime-registry`):**
+- `apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts`
+- `apps/desktop/src/renderer/lib/terminal/terminal-addons.ts`
+- v2 pane: `apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx`
+
+**References (verified locally):**
+- VS Code: `/Users/kietho/workplace/vscode/src/vs/workbench/contrib/terminal/browser/xterm/xtermTerminal.ts`
+- Tabby: `/Users/kietho/workplace/tabby/tabby-terminal/src/frontends/xtermFrontend.ts`
+- Hyper: `/Users/kietho/workplace/hyper/lib/components/term.tsx`
+
+---
+
+## 1. Font loading race on first open
+
+**Status:** Partially valid.
+
+**Us:** `terminal-runtime.ts:232` — `terminal.open(wrapper)` runs immediately
+after construction. xterm measures cell width with whatever font is resolved at
+that moment. If the final font loads after the first measurement, dimensions and
+WebGL atlas contents can diverge from the actual rendered font, causing
+mis-clipped chars, ghost glyphs, or first-paint reflow.
+
+**Correction:** The original text overemphasized JetBrains Mono. In our default
+stack, JetBrains Mono is a local/system font candidate, not an app-bundled
+`@font-face`. The stronger async risk is `SF Mono` via
+`apps/desktop/src/renderer/styles/bundled-fonts.css` (`font-display: swap`) and
+any user-selected font that is resolved through CSS font loading. Also, Tabby
+does not wait before `open()`; it opens first, waits a tick for font/layout
+settling, then configures colors/WebGL (`xtermFrontend.ts:275-306`).
+
+**Fix:** Do not make `createRuntime()` async unless the registry lifecycle is
+rewired. Prefer a bounded post-open font-settle step:
+- after `terminal.open(wrapper)`, wait for `document.fonts.ready` or
+  `document.fonts.load(\`${size}px ${family}\`)` when available;
+- then call `measureAndResize(runtime)`, `terminal.clearTextureAtlas()` if using
+  the built-in API or the WebGL addon is exposed, and `terminal.refresh(...)`;
+- apply the same settle/refit path after font changes at
+  `terminal-runtime.ts:317`.
+
+---
+
+## 2. `devicePixelRatio` / display-metrics monitoring
+
+**Status:** Mostly invalid as originally written.
+
+**Us:** Superset app code does not add its own DPR listener. However, xterm 6.1
+already monitors DPR internally:
+- `@xterm/xterm/src/browser/services/CoreBrowserService.ts` has
+  `ScreenDprMonitor`, implemented with `matchMedia("screen and (resolution:
+  ...dppx)")` and re-armed on every change.
+- `RenderService.handleDevicePixelRatioChange()` remeasures char size and
+  forwards DPR changes to the active renderer.
+- `@xterm/addon-webgl/src/WebglRenderer.ts` updates `_devicePixelRatio`, resizes
+  render dimensions, refreshes the atlas, and redraws.
+
+**Ref:** Tabby additionally subscribes to `displayMetricsChanged$` and clears
+both atlases:
+```
+xtermFrontend.ts:290  this.webGLAddon?.clearTextureAtlas()
+xtermFrontend.ts:301  this.canvasAddon?.clearTextureAtlas()
+```
+
+**Fix:** Do not add an app-level DPR listener without a reproducible Electron
+case showing xterm's built-in monitor is insufficient. If we later see stale
+atlases after monitor moves or zoom changes, expose a `forceRedraw()`/atlas-clear
+method from our addon loader and call it from the existing visibility/focus
+recovery path, not from a duplicate global DPR watcher by default.
+
+---
+
+## 3. Subpixel container sizing in v2 pane
+
+**Status:** Plausible, but overclaimed.
+
+**Us:** `TerminalPane.tsx:382-396`
+```
+className="flex h-full w-full flex-col p-2"      ← outer p-2
+  └ "relative min-h-0 flex-1 overflow-hidden"     ← flex-1 middle
+      └ "h-full w-full"                            ← xterm mounts here
+```
+
+`connectionState === "closed"` adds a real sibling row at `TerminalPane.tsx:405`.
+`TerminalSearch` is absolute positioned and does not participate in flex layout,
+so it should not be counted as a sizing sibling. The outer `p-2` and flex sizing
+can still leave the xterm parent with fractional CSS dimensions depending on the
+split/pane layout. `fitAddon.fit()` floors cols/rows based on parsed parent
+dimensions and xterm's WebGL canvas derives its own rounded CSS dimensions from
+device pixels, so this remains a plausible source of 1-2px drift or blur.
+
+**Ref:** VS Code does not pad the xterm container itself; Hyper applies padding via `term.element.style.padding` (`term.tsx:253,460`) so xterm sees and accounts for it.
+
+**Fix:** Instrument before changing layout: log/compare the container
+`contentRect`, `terminal.dimensions.css.canvas`, and actual canvas style size
+across split widths and DPR values. If confirmed, either move padding off the
+wrapper chain so xterm mounts in a stable integer-sized box, or apply padding via
+`terminal.element.style.padding` after `open()` like Hyper so the fit addon
+subtracts it intentionally.
+
+---
+
+## 4. ResizeObserver fires `fit()` undebounced
+
+**Status:** Valid.
+
+**Us:** `terminal-runtime.ts:284-285` — observer callback calls `measureAndResize` (which calls `fitAddon.fit()`) directly. Sidebar/pane animations fire 10+ times per second.
+
+**Ref:**
+- Tabby defers via `setImmediate` (`xtermFrontend.ts:508`).
+- Hyper uses `setTimeout` debounce (`term.tsx:486`).
+- VS Code uses `@debounce(100)` on refresh paths.
+
+**Fix:** Wrap the observer callback in a ~50-100ms debounce, or rAF + trailing
+edge. Skip when `entry.contentRect.width === 0 || height === 0`. Also only call
+`onResize`/send backend resize when `terminal.cols` or `terminal.rows` actually
+changed; the current callback always calls `onResize?.()` after `measureAndResize`.
+
+---
+
+## 5. No scroll-position preservation across resize
+
+**Status:** Valid.
+
+**Us:** `terminal-runtime.ts:207-212` `measureAndResize` calls `fit()` without saving viewport.
+
+**Ref:** Tabby saves and restores around resize:
+```
+xtermFrontend.ts:427  const savedViewportY = this.xterm.buffer.active.viewportY
+xtermFrontend.ts:432  // Restore scroll position — xterm internally disturbs viewportY
+xtermFrontend.ts:437  if (this.xterm.buffer.active.viewportY !== targetY) ...
+```
+
+**Fix:** Mirror Tabby's pattern in `measureAndResize`, but preserve pinned-to-bottom
+separately:
+- before `fit()`, capture `viewportY`, `baseY`, and whether the viewport is at
+  the bottom;
+- after `fit()`, if it was pinned, `scrollToBottom()`;
+- otherwise clamp the saved `viewportY` to the new `baseY` and `scrollToLine`.
+
+---
+
+## 6. Missing xterm options
+
+**Status:** Partially valid, but not all options are rendering-bug fixes.
+
+**Us:** `terminal-runtime.ts:106-108` sets `cursorBlink`, `fontFamily`, `fontSize`, theme, scrollback. Does **not** set `minimumContrastRatio`, `drawBoldTextInBrightColors`, or `allowTransparency`.
+
+**Ref:** VS Code sets all three:
+```
+xtermTerminal.ts:226  drawBoldTextInBrightColors: config.drawBoldTextInBrightColors
+xtermTerminal.ts:235  minimumContrastRatio: config.minimumContrastRatio
+xtermTerminal.ts:261  allowTransparency: config.enableImages
+```
+
+**Correction:** `drawBoldTextInBrightColors` defaults to `true` in xterm 6.1, so
+setting it explicitly is documentation more than behavior change. Built-in
+terminal backgrounds are opaque hex colors (`ember`, `monokai`, `light`, and the
+dark/light defaults), while only selection colors use alpha; therefore
+`allowTransparency: false` is currently the correct performance-oriented value.
+`minimumContrastRatio: 4.5` is valid for accessibility, but it changes colors
+dynamically and should be treated as a product/color decision rather than a
+rendering-fidelity fix.
+
+**Fix:** Optionally set `drawBoldTextInBrightColors: true` and
+`allowTransparency: false` explicitly to lock in intended behavior. Defer
+`minimumContrastRatio` to a separate accessibility/theme decision.
+
+---
+
+## 7. No PTY backpressure on the renderer side
+
+**Status:** Valid problem, incomplete proposed fix.
+
+**Us:** Stream handler calls `terminal.write(data)` without the completion callback, so xterm's internal queue can grow unbounded under bursty output (e.g. `cat large.log`).
+
+**Ref:** Tabby's `FlowControl` class blocks past N pending callbacks:
+```
+xtermFrontend.ts:25   class FlowControl {
+xtermFrontend.ts:119  this.flowControl = new FlowControl(this.xterm)
+```
+
+**Correction:** Browser `WebSocket` cannot be paused like a Node stream. Host
+service sends with `socket.send(JSON.stringify(message))` and does not currently
+have a renderer ack/backpressure protocol. A renderer-side write queue can
+prevent unbounded xterm writes, but it will not stop upstream buffering by itself.
+
+**Fix:** Short term: wrap `terminal.write(data, callback)` in a renderer queue
+with high/low watermarks so xterm is not flooded. Long term: add an explicit
+pause/resume or credit/ack protocol between renderer and host service before
+claiming end-to-end PTY backpressure.
+
+---
+
+## 8. WebGL/ligatures recreation on context loss
+
+**Status:** Partially valid, but the original wording was inaccurate.
+
+**Us:** `terminal-addons.ts:43` loads `LigaturesAddon` in try/catch. WebGL load
+at `:46-56` already registers `webglAddon.onContextLoss`, disposes the WebGL
+addon, nulls it, and refreshes. What is missing is an intentional reinitialization
+strategy after falling back to DOM and any coordination between ligatures and
+WebGL atlas recreation.
+
+**Ref:** VS Code has `_refreshLigaturesAddon()` that disposes+recreates when WebGL toggles or recovers (xtermTerminal.ts, search `_refreshLigaturesAddon`).
+
+**Fix:** Keep the existing context-loss disposal, but expose a recovery path:
+dispose/recreate WebGL and refresh ligatures when GPU rendering is re-enabled or
+on the next visibility/focus recovery. Lower priority because it only triggers on
+real GPU resets.
+
+---
+
+## Suggested fix order
+
+1. Resize handling (#4 + #5) — debounce observer callbacks, skip zero-size
+   entries, send backend resize only on cols/rows changes, and preserve
+   scroll/pinned-to-bottom state across `fit()`.
+2. Font settle/refit (#1) — add a bounded post-open and post-font-change font
+   readiness/refit path without making the registry lifecycle accidentally async.
+3. Subpixel padding investigation (#3) — instrument actual container/canvas sizes
+   first; only then move padding or apply it via `terminal.element.style.padding`.
+4. xterm option explicitness (#6) — explicitly set defaults we rely on
+   (`drawBoldTextInBrightColors: true`, `allowTransparency: false`) if desired;
+   treat `minimumContrastRatio` as a separate theme/accessibility decision.
+5. Renderer write queue / protocol backpressure (#7) — useful for heavy output,
+   but needs a renderer queue first and host-service protocol work for true
+   backpressure.
+6. WebGL/ligature recovery (#8) — separate low-priority follow-up.
+
+Do not prioritize an app-level DPR listener (#2) unless there is a concrete repro
+showing xterm 6.1's built-in DPR monitor fails in our Electron window.


### PR DESCRIPTION
## Summary

upstream (superset-sh/superset) からの 9 commits 取り込みバッチの **PR2**（単一ファイル競合・UI 系 3 commits）。3 commits を `cherry-pick` で取り込み、merge-tree dry-run で予測した競合を fork 固有機能を保持する形で手動マージ。

## 取り込み内容

| Commit | upstream PR | 概要 |
|---|---|---|
| `3012b5a57` | #3722 | Optimistic Electric collection updates。tasks 系の status/priority/assignee 等を `useOptimisticCollectionActions` 経由の楽観更新に集約。 |
| `6a3be2d35` | #3739 | v2 terminal resize 安定化。`measureAndResize` がスクロール状態を保持し、`createResizeScheduler` で debounce + dispose を提供。 |
| `8928ac62e` | #3737 | v2 pane header 応答性改善。アイコンサイズ縮小、`isActive` ベースの `text-foreground` / `text-muted-foreground` 切替、`min-w-0 truncate` レイアウト等。 |

## Fork 側のコンフリクト解決

### `useDashboardSidebarWorkspaceItemActions.ts` (3012b5a57)
- import 競合: fork の `useCollections`（`handleDeleted` で使用）と upstream の `useOptimisticCollectionActions`（`submitRename` で使用）を**両方残す**。

### `terminal-runtime.ts` (6a3be2d35)
- `attachToContainer`: fork の `terminalRendererDebug.info` ログを残しつつ、upstream の `if (measureAndResize(runtime)) onResize?.()` 戻り値判定を採用。`runtime.terminal.refresh(0, ...)` は新 `measureAndResize` 内に内包されるので削除。
- `detachFromContainer`: fork の debug log を残しつつ、upstream の `_disposeResizeObserver` クリーンアップを末尾に追加。

### `FilePane.tsx` / `page.tsx` (8928ac62e)
- `getBaseName` import を採用（fork の `pathBasename.ts` は既に Windows 対応済み `/[/\\]/` 実装）。
- インラインの `filePath.split(/[/\\]/).pop()` を `getBaseName(filePath)` に置換。Windows 対応は維持。

### `useWorkspaceHotkeys.ts` (8928ac62e)
- `useMemo` import を追加。upstream の `visiblePresets` filter（`pinnedToBar !== false`）を採用。
- fork の `useCollections` ベースの sidebar 状態管理を維持し、upstream の `useV2UserPreferences` は不採用（fork は `v2WorkspaceLocalState` 経由で同等管理済み）。

### `usePaneRegistry.tsx` (8928ac62e、最大の競合 6 ブロック)
- `getFileName` を `getBaseName` ベースに統一（FORK NOTE で Windows 対応理由を残す）。
- fork の `FilePaneTabTitle` → `FilePaneTabTitleStatic` / `FilePaneTabTitleWithDocument` 二段構成（spreadsheet 分岐 + memo `displayName`）を維持しつつ、`isActive` プロパティを各層に伝播し、upstream の新スタイル（`min-w-0 items-center gap-1.5 text-xs transition-colors duration-150`、`size-3.5`、`isActive ? text-foreground : text-muted-foreground`、`title={filePath}` ホバー）を両方の Title コンポーネントに適用。
- `file.renderTitle` の prop 渡しで `displayName` と `isActive` を併存。
- `file.onBeforeClose` の name 計算を `getFileName(data.filePath)` に統一。

### format fix
- biome formatter による `<FileIcon ... />` の多行整形のみを別 commit として記録（`d3e31704d`）。

## Fork 固有機能ヘルスチェック

- 19 tRPC procedure: 全件健在
- ansi_up=1, @vscode/ripgrep=2, @xyflow/react=2 健在
- TERMINAL_OPTIONS / SUPERSET_WORKSPACE_NAME / moonshot-ai.kimi-code / MainWindowEffects / INCEPTION_AUTH_PROVIDER_ID / v1MigrationState / TiptapPromptEditor 全件健在
- desktop 1.5.10、drizzle idx (db=0035 / local-db=0072) 維持

## 検証

- `bun install`: ✅ (5757 packages, 154s)
- `bun run typecheck`: ✅ (27/27 successful)
- `bun run lint`: ✅ (Biome: 4323 files, no fixes applied; format fix は別 commit で吸収)
- `bun run --filter @superset/desktop compile:app`: ✅ (electron-vite build, 6m 4s, exit 0)

`bun run --filter @superset/desktop build` (electron-builder の dmg 生成) は時間消費が大きいので省略。マージ後の CI / リリース時に確認。

## 後続 PR の予定

- **PR3**（host-service restart、competing 領域に大幅 fork カスタマイズあり）: `1f55c623a` + `0fe65d230`
- **PR4**（remote ports 大物、78 files / 9 conflict）: `7c0d22b77`

## Test plan

- [ ] v2 ワークスペース: ファイルタブで isActive/non-active の文字色切替、ホバーで `title` 表示
- [ ] v2 ワークスペース: スプレッドシートファイル（.xlsx 等）でも displayName + Static title が正常表示
- [ ] v2 ワークスペース: メモタブで displayName が markdown 第1見出しに従う
- [ ] v2 ワークスペース: ターミナルペインのリサイズ時にスクロール位置が保持される（preset 切替・split 切替）
- [ ] v2 ワークスペース: ターミナル切替で `_disposeResizeObserver` がクリーンに走る（メモリリーク回帰なし）
- [ ] v2 ワークスペース: tasks 系（status/priority/assignee 変更）で楽観更新の挙動
- [ ] v2 ワークスペース: workspace rename が `useOptimisticCollectionActions.renameWorkspace` 経由で動く
- [ ] v2 ワークスペース: visiblePresets フィルタで `pinnedToBar=false` のプリセットが hotkey 対象から外れる

