### PR TITLE
upstream merge 2026-05-08 PR 3: sidebar polish + jwt API

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarShortcuts/useDashboardSidebarShortcuts.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarShortcuts/useDashboardSidebarShortcuts.ts
@@ -2,8 +2,16 @@ import { useMatchRoute, useNavigate } from "@tanstack/react-router";
 import { useCallback, useMemo, useRef } from "react";
 import { useHotkey } from "renderer/hotkeys";
 import { navigateToV2Workspace } from "renderer/routes/_authenticated/_dashboard/utils/workspace-navigation";
+import { useDashboardSidebarState } from "renderer/routes/_authenticated/hooks/useDashboardSidebarState";
 import type { DashboardSidebarProject } from "../../types";
 import { getProjectChildrenWorkspaces } from "../../utils/projectChildren";
+
+interface WorkspaceLocation {
+	projectId: string;
+	projectIsCollapsed: boolean;
+	sectionId: string | null;
+	sectionIsCollapsed: boolean;
+}
 
 const MAX_SHORTCUT_COUNT = 9;
 
@@ -43,6 +51,8 @@ export function useDashboardSidebarShortcuts(
 	groups: DashboardSidebarProject[],
 ) {
 	const navigate = useNavigate();
+	const { toggleProjectCollapsed, toggleSectionCollapsed } =
+		useDashboardSidebarState();
 	const flattenedWorkspaces = useMemo(
 		() =>
 			groups
@@ -53,14 +63,55 @@ export function useDashboardSidebarShortcuts(
 	const workspaceShortcutLabels =
 		useStableWorkspaceShortcutLabels(flattenedWorkspaces);
 
+	const workspaceLocations = useMemo(() => {
+		const map = new Map<string, WorkspaceLocation>();
+		for (const project of groups) {
+			for (const child of project.children) {
+				if (child.type === "workspace") {
+					map.set(child.workspace.id, {
+						projectId: project.id,
+						projectIsCollapsed: project.isCollapsed,
+						sectionId: null,
+						sectionIsCollapsed: false,
+					});
+					continue;
+				}
+				for (const workspace of child.section.workspaces) {
+					map.set(workspace.id, {
+						projectId: project.id,
+						projectIsCollapsed: project.isCollapsed,
+						sectionId: child.section.id,
+						sectionIsCollapsed: child.section.isCollapsed,
+					});
+				}
+			}
+		}
+		return map;
+	}, [groups]);
+
+	const revealWorkspace = useCallback(
+		(workspaceId: string) => {
+			const location = workspaceLocations.get(workspaceId);
+			if (!location) return;
+			if (location.projectIsCollapsed) {
+				toggleProjectCollapsed(location.projectId);
+			}
+			if (location.sectionId && location.sectionIsCollapsed) {
+				toggleSectionCollapsed(location.sectionId);
+			}
+		},
+		[workspaceLocations, toggleProjectCollapsed, toggleSectionCollapsed],
+	);
+
 	const switchToWorkspace = useCallback(
 		(index: number) => {
 			const workspace = flattenedWorkspaces[index];
 			if (workspace) {
+				revealWorkspace(workspace.id);
 				navigateToV2Workspace(workspace.id, navigate);
 			}
 		},
-		[flattenedWorkspaces, navigate],
+		[flattenedWorkspaces, navigate, revealWorkspace],
 	);
 
 	useHotkey("JUMP_TO_WORKSPACE_1", () => switchToWorkspace(0));
@@ -88,7 +139,9 @@ export function useDashboardSidebarShortcuts(
 		);
 		if (index === -1) return;
 		const prevIndex = index <= 0 ? flattenedWorkspaces.length - 1 : index - 1;
-		navigateToV2Workspace(flattenedWorkspaces[prevIndex].id, navigate);
+		const target = flattenedWorkspaces[prevIndex];
+		revealWorkspace(target.id);
+		navigateToV2Workspace(target.id, navigate);
 	});
 
 	useHotkey("NEXT_WORKSPACE", () => {
@@ -98,7 +151,9 @@ export function useDashboardSidebarShortcuts(
 		);
 		if (index === -1) return;
 		const nextIndex = index >= flattenedWorkspaces.length - 1 ? 0 : index + 1;
-		navigateToV2Workspace(flattenedWorkspaces[nextIndex].id, navigate);
+		const target = flattenedWorkspaces[nextIndex];
+		revealWorkspace(target.id);
+		navigateToV2Workspace(target.id, navigate);
 	});
 
 	return workspaceShortcutLabels;

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/WorkspaceSidebar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/WorkspaceSidebar.tsx
@@ -131,6 +131,7 @@ export function WorkspaceSidebar({
 		workspaceId,
 		gitStatus,
 		onSelectFile: onSelectDiffFile,
+		onOpenFile: onSelectFile,
 	});
 	const changesTab: SidebarTabDefinition = {
 		...changesTabDef,

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/ChangesFileList.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/ChangesFileList.tsx
@@ -7,6 +7,7 @@ interface ChangesFileListProps {
 	isLoading?: boolean;
 	worktreePath?: string;
 	onSelectFile?: (path: string, openInNewTab?: boolean) => void;
+	onOpenFile?: (absolutePath: string, openInNewTab?: boolean) => void;
 	onOpenInEditor?: (path: string) => void;
 }
 
@@ -15,6 +16,7 @@ export const ChangesFileList = memo(function ChangesFileList({
 	isLoading,
 	worktreePath,
 	onSelectFile,
+	onOpenFile,
 	onOpenInEditor,
 }: ChangesFileListProps) {
 	if (isLoading) {
@@ -41,6 +43,7 @@ export const ChangesFileList = memo(function ChangesFileList({
 					file={file}
 					worktreePath={worktreePath}
 					onSelect={onSelectFile}
+					onOpenFile={onOpenFile}
 					onOpenInEditor={onOpenInEditor}
 				/>
 			))}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/components/FileRow/FileRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/components/FileRow/FileRow.tsx
@@ -6,7 +6,15 @@ import {
 	ContextMenuShortcut,
 	ContextMenuTrigger,
 } from "@superset/ui/context-menu";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuShortcut,
+	DropdownMenuTrigger,
+} from "@superset/ui/dropdown-menu";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
+import { ChevronDown } from "lucide-react";
 import { memo } from "react";
 import { StatusIndicator } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/StatusIndicator";
 import { PathActionsMenuItems } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/components/WorkspaceFilesTreeItem/components/PathActionsMenuItems";
@@ -33,6 +41,7 @@ interface FileRowProps {
 	file: ChangesetFile;
 	worktreePath?: string;
 	onSelect?: (path: string, openInNewTab?: boolean) => void;
+	onOpenFile?: (absolutePath: string, openInNewTab?: boolean) => void;
 	onOpenInEditor?: (path: string) => void;
 }
 
@@ -40,6 +49,7 @@ export const FileRow = memo(function FileRow({
 	file,
 	worktreePath,
 	onSelect,
+	onOpenFile,
 	onOpenInEditor,
 }: FileRowProps) {
 	const { dir, basename } = splitPath(file.path);
@@ -52,46 +62,90 @@ export const FileRow = memo(function FileRow({
 		: undefined;
 
 	const rowButton = (
-		<button
-			type="button"
-			className="flex w-full items-center gap-1.5 py-1 pr-3 pl-3 text-left text-xs hover:bg-accent/50"
-			onClick={(e) => {
-				const intent = getSidebarClickIntent(e);
-				if (intent === "openInEditor") {
-					onOpenInEditor?.(file.path);
-				} else {
-					onSelect?.(file.path, intent === "openInNewTab");
-				}
-			}}
-		>
-			<FileIcon fileName={basename} className="size-3.5 shrink-0" />
-			<span className="flex min-w-0 flex-1 items-baseline overflow-hidden">
-				{dir && <span className="truncate text-muted-foreground">{dir}</span>}
-				{oldBasename && (
-					<span className="truncate text-muted-foreground">
-						{oldBasename}
-						<span className="px-1">→</span>
+		<div className="group relative">
+			<button
+				type="button"
+				className="flex w-full items-center gap-1.5 py-1 pr-3 pl-3 text-left text-xs hover:bg-accent/50"
+				onClick={(e) => {
+					const intent = getSidebarClickIntent(e);
+					if (intent === "openInEditor") {
+						onOpenInEditor?.(file.path);
+					} else {
+						onSelect?.(file.path, intent === "openInNewTab");
+					}
+				}}
+			>
+				<FileIcon fileName={basename} className="size-3.5 shrink-0" />
+				<span className="flex min-w-0 flex-1 items-baseline overflow-hidden">
+					{dir && <span className="truncate text-muted-foreground">{dir}</span>}
+					{oldBasename && (
+						<span className="truncate text-muted-foreground">
+							{oldBasename}
+							<span className="px-1">→</span>
+						</span>
+					)}
+					<span className="min-w-[120px] truncate font-medium text-foreground">
+						{basename}
 					</span>
-				)}
-				<span className="min-w-[120px] truncate font-medium text-foreground">
-					{basename}
 				</span>
-			</span>
-			<span className="ml-auto flex shrink-0 items-center gap-1.5">
-				{(file.additions > 0 || file.deletions > 0) && (
-					<span className="text-[10px] text-muted-foreground">
-						{file.additions > 0 && (
-							<span className="text-green-400">+{file.additions}</span>
-						)}
-						{file.additions > 0 && file.deletions > 0 && " "}
-						{file.deletions > 0 && (
-							<span className="text-red-400">-{file.deletions}</span>
-						)}
-					</span>
-				)}
-				<StatusIndicator status={file.status} />
-			</span>
-		</button>
+				<span className="ml-auto flex shrink-0 items-center gap-1.5 group-hover:invisible">
+					{(file.additions > 0 || file.deletions > 0) && (
+						<span className="text-[10px] text-muted-foreground">
+							{file.additions > 0 && (
+								<span className="text-green-400">+{file.additions}</span>
+							)}
+							{file.additions > 0 && file.deletions > 0 && " "}
+							{file.deletions > 0 && (
+								<span className="text-red-400">-{file.deletions}</span>
+							)}
+						</span>
+					)}
+					<StatusIndicator status={file.status} />
+				</span>
+			</button>
+			<div className="pointer-events-none absolute inset-y-0 right-2 flex items-center gap-0.5 opacity-0 group-hover:pointer-events-auto group-hover:opacity-100 has-[[data-state=open]]:pointer-events-auto has-[[data-state=open]]:opacity-100">
+				<DropdownMenu>
+					<DropdownMenuTrigger asChild>
+						<button
+							type="button"
+							aria-label="More actions"
+							className="flex size-5 items-center justify-center rounded text-muted-foreground hover:bg-accent hover:text-foreground data-[state=open]:bg-accent data-[state=open]:text-foreground"
+							onClick={(e) => e.stopPropagation()}
+						>
+							<ChevronDown className="size-3.5" />
+						</button>
+					</DropdownMenuTrigger>
+					<DropdownMenuContent align="end" className="w-56">
+						<DropdownMenuItem onSelect={() => onSelect?.(file.path)}>
+							Open Diff
+						</DropdownMenuItem>
+						<DropdownMenuItem onSelect={() => onSelect?.(file.path, true)}>
+							Open Diff in New Tab
+							<DropdownMenuShortcut>{SHIFT_CLICK_LABEL}</DropdownMenuShortcut>
+						</DropdownMenuItem>
+						<DropdownMenuItem
+							onSelect={() => absolutePath && onOpenFile?.(absolutePath)}
+							disabled={!onOpenFile || !absolutePath}
+						>
+							Open File
+						</DropdownMenuItem>
+						<DropdownMenuItem
+							onSelect={() => absolutePath && onOpenFile?.(absolutePath, true)}
+							disabled={!onOpenFile || !absolutePath}
+						>
+							Open File in New Tab
+						</DropdownMenuItem>
+						<DropdownMenuItem
+							onSelect={() => onOpenInEditor?.(file.path)}
+							disabled={!onOpenInEditor}
+						>
+							Open in Editor
+							<DropdownMenuShortcut>{MOD_CLICK_LABEL}</DropdownMenuShortcut>
+						</DropdownMenuItem>
+					</DropdownMenuContent>
+				</DropdownMenu>
+			</div>
+		</div>
 	);
 
 	return (
@@ -109,6 +163,18 @@ export const FileRow = memo(function FileRow({
 				<ContextMenuItem onSelect={() => onSelect?.(file.path, true)}>
 					Open Diff in New Tab
 					<ContextMenuShortcut>{SHIFT_CLICK_LABEL}</ContextMenuShortcut>
+				</ContextMenuItem>
+				<ContextMenuItem
+					onSelect={() => absolutePath && onOpenFile?.(absolutePath)}
+					disabled={!onOpenFile || !absolutePath}
+				>
+					Open File
+				</ContextMenuItem>
+				<ContextMenuItem
+					onSelect={() => absolutePath && onOpenFile?.(absolutePath, true)}
+					disabled={!onOpenFile || !absolutePath}
+				>
+					Open File in New Tab
 				</ContextMenuItem>
 				<ContextMenuItem
 					onSelect={() => onOpenInEditor?.(file.path)}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesTabContent/ChangesTabContent.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesTabContent/ChangesTabContent.tsx
@@ -24,6 +24,7 @@ interface ChangesTabContentProps {
 	totalDeletions: number;
 	worktreePath?: string;
 	onSelectFile?: (path: string, openInNewTab?: boolean) => void;
+	onOpenFile?: (absolutePath: string, openInNewTab?: boolean) => void;
 	onOpenInEditor?: (path: string) => void;
 	onFilterChange: (filter: ChangesFilter) => void;
 	onBaseBranchChange: (branchName: string) => void;
@@ -44,6 +45,7 @@ export const ChangesTabContent = memo(function ChangesTabContent({
 	totalDeletions,
 	worktreePath,
 	onSelectFile,
+	onOpenFile,
 	onOpenInEditor,
 	onFilterChange,
 	onBaseBranchChange,
@@ -92,6 +94,7 @@ export const ChangesTabContent = memo(function ChangesTabContent({
 					isLoading={isLoading}
 					worktreePath={worktreePath}
 					onSelectFile={onSelectFile}
+					onOpenFile={onOpenFile}
 					onOpenInEditor={onOpenInEditor}
 				/>
 			</div>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/useChangesTab.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/useChangesTab.tsx
@@ -22,12 +22,14 @@ interface UseChangesTabParams {
 	workspaceId: string;
 	gitStatus: ReturnType<typeof useGitStatus>;
 	onSelectFile?: (path: string, openInNewTab?: boolean) => void;
+	onOpenFile?: (absolutePath: string, openInNewTab?: boolean) => void;
 }
 
 export function useChangesTab({
 	workspaceId,
 	gitStatus: status,
 	onSelectFile,
+	onOpenFile,
 }: UseChangesTabParams): SidebarTabDefinition {
 	const collections = useCollections();
 	const utils = workspaceTrpc.useUtils();
@@ -192,6 +194,7 @@ export function useChangesTab({
 			totalDeletions={totalDeletions}
 			worktreePath={worktreePath}
 			onSelectFile={onSelectFile}
+			onOpenFile={onOpenFile}
 			onOpenInEditor={handleOpenInEditor}
 			onFilterChange={setFilter}
 			onBaseBranchChange={setBaseBranch}

--- a/apps/docs/next.config.mjs
+++ b/apps/docs/next.config.mjs
@@ -29,12 +29,12 @@ const config = {
 		return [
 			{
 				source: "/",
-				destination: "/installation",
+				destination: "/overview",
 				permanent: false,
 			},
 			{
 				source: "/docs",
-				destination: "/installation",
+				destination: "/overview",
 				permanent: false,
 			},
 		];

--- a/apps/docs/src/app/sitemap.ts
+++ b/apps/docs/src/app/sitemap.ts
@@ -11,6 +11,6 @@ export default function sitemap(): MetadataRoute.Sitemap {
 		url: `${baseUrl}${page.url}`,
 		lastModified: new Date(),
 		changeFrequency: "weekly" as const,
-		priority: page.url === "/installation" ? 1.0 : 0.8,
+		priority: page.url === "/overview" ? 1.0 : 0.8,
 	}));
 }

--- a/packages/panes/src/react/components/Workspace/components/TabBar/TabBar.tsx
+++ b/packages/panes/src/react/components/Workspace/components/TabBar/TabBar.tsx
@@ -45,8 +45,8 @@ function AddTabButton<_TData>({
 }) {
 	const button = (
 		<Button
-			className="h-full w-full rounded-none border-0 bg-transparent px-0 text-muted-foreground shadow-none hover:bg-tertiary/20 hover:text-foreground"
-			size="sm"
+			className="size-7 rounded-md border border-border/60 bg-muted/30 px-1 text-muted-foreground shadow-none hover:bg-accent/60 hover:text-foreground"
+			size="icon"
 			type="button"
 			variant="ghost"
 		>
@@ -168,7 +168,7 @@ export function TabBar<TData>({
 				ref={setRootRef}
 				className="group/root-tabs flex h-10 min-w-0 shrink-0 items-stretch border-b border-border bg-background"
 			>
-				<div className="flex h-full w-10 shrink-0 items-stretch bg-background">
+				<div className="flex h-full w-10 shrink-0 items-center justify-center bg-background">
 					<AddTabButton renderAddTabMenu={renderAddTabMenu} />
 				</div>
 				<div className="flex min-w-0 flex-1 items-stretch" />
@@ -215,14 +215,14 @@ export function TabBar<TData>({
 						/>
 					)}
 					{!hasHorizontalOverflow && (
-						<div className="flex h-full w-10 shrink-0 items-stretch">
+						<div className="flex h-full w-10 shrink-0 items-center justify-center">
 							<AddTabButton renderAddTabMenu={renderAddTabMenu} />
 						</div>
 					)}
 				</div>
 			</OverflowFadeContainer>
 			{hasHorizontalOverflow && (
-				<div className="flex h-full w-10 shrink-0 items-stretch bg-background">
+				<div className="flex h-full w-10 shrink-0 items-center justify-center bg-background">
 					<AddTabButton renderAddTabMenu={renderAddTabMenu} />
 				</div>
 			)}

--- a/packages/panes/src/react/components/Workspace/components/TabBar/components/TabItem/TabItem.tsx
+++ b/packages/panes/src/react/components/Workspace/components/TabBar/components/TabItem/TabItem.tsx
@@ -113,7 +113,7 @@ export function TabItem<TData>({
 					className={cn(
 						"group relative flex h-full w-full items-center border-r border-border transition-colors",
 						isActive
-							? "bg-muted text-foreground"
+							? "bg-border/30 text-foreground"
 							: "text-muted-foreground/70 hover:bg-tertiary/20 hover:text-muted-foreground",
 						isPaneOver && "bg-primary/5",
 						isDragging && "opacity-30",

--- a/packages/trpc/src/trpc.ts
+++ b/packages/trpc/src/trpc.ts
@@ -77,36 +77,57 @@ export const protectedProcedure = t.procedure
 
 export const jwtProcedure = t.procedure.use(async ({ ctx, next }) => {
 	const authHeader = ctx.headers.get("authorization");
-	if (!authHeader?.startsWith("Bearer ")) {
-		throw new TRPCError({
-			code: "UNAUTHORIZED",
-			message: "JWT bearer token required",
-		});
+	const bearer = authHeader?.startsWith("Bearer ") ? authHeader.slice(7) : null;
+
+	if (bearer) {
+		try {
+			const { payload } = await ctx.auth.api.verifyJWT({
+				body: { token: bearer },
+			});
+			if (payload?.sub) {
+				const organizationIds = (payload.organizationIds as string[]) ?? [];
+				return next({
+					ctx: {
+						userId: payload.sub,
+						email: (payload.email as string) ?? "",
+						organizationIds,
+						activeOrganizationId: organizationIds[0] ?? null,
+					},
+				});
+			}
+		} catch (error) {
+			// A live session is the legit fallback for an unverifiable token
+			// (expired/missing). A TRPCError from verifyJWT is an explicit
+			// rejection (revoked/forged) — surface it instead of laundering
+			// it into session auth.
+			if (error instanceof TRPCError) throw error;
+		}
 	}
 
-	const token = authHeader.slice(7);
-	try {
-		const { payload } = await ctx.auth.api.verifyJWT({ body: { token } });
-		if (!payload?.sub) {
-			throw new TRPCError({ code: "UNAUTHORIZED", message: "Invalid JWT" });
-		}
-
-		const organizationIds = (payload.organizationIds as string[]) ?? [];
+	if (ctx.session) {
+		const userId = ctx.session.user.id;
+		const memberRows = await db.query.members.findMany({
+			where: eq(members.userId, userId),
+			columns: { organizationId: true },
+		});
+		const organizationIds = memberRows.map((row) => row.organizationId);
 		return next({
 			ctx: {
-				userId: payload.sub,
-				email: (payload.email as string) ?? "",
+				userId,
+				email: ctx.session.user.email ?? "",
 				organizationIds,
-				activeOrganizationId: organizationIds[0] ?? null,
+				activeOrganizationId:
+					ctx.session.session.activeOrganizationId ??
+					organizationIds[0] ??
+					null,
 			},
 		});
-	} catch (error) {
-		if (error instanceof TRPCError) throw error;
-		throw new TRPCError({
-			code: "UNAUTHORIZED",
-			message: "JWT verification failed",
-		});
 	}
+
+	throw new TRPCError({
+		code: "UNAUTHORIZED",
+		message: "Not authenticated. Provide a bearer JWT, x-api-key, or session.",
+	});
 });
 
 export const adminProcedure = protectedProcedure.use(async ({ ctx, next }) => {


### PR DESCRIPTION
## Summary
upstream 同期バッチ第 3 弾。**sidebar polish + jwt API 対応 (5 commits)**。

進捗: PR 1 (9) + PR 2 (12) + PR 3 (5) = 26 / 223。

## 取り込み内容

| upstream PR | SHA | 概要 |
|---|---|---|
| #3848 | db4378e82 | キーボードでワークスペース cycle 時に collapsed sections を展開 |
| #3895 | d13a509fa | jwtProcedure が x-api-key / session フォールバックも受け付け |
| #3897 | a741f514e | changes sidebar rows に hover dropdown actions を追加 |
| #3935 | b6d7b09da | docs root を /overview にリダイレクト |
| #3939 | 478d7c07b | v2 tab + add-button styling を v1 に揃える |

## Fork 側のコンフリクト解決

- **`packages/trpc/src/trpc.ts`** (#3895): fork が `Bearer 必須` だった `jwtProcedure` を upstream の「Bearer → session フォールバック」構造に置換。fork の `ORGANIZATION_HEADER` / `ctx.activeOrganizationId` 関連は別 procedure (`paidPlanProcedure` 等) に残るので影響なし。`db.query.members.findMany` での org 解決を採用

## 除外した commits（このバッチでは保留）

| upstream PR | 理由 |
|---|---|
| #3892 (marketing trusted by) | fork 独自ロゴ選定 (Perplexity 維持)、upstream の wordware 差し替えは採らない |
| #3899 (90fed3bdd v2 diff pane polish) | DiffFileHeader / WorkspaceDiff の構造的再設計（copy-contents → copy-path 置換 + filename split + DiffPaneHeaderExtras 切り出し）。fork の onCopyContents/onDiscard と整合させる必要あり、PR 5 (v2 diff pane batch) に移送 |
| #3911 (truncate diff file path + copy-path) | #3899 と同系統、PR 5 に同梱 |
| #3912 (delete-workspace dialog 14 files) | host-service saga 系で副次依存、PR 4-7 と相談 |
| #3933 (#3878 paywall subscription sync) | useCurrentPlan 戻り値が #3878 (PR 2 #2e9494f55) に依存。PR 2 マージ後に取り込み |
| #3948 (cli docs install URL) | fork は CLI docs 未取り込み（PR 6 で SDK/CLI 一括時に処理） |
| #3967 (v2 workspaces sort tiebreaker) | fork 側の sort 関数構造が upstream と一致せず |

## Fork 固有機能ヘルスチェック

- 19 tRPC `githubExtended` procedure 健在
- 依存 / マーカー全て残存
- migration max idx 変動なし

## Test plan

- [x] `bun install` 成功
- [x] `bun run typecheck` 全 task green
- [x] `bun run lint` exit 0
- [ ] CI green
- [ ] CodeRabbit / Codex レビュー対応

## 次の PR
PR 4: host-service tRPC retry/cache/jwt + 周辺 fix
