### PR TITLE
upstream merge 2026-05-08 PR 5: v2 diff pane / file pane polish

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/StatusIndicator/StatusIndicator.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/StatusIndicator/StatusIndicator.tsx
@@ -26,8 +26,7 @@ const STATUS_COLORS: Record<FileStatus, string> = {
 	untracked: "text-green-700 dark:text-green-400",
 };
 
-function getStatusIcon(status: FileStatus): ReactNode {
-	const iconClass = "w-3 h-3";
+function getStatusIcon(status: FileStatus, iconClass: string): ReactNode {
 	switch (status) {
 		case "added":
 		case "untracked":
@@ -49,15 +48,17 @@ function getStatusIcon(status: FileStatus): ReactNode {
 export function StatusIndicator({
 	status,
 	className,
+	iconClassName = "w-3 h-3",
 }: {
 	status: string;
 	className?: string;
+	iconClassName?: string;
 }) {
 	return (
 		<span
 			className={`flex shrink-0 items-center ${STATUS_COLORS[status as FileStatus] ?? ""} ${className ?? ""}`}
 		>
-			{getStatusIcon(status as FileStatus)}
+			{getStatusIcon(status as FileStatus, iconClassName)}
 		</span>
 	);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/DiffPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/DiffPane.tsx
@@ -81,10 +81,10 @@ export function DiffPane({ context, workspaceId, onOpenFile }: DiffPaneProps) {
 		[updateData],
 	);
 
-	if (!isLoading && files.length === 0) {
+	if (files.length === 0) {
 		return (
 			<div className="flex h-full w-full items-center justify-center text-sm text-muted-foreground">
-				No changes
+				{isLoading ? "Loading…" : "No changes"}
 			</div>
 		);
 	}
@@ -92,7 +92,7 @@ export function DiffPane({ context, workspaceId, onOpenFile }: DiffPaneProps) {
 	return (
 		<Virtualizer
 			className="h-full w-full overflow-auto"
-			contentClassName="space-y-2 px-2 py-2"
+			contentClassName="space-y-2"
 		>
 			<ScrollToFile path={data.path} />
 			{files.map((file) => (

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/DiffFileEntry/DiffFileEntry.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/DiffFileEntry/DiffFileEntry.tsx
@@ -1,3 +1,4 @@
+import { Button } from "@superset/ui/button";
 import { toast } from "@superset/ui/sonner";
 import { memo, useCallback, useRef, useState } from "react";
 import type { ChangesetFile } from "../../../../../useChangeset";
@@ -192,7 +193,7 @@ function DeferredDiffPlaceholder({
 		: `${(file.additions + file.deletions).toLocaleString()} changed lines`;
 
 	return (
-		<div className="flex flex-col overflow-hidden rounded-md border border-border">
+		<div className="flex flex-col overflow-hidden">
 			<DiffFileHeader
 				path={file.path}
 				status={file.status}
@@ -215,13 +216,15 @@ function DeferredDiffPlaceholder({
 					{subtitle && (
 						<div className="text-xs text-muted-foreground">{subtitle}</div>
 					)}
-					<button
+					<Button
 						type="button"
+						size="xs"
+						variant="outline"
 						onClick={onShow}
-						className="mt-1 rounded border border-border bg-background px-3 py-1.5 text-xs font-medium text-foreground hover:bg-muted"
+						className="mt-1"
 					>
 						Show diff
-					</button>
+					</Button>
 				</div>
 			)}
 		</div>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/DiffFileHeader/DiffFileHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/DiffFileHeader/DiffFileHeader.tsx
@@ -2,11 +2,13 @@ import { Checkbox } from "@superset/ui/checkbox";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { ChevronDown, ChevronRight, Eye, EyeOff } from "lucide-react";
 import { useId } from "react";
-import { LuCopy, LuUndo2 } from "react-icons/lu";
+import { LuCheck, LuCopy, LuUndo2 } from "react-icons/lu";
+import { useCopyToClipboard } from "renderer/hooks/useCopyToClipboard";
 import { StatusIndicator } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/StatusIndicator";
 import { CLICK_HINT_TOOLTIP } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/utils/clickModifierLabels";
 import { getSidebarClickIntent } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/utils/getSidebarClickIntent";
 import { FileIcon } from "renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/utils";
+import { GIT_STAT_TEXT_CLASSES } from "../../utils/gitDecorationColors";
 
 interface DiffFileHeaderProps {
 	path: string;
@@ -21,7 +23,6 @@ interface DiffFileHeaderProps {
 	onToggleViewed: () => void;
 	onOpenFile?: (openInNewTab?: boolean) => void;
 	onOpenInExternalEditor?: () => void;
-	onCopyContents?: () => void;
 	onDiscard?: () => void;
 }
 
@@ -38,18 +39,25 @@ export function DiffFileHeader({
 	onToggleViewed,
 	onOpenFile,
 	onOpenInExternalEditor,
-	onCopyContents,
 	onDiscard,
 }: DiffFileHeaderProps) {
 	const viewedId = useId();
+	const { copyToClipboard, copied } = useCopyToClipboard();
+
+	// Split into directory + basename so the basename stays visible when the
+	// header is narrow — the directory truncates with ellipsis instead of
+	// hiding the filename behind it.
+	const lastSlash = path.lastIndexOf("/");
+	const dir = lastSlash >= 0 ? path.slice(0, lastSlash + 1) : "";
+	const name = lastSlash >= 0 ? path.slice(lastSlash + 1) : path;
 
 	return (
-		<div className="@container/diff-file-header flex min-w-0 flex-wrap items-center gap-1 px-2 py-1.5">
+		<div className="@container/diff-file-header flex min-w-0 flex-nowrap items-center gap-1 border-y border-border bg-muted/30 px-3 py-2">
 			<button
 				type="button"
 				onClick={onToggleCollapsed}
 				aria-label={collapsed ? "Expand file" : "Collapse file"}
-				className="shrink-0 rounded p-0.5 text-muted-foreground/60 transition-colors hover:bg-accent hover:text-muted-foreground"
+				className="shrink-0 rounded p-1 text-muted-foreground/60 transition-colors hover:bg-accent hover:text-muted-foreground"
 			>
 				{collapsed ? (
 					<ChevronRight className="size-3.5" />
@@ -57,8 +65,7 @@ export function DiffFileHeader({
 					<ChevronDown className="size-3.5" />
 				)}
 			</button>
-			<StatusIndicator status={status} />
-			<Tooltip delayDuration={300}>
+			<Tooltip>
 				<TooltipTrigger asChild>
 					<button
 						type="button"
@@ -72,11 +79,16 @@ export function DiffFileHeader({
 						}}
 						disabled={!onOpenFile && !onOpenInExternalEditor}
 						aria-label="Open in file viewer"
-						className="flex h-6 min-w-0 items-center gap-1.5 rounded border border-border px-1.5 py-0.5 text-left transition-colors hover:bg-accent disabled:pointer-events-none disabled:opacity-60"
+						className="flex h-6 min-w-0 flex-1 items-center gap-1.5 rounded px-1 text-left transition-colors hover:bg-accent disabled:pointer-events-none disabled:opacity-60"
 					>
 						<FileIcon fileName={path} className="size-3.5 shrink-0" />
-						<span className="min-w-0 truncate font-mono text-xs text-foreground">
-							{path}
+						<span className="flex min-w-0 items-baseline font-mono text-xs">
+							{dir && (
+								<span className="min-w-0 truncate text-muted-foreground">
+									{dir}
+								</span>
+							)}
+							<span className="shrink-0 text-foreground">{name}</span>
 						</span>
 					</button>
 				</TooltipTrigger>
@@ -84,17 +96,37 @@ export function DiffFileHeader({
 					{CLICK_HINT_TOOLTIP}
 				</TooltipContent>
 			</Tooltip>
+			<Tooltip>
+				<TooltipTrigger asChild>
+					<button
+						type="button"
+						onClick={() => void copyToClipboard(path)}
+						aria-label="Copy path"
+						className="shrink-0 rounded p-1 text-muted-foreground/60 transition-colors hover:bg-accent hover:text-muted-foreground"
+					>
+						{copied ? (
+							<LuCheck className="size-3.5" />
+						) : (
+							<LuCopy className="size-3.5" />
+						)}
+					</button>
+				</TooltipTrigger>
+				<TooltipContent side="bottom" showArrow={false}>
+					{copied ? "Copied" : "Copy path"}
+				</TooltipContent>
+			</Tooltip>
 			<div className="ml-auto flex shrink-0 items-center gap-1.5">
+				<StatusIndicator status={status} iconClassName="size-3.5" />
 				{(additions > 0 || deletions > 0) && (
-					<span className="font-mono text-[10px] text-muted-foreground">
+					<span className="font-mono text-xs text-muted-foreground">
 						{additions > 0 && (
-							<span className="text-green-700 dark:text-green-400">
+							<span className={GIT_STAT_TEXT_CLASSES.addition}>
 								+{additions}
 							</span>
 						)}
 						{additions > 0 && deletions > 0 && " "}
 						{deletions > 0 && (
-							<span className="text-red-700 dark:text-red-500">
+							<span className={GIT_STAT_TEXT_CLASSES.deletion}>
 								-{deletions}
 							</span>
 						)}
@@ -110,7 +142,7 @@ export function DiffFileHeader({
 					/>
 					<label
 						htmlFor={viewedId}
-						className="hidden cursor-pointer select-none text-[10px] text-muted-foreground @min-[380px]/diff-file-header:inline"
+						className="hidden cursor-pointer select-none text-xs text-muted-foreground @min-[380px]/diff-file-header:inline"
 					>
 						Viewed
 					</label>
@@ -125,7 +157,7 @@ export function DiffFileHeader({
 							aria-label={
 								expandUnchanged ? "Hide unchanged regions" : "Show all lines"
 							}
-							className="rounded p-0.5 text-muted-foreground/60 transition-colors hover:bg-accent hover:text-muted-foreground disabled:pointer-events-none disabled:opacity-40"
+							className="rounded p-1 text-muted-foreground/60 transition-colors hover:bg-accent hover:text-muted-foreground disabled:pointer-events-none disabled:opacity-40"
 						>
 							{expandUnchanged ? (
 								<EyeOff className="size-3.5" />
@@ -143,27 +175,10 @@ export function DiffFileHeader({
 					<TooltipTrigger asChild>
 						<button
 							type="button"
-							onClick={onCopyContents}
-							disabled={!onCopyContents}
-							aria-label="Copy file contents"
-							className="rounded p-0.5 text-muted-foreground/60 transition-colors hover:bg-accent hover:text-muted-foreground disabled:pointer-events-none disabled:opacity-40"
-						>
-							<LuCopy className="size-3.5" />
-						</button>
-					</TooltipTrigger>
-					<TooltipContent side="bottom" showArrow={false}>
-						Copy file contents
-					</TooltipContent>
-				</Tooltip>
-
-				<Tooltip>
-					<TooltipTrigger asChild>
-						<button
-							type="button"
 							onClick={onDiscard}
 							disabled={!onDiscard}
 							aria-label="Discard changes"
-							className="rounded p-0.5 text-muted-foreground/60 transition-colors hover:bg-accent hover:text-destructive disabled:pointer-events-none disabled:opacity-40"
+							className="rounded p-1 text-muted-foreground/60 transition-colors hover:bg-accent hover:text-destructive disabled:pointer-events-none disabled:opacity-40"
 						>
 							<LuUndo2 className="size-3.5" />
 						</button>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/DiffFileHeader/DiffFileHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/DiffFileHeader/DiffFileHeader.tsx
@@ -45,8 +45,8 @@ export function DiffFileHeader({
 	const { copyToClipboard, copied } = useCopyToClipboard();
 
 	// Split into directory + basename so the basename stays visible when the
-	// header is narrow — the directory truncates with ellipsis instead of
-	// hiding the filename behind it.
+	// header is narrow — the directory truncates with ellipsis first, and the
+	// basename truncates only as a fallback (very narrow pane or no directory).
 	const lastSlash = path.lastIndexOf("/");
 	const dir = lastSlash >= 0 ? path.slice(0, lastSlash + 1) : "";
 	const name = lastSlash >= 0 ? path.slice(lastSlash + 1) : path;
@@ -84,11 +84,11 @@ export function DiffFileHeader({
 						<FileIcon fileName={path} className="size-3.5 shrink-0" />
 						<span className="flex min-w-0 items-baseline font-mono text-xs">
 							{dir && (
-								<span className="min-w-0 truncate text-muted-foreground">
+								<span className="min-w-0 shrink-[1000] truncate text-muted-foreground">
 									{dir}
 								</span>
 							)}
-							<span className="shrink-0 text-foreground">{name}</span>
+							<span className="min-w-0 truncate text-foreground">{name}</span>
 						</span>
 					</button>
 				</TooltipTrigger>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/DiffPaneHeaderExtras/DiffPaneHeaderExtras.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/DiffPaneHeaderExtras/DiffPaneHeaderExtras.tsx
@@ -1,0 +1,59 @@
+import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
+import { cn } from "@superset/ui/utils";
+import { SquareSplitHorizontal } from "lucide-react";
+import { TbScan } from "react-icons/tb";
+import { useSettings } from "renderer/stores/settings";
+
+export function DiffPaneHeaderExtras() {
+	const diffStyle = useSettings((s) => s.diffStyle);
+	const updateSetting = useSettings((s) => s.update);
+
+	const buttonClass = (active: boolean) =>
+		cn(
+			"flex size-5 items-center justify-center transition-colors",
+			active
+				? "bg-secondary text-foreground"
+				: "text-muted-foreground hover:text-foreground",
+		);
+
+	return (
+		<div className="flex items-center">
+			<Tooltip>
+				<TooltipTrigger asChild>
+					<button
+						type="button"
+						onClick={() => updateSetting("diffStyle", "unified")}
+						aria-label="Unified view"
+						aria-pressed={diffStyle === "unified"}
+						className={buttonClass(diffStyle === "unified")}
+					>
+						<TbScan className="size-3.5" />
+					</button>
+				</TooltipTrigger>
+				<TooltipContent side="bottom" showArrow={false}>
+					Unified view
+				</TooltipContent>
+			</Tooltip>
+			<Tooltip>
+				<TooltipTrigger asChild>
+					<button
+						type="button"
+						onClick={() => updateSetting("diffStyle", "split")}
+						aria-label="Split view"
+						aria-pressed={diffStyle === "split"}
+						className={buttonClass(diffStyle === "split")}
+					>
+						<SquareSplitHorizontal className="size-3.5" />
+					</button>
+				</TooltipTrigger>
+				<TooltipContent side="bottom" showArrow={false}>
+					Split view
+				</TooltipContent>
+			</Tooltip>
+			<div
+				className="mx-1 h-3.5 w-px bg-muted-foreground/30"
+				aria-hidden="true"
+			/>
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/DiffPaneHeaderExtras/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/DiffPaneHeaderExtras/index.ts
@@ -1,0 +1,1 @@
+export { DiffPaneHeaderExtras } from "./DiffPaneHeaderExtras";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/WorkspaceDiff/WorkspaceDiff.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/WorkspaceDiff/WorkspaceDiff.tsx
@@ -1,15 +1,14 @@
 import { MultiFileDiff } from "@pierre/diffs/react";
 import { toast } from "@superset/ui/sonner";
 import { workspaceTrpc } from "@superset/workspace-client";
+import { useQuery } from "@tanstack/react-query";
 import { memo, useMemo } from "react";
-import { useCopyToClipboard } from "renderer/hooks/useCopyToClipboard";
-import { electronTrpc } from "renderer/lib/electron-trpc";
 import { electronTrpcClient } from "renderer/lib/trpc-client";
 import {
 	getDiffsTheme,
 	getDiffViewerStyle,
 } from "renderer/screens/main/components/WorkspaceView/utils/code-theme";
-import { useResolvedTheme } from "renderer/stores/theme";
+import { useResolvedTheme, useTerminalTheme } from "renderer/stores/theme";
 import type { DiffFileSource } from "../../../../../useChangeset";
 import { DiffFileHeader } from "../DiffFileHeader";
 
@@ -49,10 +48,12 @@ export const WorkspaceDiff = memo(function WorkspaceDiff({
 	onOpenInExternalEditor,
 }: WorkspaceDiffProps) {
 	const activeTheme = useResolvedTheme();
-	const { data: fontSettings } = electronTrpc.settings.getFontSettings.useQuery(
-		undefined,
-		{ staleTime: 30_000 },
-	);
+	const terminalTheme = useTerminalTheme();
+	const { data: fontSettings } = useQuery({
+		queryKey: ["electron", "settings", "getFontSettings"],
+		queryFn: () => electronTrpcClient.settings.getFontSettings.query(),
+		staleTime: 30_000,
+	});
 	const shikiTheme = getDiffsTheme(activeTheme);
 	const parsedEditorFontSize =
 		typeof fontSettings?.editorFontSize === "number"
@@ -60,31 +61,18 @@ export const WorkspaceDiff = memo(function WorkspaceDiff({
 			: typeof fontSettings?.editorFontSize === "string"
 				? Number.parseFloat(fontSettings.editorFontSize)
 				: Number.NaN;
-	const baseThemeVars = getDiffViewerStyle(activeTheme, {
-		fontFamily: fontSettings?.editorFontFamily ?? undefined,
-		fontSize: Number.isFinite(parsedEditorFontSize)
-			? parsedEditorFontSize
-			: undefined,
-	});
-	// Match the file tree's git decoration colors (v2 WorkspaceFilesTreeItem)
-	// so addition/deletion/modified highlights read the same across the pane.
-	const gitDecorationColors =
-		activeTheme.type === "dark"
-			? {
-					addition: "var(--color-green-400)",
-					deletion: "var(--color-red-500)",
-					modified: "var(--color-yellow-400)",
-				}
-			: {
-					addition: "var(--color-green-700)",
-					deletion: "var(--color-red-700)",
-					modified: "var(--color-yellow-600)",
-				};
+	// Match the terminal pane's surface color so the diff body blends with
+	// the chrome. The actual override happens in unsafeCSS below — this just
+	// paints the wrapper before the diff mounts.
+	const surfaceBg = terminalTheme?.background ?? "var(--background)";
 	const themeVars = {
-		...baseThemeVars,
-		"--diffs-addition-color-override": gitDecorationColors.addition,
-		"--diffs-deletion-color-override": gitDecorationColors.deletion,
-		"--diffs-modified-color-override": gitDecorationColors.modified,
+		...getDiffViewerStyle(activeTheme, {
+			fontFamily: fontSettings?.editorFontFamily ?? undefined,
+			fontSize: Number.isFinite(parsedEditorFontSize)
+				? parsedEditorFontSize
+				: undefined,
+		}),
+		backgroundColor: surfaceBg,
 	};
 
 	const diffInput = useMemo(() => {
@@ -117,14 +105,6 @@ export const WorkspaceDiff = memo(function WorkspaceDiff({
 	});
 	const worktreePath = workspaceQuery.data?.worktreePath;
 
-	const { copyToClipboard } = useCopyToClipboard();
-	const newContents = diffQuery.data?.newFile.contents;
-	const handleCopyContents = useMemo(
-		() =>
-			newContents != null ? () => copyToClipboard(newContents) : undefined,
-		[newContents, copyToClipboard],
-	);
-
 	const utils = workspaceTrpc.useUtils();
 	const handleDiscard = useMemo(() => {
 		if (source.kind !== "unstaged" || !worktreePath) return undefined;
@@ -144,7 +124,7 @@ export const WorkspaceDiff = memo(function WorkspaceDiff({
 	}, [source.kind, worktreePath, path, workspaceId, utils]);
 
 	return (
-		<div className="flex flex-col overflow-hidden rounded-md border border-border">
+		<div className="flex flex-col overflow-hidden">
 			<DiffFileHeader
 				path={path}
 				status={status}
@@ -158,7 +138,6 @@ export const WorkspaceDiff = memo(function WorkspaceDiff({
 				onToggleViewed={onToggleViewed}
 				onOpenFile={onOpenFile}
 				onOpenInExternalEditor={onOpenInExternalEditor}
-				onCopyContents={handleCopyContents}
 				onDiscard={handleDiscard}
 			/>
 			{diffQuery.data ? (
@@ -175,9 +154,26 @@ export const WorkspaceDiff = memo(function WorkspaceDiff({
 						theme: shikiTheme,
 						themeType: activeTheme.type,
 						unsafeCSS: `
-							* {
-								user-select: text;
-								-webkit-user-select: text;
+							* { user-select: text; -webkit-user-select: text; }
+							/* Pierre sets --diffs-light-bg/--diffs-dark-bg
+							 * inline on <pre data-diff> from the Shiki theme;
+							 * inline beats :host so we override at the pre. */
+							[data-diff] {
+								--diffs-light-bg: ${surfaceBg} !important;
+								--diffs-dark-bg: ${surfaceBg} !important;
+							}
+							/* Flatten the "N unmodified lines" strip flush to
+							 * the pane edges (kills wrapper/content/expand-
+							 * button rounding + inline gap on both
+							 * line-info and line-info-basic). */
+							[data-separator^='line-info'] [data-separator-wrapper],
+							[data-separator^='line-info'] [data-separator-content],
+							[data-separator^='line-info'] [data-expand-up],
+							[data-separator^='line-info'] [data-expand-down],
+							[data-separator^='line-info'] [data-expand-both] {
+								border-radius: 0 !important;
+								margin-inline: 0 !important;
+								padding-inline: 0 !important;
 							}
 						`,
 					}}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/utils/gitDecorationColors/gitDecorationColors.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/utils/gitDecorationColors/gitDecorationColors.ts
@@ -1,0 +1,5 @@
+export const GIT_STAT_TEXT_CLASSES = {
+	addition: "text-green-700 dark:text-green-400",
+	deletion: "text-red-700 dark:text-red-500",
+	modified: "text-yellow-600 dark:text-yellow-400",
+} as const;

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/utils/gitDecorationColors/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/utils/gitDecorationColors/index.ts
@@ -1,0 +1,1 @@
+export { GIT_STAT_TEXT_CLASSES } from "./gitDecorationColors";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/components/FilePaneHeaderExtras/FilePaneHeaderExtras.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/components/FilePaneHeaderExtras/FilePaneHeaderExtras.tsx
@@ -1,7 +1,9 @@
 import type { RendererContext } from "@superset/panes";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { useCallback } from "react";
+import { LuCheck, LuCopy } from "react-icons/lu";
 import { TbExternalLink } from "react-icons/tb";
+import { useCopyToClipboard } from "renderer/hooks/useCopyToClipboard";
 import { useOpenInExternalEditor } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useOpenInExternalEditor";
 import { isSpreadsheetFile } from "shared/file-types";
 import { useSharedFileDocument } from "../../../../../../state/fileDocumentStore";
@@ -48,6 +50,7 @@ function FilePaneHeaderExtrasInner({
 	data: FilePaneData;
 }) {
 	const openInExternalEditor = useOpenInExternalEditor(workspaceId);
+	const { copyToClipboard, copied } = useCopyToClipboard();
 	const document = useSharedFileDocument({
 		workspaceId,
 		absolutePath: filePath,
@@ -81,6 +84,25 @@ function FilePaneHeaderExtrasInner({
 					onChange={handleChangeView}
 				/>
 			)}
+			<Tooltip>
+				<TooltipTrigger asChild>
+					<button
+						type="button"
+						aria-label="Copy path"
+						onClick={() => void copyToClipboard(filePath)}
+						className="rounded p-1 text-muted-foreground/60 transition-colors hover:text-muted-foreground"
+					>
+						{copied ? (
+							<LuCheck className="size-3.5" />
+						) : (
+							<LuCopy className="size-3.5" />
+						)}
+					</button>
+				</TooltipTrigger>
+				<TooltipContent side="bottom" showArrow={false}>
+					{copied ? "Copied" : "Copy path"}
+				</TooltipContent>
+			</Tooltip>
 			<Tooltip>
 				<TooltipTrigger asChild>
 					<button

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/usePaneRegistry.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/usePaneRegistry.tsx
@@ -5,7 +5,6 @@ import type {
 } from "@superset/panes";
 import { alert } from "@superset/ui/atoms/Alert";
 import { toast } from "@superset/ui/sonner";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { cn } from "@superset/ui/utils";
 import { workspaceTrpc } from "@superset/workspace-client";
 import {
@@ -13,7 +12,6 @@ import {
 	GitCompareArrows,
 	Globe,
 	MessageSquare,
-	SquareSplitHorizontal,
 	TerminalSquare,
 } from "lucide-react";
 import { useMemo } from "react";
@@ -24,12 +22,10 @@ import {
 	LuEraser,
 	LuPower,
 } from "react-icons/lu";
-import { TbScan } from "react-icons/tb";
 import { useHotkeyDisplay } from "renderer/hotkeys";
 import { getBaseName } from "renderer/lib/pathBasename";
 import { terminalRuntimeRegistry } from "renderer/lib/terminal/terminal-runtime-registry";
 import { FileIcon } from "renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/utils";
-import { useSettings } from "renderer/stores/settings";
 import { getV2NotificationSourcesForPane } from "renderer/stores/v2-notifications";
 import { isSpreadsheetFile } from "shared/file-types";
 import { V2NotificationStatusIndicator } from "../../components/V2NotificationStatusIndicator";
@@ -53,6 +49,7 @@ import { CommentPane } from "./components/CommentPane";
 import { CommentPaneHeaderExtras } from "./components/CommentPane/components/CommentPaneHeaderExtras";
 import { CommentPaneTitle } from "./components/CommentPane/components/CommentPaneTitle";
 import { DiffPane } from "./components/DiffPane";
+import { DiffPaneHeaderExtras } from "./components/DiffPane/components/DiffPaneHeaderExtras";
 import { FilePane } from "./components/FilePane";
 import { FilePaneHeaderExtras } from "./components/FilePane/components/FilePaneHeaderExtras";
 import { TerminalPane } from "./components/TerminalPane";
@@ -180,60 +177,6 @@ const MOD_KEY = navigator.platform.toLowerCase().includes("mac")
 	? "⌘"
 	: "Ctrl+";
 
-function DiffViewModeToggle() {
-	const diffStyle = useSettings((s) => s.diffStyle);
-	const updateSetting = useSettings((s) => s.update);
-
-	const buttonClass = (active: boolean) =>
-		cn(
-			"flex size-5 items-center justify-center transition-colors",
-			active
-				? "bg-secondary text-foreground"
-				: "text-muted-foreground hover:text-foreground",
-		);
-
-	return (
-		<div className="flex items-center">
-			<Tooltip>
-				<TooltipTrigger asChild>
-					<button
-						type="button"
-						onClick={() => updateSetting("diffStyle", "unified")}
-						aria-label="Unified view"
-						aria-pressed={diffStyle === "unified"}
-						className={buttonClass(diffStyle === "unified")}
-					>
-						<TbScan className="size-3.5" />
-					</button>
-				</TooltipTrigger>
-				<TooltipContent side="bottom" showArrow={false}>
-					Unified view
-				</TooltipContent>
-			</Tooltip>
-			<Tooltip>
-				<TooltipTrigger asChild>
-					<button
-						type="button"
-						onClick={() => updateSetting("diffStyle", "split")}
-						aria-label="Split view"
-						aria-pressed={diffStyle === "split"}
-						className={buttonClass(diffStyle === "split")}
-					>
-						<SquareSplitHorizontal className="size-3.5" />
-					</button>
-				</TooltipTrigger>
-				<TooltipContent side="bottom" showArrow={false}>
-					Split view
-				</TooltipContent>
-			</Tooltip>
-			<div
-				className="mx-1 h-3.5 w-px bg-muted-foreground/30"
-				aria-hidden="true"
-			/>
-		</div>
-	);
-}
-
 interface UsePaneRegistryOptions {
 	onOpenFile: (path: string, openInNewTab?: boolean) => void;
 	onRevealPath: (path: string) => void;
@@ -348,7 +291,7 @@ export function usePaneRegistry(
 						onOpenFile={onOpenFile}
 					/>
 				),
-				renderHeaderExtras: () => <DiffViewModeToggle />,
+				renderHeaderExtras: () => <DiffPaneHeaderExtras />,
 				contextMenuActions: (_ctx, defaults) =>
 					defaults.map((d) =>
 						d.key === "close-pane" ? { ...d, label: "Close Diff" } : d,


### PR DESCRIPTION
## Summary
upstream 同期バッチ第 5 弾。**v2 diff pane / file pane polish (2 commits)**。

進捗: PR1+2+3+4 完了、PR5 で 31 / 223 (4 まだ未マージ)。

## 取り込み内容

| upstream PR | SHA | 概要 |
|---|---|---|
| #3899 | 68b60e414 | v2 diff pane header / file path / unmodified-lines strip の polish (Copy contents → Copy path 置換 + DiffPaneHeaderExtras 切り出し + bg-muted/30 chrome) |
| #3911 | 66ae5e2e0 | diff file path を truncate + file pane に copy-path action |

## Fork 側のコンフリクト解決

- **`DiffFileHeader.tsx`** (#3899): wrapper div className を upstream 採用 (`flex-nowrap`, `border-y bg-muted/30`)。fork の `onDiscard` prop は維持、`onCopyContents` は upstream の方針で drop。upstream の Copy path button が fork の `useCopyToClipboard` をすでに使っているため fork 互換
- **`WorkspaceDiff.tsx`** (#3899):
  - imports: fork の `useCopyToClipboard` / `electronTrpc` を drop（後段で使われなくなる）、upstream の `useQuery` from `@tanstack/react-query` を採用
  - fontSettings: upstream の `useQuery({ queryKey, queryFn: () => electronTrpcClient... })` 形式を採用（cleaner）
  - handleCopyContents: drop（Copy contents UX 廃止）
  - **fork の `const utils = workspaceTrpc.useUtils();` は維持**（fork の `handleDiscard` 内で `utils.git.getDiff/getStatus.invalidate` を呼ぶ — 重要 cache 無効化挙動）
- **`FilePaneHeaderExtras.tsx`** (#3911): fork は外側 wrapper (spreadsheet 早期 return) + Inner に分割している構造を維持。upstream が外側に追加した `useCopyToClipboard` を Inner に移動して `copyToClipboard(filePath)` / `copied` をその場で利用

## Fork 固有機能ヘルスチェック

- 19 tRPC `githubExtended` procedure 健在
- terminal-host / aivis / todo-agent / vscode-shim 触らず
- isSpreadsheetFile spreadsheet 早期 return 維持
- migration max idx 変動なし

## Test plan

- [x] sub-agent 委譲で全 conflict resolve (Codex/Claude が dual で確認)
- [x] `bun run typecheck` exit 0 (28/28 tasks)
- [x] `bun run lint` exit 0 (4456 files)
- [ ] CI green
- [ ] CodeRabbit review

## 次の PR
PR 6: CLI v1 / SDK / packages 大型バッチ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新機能

* Diffペインに表示スタイル切り替え機能を追加（Unified/Split表示の選択可能）
* ファイルヘッダーにパスコピーボタンを追加

## 改善

* 空の状態の表示ロジックと UI を改善
* Diff ビューアのテーマカラー統合を強化
* ファイルエントリーのプレースホルダー UI を最適化
* ヘッダーレイアウトとスタイリングを調整

<!-- end of auto-generated comment: release notes by coderabbit.ai -->