### PR TITLE
upstream merge 2026-04-27 PR-D3: v2 cloud opt-in policy (fork流に書換)

### DIFF
--- a/apps/desktop/src/renderer/hooks/useIsV2CloudEnabled.ts
+++ b/apps/desktop/src/renderer/hooks/useIsV2CloudEnabled.ts
@@ -3,17 +3,17 @@ import { useFeatureFlagEnabled } from "posthog-js/react";
 import { useV2LocalOverrideStore } from "renderer/stores/v2-local-override";
 
 /**
- * Returns effective v2 state: remote PostHog flag AND local override.
+ * Returns effective v2 state: remote PostHog flag AND local opt-in.
  * Also returns the raw remote flag so the toggle can be shown conditionally.
  */
 export function useIsV2CloudEnabled() {
 	const remoteV2Enabled =
 		useFeatureFlagEnabled(FEATURE_FLAGS.V2_CLOUD) ?? false;
-	const forceV1 = useV2LocalOverrideStore((s) => s.forceV1);
+	const optInV2 = useV2LocalOverrideStore((s) => s.optInV2);
 
 	return {
 		/** The effective value — use this wherever you previously checked the flag directly. */
-		isV2CloudEnabled: remoteV2Enabled && !forceV1,
+		isV2CloudEnabled: remoteV2Enabled && optInV2,
 		/** Whether the remote PostHog flag is on (for showing the toggle). */
 		isRemoteV2Enabled: remoteV2Enabled,
 	};

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/VersionToggle/VersionToggle.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/VersionToggle/VersionToggle.tsx
@@ -3,8 +3,8 @@ import { cn } from "@superset/ui/utils";
 import { useV2LocalOverrideStore } from "renderer/stores/v2-local-override";
 
 export function VersionToggle() {
-	const { forceV1, toggle } = useV2LocalOverrideStore();
-	const activeVersion = forceV1 ? "v1" : "v2";
+	const { optInV2, toggle } = useV2LocalOverrideStore();
+	const activeVersion = optInV2 ? "v2" : "v1";
 
 	return (
 		<Tooltip delayDuration={300}>
@@ -37,9 +37,9 @@ export function VersionToggle() {
 				</button>
 			</TooltipTrigger>
 			<TooltipContent>
-				{forceV1
-					? "Early Access: Switch to Superset V2"
-					: "Switch to Superset V1"}
+				{optInV2
+					? "Switch to Superset V1"
+					: "Early Access: Switch to Superset V2"}
 			</TooltipContent>
 		</Tooltip>
 	);

--- a/apps/desktop/src/renderer/stores/v2-local-override.ts
+++ b/apps/desktop/src/renderer/stores/v2-local-override.ts
@@ -2,8 +2,8 @@ import { create } from "zustand";
 import { devtools, persist } from "zustand/middleware";
 
 interface V2LocalOverrideState {
-	/** When true, forces v1 mode locally even though v2 is enabled remotely. */
-	forceV1: boolean;
+	/** When true, the user has opted into v2. v2 is gated behind both the remote flag and this opt-in. */
+	optInV2: boolean;
 	toggle: () => void;
 }
 
@@ -11,10 +11,10 @@ export const useV2LocalOverrideStore = create<V2LocalOverrideState>()(
 	devtools(
 		persist(
 			(set, get) => ({
-				forceV1: false,
-				toggle: () => set({ forceV1: !get().forceV1 }),
+				optInV2: false,
+				toggle: () => set({ optInV2: !get().optInV2 }),
 			}),
-			{ name: "v2-local-override" },
+			{ name: "v2-local-override-v2" },
 		),
 		{ name: "V2LocalOverrideStore" },
 	),


### PR DESCRIPTION
## Summary

upstream 2026-04-27 後半バッチ第3弾。**PR-D3: v2 cloud opt-in policy** (1 commit + fork-specific 移植)。

> 依存: [#449 (PR-D2)](https://github.com/MocA-Love/superset/pull/449) の上に乗っている。

## 取り込み

| SHA | upstream | 概要 |
|---|---|---|
| 1 fork-specific | #3802 | v2 cloud を opt-out (`forceV1`) から opt-in (`optInV2`) へ反転 |

## upstream の意図

- `forceV1` を撤廃して `optInV2` を新設 (デフォルト false = v1)。明示的に opt-in したユーザーだけが v2 を使う形に変更
- persist key を `v2-local-override` → `v2-local-override-v2` に変更し、既存ユーザーは optInV2=false で初期化される (= v1 起動)
- `useIsV2CloudEnabled` の判定式は `remoteV2Enabled && optInV2` (PostHog flag AND opt-in)

## Fork 側コンフリクト解決

upstream は `setForceV1` setter ベースだが、fork の store API は `toggle()` メソッドを使う独自実装で、ExperimentalSettings UI も削除済み。raw cherry-pick せず手動移植:

### `apps/desktop/src/renderer/stores/v2-local-override.ts`
- `forceV1` → `optInV2` (型 / 初期値 / toggle ロジック)
- persist key を `v2-local-override-v2` に
- `toggle()` メソッドは fork API として維持

### `apps/desktop/src/renderer/hooks/useIsV2CloudEnabled.ts`
- `!forceV1` → `optInV2` に反転
- コメントも opt-in 表現へ更新

### `apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/VersionToggle/VersionToggle.tsx`
- store API 変更に追随 (`forceV1` → `optInV2`)
- active 表示と tooltip 文言も意味反転 (`forceV1 ? "v1" : "v2"` → `optInV2 ? "v2" : "v1"`)
- tooltip: `optInV2 ? "Switch to V1" : "Early Access: Switch to V2"`

## Fork ユーザーへの影響

`useIsV2CloudEnabled` の AND 条件は upstream そのまま (`remoteV2Enabled && optInV2`)。fork ユーザーで PostHog `V2_CLOUD` flag が無効な環境では、トグルを ON にしても **v2 が起動しない** 点は注意。これは PostHog gate 自体は撤廃していないため (upstream の挙動を尊重)。

PostHog flag が有効な fork ユーザーはこの PR 後、明示的にトグルを ON にしないと v2 が起動しなくなる (デフォ v1 起動)。

## Test plan

- [x] `bun install` 整合性 OK
- [x] `bun run typecheck` 全 28 task green
- [x] `bun run lint` biome green
- [ ] (手動) アプリ起動時に v1 起動 (デフォルト) を確認
- [ ] (手動) TopBar の VersionToggle で v2 へ切り替え (PostHog flag が ON の場合)
- [ ] (手動) persist key 変更により旧 `v2-local-override` の `forceV1` 設定がリセットされることを確認
