### PR TITLE
Fix v2 workspace parity UI

### DIFF
--- a/apps/desktop/src/renderer/lib/electron-trpc.ts
+++ b/apps/desktop/src/renderer/lib/electron-trpc.ts
@@ -1,6 +1,9 @@
 import { createTRPCReact } from "@trpc/react-query";
 import type { inferRouterOutputs } from "@trpc/server";
 import type { AppRouter } from "lib/trpc/routers";
+import { createContext } from "react";
+
+const electronTrpcReactContext = createContext<unknown>(null);
 
 /**
  * tRPC React client for Electron IPC communication with main process.
@@ -8,6 +11,7 @@ import type { AppRouter } from "lib/trpc/routers";
  */
 export const electronTrpc = createTRPCReact<AppRouter>({
 	abortOnUnmount: true,
+	context: electronTrpcReactContext,
 });
 
 export type ElectronRouterOutputs = inferRouterOutputs<AppRouter>;

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/TopBar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/TopBar.tsx
@@ -40,8 +40,9 @@ export function TopBar() {
 	);
 	// Default to Mac layout while loading to avoid overlap with traffic lights
 	const isMac = platform === undefined || platform === "darwin";
-	// In v2, the expanded dashboard sidebar lives outside the TopBar column.
-	// Let that sidebar header host the traffic-light pad and left chrome.
+	// The TopBar spans the full window width even when the v2 dashboard sidebar
+	// is expanded below it, so it must always reserve the macOS traffic-light
+	// inset itself.
 	const sidebarHostsChrome =
 		isV2CloudEnabled && isWorkspaceSidebarOpen && !isWorkspaceSidebarCollapsed;
 
@@ -50,7 +51,7 @@ export function TopBar() {
 			<div
 				className="flex items-center gap-1.5 h-full"
 				style={{
-					paddingLeft: isMac && !sidebarHostsChrome ? "80px" : "16px",
+					paddingLeft: isMac ? "80px" : "16px",
 				}}
 			>
 				{!sidebarHostsChrome && (

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/WorkspaceSidebar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/WorkspaceSidebar.tsx
@@ -1,3 +1,4 @@
+import type { PullRequestComment } from "@superset/local-db";
 import { Button } from "@superset/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { eq } from "@tanstack/db";
@@ -15,24 +16,19 @@ import {
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { useWorkspaceGitStatus } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/providers/WorkspaceGitStatusProvider";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
+import { ChangesView } from "renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView";
 import { DatabasesView } from "renderer/screens/main/components/WorkspaceView/RightSidebar/DatabasesView";
 import { DockerView } from "renderer/screens/main/components/WorkspaceView/RightSidebar/DockerView";
 import { ProblemsView } from "renderer/screens/main/components/WorkspaceView/RightSidebar/ProblemsView";
 import { SearchView } from "renderer/screens/main/components/WorkspaceView/RightSidebar/SearchView";
 import { WorkspaceIdProvider } from "renderer/screens/main/components/WorkspaceView/WorkspaceIdContext";
+import { toAbsoluteWorkspacePath } from "shared/absolute-paths";
+import type { ChangeCategory, ChangedFile } from "shared/changes-types";
+import type { ActionLogsJob } from "shared/tabs-types";
 import type { CommentPaneData, DiffFocusSide } from "../../types";
 import { FilesTab } from "./components/FilesTab";
-import { PRActionHeader } from "./components/PRActionHeader";
 import { SidebarHeader } from "./components/SidebarHeader";
-import { useChangesTab } from "./hooks/useChangesTab";
-import { type OpenChatFn, usePRFlowDispatch } from "./hooks/usePRFlowDispatch";
-import { usePRFlowState } from "./hooks/usePRFlowState";
 import type { SidebarTabDefinition } from "./types";
-
-// Gates the "Create PR" button only — the chat-driven create flow doesn't
-// exist in v2 yet. The PR status group (link + merge dropdown for an open PR)
-// always renders so users can see PR state and merge once a PR exists.
-const CREATE_PR_BUTTON_ENABLED = false;
 
 type SidebarTabId =
 	| "changes"
@@ -69,10 +65,13 @@ interface WorkspaceSidebarProps {
 		side?: DiffFocusSide,
 	) => void;
 	onOpenComment?: (comment: CommentPaneData) => void;
-	onOpenChat?: OpenChatFn;
 	onSearch?: () => void;
+	onOpenDatabaseExplorer?: (connectionId: string) => void;
 	onOpenFileAtLine?: (path: string, line?: number, column?: number) => void;
 	onOpenUrl?: (url: string) => void;
+	onOpenActionLogs?: (jobs: ActionLogsJob[], initialJobIndex?: number) => void;
+	isGitGraphOpen?: boolean;
+	onOpenGitGraph?: () => void;
 	onOpenCommandInTerminal?: (args: {
 		command: string;
 		cwd?: string;
@@ -113,10 +112,13 @@ export function WorkspaceSidebar({
 	onSelectFile,
 	onSelectDiffFile,
 	onOpenComment,
-	onOpenChat,
 	onSearch,
+	onOpenDatabaseExplorer,
 	onOpenFileAtLine,
 	onOpenUrl,
+	onOpenActionLogs,
+	isGitGraphOpen,
+	onOpenGitGraph,
 	onOpenCommandInTerminal,
 	selectedFilePath,
 	pendingReveal,
@@ -183,6 +185,13 @@ export function WorkspaceSidebar({
 			staleTime: 10000,
 		},
 	);
+	const { data: workspace } = electronTrpc.workspaces.get.useQuery(
+		{ id: workspaceId },
+		{
+			enabled: Boolean(workspaceId),
+		},
+	);
+	const worktreePath = workspace?.worktreePath;
 
 	electronTrpc.languageServices.subscribeDiagnostics.useSubscription(
 		{ workspaceId },
@@ -207,25 +216,61 @@ export function WorkspaceSidebar({
 		[onOpenFileAtLine, onSelectFile],
 	);
 
-	const changesTabDef = useChangesTab({
-		workspaceId,
-		selectedFilePath,
-		onSelectFile: onSelectDiffFile,
-		onOpenFile: onSelectFile,
-		onOpenFileAtLine: handleOpenFileAtLine,
-		onOpenComment,
-		onOpenUrl,
-		isActive: activeTab === "changes",
-	});
+	const handleChangeFileOpen = useCallback(
+		(file: ChangedFile, category: ChangeCategory, commitHash?: string) => {
+			if (collections.v2WorkspaceLocalState.get(workspaceId)) {
+				collections.v2WorkspaceLocalState.update(workspaceId, (draft) => {
+					draft.sidebarState.changesFilter =
+						category === "committed" && commitHash
+							? { kind: "commit", hash: commitHash }
+							: { kind: "all" };
+				});
+			}
+			if (onSelectDiffFile) {
+				onSelectDiffFile(file.path);
+				return;
+			}
+			if (!worktreePath) return;
+			onSelectFile(toAbsoluteWorkspacePath(worktreePath, file.path));
+		},
+		[collections, onSelectDiffFile, onSelectFile, workspaceId, worktreePath],
+	);
+	const handleOpenReviewComment = useCallback(
+		(comment: PullRequestComment) => {
+			onOpenComment?.({
+				commentId: comment.id,
+				authorLogin: comment.authorLogin,
+				avatarUrl: comment.avatarUrl,
+				body: comment.body,
+				url: comment.url,
+				path: comment.path,
+				line: comment.line,
+			});
+		},
+		[onOpenComment],
+	);
+	const totalChanges =
+		(gitStatus.data?.againstBase.length ?? 0) +
+		(gitStatus.data?.staged.length ?? 0) +
+		(gitStatus.data?.unstaged.length ?? 0);
 	const changesTab: SidebarTabDefinition = {
-		...changesTabDef,
+		id: "changes",
+		label: "Git",
 		icon: LuGitCompareArrows,
+		badge: totalChanges > 0 ? totalChanges : undefined,
+		content: (
+			<ChangesView
+				onFileOpen={handleChangeFileOpen}
+				onOpenFileAtLine={handleOpenFileAtLine}
+				onOpenComment={handleOpenReviewComment}
+				onOpenUrl={onOpenUrl}
+				onOpenActionLogs={onOpenActionLogs}
+				isGitGraphOpen={isGitGraphOpen}
+				onToggleGitGraph={onOpenGitGraph}
+				isActive={activeTab === "changes"}
+			/>
+		),
 	};
-
-	const { flowState, onRetry } = usePRFlowState(workspaceId);
-	const dispatch = usePRFlowDispatch({
-		onOpenChat: onOpenChat ?? (() => {}),
-	});
 
 	const filesTab: SidebarTabDefinition = {
 		id: "files",
@@ -297,7 +342,12 @@ export function WorkspaceSidebar({
 		id: "databases",
 		label: "Databases",
 		icon: LuDatabase,
-		content: <DatabasesView workspaceId={workspaceId} />,
+		content: (
+			<DatabasesView
+				workspaceId={workspaceId}
+				onOpenExplorer={onOpenDatabaseExplorer}
+			/>
+		),
 	};
 
 	const tabs: SidebarTabDefinition[] = [
@@ -328,13 +378,6 @@ export function WorkspaceSidebar({
 				ref={containerRef}
 				className="isolate flex h-full w-full min-h-0 flex-col overflow-hidden bg-background"
 			>
-				<PRActionHeader
-					workspaceId={workspaceId}
-					state={flowState}
-					dispatch={dispatch}
-					onRetry={onRetry}
-					createPREnabled={CREATE_PR_BUTTON_ENABLED}
-				/>
 				<SidebarHeader
 					tabs={tabs}
 					activeTab={activeTab}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/WorkspaceSidebar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/WorkspaceSidebar.tsx
@@ -80,6 +80,9 @@ interface WorkspaceSidebarProps {
 	selectedFilePath?: string;
 	pendingReveal?: PendingReveal | null;
 	workspaceId: string;
+	worktreePath: string;
+	projectId: string;
+	workspaceBranch?: string | null;
 }
 
 function IconButton({
@@ -123,6 +126,9 @@ export function WorkspaceSidebar({
 	selectedFilePath,
 	pendingReveal,
 	workspaceId,
+	worktreePath,
+	projectId,
+	workspaceBranch,
 }: WorkspaceSidebarProps) {
 	const gitStatus = useWorkspaceGitStatus();
 	const collections = useCollections();
@@ -185,14 +191,6 @@ export function WorkspaceSidebar({
 			staleTime: 10000,
 		},
 	);
-	const { data: workspace } = electronTrpc.workspaces.get.useQuery(
-		{ id: workspaceId },
-		{
-			enabled: Boolean(workspaceId),
-		},
-	);
-	const worktreePath = workspace?.worktreePath;
-
 	electronTrpc.languageServices.subscribeDiagnostics.useSubscription(
 		{ workspaceId },
 		{
@@ -267,6 +265,11 @@ export function WorkspaceSidebar({
 				onOpenActionLogs={onOpenActionLogs}
 				isGitGraphOpen={isGitGraphOpen}
 				onToggleGitGraph={onOpenGitGraph}
+				workspaceOverride={{
+					worktreePath,
+					projectId,
+					branch: workspaceBranch,
+				}}
 				isActive={activeTab === "changes"}
 			/>
 		),

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/WorkspaceSidebar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/WorkspaceSidebar.tsx
@@ -145,10 +145,9 @@ export function WorkspaceSidebar({
 		[collections, workspaceId],
 	);
 	const localState = localStateRows[0];
+	const rawActiveTab = localState?.sidebarState.activeTab;
 	const activeTab: SidebarTabId =
-		localState && isSidebarTabId(localState.sidebarState.activeTab)
-			? localState.sidebarState.activeTab
-			: "changes";
+		rawActiveTab && isSidebarTabId(rawActiveTab) ? rawActiveTab : "changes";
 
 	const setActiveTab = useCallback(
 		(tab: string) => {
@@ -160,6 +159,11 @@ export function WorkspaceSidebar({
 		},
 		[collections, workspaceId],
 	);
+	useEffect(() => {
+		if (rawActiveTab === "review") {
+			setActiveTab("changes");
+		}
+	}, [rawActiveTab, setActiveTab]);
 
 	const containerRef = useRef<HTMLDivElement>(null);
 	const [compact, setCompact] = useState(false);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/WorkspaceSidebar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/WorkspaceSidebar.tsx
@@ -3,11 +3,23 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { eq } from "@tanstack/db";
 import { useLiveQuery } from "@tanstack/react-db";
 import { Search } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
-import { LuFile, LuGitCompareArrows } from "react-icons/lu";
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+	LuBox,
+	LuCircleAlert,
+	LuDatabase,
+	LuFile,
+	LuGitCompareArrows,
+	LuSearch,
+} from "react-icons/lu";
+import { electronTrpc } from "renderer/lib/electron-trpc";
 import { useWorkspaceGitStatus } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/providers/WorkspaceGitStatusProvider";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
-import { useSettings } from "renderer/stores/settings";
+import { DatabasesView } from "renderer/screens/main/components/WorkspaceView/RightSidebar/DatabasesView";
+import { DockerView } from "renderer/screens/main/components/WorkspaceView/RightSidebar/DockerView";
+import { ProblemsView } from "renderer/screens/main/components/WorkspaceView/RightSidebar/ProblemsView";
+import { SearchView } from "renderer/screens/main/components/WorkspaceView/RightSidebar/SearchView";
+import { WorkspaceIdProvider } from "renderer/screens/main/components/WorkspaceView/WorkspaceIdContext";
 import type { CommentPaneData, DiffFocusSide } from "../../types";
 import { FilesTab } from "./components/FilesTab";
 import { PRActionHeader } from "./components/PRActionHeader";
@@ -15,7 +27,6 @@ import { SidebarHeader } from "./components/SidebarHeader";
 import { useChangesTab } from "./hooks/useChangesTab";
 import { type OpenChatFn, usePRFlowDispatch } from "./hooks/usePRFlowDispatch";
 import { usePRFlowState } from "./hooks/usePRFlowState";
-import { useReviewTab } from "./hooks/useReviewTab";
 import type { SidebarTabDefinition } from "./types";
 
 // Gates the "Create PR" button only — the chat-driven create flow doesn't
@@ -23,9 +34,22 @@ import type { SidebarTabDefinition } from "./types";
 // always renders so users can see PR state and merge once a PR exists.
 const CREATE_PR_BUTTON_ENABLED = false;
 
-type SidebarTabId = "changes" | "files" | "review";
+type SidebarTabId =
+	| "changes"
+	| "docker"
+	| "files"
+	| "search"
+	| "problems"
+	| "databases";
 
-const VALID_TAB_IDS: readonly SidebarTabId[] = ["changes", "files", "review"];
+const VALID_TAB_IDS: readonly SidebarTabId[] = [
+	"changes",
+	"docker",
+	"files",
+	"search",
+	"problems",
+	"databases",
+];
 
 function isSidebarTabId(tab: string): tab is SidebarTabId {
 	return (VALID_TAB_IDS as readonly string[]).includes(tab);
@@ -47,6 +71,13 @@ interface WorkspaceSidebarProps {
 	onOpenComment?: (comment: CommentPaneData) => void;
 	onOpenChat?: OpenChatFn;
 	onSearch?: () => void;
+	onOpenFileAtLine?: (path: string, line?: number, column?: number) => void;
+	onOpenUrl?: (url: string) => void;
+	onOpenCommandInTerminal?: (args: {
+		command: string;
+		cwd?: string;
+		title: string;
+	}) => void | Promise<void>;
 	selectedFilePath?: string;
 	pendingReveal?: PendingReveal | null;
 	workspaceId: string;
@@ -84,6 +115,9 @@ export function WorkspaceSidebar({
 	onOpenComment,
 	onOpenChat,
 	onSearch,
+	onOpenFileAtLine,
+	onOpenUrl,
+	onOpenCommandInTerminal,
 	selectedFilePath,
 	pendingReveal,
 	workspaceId,
@@ -107,13 +141,16 @@ export function WorkspaceSidebar({
 			? localState.sidebarState.activeTab
 			: "changes";
 
-	function setActiveTab(tab: string) {
-		if (!isSidebarTabId(tab)) return;
-		if (!collections.v2WorkspaceLocalState.get(workspaceId)) return;
-		collections.v2WorkspaceLocalState.update(workspaceId, (draft) => {
-			draft.sidebarState.activeTab = tab;
-		});
-	}
+	const setActiveTab = useCallback(
+		(tab: string) => {
+			if (!isSidebarTabId(tab)) return;
+			if (!collections.v2WorkspaceLocalState.get(workspaceId)) return;
+			collections.v2WorkspaceLocalState.update(workspaceId, (draft) => {
+				draft.sidebarState.activeTab = tab;
+			});
+		},
+		[collections, workspaceId],
+	);
 
 	const containerRef = useRef<HTMLDivElement>(null);
 	const [compact, setCompact] = useState(false);
@@ -125,34 +162,65 @@ export function WorkspaceSidebar({
 			const width = entry.contentRect.width;
 			// Hysteresis: expand back to labels only once we're clearly past
 			// the breakpoint, so the labels don't jitter on the edge.
-			setCompact((prev) => (prev ? width < 280 : width < 260));
+			setCompact((prev) => (prev ? width < 520 : width < 500));
 		});
 		ro.observe(el);
 		return () => ro.disconnect();
 	}, []);
+	const trpcUtils = electronTrpc.useUtils();
+	const { data: workspaceDiagnostics } =
+		electronTrpc.languageServices.getWorkspaceDiagnostics.useQuery(
+			{ workspaceId },
+			{
+				enabled: Boolean(workspaceId),
+				staleTime: Infinity,
+			},
+		);
+	const dockerComposeFilesQuery = electronTrpc.docker.getComposeFiles.useQuery(
+		{ workspaceId },
+		{
+			enabled: Boolean(workspaceId),
+			staleTime: 10000,
+		},
+	);
+
+	electronTrpc.languageServices.subscribeDiagnostics.useSubscription(
+		{ workspaceId },
+		{
+			enabled: Boolean(workspaceId),
+			onData: () => {
+				void trpcUtils.languageServices.getWorkspaceDiagnostics.invalidate({
+					workspaceId,
+				});
+			},
+		},
+	);
+
+	const handleOpenFileAtLine = useCallback(
+		(path: string, line?: number, column?: number) => {
+			if (onOpenFileAtLine) {
+				onOpenFileAtLine(path, line, column);
+				return;
+			}
+			onSelectFile(path);
+		},
+		[onOpenFileAtLine, onSelectFile],
+	);
 
 	const changesTabDef = useChangesTab({
 		workspaceId,
 		selectedFilePath,
 		onSelectFile: onSelectDiffFile,
 		onOpenFile: onSelectFile,
+		onOpenFileAtLine: handleOpenFileAtLine,
+		onOpenComment,
+		onOpenUrl,
+		isActive: activeTab === "changes",
 	});
 	const changesTab: SidebarTabDefinition = {
 		...changesTabDef,
 		icon: LuGitCompareArrows,
 	};
-
-	const reviewTab = useReviewTab({
-		workspaceId,
-		onOpenComment,
-		onOpenInDiff: onSelectDiffFile
-			? (path, line, openInNewTab, side) => {
-					// Force annotations on so the user lands on the comment, not an empty line.
-					useSettings.getState().update("showDiffComments", true);
-					onSelectDiffFile(path, openInNewTab ?? false, line, side);
-				}
-			: undefined,
-	});
 
 	const { flowState, onRetry } = usePRFlowState(workspaceId);
 	const dispatch = usePRFlowDispatch({
@@ -175,30 +243,108 @@ export function WorkspaceSidebar({
 		),
 	};
 
-	const tabs: SidebarTabDefinition[] = [filesTab, changesTab, reviewTab];
+	const searchTab: SidebarTabDefinition = {
+		id: "search",
+		label: "Search",
+		icon: LuSearch,
+		content: (
+			<SearchView
+				isActive={activeTab === "search"}
+				onOpenFileAtLine={handleOpenFileAtLine}
+			/>
+		),
+	};
+
+	const problemErrorCount = workspaceDiagnostics?.summary.errorCount ?? 0;
+	const problemCount =
+		problemErrorCount +
+		(workspaceDiagnostics?.summary.warningCount ?? 0) +
+		(workspaceDiagnostics?.summary.infoCount ?? 0) +
+		(workspaceDiagnostics?.summary.hintCount ?? 0);
+	const problemsTab: SidebarTabDefinition = {
+		id: "problems",
+		label: "Problems",
+		icon: LuCircleAlert,
+		badge: problemCount > 0 ? problemCount : undefined,
+		content: (
+			<ProblemsView
+				isActive={activeTab === "problems"}
+				onOpenFileAtLine={(path, line) => handleOpenFileAtLine(path, line)}
+			/>
+		),
+	};
+
+	const dockerComposeFiles = dockerComposeFilesQuery.data;
+	const isResolvingDockerVisibility =
+		activeTab === "docker" && dockerComposeFilesQuery.status === "pending";
+	const showDockerTab = isResolvingDockerVisibility
+		? true
+		: (dockerComposeFiles?.composeFiles.length ?? 0) > 0 ||
+			(dockerComposeFiles?.dockerfiles?.length ?? 0) > 0;
+	const dockerTab: SidebarTabDefinition = {
+		id: "docker",
+		label: "Docker",
+		icon: LuBox,
+		content: (
+			<DockerView
+				isActive={activeTab === "docker"}
+				onOpenCommandInTerminal={onOpenCommandInTerminal}
+			/>
+		),
+	};
+
+	const databasesTab: SidebarTabDefinition = {
+		id: "databases",
+		label: "Databases",
+		icon: LuDatabase,
+		content: <DatabasesView workspaceId={workspaceId} />,
+	};
+
+	const tabs: SidebarTabDefinition[] = [
+		changesTab,
+		...(showDockerTab ? [dockerTab] : []),
+		filesTab,
+		searchTab,
+		problemsTab,
+		databasesTab,
+	];
 	const activeTabDef = tabs.find((t) => t.id === activeTab);
+	const activeTabDefId = activeTabDef?.id;
+	const fallbackTabId = tabs[0]?.id;
+
+	useEffect(() => {
+		if (activeTabDefId || isResolvingDockerVisibility) return;
+		if (fallbackTabId) setActiveTab(fallbackTabId);
+	}, [
+		activeTabDefId,
+		fallbackTabId,
+		isResolvingDockerVisibility,
+		setActiveTab,
+	]);
 
 	return (
-		<div
-			ref={containerRef}
-			className="isolate flex h-full w-full min-h-0 flex-col overflow-hidden bg-background"
-		>
-			<PRActionHeader
-				workspaceId={workspaceId}
-				state={flowState}
-				dispatch={dispatch}
-				onRetry={onRetry}
-				createPREnabled={CREATE_PR_BUTTON_ENABLED}
-			/>
-			<SidebarHeader
-				tabs={tabs}
-				activeTab={activeTab}
-				onTabChange={setActiveTab}
-				compact={compact}
-			/>
-			<div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
-				{activeTabDef?.content}
+		<WorkspaceIdProvider value={workspaceId}>
+			<div
+				ref={containerRef}
+				className="isolate flex h-full w-full min-h-0 flex-col overflow-hidden bg-background"
+			>
+				<PRActionHeader
+					workspaceId={workspaceId}
+					state={flowState}
+					dispatch={dispatch}
+					onRetry={onRetry}
+					createPREnabled={CREATE_PR_BUTTON_ENABLED}
+				/>
+				<SidebarHeader
+					tabs={tabs}
+					activeTab={activeTab}
+					onTabChange={setActiveTab}
+					compact={compact}
+				/>
+				<div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
+					{activeTabDef?.content}
+				</div>
 			</div>
-		</div>
+		</WorkspaceIdProvider>
 	);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/WorkspaceSidebar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/WorkspaceSidebar.tsx
@@ -16,6 +16,7 @@ import {
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { useWorkspaceGitStatus } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/providers/WorkspaceGitStatusProvider";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
+import { ScrollProvider } from "renderer/screens/main/components/WorkspaceView/ChangesContent";
 import { ChangesView } from "renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView";
 import { DatabasesView } from "renderer/screens/main/components/WorkspaceView/RightSidebar/DatabasesView";
 import { DockerView } from "renderer/screens/main/components/WorkspaceView/RightSidebar/DockerView";
@@ -257,21 +258,23 @@ export function WorkspaceSidebar({
 		icon: LuGitCompareArrows,
 		badge: totalChanges > 0 ? totalChanges : undefined,
 		content: (
-			<ChangesView
-				onFileOpen={handleChangeFileOpen}
-				onOpenFileAtLine={handleOpenFileAtLine}
-				onOpenComment={handleOpenReviewComment}
-				onOpenUrl={onOpenUrl}
-				onOpenActionLogs={onOpenActionLogs}
-				isGitGraphOpen={isGitGraphOpen}
-				onToggleGitGraph={onOpenGitGraph}
-				workspaceOverride={{
-					worktreePath,
-					projectId,
-					branch: workspaceBranch,
-				}}
-				isActive={activeTab === "changes"}
-			/>
+			<ScrollProvider>
+				<ChangesView
+					onFileOpen={handleChangeFileOpen}
+					onOpenFileAtLine={handleOpenFileAtLine}
+					onOpenComment={handleOpenReviewComment}
+					onOpenUrl={onOpenUrl}
+					onOpenActionLogs={onOpenActionLogs}
+					isGitGraphOpen={isGitGraphOpen}
+					onToggleGitGraph={onOpenGitGraph}
+					workspaceOverride={{
+						worktreePath,
+						projectId,
+						branch: workspaceBranch,
+					}}
+					isActive={activeTab === "changes"}
+				/>
+			</ScrollProvider>
 		),
 	};
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/WorkspaceSidebar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/WorkspaceSidebar.tsx
@@ -300,6 +300,10 @@ export function WorkspaceSidebar({
 		icon: LuSearch,
 		content: (
 			<SearchView
+				backend="workspace"
+				workspaceId={workspaceId}
+				projectId={projectId}
+				branch={workspaceBranch}
 				isActive={activeTab === "search"}
 				onOpenFileAtLine={handleOpenFileAtLine}
 			/>
@@ -351,6 +355,7 @@ export function WorkspaceSidebar({
 		content: (
 			<DatabasesView
 				workspaceId={workspaceId}
+				worktreePathOverride={worktreePath}
 				onOpenExplorer={onOpenDatabaseExplorer}
 			/>
 		),

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ReviewPanelSection/ReviewPanelSection.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ReviewPanelSection/ReviewPanelSection.tsx
@@ -1,0 +1,263 @@
+import type { GitHubStatus } from "@superset/local-db";
+import { Button } from "@superset/ui/button";
+import { toast } from "@superset/ui/sonner";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
+import { useCallback, useState } from "react";
+import { VscRefresh } from "react-icons/vsc";
+import { electronTrpc } from "renderer/lib/electron-trpc";
+import {
+	getGitHubPRCommentsQueryPolicy,
+	getGitHubStatusQueryPolicy,
+} from "renderer/lib/githubQueryPolicy";
+import { ReviewPanel } from "renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/ReviewPanel";
+import {
+	checkSummaryIconConfig,
+	countOpenPullRequestComments,
+} from "renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/ReviewPanel/utils";
+import type { ActionLogsJob } from "shared/tabs-types";
+import type { CommentPaneData } from "../../../../../../types";
+
+type GitHubStatusCacheValue = GitHubStatus | null | undefined;
+
+interface ReviewPanelSectionProps {
+	workspaceId: string;
+	isActive: boolean;
+	onOpenFileAtLine?: (path: string, line?: number) => void;
+	onOpenComment?: (comment: CommentPaneData) => void;
+	onOpenUrl?: (url: string) => void;
+}
+
+function buildGitHubCommentsQueryInput({
+	workspaceId,
+	githubStatus,
+	forceFresh,
+}: {
+	workspaceId: string;
+	githubStatus:
+		| {
+				pr?: {
+					number: number;
+					url: string;
+				} | null;
+				repoUrl?: string;
+				upstreamUrl?: string;
+				isFork?: boolean;
+		  }
+		| null
+		| undefined;
+	forceFresh?: boolean;
+}) {
+	if (!githubStatus?.pr) {
+		return {
+			workspaceId,
+			...(forceFresh ? { forceFresh: true } : {}),
+		};
+	}
+
+	return {
+		workspaceId,
+		prNumber: githubStatus.pr.number,
+		prUrl: githubStatus.pr.url,
+		repoUrl: githubStatus.repoUrl,
+		upstreamUrl: githubStatus.upstreamUrl,
+		isFork: githubStatus.isFork,
+		...(forceFresh ? { forceFresh: true } : {}),
+	};
+}
+
+export function ReviewPanelSection({
+	workspaceId,
+	isActive,
+	onOpenFileAtLine,
+	onOpenComment,
+	onOpenUrl,
+}: ReviewPanelSectionProps) {
+	const trpcUtils = electronTrpc.useUtils();
+	const [isReviewRefreshing, setIsReviewRefreshing] = useState(false);
+	const githubStatusQueryPolicy = getGitHubStatusQueryPolicy(
+		"changes-sidebar",
+		{
+			hasWorkspaceId: !!workspaceId,
+			isActive,
+			isReviewTabActive: isActive,
+		},
+	);
+	const { data: githubStatus, isLoading: isGitHubStatusLoading } =
+		electronTrpc.workspaces.getGitHubStatus.useQuery(
+			{ workspaceId },
+			githubStatusQueryPolicy,
+		);
+	const activePullRequest = githubStatus?.pr ?? null;
+	const githubPRCommentsQueryPolicy = getGitHubPRCommentsQueryPolicy({
+		hasWorkspaceId: !!workspaceId,
+		hasActivePullRequest: !!activePullRequest,
+		isActive,
+		isReviewTabActive: isActive,
+	});
+	const { data: githubComments = [], isLoading: isGitHubCommentsLoading } =
+		electronTrpc.workspaces.getGitHubPRComments.useQuery(
+			buildGitHubCommentsQueryInput({
+				workspaceId,
+				githubStatus,
+			}),
+			githubPRCommentsQueryPolicy,
+		);
+
+	const setGitHubStatusCaches = useCallback(
+		(
+			nextValue:
+				| GitHubStatusCacheValue
+				| ((current: GitHubStatusCacheValue) => GitHubStatusCacheValue),
+		) => {
+			trpcUtils.workspaces.getGitHubStatus.setData({ workspaceId }, nextValue);
+			trpcUtils.workspaces.getGitHubStatus.setData(
+				{ workspaceId, includePreview: true },
+				nextValue,
+			);
+		},
+		[trpcUtils, workspaceId],
+	);
+
+	const handleReviewRefresh = useCallback(
+		async (scope: "full" | "status" = "full") => {
+			if (!workspaceId || isReviewRefreshing) {
+				return;
+			}
+
+			setIsReviewRefreshing(true);
+			try {
+				const freshGitHubStatus =
+					await trpcUtils.workspaces.getGitHubStatus.fetch({
+						workspaceId,
+						forceFresh: true,
+						includePreview: true,
+					});
+				setGitHubStatusCaches(freshGitHubStatus);
+
+				if (scope === "full") {
+					const freshComments =
+						await trpcUtils.workspaces.getGitHubPRComments.fetch(
+							buildGitHubCommentsQueryInput({
+								workspaceId,
+								githubStatus: freshGitHubStatus,
+								forceFresh: true,
+							}),
+						);
+					trpcUtils.workspaces.getGitHubPRComments.setData(
+						buildGitHubCommentsQueryInput({
+							workspaceId,
+							githubStatus: freshGitHubStatus,
+						}),
+						freshComments,
+					);
+				}
+			} catch (error) {
+				const message =
+					error instanceof Error ? error.message : "Unknown error";
+				toast.error(`Failed to refresh review: ${message}`);
+			} finally {
+				setIsReviewRefreshing(false);
+			}
+		},
+		[isReviewRefreshing, setGitHubStatusCaches, trpcUtils, workspaceId],
+	);
+
+	const reviewCommentCount = activePullRequest
+		? countOpenPullRequestComments(githubComments)
+		: 0;
+	const relevantReviewTabChecks =
+		activePullRequest?.checks.filter(
+			(check) => check.status !== "skipped" && check.status !== "cancelled",
+		) ?? [];
+	const reviewTabChecksStatus =
+		relevantReviewTabChecks.length > 0
+			? (activePullRequest?.checksStatus ?? "none")
+			: "none";
+	const reviewTabChecksStatusConfig =
+		checkSummaryIconConfig[reviewTabChecksStatus];
+	const ReviewTabChecksIcon = reviewTabChecksStatusConfig.icon;
+
+	return (
+		<div className="flex h-full min-h-0 flex-col overflow-hidden bg-background">
+			<div className="flex h-8 shrink-0 items-center gap-2 border-b bg-background px-3 text-xs font-medium text-foreground">
+				<span>Review</span>
+				<span className="text-[11px] text-muted-foreground/60 tabular-nums">
+					{reviewCommentCount}
+				</span>
+				{activePullRequest ? (
+					<ReviewTabChecksIcon
+						className={[
+							"size-3 shrink-0",
+							reviewTabChecksStatusConfig.className,
+							reviewTabChecksStatus === "pending" ? "animate-spin" : "",
+						]
+							.filter(Boolean)
+							.join(" ")}
+					/>
+				) : null}
+				<Tooltip>
+					<TooltipTrigger asChild>
+						<Button
+							variant="ghost"
+							size="icon"
+							onClick={() => {
+								void handleReviewRefresh();
+							}}
+							disabled={isReviewRefreshing || !workspaceId}
+							className="ml-auto size-6 p-0"
+						>
+							<VscRefresh
+								className={`size-3.5 ${isReviewRefreshing ? "animate-spin" : ""}`}
+							/>
+						</Button>
+					</TooltipTrigger>
+					<TooltipContent side="top" showArrow={false}>
+						Refresh review
+					</TooltipContent>
+				</Tooltip>
+			</div>
+			<div className="min-h-0 flex-1">
+				<ReviewPanel
+					pr={isGitHubStatusLoading ? null : activePullRequest}
+					comments={githubComments}
+					isLoading={isGitHubStatusLoading}
+					isCommentsLoading={isGitHubCommentsLoading}
+					commentsQueryInput={buildGitHubCommentsQueryInput({
+						workspaceId,
+						githubStatus,
+					})}
+					onOpenFile={onOpenFileAtLine}
+					onOpenComment={(comment) =>
+						onOpenComment?.({
+							commentId: comment.id,
+							authorLogin: comment.authorLogin,
+							avatarUrl: comment.avatarUrl,
+							body: comment.body,
+							url: comment.url,
+							path: comment.path,
+							line: comment.line,
+						})
+					}
+					onOpenUrl={onOpenUrl}
+					onOpenActionLogs={(jobs, initialJobIndex) => {
+						openActionLogInBrowser(jobs, initialJobIndex, onOpenUrl);
+					}}
+					onRefreshReview={handleReviewRefresh}
+				/>
+			</div>
+		</div>
+	);
+}
+
+function openActionLogInBrowser(
+	jobs: ActionLogsJob[],
+	initialJobIndex: number | undefined,
+	onOpenUrl: ((url: string) => void) | undefined,
+) {
+	if (!onOpenUrl) return;
+	const job =
+		(initialJobIndex !== undefined ? jobs[initialJobIndex] : undefined) ??
+		jobs.find((candidate) => candidate.status === "failure") ??
+		jobs[0];
+	if (job) onOpenUrl(job.detailsUrl);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ReviewPanelSection/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ReviewPanelSection/index.ts
@@ -1,0 +1,1 @@
+export { ReviewPanelSection } from "./ReviewPanelSection";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/useChangesTab.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/useChangesTab.tsx
@@ -15,9 +15,16 @@ import type {
 	ChangesFilter,
 	ChangesViewMode,
 } from "renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema";
+import { VerticalResizablePanels } from "renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/VerticalResizablePanels";
+import {
+	DEFAULT_DIFFS_PANE_PERCENTAGE,
+	useChangesStore,
+} from "renderer/stores/changes";
 import { toAbsoluteWorkspacePath } from "shared/absolute-paths";
+import type { CommentPaneData } from "../../../../types";
 import type { SidebarTabDefinition } from "../../types";
 import { ChangesTabContent } from "./components/ChangesTabContent";
+import { ReviewPanelSection } from "./components/ReviewPanelSection";
 
 export type { ChangesFilter, ChangesViewMode };
 
@@ -27,6 +34,10 @@ interface UseChangesTabParams {
 	selectedFilePath?: string;
 	onSelectFile?: (path: string, openInNewTab?: boolean) => void;
 	onOpenFile?: (absolutePath: string, openInNewTab?: boolean) => void;
+	onOpenFileAtLine?: (path: string, line?: number) => void;
+	onOpenComment?: (comment: CommentPaneData) => void;
+	onOpenUrl?: (url: string) => void;
+	isActive?: boolean;
 }
 
 export function useChangesTab({
@@ -34,10 +45,15 @@ export function useChangesTab({
 	selectedFilePath,
 	onSelectFile,
 	onOpenFile,
+	onOpenFileAtLine,
+	onOpenComment,
+	onOpenUrl,
+	isActive = true,
 }: UseChangesTabParams): SidebarTabDefinition {
 	const status = useWorkspaceGitStatus();
 	const collections = useCollections();
 	const utils = workspaceTrpc.useUtils();
+	const { diffsPanePercentage, setDiffsPanePercentage } = useChangesStore();
 	const localState = collections.v2WorkspaceLocalState.get(workspaceId);
 	const filter: ChangesFilter = localState?.sidebarState?.changesFilter ?? {
 		kind: "all",
@@ -201,29 +217,47 @@ export function useChangesTab({
 	);
 
 	const content = (
-		<ChangesTabContent
-			workspaceId={workspaceId}
-			status={status}
-			commits={commits}
-			branches={branches}
-			filter={filter}
-			viewMode={viewMode}
-			baseBranch={baseBranch}
-			files={files}
-			isLoading={isLoading}
-			totalChanges={totalChanges}
-			totalAdditions={totalAdditions}
-			totalDeletions={totalDeletions}
-			worktreePath={worktreePath}
-			selectedFilePath={selectedFilePath}
-			onSelectFile={onSelectFile}
-			onOpenFile={onOpenFile}
-			onOpenInEditor={handleOpenInEditor}
-			onFilterChange={setFilter}
-			onViewModeChange={setViewMode}
-			onBaseBranchChange={setBaseBranch}
-			onRenameBranch={handleRenameBranch}
-			canRenameBranch={canRenameBranch}
+		<VerticalResizablePanels
+			topSizePercentage={diffsPanePercentage}
+			onTopSizePercentageChange={setDiffsPanePercentage}
+			minTopHeight={220}
+			minBottomHeight={180}
+			defaultTopSizePercentage={DEFAULT_DIFFS_PANE_PERCENTAGE}
+			top={
+				<ChangesTabContent
+					workspaceId={workspaceId}
+					status={status}
+					commits={commits}
+					branches={branches}
+					filter={filter}
+					viewMode={viewMode}
+					baseBranch={baseBranch}
+					files={files}
+					isLoading={isLoading}
+					totalChanges={totalChanges}
+					totalAdditions={totalAdditions}
+					totalDeletions={totalDeletions}
+					worktreePath={worktreePath}
+					selectedFilePath={selectedFilePath}
+					onSelectFile={onSelectFile}
+					onOpenFile={onOpenFile}
+					onOpenInEditor={handleOpenInEditor}
+					onFilterChange={setFilter}
+					onViewModeChange={setViewMode}
+					onBaseBranchChange={setBaseBranch}
+					onRenameBranch={handleRenameBranch}
+					canRenameBranch={canRenameBranch}
+				/>
+			}
+			bottom={
+				<ReviewPanelSection
+					workspaceId={workspaceId}
+					isActive={isActive}
+					onOpenFileAtLine={onOpenFileAtLine}
+					onOpenComment={onOpenComment}
+					onOpenUrl={onOpenUrl}
+				/>
+			}
 		/>
 	);
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DatabasePane/DatabasePane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DatabasePane/DatabasePane.tsx
@@ -1,0 +1,29 @@
+import type { RendererContext } from "@superset/panes";
+import { DatabasesView } from "renderer/screens/main/components/WorkspaceView/RightSidebar/DatabasesView";
+import { WorkspaceIdProvider } from "renderer/screens/main/components/WorkspaceView/WorkspaceIdContext";
+import type { DatabasePaneData, PaneViewerData } from "../../../../types";
+
+interface DatabasePaneProps {
+	context: RendererContext<PaneViewerData>;
+	workspaceId: string;
+}
+
+export function DatabasePane({ context, workspaceId }: DatabasePaneProps) {
+	const data = context.pane.data as DatabasePaneData;
+
+	return (
+		<WorkspaceIdProvider value={workspaceId}>
+			<DatabasesView
+				mode="pane"
+				selectedConnectionId={data.connectionId}
+				onSelectConnectionId={(connectionId) =>
+					context.actions.updateData({
+						...data,
+						connectionId,
+					} as PaneViewerData)
+				}
+				workspaceId={workspaceId}
+			/>
+		</WorkspaceIdProvider>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DatabasePane/DatabasePane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DatabasePane/DatabasePane.tsx
@@ -1,4 +1,5 @@
 import type { RendererContext } from "@superset/panes";
+import { workspaceTrpc } from "@superset/workspace-client";
 import { DatabasesView } from "renderer/screens/main/components/WorkspaceView/RightSidebar/DatabasesView";
 import { WorkspaceIdProvider } from "renderer/screens/main/components/WorkspaceView/WorkspaceIdContext";
 import type { DatabasePaneData, PaneViewerData } from "../../../../types";
@@ -10,6 +11,9 @@ interface DatabasePaneProps {
 
 export function DatabasePane({ context, workspaceId }: DatabasePaneProps) {
 	const data = context.pane.data as DatabasePaneData;
+	const workspaceQuery = workspaceTrpc.workspace.get.useQuery({
+		id: workspaceId,
+	});
 
 	return (
 		<WorkspaceIdProvider value={workspaceId}>
@@ -23,6 +27,7 @@ export function DatabasePane({ context, workspaceId }: DatabasePaneProps) {
 					} as PaneViewerData)
 				}
 				workspaceId={workspaceId}
+				worktreePathOverride={workspaceQuery.data?.worktreePath}
 			/>
 		</WorkspaceIdProvider>
 	);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DatabasePane/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DatabasePane/index.ts
@@ -1,0 +1,1 @@
+export { DatabasePane } from "./DatabasePane";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/GitGraphPane/GitGraphPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/GitGraphPane/GitGraphPane.tsx
@@ -1,0 +1,22 @@
+import type { RendererContext } from "@superset/panes";
+import { GitGraphView } from "renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/GitGraphView";
+import { WorkspaceIdProvider } from "renderer/screens/main/components/WorkspaceView/WorkspaceIdContext";
+import type { GitGraphPaneData, PaneViewerData } from "../../../../types";
+
+interface GitGraphPaneProps {
+	context: RendererContext<PaneViewerData>;
+	workspaceId: string;
+}
+
+export function GitGraphPane({ context, workspaceId }: GitGraphPaneProps) {
+	const data = context.pane.data as GitGraphPaneData;
+
+	return (
+		<WorkspaceIdProvider value={workspaceId}>
+			<GitGraphView
+				worktreePath={data.worktreePath}
+				workspaceId={workspaceId}
+			/>
+		</WorkspaceIdProvider>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/GitGraphPane/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/GitGraphPane/index.ts
@@ -1,0 +1,1 @@
+export { GitGraphPane } from "./GitGraphPane";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/usePaneRegistry.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/usePaneRegistry.tsx
@@ -8,7 +8,13 @@ import { alert } from "@superset/ui/atoms/Alert";
 import { toast } from "@superset/ui/sonner";
 import { cn } from "@superset/ui/utils";
 import { workspaceTrpc } from "@superset/workspace-client";
-import { Circle, GitCompareArrows, Globe, MessageSquare } from "lucide-react";
+import {
+	Circle,
+	Database,
+	GitCompareArrows,
+	Globe,
+	MessageSquare,
+} from "lucide-react";
 import { useCallback, useMemo } from "react";
 import {
 	LuArrowDownToLine,
@@ -51,10 +57,12 @@ import { ChatPaneTitle } from "./components/ChatPane/components/ChatPaneTitle";
 import { CommentPane } from "./components/CommentPane";
 import { CommentPaneHeaderExtras } from "./components/CommentPane/components/CommentPaneHeaderExtras";
 import { CommentPaneTitle } from "./components/CommentPane/components/CommentPaneTitle";
+import { DatabasePane } from "./components/DatabasePane";
 import { DiffPane } from "./components/DiffPane";
 import { DiffPaneHeaderExtras } from "./components/DiffPane/components/DiffPaneHeaderExtras";
 import { FilePane } from "./components/FilePane";
 import { FilePaneHeaderExtras } from "./components/FilePane/components/FilePaneHeaderExtras";
+import { GitGraphPane } from "./components/GitGraphPane";
 import { TerminalPane } from "./components/TerminalPane";
 import { TerminalHeaderExtras } from "./components/TerminalPane/components/TerminalHeaderExtras";
 import { TerminalPaneIcon } from "./components/TerminalPane/components/TerminalPaneIcon";
@@ -373,6 +381,30 @@ export function usePaneRegistry({
 				contextMenuActions: (_ctx, defaults) =>
 					defaults.map((d) =>
 						d.key === "close-pane" ? { ...d, label: "Close Diff" } : d,
+					),
+			},
+			database: {
+				getIcon: () => <Database className="size-3.5" />,
+				getTitle: () => "Database Explorer",
+				renderPane: (ctx: RendererContext<PaneViewerData>) => (
+					<DatabasePane context={ctx} workspaceId={workspaceId} />
+				),
+				contextMenuActions: (_ctx, defaults) =>
+					defaults.map((d) =>
+						d.key === "close-pane"
+							? { ...d, label: "Close Database Explorer" }
+							: d,
+					),
+			},
+			"git-graph": {
+				getIcon: () => <GitCompareArrows className="size-3.5" />,
+				getTitle: () => "Git Graph",
+				renderPane: (ctx: RendererContext<PaneViewerData>) => (
+					<GitGraphPane context={ctx} workspaceId={workspaceId} />
+				),
+				contextMenuActions: (_ctx, defaults) =>
+					defaults.map((d) =>
+						d.key === "close-pane" ? { ...d, label: "Close Git Graph" } : d,
 					),
 			},
 			terminal: {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
@@ -618,16 +618,24 @@ function WorkspaceContent({
 			cwd?: string;
 			title: string;
 		}) => {
-			const terminalId = await launcher.create({ command, cwd });
-			store.getState().addTab({
-				titleOverride: title,
-				panes: [
-					{
-						kind: "terminal",
-						data: { terminalId } as TerminalPaneData,
-					},
-				],
-			});
+			try {
+				const terminalId = await launcher.create({ command, cwd });
+				store.getState().addTab({
+					titleOverride: title,
+					panes: [
+						{
+							kind: "terminal",
+							data: { terminalId } as TerminalPaneData,
+						},
+					],
+				});
+			} catch (error) {
+				toast.error(
+					`Failed to open command in terminal: ${
+						error instanceof Error ? error.message : String(error)
+					}`,
+				);
+			}
 		},
 		[launcher, store],
 	);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
@@ -1,10 +1,17 @@
 import { type LayoutNode, type SplitPath, Workspace } from "@superset/panes";
+import {
+	ContextMenuSub,
+	ContextMenuSubContent,
+	ContextMenuSubTrigger,
+} from "@superset/ui/context-menu";
 import { toast } from "@superset/ui/sonner";
 import { workspaceTrpc } from "@superset/workspace-client";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { PaletteIcon } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { createPortal } from "react-dom";
 import { useQuickOpenStore } from "renderer/commandPalette/ui/QuickOpen/quickOpenStore";
+import { ColorSelector } from "renderer/components/ColorSelector";
 import { useRightSidebarOpenViewWidth } from "renderer/hooks/useRightSidebarOpenViewWidth";
 import { useV2UserPreferences } from "renderer/hooks/useV2UserPreferences";
 import { useHotkey } from "renderer/hotkeys";
@@ -24,6 +31,7 @@ import {
 	toAbsoluteWorkspacePath,
 	toRelativeWorkspacePath,
 } from "shared/absolute-paths";
+import { PROJECT_COLOR_DEFAULT } from "shared/constants/project-colors";
 import { useStore } from "zustand";
 import { useWorkspace } from "../providers/WorkspaceProvider";
 import { AddTabMenu } from "./components/AddTabMenu";
@@ -52,7 +60,12 @@ import { useWorkspaceHotkeys } from "./hooks/useWorkspaceHotkeys";
 import { useWorkspacePaneOpeners } from "./hooks/useWorkspacePaneOpeners";
 import { WorkspaceGitStatusProvider } from "./providers/WorkspaceGitStatusProvider";
 import { FileDocumentStoreProvider } from "./state/fileDocumentStore";
-import type { BrowserPaneData, FilePaneData, PaneViewerData } from "./types";
+import type {
+	BrowserPaneData,
+	FilePaneData,
+	PaneViewerData,
+	TerminalPaneData,
+} from "./types";
 import type { V2WorkspaceUrlOpenTarget } from "./utils/openUrlInV2Workspace";
 
 interface WorkspaceSearch {
@@ -483,6 +496,16 @@ function WorkspaceContent({
 		},
 		[openFilePane, openSidebarFilePane],
 	);
+	const handleOpenFileAtLine = useCallback(
+		(path: string, line?: number, column?: number) => {
+			const absolutePath =
+				worktreePath && !path.startsWith("/")
+					? toAbsoluteWorkspacePath(worktreePath, path)
+					: path;
+			openFilePane(absolutePath, undefined, { line, column });
+		},
+		[openFilePane, worktreePath],
+	);
 
 	const paneRegistry = usePaneRegistry({
 		onOpenFile: handleTerminalOpenFile,
@@ -509,6 +532,42 @@ function WorkspaceContent({
 
 	const defaultPaneActions = useDefaultPaneActions({ launcher });
 	const onBeforeCloseTab = useDirtyTabCloseGuard();
+	const openBrowserUrl = useCallback(
+		(url: string) => {
+			store.getState().addTab({
+				panes: [
+					{
+						kind: "browser",
+						data: { url, mode: "generic" } as BrowserPaneData,
+					},
+				],
+			});
+		},
+		[store],
+	);
+	const handleOpenCommandInTerminal = useCallback(
+		async ({
+			command,
+			cwd,
+			title,
+		}: {
+			command: string;
+			cwd?: string;
+			title: string;
+		}) => {
+			const terminalId = await launcher.create({ command, cwd });
+			store.getState().addTab({
+				titleOverride: title,
+				panes: [
+					{
+						kind: "terminal",
+						data: { terminalId } as TerminalPaneData,
+					},
+				],
+			});
+		},
+		[launcher, store],
+	);
 
 	// FORK NOTE: Fork-only "New Memo" action from the add-tab menu. Creates
 	// an empty markdown memo in ~/.superset/memos and opens it in the file
@@ -680,6 +739,26 @@ function WorkspaceContent({
 								sources={getV2NotificationSourcesForTab(tab)}
 							/>
 						)}
+						renderTabContextMenuItems={(tab) => (
+							<ContextMenuSub>
+								<ContextMenuSubTrigger>
+									<PaletteIcon className="size-4" />
+									Set Color
+								</ContextMenuSubTrigger>
+								<ContextMenuSubContent className="max-h-80 w-40 overflow-y-auto">
+									<ColorSelector
+										variant="menu"
+										selectedColor={tab.color}
+										onSelectColor={(color) =>
+											store.getState().setTabColor({
+												tabId: tab.id,
+												color: color === PROJECT_COLOR_DEFAULT ? null : color,
+											})
+										}
+									/>
+								</ContextMenuSubContent>
+							</ContextMenuSub>
+						)}
 						renderTabBarTrailing={() => (
 							<BackgroundTerminalsButton
 								workspaceId={workspaceId}
@@ -744,6 +823,9 @@ function WorkspaceContent({
 								onSelectDiffFile={openDiffPane}
 								onOpenComment={openCommentPane}
 								onSearch={handleQuickOpen}
+								onOpenFileAtLine={handleOpenFileAtLine}
+								onOpenUrl={openBrowserUrl}
+								onOpenCommandInTerminal={handleOpenCommandInTerminal}
 								selectedFilePath={selectedFilePath}
 								pendingReveal={pendingReveal}
 							/>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
@@ -32,6 +32,7 @@ import {
 	toRelativeWorkspacePath,
 } from "shared/absolute-paths";
 import { PROJECT_COLOR_DEFAULT } from "shared/constants/project-colors";
+import type { ActionLogsJob } from "shared/tabs-types";
 import { useStore } from "zustand";
 import { useWorkspace } from "../providers/WorkspaceProvider";
 import { AddTabMenu } from "./components/AddTabMenu";
@@ -62,7 +63,9 @@ import { WorkspaceGitStatusProvider } from "./providers/WorkspaceGitStatusProvid
 import { FileDocumentStoreProvider } from "./state/fileDocumentStore";
 import type {
 	BrowserPaneData,
+	DatabasePaneData,
 	FilePaneData,
+	GitGraphPaneData,
 	PaneViewerData,
 	TerminalPaneData,
 } from "./types";
@@ -260,6 +263,17 @@ function WorkspaceContent({
 		id: workspaceId,
 	});
 	const worktreePath = workspaceQuery.data?.worktreePath ?? "";
+	const isGitGraphOpen = useStore(store, (s) =>
+		worktreePath
+			? s.tabs.some((tab) =>
+					Object.values(tab.panes).some(
+						(pane) =>
+							pane.kind === "git-graph" &&
+							(pane.data as GitGraphPaneData).worktreePath === worktreePath,
+					),
+				)
+			: false,
+	);
 
 	const { recentFiles, recordView } = useRecentlyViewedFiles(workspaceId);
 
@@ -545,6 +559,55 @@ function WorkspaceContent({
 		},
 		[store],
 	);
+	const openActionLogsInBrowser = useCallback(
+		(jobs: ActionLogsJob[], initialJobIndex?: number) => {
+			const job =
+				(initialJobIndex !== undefined ? jobs[initialJobIndex] : undefined) ??
+				jobs.find((candidate) => candidate.status === "failure") ??
+				jobs[0];
+			if (job) openBrowserUrl(job.detailsUrl);
+		},
+		[openBrowserUrl],
+	);
+	const openDatabaseExplorer = useCallback(
+		(connectionId: string) => {
+			store.getState().addTab({
+				titleOverride: "Database Explorer",
+				panes: [
+					{
+						kind: "database",
+						data: { connectionId } as DatabasePaneData,
+					},
+				],
+			});
+		},
+		[store],
+	);
+	const openGitGraph = useCallback(() => {
+		if (!worktreePath) return;
+		const state = store.getState();
+		for (const tab of state.tabs) {
+			for (const pane of Object.values(tab.panes)) {
+				if (
+					pane.kind === "git-graph" &&
+					(pane.data as GitGraphPaneData).worktreePath === worktreePath
+				) {
+					state.setActiveTab(tab.id);
+					state.setActivePane({ tabId: tab.id, paneId: pane.id });
+					return;
+				}
+			}
+		}
+		state.addTab({
+			titleOverride: "Git Graph",
+			panes: [
+				{
+					kind: "git-graph",
+					data: { worktreePath } as GitGraphPaneData,
+				},
+			],
+		});
+	}, [store, worktreePath]);
 	const handleOpenCommandInTerminal = useCallback(
 		async ({
 			command,
@@ -823,8 +886,12 @@ function WorkspaceContent({
 								onSelectDiffFile={openDiffPane}
 								onOpenComment={openCommentPane}
 								onSearch={handleQuickOpen}
+								onOpenDatabaseExplorer={openDatabaseExplorer}
 								onOpenFileAtLine={handleOpenFileAtLine}
 								onOpenUrl={openBrowserUrl}
+								onOpenActionLogs={openActionLogsInBrowser}
+								isGitGraphOpen={isGitGraphOpen}
+								onOpenGitGraph={openGitGraph}
 								onOpenCommandInTerminal={handleOpenCommandInTerminal}
 								selectedFilePath={selectedFilePath}
 								pendingReveal={pendingReveal}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
@@ -882,6 +882,9 @@ function WorkspaceContent({
 						>
 							<WorkspaceSidebar
 								workspaceId={workspaceId}
+								worktreePath={worktreePath}
+								projectId={projectId}
+								workspaceBranch={workspaceQuery.data?.branch}
 								onSelectFile={openSidebarFilePane}
 								onSelectDiffFile={openDiffPane}
 								onOpenComment={openCommentPane}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/types.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/types.ts
@@ -52,6 +52,14 @@ export interface DevtoolsPaneData {
 	targetTitle: string;
 }
 
+export interface DatabasePaneData {
+	connectionId: string | null;
+}
+
+export interface GitGraphPaneData {
+	worktreePath: string;
+}
+
 export type DiffFocusSide = "deletions" | "additions";
 
 export interface DiffPaneData {
@@ -80,5 +88,7 @@ export type PaneViewerData =
 	| ChatPaneData
 	| BrowserPaneData
 	| DevtoolsPaneData
+	| DatabasePaneData
+	| GitGraphPaneData
 	| DiffPaneData
 	| CommentPaneData;

--- a/apps/desktop/src/renderer/routes/_authenticated/components/V1ImportModal/ImportPresetsPage/ImportPresetsPage.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/V1ImportModal/ImportPresetsPage/ImportPresetsPage.tsx
@@ -1,6 +1,7 @@
 import type { TerminalPreset } from "@superset/local-db";
 import {
 	AGENT_LABELS,
+	AGENT_PRESET_COMMANDS,
 	AGENT_TYPES,
 	type AgentType,
 } from "@superset/shared/agent-command";
@@ -88,6 +89,12 @@ export function ImportPresetsPage({ organizationId }: ImportPresetsPageProps) {
 				const v2Name = builtInAgentId
 					? AGENT_LABELS[builtInAgentId]
 					: preset.name;
+				const commands =
+					preset.commands.length > 0
+						? preset.commands
+						: builtInAgentId
+							? AGENT_PRESET_COMMANDS[builtInAgentId]
+							: preset.commands;
 				const alreadyImported = linkedAgentId
 					? importedAgentIds.has(linkedAgentId) ||
 						(!!builtInAgentId && importedAgentIds.has(builtInAgentId))
@@ -99,6 +106,7 @@ export function ImportPresetsPage({ organizationId }: ImportPresetsPageProps) {
 						tabOrder={index}
 						linkedAgentId={linkedAgentId}
 						v2Name={v2Name}
+						commands={commands}
 						alreadyImported={alreadyImported}
 						organizationId={organizationId}
 					/>
@@ -113,6 +121,7 @@ interface PresetRowProps {
 	tabOrder: number;
 	linkedAgentId: string | undefined;
 	v2Name: string;
+	commands: string[];
 	alreadyImported: boolean;
 	organizationId: string;
 }
@@ -122,6 +131,7 @@ function PresetRow({
 	tabOrder,
 	linkedAgentId,
 	v2Name,
+	commands,
 	alreadyImported,
 	organizationId,
 }: PresetRowProps) {
@@ -138,7 +148,7 @@ function PresetRow({
 				name: v2Name,
 				description: preset.description,
 				cwd: preset.cwd,
-				commands: preset.commands,
+				commands,
 				projectIds: preset.projectIds ?? null,
 				pinnedToBar: preset.pinnedToBar,
 				applyOnWorkspaceCreated: preset.applyOnWorkspaceCreated,
@@ -175,7 +185,7 @@ function PresetRow({
 		<ImportRow
 			icon={<LuTerminal className="size-3.5" strokeWidth={2} />}
 			primary={v2Name}
-			secondary={preset.description ?? preset.commands[0]}
+			secondary={preset.description ?? commands[0]}
 			action={action}
 		/>
 	);

--- a/apps/desktop/src/renderer/routes/_authenticated/components/V1ImportModal/ImportProjectsPage/ImportProjectsPage.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/V1ImportModal/ImportProjectsPage/ImportProjectsPage.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "bun:test";
+import {
+	getDefaultV1ProjectImportCandidate,
+	isProjectAlreadyImported,
+	shouldSkipV1ProjectImportAll,
+} from "./importProjectPolicy";
+
+const localCandidate = {
+	id: "local-project",
+	name: "Local Project",
+	repoCloneUrl: "https://github.com/acme/app",
+	source: "local-path",
+	matchesExpected: true,
+	staleLocalLink: false,
+} as const;
+
+const remoteCandidate = {
+	id: "cloud-project",
+	name: "Cloud Project",
+	repoCloneUrl: "https://github.com/acme/app",
+	source: "remote",
+	matchesExpected: true,
+	staleLocalLink: false,
+} as const;
+
+describe("v1 project import candidate policy", () => {
+	test("treats only local-path candidates as already imported", () => {
+		expect(
+			isProjectAlreadyImported({
+				candidates: [remoteCandidate],
+				cloudErrors: [],
+			}),
+		).toBe(false);
+		expect(
+			isProjectAlreadyImported({
+				candidates: [localCandidate, remoteCandidate],
+				cloudErrors: [],
+			}),
+		).toBe(true);
+	});
+
+	test("does not auto-link remote-only candidates", () => {
+		expect(
+			getDefaultV1ProjectImportCandidate({
+				candidates: [remoteCandidate],
+				cloudErrors: [],
+			}),
+		).toBeNull();
+		expect(
+			getDefaultV1ProjectImportCandidate({
+				candidates: [localCandidate, remoteCandidate],
+				cloudErrors: [],
+			})?.id,
+		).toBe("local-project");
+	});
+
+	test("allows Import all to create a path-specific project for remote-only matches", () => {
+		expect(
+			shouldSkipV1ProjectImportAll({
+				candidates: [remoteCandidate],
+				cloudErrors: [],
+			}),
+		).toBe(false);
+		expect(
+			shouldSkipV1ProjectImportAll({
+				candidates: [],
+				cloudErrors: [
+					{ url: "https://github.com/acme/app", message: "offline" },
+				],
+			}),
+		).toBe(true);
+	});
+});

--- a/apps/desktop/src/renderer/routes/_authenticated/components/V1ImportModal/ImportProjectsPage/ImportProjectsPage.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/V1ImportModal/ImportProjectsPage/ImportProjectsPage.tsx
@@ -13,6 +13,12 @@ import { getBaseName } from "renderer/lib/pathBasename";
 import { useFinalizeProjectSetup } from "renderer/react-query/projects";
 import { ImportPageShell } from "../components/ImportPageShell";
 import { ImportRow, type RowAction } from "../components/ImportRow";
+import {
+	getDefaultV1ProjectImportCandidate,
+	getLocalPathCandidates,
+	isProjectAlreadyImported,
+	shouldSkipV1ProjectImportAll,
+} from "./importProjectPolicy";
 
 interface ImportProjectsPageProps {
 	organizationId: string;
@@ -81,13 +87,7 @@ export function ImportProjectsPage({
 					if (isProjectAlreadyImported(findByPathResult)) {
 						continue;
 					}
-					if (findByPathResult.candidates.length > 1) {
-						continue;
-					}
-					if (
-						findByPathResult.candidates.length === 0 &&
-						findByPathResult.cloudErrors.length > 0
-					) {
+					if (shouldSkipV1ProjectImportAll(findByPathResult)) {
 						continue;
 					}
 					const result = await importProject({
@@ -216,12 +216,6 @@ function fetchProjectFindByPath(
 	});
 }
 
-function isProjectAlreadyImported(
-	findByPathResult: ProjectFindByPathResult | undefined,
-) {
-	return !!findByPathResult?.candidates.find((c) => c.source === "local-path");
-}
-
 type FinalizeProjectSetup = ReturnType<typeof useFinalizeProjectSetup>;
 
 async function importProject({
@@ -251,7 +245,7 @@ async function importProject({
 
 	const targetCandidate = linkToProjectId
 		? candidates.find((c) => c.id === linkToProjectId)
-		: candidates[0];
+		: getDefaultV1ProjectImportCandidate(findByPathResult);
 
 	if (linkToProjectId && !targetCandidate) {
 		throw new Error(
@@ -426,8 +420,13 @@ function ProjectRow({
 			};
 		}
 		const candidates = findByPathQuery.data?.candidates ?? [];
+		const localPathCandidates = getLocalPathCandidates(findByPathQuery.data);
 		const cloudErrors = findByPathQuery.data?.cloudErrors ?? [];
-		if (candidates.length === 0 && cloudErrors.length > 0) {
+		if (
+			localPathCandidates.length === 0 &&
+			candidates.length === 0 &&
+			cloudErrors.length > 0
+		) {
 			const first = cloudErrors[0];
 			return {
 				kind: "error",
@@ -439,11 +438,11 @@ function ProjectRow({
 				},
 			};
 		}
-		if (candidates.length > 1) {
+		if (localPathCandidates.length > 1) {
 			return {
 				kind: "pick",
 				label: "Link to…",
-				candidates,
+				candidates: localPathCandidates,
 				onPick: (id) => {
 					void runImport(id);
 				},
@@ -451,7 +450,7 @@ function ProjectRow({
 		}
 		return {
 			kind: "ready",
-			label: candidates.length === 1 ? "Link" : "Import",
+			label: localPathCandidates.length === 1 ? "Link" : "Import",
 			onClick: () => {
 				void runImport();
 			},

--- a/apps/desktop/src/renderer/routes/_authenticated/components/V1ImportModal/ImportProjectsPage/importProjectPolicy.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/V1ImportModal/ImportProjectsPage/importProjectPolicy.ts
@@ -1,0 +1,41 @@
+interface ProjectImportCandidate {
+	source: string;
+}
+
+interface ProjectFindByPathLike<TCandidate extends ProjectImportCandidate> {
+	candidates: TCandidate[];
+	cloudErrors: unknown[];
+}
+
+export function getLocalPathCandidates<
+	TCandidate extends ProjectImportCandidate,
+>(findByPathResult: ProjectFindByPathLike<TCandidate> | undefined) {
+	return (
+		findByPathResult?.candidates.filter((c) => c.source === "local-path") ?? []
+	);
+}
+
+export function getDefaultV1ProjectImportCandidate<
+	TCandidate extends ProjectImportCandidate,
+>(findByPathResult: ProjectFindByPathLike<TCandidate> | undefined) {
+	return getLocalPathCandidates(findByPathResult)[0] ?? null;
+}
+
+export function shouldSkipV1ProjectImportAll<
+	TCandidate extends ProjectImportCandidate,
+>(findByPathResult: ProjectFindByPathLike<TCandidate>) {
+	const localPathCandidateCount =
+		getLocalPathCandidates(findByPathResult).length;
+	if (localPathCandidateCount > 1) return true;
+	return (
+		localPathCandidateCount === 0 &&
+		findByPathResult.candidates.length === 0 &&
+		findByPathResult.cloudErrors.length > 0
+	);
+}
+
+export function isProjectAlreadyImported<
+	TCandidate extends ProjectImportCandidate,
+>(findByPathResult: ProjectFindByPathLike<TCandidate> | undefined) {
+	return getLocalPathCandidates(findByPathResult).length > 0;
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema.ts
@@ -61,7 +61,17 @@ export const workspaceLocalStateSchema = z.object({
 		sectionId: z.string().uuid().nullable().default(null),
 		changesFilter: changesFilterSchema.default({ kind: "all" }),
 		changesViewMode: z.enum(["folders", "tree"]).default("folders"),
-		activeTab: z.enum(["changes", "files", "review"]).default("changes"),
+		activeTab: z
+			.enum([
+				"changes",
+				"docker",
+				"files",
+				"search",
+				"problems",
+				"databases",
+				"review",
+			])
+			.default("changes"),
 		// FORK NOTE: keep `changesSubtab` for the fork's in-Changes review
 		// UX. upstream #3777 promoted review to a top-level tab; keeping
 		// both lets existing rows migrate cleanly.
@@ -244,7 +254,17 @@ export const v2UserPreferencesSchema = z.object({
 	sidebarFileLinks: linkTierMapSchema.default(DEFAULT_SIDEBAR_FILE_LINKS),
 	terminalPresetsInitialized: z.boolean().default(false),
 	rightSidebarOpen: z.boolean().default(true),
-	rightSidebarTab: z.enum(["changes", "files"]).default("changes"),
+	rightSidebarTab: z
+		.enum([
+			"changes",
+			"docker",
+			"files",
+			"search",
+			"problems",
+			"databases",
+			"review",
+		])
+		.default("changes"),
 	rightSidebarWidth: z.number().default(340),
 	deleteLocalBranch: z.boolean().default(false),
 	showPresetsBar: z.boolean().default(true),

--- a/apps/desktop/src/renderer/routes/error.tsx
+++ b/apps/desktop/src/renderer/routes/error.tsx
@@ -20,14 +20,11 @@ export function ErrorPage({ error, info }: ErrorComponentProps) {
 
 	const [showDetails, setShowDetails] = useState(IS_DEV);
 	const [copied, setCopied] = useState(false);
-	const copyToClipboard = useCallback(
-		async (text: string) => {
-			await navigator.clipboard.writeText(text);
-			setCopied(true);
-			setTimeout(() => setCopied(false), 2000);
-		},
-		[],
-	);
+	const copyToClipboard = useCallback(async (text: string) => {
+		await navigator.clipboard.writeText(text);
+		setCopied(true);
+		setTimeout(() => setCopied(false), 2000);
+	}, []);
 
 	useEffect(() => {
 		console.error("[renderer] Route error caught:", error, componentStack);

--- a/apps/desktop/src/renderer/routes/error.tsx
+++ b/apps/desktop/src/renderer/routes/error.tsx
@@ -1,13 +1,12 @@
 import { Button } from "@superset/ui/button";
 import type { ErrorComponentProps } from "@tanstack/react-router";
 import { Link } from "@tanstack/react-router";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import {
 	HiCheck,
 	HiExclamationTriangle,
 	HiOutlineClipboard,
 } from "react-icons/hi2";
-import { useCopyToClipboard } from "renderer/hooks/useCopyToClipboard";
 
 const IS_DEV = process.env.NODE_ENV === "development";
 const ERROR_DETAILS_ID = "error-details";
@@ -20,7 +19,15 @@ export function ErrorPage({ error, info }: ErrorComponentProps) {
 	const componentStack = info?.componentStack;
 
 	const [showDetails, setShowDetails] = useState(IS_DEV);
-	const { copyToClipboard, copied } = useCopyToClipboard();
+	const [copied, setCopied] = useState(false);
+	const copyToClipboard = useCallback(
+		async (text: string) => {
+			await navigator.clipboard.writeText(text);
+			setCopied(true);
+			setTimeout(() => setCopied(false), 2000);
+		},
+		[],
+	);
 
 	useEffect(() => {
 		console.error("[renderer] Route error caught:", error, componentStack);

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/ChangesView.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/ChangesView.tsx
@@ -956,6 +956,8 @@ export function ChangesView({
 	return (
 		<div className="flex flex-col flex-1 min-h-0">
 			<RepositoryPanel
+				backend={workspaceOverride ? "workspace" : "classic"}
+				workspaceId={workspaceId}
 				isActive={isActive}
 				onOpenUrl={onOpenUrl}
 				onOpenActionLogs={onOpenActionLogs}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/ChangesView.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/ChangesView.tsx
@@ -69,6 +69,11 @@ interface ChangesViewProps {
 	onOpenActionLogs?: (jobs: ActionLogsJob[], initialJobIndex?: number) => void;
 	isGitGraphOpen?: boolean;
 	onToggleGitGraph?: () => void;
+	workspaceOverride?: {
+		worktreePath: string | null;
+		projectId?: string | null;
+		branch?: string | null;
+	};
 	isExpandedView?: boolean;
 	isActive?: boolean;
 }
@@ -156,17 +161,20 @@ export function ChangesView({
 	onOpenActionLogs,
 	isGitGraphOpen: isGitGraphOpenOverride,
 	onToggleGitGraph,
+	workspaceOverride,
 	isExpandedView,
 	isActive = true,
 }: ChangesViewProps) {
 	const workspaceId = useWorkspaceId();
 	const trpcUtils = electronTrpc.useUtils();
-	const { data: workspace } = electronTrpc.workspaces.get.useQuery(
+	const { data: workspaceFromElectron } = electronTrpc.workspaces.get.useQuery(
 		{ id: workspaceId ?? "" },
-		{ enabled: !!workspaceId },
+		{ enabled: !!workspaceId && !workspaceOverride },
 	);
-	const worktreePath = workspace?.worktreePath;
-	const projectId = workspace?.projectId;
+	const workspace = workspaceOverride ?? workspaceFromElectron;
+	const worktreePath = workspace?.worktreePath ?? undefined;
+	const projectId = workspace?.projectId ?? undefined;
+	const workspaceBranch = workspace?.branch ?? undefined;
 	const addGitGraphTab = useTabsStore((s) => s.addGitGraphTab);
 	const isGitGraphOpenFromV1Store = useTabsStore((s) =>
 		worktreePath
@@ -410,7 +418,7 @@ export function ChangesView({
 
 	useBranchSyncInvalidation({
 		gitBranch: status?.branch ?? branchData?.currentBranch ?? undefined,
-		workspaceBranch: workspace?.branch,
+		workspaceBranch,
 		workspaceId: workspaceId ?? "",
 	});
 

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/ChangesView.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/ChangesView.tsx
@@ -1,4 +1,4 @@
-import type { GitHubStatus } from "@superset/local-db";
+import type { GitHubStatus, PullRequestComment } from "@superset/local-db";
 import { Button } from "@superset/ui/button";
 import { toast } from "@superset/ui/sonner";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
@@ -31,6 +31,7 @@ import {
 } from "shared/absolute-paths";
 import type { ChangeCategory, ChangedFile } from "shared/changes-types";
 import type { FileSystemChangeEvent } from "shared/file-tree-types";
+import type { ActionLogsJob } from "shared/tabs-types";
 import { CategorySection } from "./components/CategorySection";
 import { ChangesHeader } from "./components/ChangesHeader";
 import { CommitInput } from "./components/CommitInput";
@@ -63,6 +64,11 @@ interface ChangesViewProps {
 		commitHash?: string,
 	) => void;
 	onOpenFileAtLine?: (path: string, line?: number) => void;
+	onOpenComment?: (comment: PullRequestComment) => void;
+	onOpenUrl?: (url: string) => void;
+	onOpenActionLogs?: (jobs: ActionLogsJob[], initialJobIndex?: number) => void;
+	isGitGraphOpen?: boolean;
+	onToggleGitGraph?: () => void;
 	isExpandedView?: boolean;
 	isActive?: boolean;
 }
@@ -145,6 +151,11 @@ function eventTargetsSelectedFile(
 export function ChangesView({
 	onFileOpen,
 	onOpenFileAtLine,
+	onOpenComment,
+	onOpenUrl,
+	onOpenActionLogs,
+	isGitGraphOpen: isGitGraphOpenOverride,
+	onToggleGitGraph,
 	isExpandedView,
 	isActive = true,
 }: ChangesViewProps) {
@@ -157,7 +168,7 @@ export function ChangesView({
 	const worktreePath = workspace?.worktreePath;
 	const projectId = workspace?.projectId;
 	const addGitGraphTab = useTabsStore((s) => s.addGitGraphTab);
-	const isGitGraphOpen = useTabsStore((s) =>
+	const isGitGraphOpenFromV1Store = useTabsStore((s) =>
 		worktreePath
 			? s.tabs.some(
 					(t) =>
@@ -174,6 +185,7 @@ export function ChangesView({
 				)
 			: false,
 	);
+	const isGitGraphOpen = isGitGraphOpenOverride ?? isGitGraphOpenFromV1Store;
 	const isReviewVisible = isActive;
 	const githubStatusQueryPolicy = getGitHubStatusQueryPolicy(
 		"changes-sidebar",
@@ -935,7 +947,11 @@ export function ChangesView({
 
 	return (
 		<div className="flex flex-col flex-1 min-h-0">
-			<RepositoryPanel isActive={isActive} />
+			<RepositoryPanel
+				isActive={isActive}
+				onOpenUrl={onOpenUrl}
+				onOpenActionLogs={onOpenActionLogs}
+			/>
 			<VerticalResizablePanels
 				topSizePercentage={diffsPanePercentage}
 				onTopSizePercentageChange={setDiffsPanePercentage}
@@ -998,6 +1014,10 @@ export function ChangesView({
 									hasConflictedFiles={conflictedFiles.length > 0}
 									isGitGraphOpen={isGitGraphOpen}
 									onToggleGitGraph={() => {
+										if (onToggleGitGraph) {
+											onToggleGitGraph();
+											return;
+										}
 										if (workspaceId && worktreePath) {
 											addGitGraphTab(workspaceId, worktreePath);
 										}
@@ -1102,6 +1122,9 @@ export function ChangesView({
 									githubStatus,
 								})}
 								onOpenFile={onOpenFileAtLine}
+								onOpenComment={onOpenComment}
+								onOpenUrl={onOpenUrl}
+								onOpenActionLogs={onOpenActionLogs}
 								onRefreshReview={handleReviewRefresh}
 							/>
 						</div>

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/RepositoryPanel/RepositoryPanel.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/RepositoryPanel/RepositoryPanel.tsx
@@ -49,6 +49,7 @@ import { electronTrpc } from "renderer/lib/electron-trpc";
 import { showGitConfirmDialog } from "renderer/lib/git/gitConfirmDialog";
 import { useWorkspaceId } from "renderer/screens/main/components/WorkspaceView/WorkspaceIdContext";
 import { useTabsStore } from "renderer/stores/tabs/store";
+import type { ActionLogsJob } from "shared/tabs-types";
 
 function formatRepositoryTimestamp(value: string | null): string {
 	if (!value) {
@@ -70,6 +71,8 @@ function formatRepositoryTimestamp(value: string | null): string {
 
 interface RepositoryPanelProps {
 	isActive?: boolean;
+	onOpenUrl?: (url: string) => void;
+	onOpenActionLogs?: (jobs: ActionLogsJob[], initialJobIndex?: number) => void;
 }
 
 interface UploadedIssueAsset {
@@ -333,7 +336,11 @@ function WorkflowRunCard({
 	);
 }
 
-export function RepositoryPanel({ isActive = true }: RepositoryPanelProps) {
+export function RepositoryPanel({
+	isActive = true,
+	onOpenUrl,
+	onOpenActionLogs,
+}: RepositoryPanelProps) {
 	const workspaceId = useWorkspaceId();
 	const trpcUtils = electronTrpc.useUtils();
 	const addBrowserTab = useTabsStore((state) => state.addBrowserTab);
@@ -459,6 +466,10 @@ export function RepositoryPanel({ isActive = true }: RepositoryPanelProps) {
 	}, [workspaceId]);
 
 	const openUrl = (url: string) => {
+		if (onOpenUrl) {
+			onOpenUrl(url);
+			return;
+		}
 		if (!workspaceId) {
 			return;
 		}
@@ -672,6 +683,10 @@ export function RepositoryPanel({ isActive = true }: RepositoryPanelProps) {
 					runId,
 				});
 			const failedIdx = jobs.findIndex((j) => j.status === "failure");
+			if (onOpenActionLogs) {
+				onOpenActionLogs(jobs, failedIdx >= 0 ? failedIdx : undefined);
+				return;
+			}
 			addActionLogsTab(
 				workspaceId,
 				jobs,

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/RepositoryPanel/RepositoryPanel.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/RepositoryPanel/RepositoryPanel.tsx
@@ -836,16 +836,23 @@ function RepositoryPanelContent({
 		workflowInputDefs?: Array<{
 			name: string;
 			required: boolean;
+			default?: string;
 		}>,
 	) => {
 		if (!workspaceId) {
 			return;
 		}
 
-		const rawInputs = workflowInputValues[workflowId];
+		const defaultInputs = Object.fromEntries(
+			(workflowInputDefs ?? []).map((def) => [def.name, def.default ?? ""]),
+		);
+		const rawInputs = {
+			...defaultInputs,
+			...(workflowInputValues[workflowId] ?? {}),
+		};
 
 		// Validate required inputs
-		if (workflowInputDefs && rawInputs) {
+		if (workflowInputDefs) {
 			const missing = workflowInputDefs.filter(
 				(def) => def.required && !rawInputs[def.name]?.trim(),
 			);
@@ -857,12 +864,10 @@ function RepositoryPanelContent({
 
 		// Strip empty values
 		let filteredInputs: Record<string, string> | undefined;
-		if (rawInputs) {
-			const cleaned = Object.fromEntries(
-				Object.entries(rawInputs).filter(([, v]) => v !== ""),
-			);
-			filteredInputs = Object.keys(cleaned).length > 0 ? cleaned : undefined;
-		}
+		const cleaned = Object.fromEntries(
+			Object.entries(rawInputs).filter(([, v]) => v !== ""),
+		);
+		filteredInputs = Object.keys(cleaned).length > 0 ? cleaned : undefined;
 
 		const runDispatch = async () => {
 			setPendingWorkflowId(workflowId);

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/RepositoryPanel/RepositoryPanel.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/RepositoryPanel/RepositoryPanel.tsx
@@ -29,6 +29,7 @@ import { toast } from "@superset/ui/sonner";
 import { Textarea } from "@superset/ui/textarea";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { cn } from "@superset/ui/utils";
+import { workspaceTrpc } from "@superset/workspace-client";
 import type { ClipboardEvent } from "react";
 import { useEffect, useMemo, useState } from "react";
 import {
@@ -73,6 +74,8 @@ interface RepositoryPanelProps {
 	isActive?: boolean;
 	onOpenUrl?: (url: string) => void;
 	onOpenActionLogs?: (jobs: ActionLogsJob[], initialJobIndex?: number) => void;
+	backend?: "classic" | "workspace";
+	workspaceId?: string;
 }
 
 interface UploadedIssueAsset {
@@ -98,6 +101,79 @@ interface WorkflowRunSummary {
 	runStartedAt?: string | null;
 	runNumber?: number | null;
 	url?: string | null;
+}
+
+interface RepositoryOverview {
+	repositoryNameWithOwner: string;
+	repositoryUrl: string;
+	upstreamUrl: string;
+	upstreamNameWithOwner: string;
+	isFork: boolean;
+	branchExistsOnRemote: boolean;
+	currentBranch: string;
+	defaultBranch: string;
+	issueAssignees: Array<{ login: string; avatarUrl: string | null }>;
+	issueLabels: Array<{ name: string; color: string; description: string }>;
+	pullsUrl: string;
+	issuesUrl: string;
+	actionsUrl: string;
+	newIssueUrl: string;
+	pullRequests: Array<{
+		number: number;
+		title: string;
+		url: string;
+		state: string;
+		headRefName: string;
+		updatedAt: string | null;
+		authorLogin: string | null;
+	}>;
+	workflows: Array<{
+		id: number;
+		name: string;
+		path: string;
+		state: string;
+		supportsDispatch: boolean;
+		inputs: Array<{
+			name: string;
+			description: string;
+			required: boolean;
+			default: string;
+			type: "string" | "choice" | "boolean" | "number" | "environment";
+			options: string[];
+		}>;
+	}>;
+}
+
+interface RepositoryRuntime {
+	workspaceId: string | undefined;
+	repositoryOverview: RepositoryOverview | undefined;
+	isLoading: boolean;
+	error: unknown;
+	isCreateIssuePending: boolean;
+	invalidateOverview: () => Promise<void>;
+	createIssue: (input: {
+		workspaceId: string;
+		title: string;
+		body?: string;
+		assignees?: string[];
+		labels?: string[];
+	}) => Promise<{ url: string }>;
+	uploadIssueAsset: (input: {
+		workspaceId: string;
+		filename: string;
+		contentBase64: string;
+		mimeType?: string;
+	}) => Promise<{ name: string; url: string; markdown: string }>;
+	dispatchWorkflow: (input: {
+		workspaceId: string;
+		workflowId: number;
+		ref?: string;
+		inputs?: Record<string, string>;
+	}) => Promise<{ success: true; ref: string; dispatchedAt: string }>;
+	getWorkflowRunJobs: (input: {
+		workspaceId: string;
+		runId: number;
+	}) => Promise<ActionLogsJob[]>;
 }
 
 function buildSelectionSummary(items: string[], emptyLabel: string): string {
@@ -207,19 +283,30 @@ function findTrackedWorkflowRun(
 	});
 }
 
-function WorkflowRunCard({
-	workspaceId,
-	tracked,
-	onOpenUrl,
-	onRemove,
-	onViewLogs,
-}: {
+interface WorkflowRunCardProps {
+	backend: "classic" | "workspace";
 	workspaceId: string;
 	tracked: TrackedWorkflowRun;
 	onOpenUrl: (url: string) => void;
 	onRemove: (workflowId: number) => void;
 	onViewLogs: (runId: number) => void;
-}) {
+}
+
+function WorkflowRunCard(props: WorkflowRunCardProps) {
+	if (props.backend === "workspace") {
+		return <WorkspaceWorkflowRunCard {...props} />;
+	}
+
+	return <ClassicWorkflowRunCard {...props} />;
+}
+
+function ClassicWorkflowRunCard({
+	workspaceId,
+	tracked,
+	onOpenUrl,
+	onRemove,
+	onViewLogs,
+}: WorkflowRunCardProps) {
 	const { data: runs = [], isFetching } =
 		electronTrpc.workspaces.githubExtended.getGitHubWorkflowRuns.useQuery(
 			{
@@ -239,6 +326,71 @@ function WorkflowRunCard({
 			},
 		);
 
+	return (
+		<WorkflowRunCardContent
+			tracked={tracked}
+			runs={runs}
+			isFetching={isFetching}
+			onOpenUrl={onOpenUrl}
+			onRemove={onRemove}
+			onViewLogs={onViewLogs}
+		/>
+	);
+}
+
+function WorkspaceWorkflowRunCard({
+	workspaceId,
+	tracked,
+	onOpenUrl,
+	onRemove,
+	onViewLogs,
+}: WorkflowRunCardProps) {
+	const { data: runs = [], isFetching } =
+		workspaceTrpc.github.getWorkflowRuns.useQuery(
+			{
+				workspaceId,
+				workflowId: tracked.workflowId,
+			},
+			{
+				refetchInterval: (query) => {
+					const matched = findTrackedWorkflowRun(
+						query.state.data ?? [],
+						tracked,
+					);
+					return matched?.status === "completed" ? false : 3_000;
+				},
+				refetchIntervalInBackground: true,
+				staleTime: 0,
+			},
+		);
+
+	return (
+		<WorkflowRunCardContent
+			tracked={tracked}
+			runs={runs}
+			isFetching={isFetching}
+			onOpenUrl={onOpenUrl}
+			onRemove={onRemove}
+			onViewLogs={onViewLogs}
+		/>
+	);
+}
+
+function WorkflowRunCardContent({
+	tracked,
+	runs,
+	isFetching,
+	onOpenUrl,
+	onRemove,
+	onViewLogs,
+}: {
+	tracked: TrackedWorkflowRun;
+	runs: WorkflowRunSummary[];
+	isFetching: boolean;
+	onOpenUrl: (url: string) => void;
+	onRemove: (workflowId: number) => void;
+	onViewLogs: (runId: number) => void;
+}) {
 	const matchedRun = findTrackedWorkflowRun(runs, tracked);
 	const statusLabel = getWorkflowRunStatusLabel(matchedRun);
 	const statusClassName = getWorkflowRunStatusClassName(matchedRun);
@@ -336,13 +488,131 @@ function WorkflowRunCard({
 	);
 }
 
-export function RepositoryPanel({
-	isActive = true,
-	onOpenUrl,
-	onOpenActionLogs,
-}: RepositoryPanelProps) {
+function useClassicRepositoryRuntime(isActive: boolean): RepositoryRuntime {
 	const workspaceId = useWorkspaceId();
 	const trpcUtils = electronTrpc.useUtils();
+	const {
+		data: repositoryOverview,
+		isLoading,
+		error,
+	} = electronTrpc.workspaces.githubExtended.getGitHubRepositoryOverview.useQuery(
+		{ workspaceId: workspaceId ?? "" },
+		{
+			enabled: !!workspaceId && isActive,
+			staleTime: 300_000,
+			refetchOnWindowFocus: isActive,
+		},
+	);
+	const createIssueMutation =
+		electronTrpc.workspaces.githubExtended.createGitHubIssue.useMutation();
+	const uploadIssueAssetMutation =
+		electronTrpc.workspaces.githubExtended.uploadGitHubIssueAsset.useMutation();
+	const dispatchWorkflowMutation =
+		electronTrpc.workspaces.githubExtended.dispatchGitHubWorkflow.useMutation();
+
+	return {
+		workspaceId,
+		repositoryOverview,
+		isLoading,
+		error,
+		isCreateIssuePending: createIssueMutation.isPending,
+		invalidateOverview: async () => {
+			if (!workspaceId) return;
+			await trpcUtils.workspaces.githubExtended.getGitHubRepositoryOverview.invalidate(
+				{ workspaceId },
+			);
+		},
+		createIssue: (input) => createIssueMutation.mutateAsync(input),
+		uploadIssueAsset: (input) => uploadIssueAssetMutation.mutateAsync(input),
+		dispatchWorkflow: (input) => dispatchWorkflowMutation.mutateAsync(input),
+		getWorkflowRunJobs: (input) =>
+			trpcUtils.workspaces.githubExtended.getWorkflowRunJobs.fetch(input),
+	};
+}
+
+function useWorkspaceRepositoryRuntime({
+	workspaceId,
+	isActive,
+}: {
+	workspaceId: string | undefined;
+	isActive: boolean;
+}): RepositoryRuntime {
+	const trpcUtils = workspaceTrpc.useUtils();
+	const {
+		data: repositoryOverview,
+		isLoading,
+		error,
+	} = workspaceTrpc.github.getRepositoryOverview.useQuery(
+		{ workspaceId: workspaceId ?? "" },
+		{
+			enabled: !!workspaceId && isActive,
+			staleTime: 300_000,
+			refetchOnWindowFocus: isActive,
+		},
+	);
+	const createIssueMutation = workspaceTrpc.github.createIssue.useMutation();
+	const uploadIssueAssetMutation =
+		workspaceTrpc.github.uploadIssueAsset.useMutation();
+	const dispatchWorkflowMutation =
+		workspaceTrpc.github.dispatchWorkflow.useMutation();
+
+	return {
+		workspaceId,
+		repositoryOverview,
+		isLoading,
+		error,
+		isCreateIssuePending: createIssueMutation.isPending,
+		invalidateOverview: async () => {
+			if (!workspaceId) return;
+			await trpcUtils.github.getRepositoryOverview.invalidate({ workspaceId });
+		},
+		createIssue: (input) => createIssueMutation.mutateAsync(input),
+		uploadIssueAsset: (input) => uploadIssueAssetMutation.mutateAsync(input),
+		dispatchWorkflow: (input) => dispatchWorkflowMutation.mutateAsync(input),
+		getWorkflowRunJobs: (input) =>
+			trpcUtils.github.getWorkflowRunJobs.fetch(input),
+	};
+}
+
+export function RepositoryPanel(props: RepositoryPanelProps) {
+	if (props.backend === "workspace") {
+		return <WorkspaceRepositoryPanel {...props} />;
+	}
+
+	return <ClassicRepositoryPanel {...props} />;
+}
+
+function ClassicRepositoryPanel(props: RepositoryPanelProps) {
+	const runtime = useClassicRepositoryRuntime(props.isActive ?? true);
+	return <RepositoryPanelContent {...props} runtime={runtime} />;
+}
+
+function WorkspaceRepositoryPanel(props: RepositoryPanelProps) {
+	const runtime = useWorkspaceRepositoryRuntime({
+		workspaceId: props.workspaceId,
+		isActive: props.isActive ?? true,
+	});
+	return <RepositoryPanelContent {...props} runtime={runtime} />;
+}
+
+function RepositoryPanelContent({
+	onOpenUrl,
+	onOpenActionLogs,
+	backend = "classic",
+	runtime,
+}: RepositoryPanelProps & { runtime: RepositoryRuntime }) {
+	const {
+		workspaceId,
+		repositoryOverview,
+		isLoading,
+		error,
+		isCreateIssuePending,
+		invalidateOverview,
+		createIssue,
+		uploadIssueAsset,
+		dispatchWorkflow,
+		getWorkflowRunJobs,
+	} = runtime;
 	const addBrowserTab = useTabsStore((state) => state.addBrowserTab);
 	const addActionLogsTab = useTabsStore((state) => state.addActionLogsTab);
 	const [open, setOpen] = useState(false);
@@ -375,25 +645,6 @@ export function RepositoryPanel({
 	const [trackedWorkflowRuns, setTrackedWorkflowRuns] = useState<
 		TrackedWorkflowRun[]
 	>([]);
-	const {
-		data: repositoryOverview,
-		isLoading,
-		error,
-	} = electronTrpc.workspaces.githubExtended.getGitHubRepositoryOverview.useQuery(
-		{ workspaceId: workspaceId ?? "" },
-		{
-			enabled: !!workspaceId && isActive,
-			staleTime: 300_000,
-			refetchOnWindowFocus: isActive,
-		},
-	);
-	const createIssueMutation =
-		electronTrpc.workspaces.githubExtended.createGitHubIssue.useMutation();
-	const uploadIssueAssetMutation =
-		electronTrpc.workspaces.githubExtended.uploadGitHubIssueAsset.useMutation();
-	const dispatchWorkflowMutation =
-		electronTrpc.workspaces.githubExtended.dispatchGitHubWorkflow.useMutation();
-
 	const availableAssignees = repositoryOverview?.issueAssignees ?? [];
 	const availableAssigneesByLogin = useMemo(
 		() =>
@@ -477,25 +728,13 @@ export function RepositoryPanel({
 		addBrowserTab(workspaceId, url);
 	};
 
-	const invalidateOverview = async () => {
-		if (!workspaceId) {
-			return;
-		}
-
-		await trpcUtils.workspaces.githubExtended.getGitHubRepositoryOverview.invalidate(
-			{
-				workspaceId,
-			},
-		);
-	};
-
 	const handleCreateIssue = async () => {
 		if (!workspaceId || !issueTitle.trim()) {
 			return;
 		}
 
 		try {
-			const result = await createIssueMutation.mutateAsync({
+			const result = await createIssue({
 				workspaceId,
 				title: issueTitle.trim(),
 				body: issueBody.trim() || undefined,
@@ -541,7 +780,7 @@ export function RepositoryPanel({
 			const uploaded: UploadedIssueAsset[] = [];
 			for (const file of files) {
 				const contentBase64 = await readFileAsBase64(file);
-				const result = await uploadIssueAssetMutation.mutateAsync({
+				const result = await uploadIssueAsset({
 					workspaceId,
 					filename: file.name || `pasted-image-${Date.now()}.png`,
 					contentBase64,
@@ -628,7 +867,7 @@ export function RepositoryPanel({
 		const runDispatch = async () => {
 			setPendingWorkflowId(workflowId);
 			try {
-				const result = await dispatchWorkflowMutation.mutateAsync({
+				const result = await dispatchWorkflow({
 					workspaceId,
 					workflowId,
 					ref: workflowRef.trim() || undefined,
@@ -677,11 +916,10 @@ export function RepositoryPanel({
 			return;
 		}
 		try {
-			const jobs =
-				await trpcUtils.workspaces.githubExtended.getWorkflowRunJobs.fetch({
-					workspaceId,
-					runId,
-				});
+			const jobs = await getWorkflowRunJobs({
+				workspaceId,
+				runId,
+			});
 			const failedIdx = jobs.findIndex((j) => j.status === "failure");
 			if (onOpenActionLogs) {
 				onOpenActionLogs(jobs, failedIdx >= 0 ? failedIdx : undefined);
@@ -1115,12 +1353,12 @@ export function RepositoryPanel({
 													void handleCreateIssue();
 												}}
 												disabled={
-													createIssueMutation.isPending ||
+													isCreateIssuePending ||
 													isUploadingAsset ||
 													!issueTitle.trim()
 												}
 											>
-												{createIssueMutation.isPending ? (
+												{isCreateIssuePending ? (
 													<LuLoaderCircle className="mr-1 size-3 animate-spin" />
 												) : null}
 												Create Issue
@@ -1216,6 +1454,7 @@ export function RepositoryPanel({
 											{trackedWorkflowRuns.map((tracked) => (
 												<WorkflowRunCard
 													key={`${tracked.workflowId}-${tracked.dispatchedAt}`}
+													backend={backend}
 													workspaceId={workspaceId}
 													tracked={tracked}
 													onOpenUrl={openUrl}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/ReviewPanel/ReviewPanel.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/ReviewPanel/ReviewPanel.tsx
@@ -40,6 +40,7 @@ import { showGitConfirmDialog } from "renderer/lib/git/gitConfirmDialog";
 import { PRIcon } from "renderer/screens/main/components/PRIcon";
 import { useWorkspaceId } from "renderer/screens/main/components/WorkspaceView/WorkspaceIdContext";
 import { useTabsStore } from "renderer/stores/tabs/store";
+import type { ActionLogsJob } from "shared/tabs-types";
 import { CheckSteps } from "./components/CheckSteps";
 import { CommentBody } from "./components/CommentBody";
 import { ReplyDialog } from "./components/ReplyDialog";
@@ -92,6 +93,9 @@ interface ReviewPanelProps {
 		isFork?: boolean;
 	};
 	onOpenFile?: (path: string, line?: number) => void;
+	onOpenComment?: (comment: PullRequestComment) => void;
+	onOpenUrl?: (url: string) => void;
+	onOpenActionLogs?: (jobs: ActionLogsJob[], initialJobIndex?: number) => void;
 	onRefreshReview?: (scope?: "full" | "status") => Promise<void>;
 }
 
@@ -104,6 +108,9 @@ export function ReviewPanel({
 	isCommentsLoading = false,
 	commentsQueryInput,
 	onOpenFile,
+	onOpenComment,
+	onOpenUrl,
+	onOpenActionLogs,
 	onRefreshReview,
 }: ReviewPanelProps) {
 	const resolvedWorkspaceId = useWorkspaceId();
@@ -114,11 +121,15 @@ export function ReviewPanel({
 		(url: string, e: React.MouseEvent) => {
 			e.preventDefault();
 			e.stopPropagation();
+			if (onOpenUrl) {
+				onOpenUrl(url);
+				return;
+			}
 			if (resolvedWorkspaceId) {
 				addBrowserTab(resolvedWorkspaceId, url);
 			}
 		},
-		[resolvedWorkspaceId, addBrowserTab],
+		[resolvedWorkspaceId, addBrowserTab, onOpenUrl],
 	);
 
 	const [checksOpen, setChecksOpen] = useState(true);
@@ -211,6 +222,10 @@ export function ReviewPanel({
 	const openCommentPane = useTabsStore((s) => s.openCommentPane);
 
 	const handleOpenComment = (comment: PullRequestComment) => {
+		if (onOpenComment) {
+			onOpenComment(comment);
+			return;
+		}
 		if (!resolvedWorkspaceId) return;
 		openCommentPane(resolvedWorkspaceId, {
 			commentId: comment.id,
@@ -1289,6 +1304,13 @@ export function ReviewPanel({
 										const failedIdx = jobs.findIndex(
 											(j) => j.status === "failure",
 										);
+										if (onOpenActionLogs) {
+											onOpenActionLogs(
+												jobs,
+												failedIdx >= 0 ? failedIdx : undefined,
+											);
+											return;
+										}
 										addActionLogsTab(
 											resolvedWorkspaceId,
 											jobs,

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/DatabasesView/DatabasesView.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/DatabasesView/DatabasesView.tsx
@@ -774,6 +774,7 @@ interface DatabasesViewProps {
 	selectedConnectionId?: string | null;
 	onSelectConnectionId?: (connectionId: string | null) => void;
 	workspaceId?: string;
+	worktreePathOverride?: string;
 }
 
 type DiscoveredWorkspaceDatabaseItem =
@@ -813,14 +814,15 @@ export function DatabasesView({
 	selectedConnectionId,
 	onSelectConnectionId,
 	workspaceId: workspaceIdProp,
+	worktreePathOverride,
 }: DatabasesViewProps) {
 	const workspaceIdFromContext = useWorkspaceId();
 	const workspaceId = workspaceIdProp ?? workspaceIdFromContext;
 	const { data: workspace } = electronTrpc.workspaces.get.useQuery(
 		{ id: workspaceId ?? "" },
-		{ enabled: !!workspaceId },
+		{ enabled: !!workspaceId && !worktreePathOverride },
 	);
-	const worktreePath = workspace?.worktreePath;
+	const worktreePath = worktreePathOverride ?? workspace?.worktreePath;
 	const isSidebarMode = mode === "sidebar";
 	const isPaneMode = mode === "pane";
 	const { copyToClipboard } = useCopyToClipboard();

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/DockerView/DockerView.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/DockerView/DockerView.tsx
@@ -37,6 +37,11 @@ import { InspectCodeBlock } from "./components/InspectCodeBlock";
 
 interface DockerViewProps {
 	isActive?: boolean;
+	onOpenCommandInTerminal?: (args: {
+		command: string;
+		cwd?: string;
+		title: string;
+	}) => void | Promise<void>;
 }
 
 type DockerListResult = ElectronRouterOutputs["docker"]["list"];
@@ -75,7 +80,10 @@ function getComposeGroupTone(group: DockerComposeGroup): string {
 	return "text-amber-400";
 }
 
-export function DockerView({ isActive = true }: DockerViewProps) {
+export function DockerView({
+	isActive = true,
+	onOpenCommandInTerminal,
+}: DockerViewProps) {
 	const workspaceId = useWorkspaceId();
 	const utils = electronTrpc.useUtils();
 	const addTab = useTabsStore((state) => state.addTab);
@@ -261,6 +269,11 @@ export function DockerView({ isActive = true }: DockerViewProps) {
 				return;
 			}
 
+			if (onOpenCommandInTerminal) {
+				await onOpenCommandInTerminal({ command, cwd, title });
+				return;
+			}
+
 			const { paneId, tabId } = addTab(workspaceId, {
 				initialCwd: cwd,
 			});
@@ -285,7 +298,14 @@ export function DockerView({ isActive = true }: DockerViewProps) {
 				});
 			}
 		},
-		[addTab, setActiveTab, setFocusedPane, setPaneName, workspaceId],
+		[
+			addTab,
+			onOpenCommandInTerminal,
+			setActiveTab,
+			setFocusedPane,
+			setPaneName,
+			workspaceId,
+		],
 	);
 
 	const handleOpenLogs = useCallback(

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/SearchView/SearchView.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/SearchView/SearchView.tsx
@@ -394,7 +394,7 @@ function useClassicSearchRuntime({
 		readFile: (input) => utils.filesystem.readFile.fetch(input),
 		writeFile: (input) => writeFileMutation.mutateAsync(input),
 		invalidateSearch: () => {
-			void utils.filesystem.searchContent.invalidate();
+			refresh();
 		},
 		invalidateReadFile: (input) => {
 			void utils.filesystem.readFile.invalidate(input);
@@ -463,6 +463,7 @@ function useWorkspaceSearchRuntime({
 		writeFile: (input) => writeFileMutation.mutateAsync(input),
 		invalidateSearch: () => {
 			void utils.filesystem.searchContent.invalidate();
+			refresh();
 		},
 		invalidateReadFile: (input) => {
 			void utils.filesystem.readFile.invalidate(input);
@@ -517,7 +518,6 @@ function SearchViewContent({
 		isFetching,
 		hasQuery,
 		validationError,
-		refresh,
 		isReplacePending,
 		isWritePending,
 		usesClassicFileEvents,
@@ -736,7 +736,6 @@ function SearchViewContent({
 				}
 
 				invalidateSearch();
-				refresh();
 			} catch (error) {
 				toast.error(
 					error instanceof Error ? error.message : "Failed to replace matches.",
@@ -750,7 +749,6 @@ function SearchViewContent({
 			isRegex,
 			multiline,
 			query,
-			refresh,
 			replacement,
 			replaceContent,
 			invalidateSearch,
@@ -826,7 +824,6 @@ function SearchViewContent({
 					absolutePath: lineMatch.absolutePath,
 				});
 				invalidateSearch();
-				refresh();
 				toast.success(
 					`Replaced ${lineMatch.matches.length} match${lineMatch.matches.length === 1 ? "" : "es"} on line ${lineMatch.line}.`,
 				);
@@ -844,7 +841,6 @@ function SearchViewContent({
 			multiline,
 			query,
 			readFile,
-			refresh,
 			replacement,
 			invalidateReadFile,
 			invalidateSearch,

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/SearchView/SearchView.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/SearchView/SearchView.tsx
@@ -3,12 +3,16 @@ import { Button } from "@superset/ui/button";
 import { toast } from "@superset/ui/sonner";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { cn } from "@superset/ui/utils";
+import { workspaceTrpc } from "@superset/workspace-client";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { LuChevronsDownUp, LuRefreshCw, LuX } from "react-icons/lu";
 import { useCopyToClipboard } from "renderer/hooks/useCopyToClipboard";
 import { electronTrpc } from "renderer/lib/electron-trpc";
-import { buildSupersetOpenLink } from "renderer/lib/superset-open-links";
+import {
+	buildSupersetOpenLink,
+	type SupersetLinkProject,
+} from "renderer/lib/superset-open-links";
 import { useWorkspaceFileEvents } from "renderer/screens/main/components/WorkspaceView/hooks/useWorkspaceFileEvents";
 import { useWorkspaceId } from "renderer/screens/main/components/WorkspaceView/WorkspaceIdContext";
 import { useSearchDialogStore } from "renderer/stores/search-dialog-state";
@@ -16,6 +20,7 @@ import { SearchFileGroup } from "./components/SearchFileGroup";
 import { SearchToolbar } from "./components/SearchToolbar";
 import { SearchTreeNode } from "./components/SearchTreeNode";
 import { useContentSearch } from "./hooks/useContentSearch";
+import { useWorkspaceContentSearch } from "./hooks/useWorkspaceContentSearch";
 import type {
 	SearchContentResult,
 	SearchLineResult,
@@ -195,46 +200,144 @@ function collectFolderPaths(nodes: SearchTreeNodeType[]): string[] {
 	return paths;
 }
 
-export function SearchView({
-	isActive,
-	onOpenFileAtLine,
-}: {
+type SearchViewBackend = "classic" | "workspace";
+
+interface SearchViewProps {
 	isActive: boolean;
 	onOpenFileAtLine: (path: string, line?: number, column?: number) => void;
-}) {
+	backend?: SearchViewBackend;
+	workspaceId?: string;
+	projectId?: string;
+	branch?: string | null;
+}
+
+interface SearchRuntimeParams {
+	workspaceId?: string;
+	projectId?: string;
+	branch?: string | null;
+	query: string;
+	includePattern: string;
+	excludePattern: string;
+	isRegex: boolean;
+	caseSensitive: boolean;
+	wholeWord: boolean;
+	multiline: boolean;
+	enabled: boolean;
+}
+
+interface SearchReplaceContentInput {
+	workspaceId: string;
+	query: string;
+	replacement: string;
+	includeHidden: boolean;
+	includePattern?: string;
+	excludePattern?: string;
+	isRegex: boolean;
+	caseSensitive: boolean;
+	wholeWord: boolean;
+	multiline: boolean;
+	paths?: string[];
+}
+
+interface SearchReplaceContentResult {
+	replacements: number;
+	filesUpdated: number;
+	conflicts: readonly unknown[];
+	failed: readonly unknown[];
+}
+
+interface SearchReadFileInput {
+	workspaceId: string;
+	absolutePath: string;
+	encoding: string;
+}
+
+type SearchReadFileResult =
+	| {
+			kind: "text";
+			content: string;
+			revision: string;
+	  }
+	| {
+			kind: string;
+			content?: unknown;
+			revision?: string;
+	  };
+
+interface SearchWriteFileInput {
+	workspaceId: string;
+	absolutePath: string;
+	content: string;
+	encoding: string;
+	precondition: { ifMatch: string };
+}
+
+type SearchWriteFileResult =
+	| {
+			ok: true;
+			revision?: string;
+	  }
+	| {
+			ok: false;
+			reason?: string;
+	  };
+
+interface SearchRuntime {
+	workspaceId: string | undefined;
+	branch: string | null | undefined;
+	supersetLinkProject: SupersetLinkProject | null;
+	searchResults: SearchContentResult[];
+	isFetching: boolean;
+	hasQuery: boolean;
+	validationError: string | null;
+	refresh: () => void;
+	isReplacePending: boolean;
+	isWritePending: boolean;
+	usesClassicFileEvents: boolean;
+	replaceContent: (
+		input: SearchReplaceContentInput,
+	) => Promise<SearchReplaceContentResult>;
+	readFile: (input: SearchReadFileInput) => Promise<SearchReadFileResult>;
+	writeFile: (input: SearchWriteFileInput) => Promise<SearchWriteFileResult>;
+	invalidateSearch: () => void;
+	invalidateReadFile: (input: {
+		workspaceId: string;
+		absolutePath: string;
+	}) => void;
+}
+
+type UseSearchRuntime = (params: SearchRuntimeParams) => SearchRuntime;
+
+export function SearchView(props: SearchViewProps) {
+	if (props.backend === "workspace") {
+		return <WorkspaceSearchView {...props} />;
+	}
+
+	return <ClassicSearchView {...props} />;
+}
+
+function ClassicSearchView(props: SearchViewProps) {
+	return <SearchViewContent {...props} useRuntime={useClassicSearchRuntime} />;
+}
+
+function WorkspaceSearchView(props: SearchViewProps) {
+	return (
+		<SearchViewContent {...props} useRuntime={useWorkspaceSearchRuntime} />
+	);
+}
+
+function useClassicSearchRuntime({
+	query,
+	includePattern,
+	excludePattern,
+	isRegex,
+	caseSensitive,
+	wholeWord,
+	multiline,
+	enabled,
+}: SearchRuntimeParams): SearchRuntime {
 	const workspaceId = useWorkspaceId();
 	const utils = electronTrpc.useUtils();
-	const { copyToClipboard } = useCopyToClipboard();
-	const searchInputRef = useRef<HTMLInputElement>(null);
-	const scrollContainerRef = useRef<HTMLDivElement>(null);
-	const [query, setQuery] = useState("");
-	const [replacement, setReplacement] = useState("");
-	const [replaceOpen, setReplaceOpen] = useState(false);
-	const [isRegex, setIsRegex] = useState(false);
-	const [caseSensitive, setCaseSensitive] = useState(false);
-	const [wholeWord, setWholeWord] = useState(false);
-	const [multiline, setMultiline] = useState(false);
-	const [openGroups, setOpenGroups] = useState<Record<string, boolean>>({});
-	const [openFolders, setOpenFolders] = useState<Record<string, boolean>>({});
-	const [ignoredMatchIds, setIgnoredMatchIds] = useState<Record<string, true>>(
-		{},
-	);
-	const resultViewMode = useSearchDialogStore((state) => state.resultViewMode);
-	const setResultViewMode = useSearchDialogStore(
-		(state) => state.setResultViewMode,
-	);
-	const includePattern = useSearchDialogStore(
-		(state) => state.byMode.keywordSearch.includePattern,
-	);
-	const excludePattern = useSearchDialogStore(
-		(state) => state.byMode.keywordSearch.excludePattern,
-	);
-	const setIncludePatternByMode = useSearchDialogStore(
-		(state) => state.setIncludePattern,
-	);
-	const setExcludePatternByMode = useSearchDialogStore(
-		(state) => state.setExcludePattern,
-	);
 	const replaceMutation = electronTrpc.filesystem.replaceContent.useMutation();
 	const writeFileMutation = electronTrpc.filesystem.writeFile.useMutation();
 	const { data: workspace } = electronTrpc.workspaces.get.useQuery(
@@ -272,8 +375,170 @@ export function SearchView({
 			// lets the regex toggle control visibility and avoids wasted
 			// ripgrep calls with `--multiline` on fixed strings.
 			multiline: isRegex && multiline,
-			enabled: isActive,
+			enabled,
 		});
+
+	return {
+		workspaceId,
+		branch: workspace?.branch,
+		supersetLinkProject,
+		searchResults,
+		isFetching,
+		hasQuery,
+		validationError,
+		refresh,
+		isReplacePending: replaceMutation.isPending,
+		isWritePending: writeFileMutation.isPending,
+		usesClassicFileEvents: true,
+		replaceContent: (input) => replaceMutation.mutateAsync(input),
+		readFile: (input) => utils.filesystem.readFile.fetch(input),
+		writeFile: (input) => writeFileMutation.mutateAsync(input),
+		invalidateSearch: () => {
+			void utils.filesystem.searchContent.invalidate();
+		},
+		invalidateReadFile: (input) => {
+			void utils.filesystem.readFile.invalidate(input);
+		},
+	};
+}
+
+function useWorkspaceSearchRuntime({
+	workspaceId,
+	projectId,
+	branch,
+	query,
+	includePattern,
+	excludePattern,
+	isRegex,
+	caseSensitive,
+	wholeWord,
+	multiline,
+	enabled,
+}: SearchRuntimeParams): SearchRuntime {
+	const utils = workspaceTrpc.useUtils();
+	const replaceMutation = workspaceTrpc.filesystem.replaceContent.useMutation();
+	const writeFileMutation = workspaceTrpc.filesystem.writeFile.useMutation();
+	const { data: project } = workspaceTrpc.project.get.useQuery(
+		{ projectId: projectId ?? "" },
+		{ enabled: Boolean(projectId) },
+	);
+	const supersetLinkProject = useMemo(
+		() =>
+			project
+				? {
+						githubOwner: project.repoOwner ?? null,
+						githubRepoName: project.repoName ?? null,
+						mainRepoPath: project.repoPath,
+					}
+				: null,
+		[project],
+	);
+	const { searchResults, isFetching, hasQuery, validationError, refresh } =
+		useWorkspaceContentSearch({
+			workspaceId,
+			query,
+			includePattern,
+			excludePattern,
+			isRegex,
+			caseSensitive,
+			wholeWord,
+			multiline: isRegex && multiline,
+			enabled,
+		});
+
+	return {
+		workspaceId,
+		branch,
+		supersetLinkProject,
+		searchResults,
+		isFetching,
+		hasQuery,
+		validationError,
+		refresh,
+		isReplacePending: replaceMutation.isPending,
+		isWritePending: writeFileMutation.isPending,
+		usesClassicFileEvents: false,
+		replaceContent: (input) => replaceMutation.mutateAsync(input),
+		readFile: (input) => utils.filesystem.readFile.fetch(input),
+		writeFile: (input) => writeFileMutation.mutateAsync(input),
+		invalidateSearch: () => {
+			void utils.filesystem.searchContent.invalidate();
+		},
+		invalidateReadFile: (input) => {
+			void utils.filesystem.readFile.invalidate(input);
+		},
+	};
+}
+
+function SearchViewContent({
+	isActive,
+	onOpenFileAtLine,
+	workspaceId: workspaceIdProp,
+	projectId,
+	branch,
+	useRuntime,
+}: SearchViewProps & { useRuntime: UseSearchRuntime }) {
+	const { copyToClipboard } = useCopyToClipboard();
+	const searchInputRef = useRef<HTMLInputElement>(null);
+	const scrollContainerRef = useRef<HTMLDivElement>(null);
+	const [query, setQuery] = useState("");
+	const [replacement, setReplacement] = useState("");
+	const [replaceOpen, setReplaceOpen] = useState(false);
+	const [isRegex, setIsRegex] = useState(false);
+	const [caseSensitive, setCaseSensitive] = useState(false);
+	const [wholeWord, setWholeWord] = useState(false);
+	const [multiline, setMultiline] = useState(false);
+	const [openGroups, setOpenGroups] = useState<Record<string, boolean>>({});
+	const [openFolders, setOpenFolders] = useState<Record<string, boolean>>({});
+	const [ignoredMatchIds, setIgnoredMatchIds] = useState<Record<string, true>>(
+		{},
+	);
+	const resultViewMode = useSearchDialogStore((state) => state.resultViewMode);
+	const setResultViewMode = useSearchDialogStore(
+		(state) => state.setResultViewMode,
+	);
+	const includePattern = useSearchDialogStore(
+		(state) => state.byMode.keywordSearch.includePattern,
+	);
+	const excludePattern = useSearchDialogStore(
+		(state) => state.byMode.keywordSearch.excludePattern,
+	);
+	const setIncludePatternByMode = useSearchDialogStore(
+		(state) => state.setIncludePattern,
+	);
+	const setExcludePatternByMode = useSearchDialogStore(
+		(state) => state.setExcludePattern,
+	);
+	const {
+		workspaceId,
+		branch: workspaceBranch,
+		supersetLinkProject,
+		searchResults,
+		isFetching,
+		hasQuery,
+		validationError,
+		refresh,
+		isReplacePending,
+		isWritePending,
+		usesClassicFileEvents,
+		replaceContent,
+		readFile,
+		writeFile,
+		invalidateSearch,
+		invalidateReadFile,
+	} = useRuntime({
+		workspaceId: workspaceIdProp,
+		projectId,
+		branch,
+		query,
+		includePattern,
+		excludePattern,
+		isRegex,
+		caseSensitive,
+		wholeWord,
+		multiline,
+		enabled: isActive,
+	});
 
 	const visibleResults = useMemo(
 		() => searchResults.filter((result) => !ignoredMatchIds[result.id]),
@@ -312,7 +577,7 @@ export function SearchView({
 
 			const link = buildSupersetOpenLink({
 				project: supersetLinkProject,
-				branch: workspace?.branch,
+				branch: workspaceBranch,
 				filePath,
 				line,
 				column,
@@ -332,7 +597,7 @@ export function SearchView({
 				});
 			});
 		},
-		[copyToClipboard, supersetLinkProject, workspace?.branch],
+		[copyToClipboard, supersetLinkProject, workspaceBranch],
 	);
 	const handleCopyFileLink = useCallback(
 		(group: SearchResultGroup) => {
@@ -407,9 +672,9 @@ export function SearchView({
 			if (!query.trim()) {
 				return;
 			}
-			void utils.filesystem.searchContent.invalidate();
+			invalidateSearch();
 		},
-		Boolean(workspaceId && query.trim().length > 0),
+		Boolean(usesClassicFileEvents && workspaceId && query.trim().length > 0),
 	);
 
 	const totalMatches = visibleResults.length;
@@ -419,8 +684,8 @@ export function SearchView({
 		replaceOpen &&
 		hasQuery &&
 		validationError === null &&
-		!replaceMutation.isPending &&
-		!writeFileMutation.isPending;
+		!isReplacePending &&
+		!isWritePending;
 	// The per-match inline replace applies the regex line by line, so a
 	// multiline pattern (e.g. `foo\nbar`) that matched across newlines can
 	// never be applied by that code path — it would simply report the hit
@@ -437,7 +702,7 @@ export function SearchView({
 			}
 
 			try {
-				const result = await replaceMutation.mutateAsync({
+				const result = await replaceContent({
 					workspaceId,
 					query,
 					replacement,
@@ -470,7 +735,7 @@ export function SearchView({
 					toast.warning("No matches were replaced.");
 				}
 
-				void utils.filesystem.searchContent.invalidate();
+				invalidateSearch();
 				refresh();
 			} catch (error) {
 				toast.error(
@@ -487,8 +752,8 @@ export function SearchView({
 			query,
 			refresh,
 			replacement,
-			replaceMutation,
-			utils.filesystem.searchContent,
+			replaceContent,
+			invalidateSearch,
 			validationError,
 			wholeWord,
 			workspaceId,
@@ -496,23 +761,22 @@ export function SearchView({
 	);
 	const replaceLineMatch = useCallback(
 		async (lineMatch: SearchLineResult) => {
-			if (
-				!workspaceId ||
-				!query.trim() ||
-				validationError ||
-				writeFileMutation.isPending
-			) {
+			if (!workspaceId || !query.trim() || validationError || isWritePending) {
 				return;
 			}
 
 			try {
-				const currentFile = await utils.filesystem.readFile.fetch({
+				const currentFile = await readFile({
 					workspaceId,
 					absolutePath: lineMatch.absolutePath,
 					encoding: "utf-8",
 				});
 
-				if (currentFile.kind !== "text") {
+				if (
+					currentFile.kind !== "text" ||
+					typeof currentFile.content !== "string" ||
+					typeof currentFile.revision !== "string"
+				) {
 					toast.error("Only text files can be updated from search results.");
 					return;
 				}
@@ -537,7 +801,7 @@ export function SearchView({
 					return;
 				}
 
-				const writeResult = await writeFileMutation.mutateAsync({
+				const writeResult = await writeFile({
 					workspaceId,
 					absolutePath: lineMatch.absolutePath,
 					content: nextContent,
@@ -557,11 +821,11 @@ export function SearchView({
 					return;
 				}
 
-				void utils.filesystem.readFile.invalidate({
+				invalidateReadFile({
 					workspaceId,
 					absolutePath: lineMatch.absolutePath,
 				});
-				void utils.filesystem.searchContent.invalidate();
+				invalidateSearch();
 				refresh();
 				toast.success(
 					`Replaced ${lineMatch.matches.length} match${lineMatch.matches.length === 1 ? "" : "es"} on line ${lineMatch.line}.`,
@@ -579,13 +843,16 @@ export function SearchView({
 			isRegex,
 			multiline,
 			query,
+			readFile,
 			refresh,
 			replacement,
-			utils,
+			invalidateReadFile,
+			invalidateSearch,
 			validationError,
 			wholeWord,
 			workspaceId,
-			writeFileMutation,
+			writeFile,
+			isWritePending,
 		],
 	);
 
@@ -660,7 +927,7 @@ export function SearchView({
 				wholeWord={wholeWord}
 				multiline={multiline}
 				canReplaceAll={canReplaceAll && totalMatches > 0}
-				isReplacing={replaceMutation.isPending || writeFileMutation.isPending}
+				isReplacing={isReplacePending || isWritePending}
 				onQueryChange={setQuery}
 				onReplacementChange={setReplacement}
 				onIncludePatternChange={(value) =>
@@ -767,7 +1034,7 @@ export function SearchView({
 								className="size-7 shrink-0"
 								disabled={!hasQuery || validationError !== null || isFetching}
 								onClick={() => {
-									void utils.filesystem.searchContent.invalidate();
+									invalidateSearch();
 								}}
 							>
 								<LuRefreshCw
@@ -835,10 +1102,7 @@ export function SearchView({
 												wholeWord={wholeWord}
 												multiline={isRegex && multiline}
 												replacement={replaceOpen ? replacement : undefined}
-												isReplacing={
-													replaceMutation.isPending ||
-													writeFileMutation.isPending
-												}
+												isReplacing={isReplacePending || isWritePending}
 												showReplaceAction={canInlineReplace}
 												openGroups={openGroups}
 												openFolders={openFolders}
@@ -870,10 +1134,7 @@ export function SearchView({
 												wholeWord={wholeWord}
 												multiline={isRegex && multiline}
 												replacement={replaceOpen ? replacement : undefined}
-												isReplacing={
-													replaceMutation.isPending ||
-													writeFileMutation.isPending
-												}
+												isReplacing={isReplacePending || isWritePending}
 												showReplaceAction={canInlineReplace}
 												showParentPath
 												variant="list"

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/SearchView/hooks/useContentSearch/useContentSearch.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/SearchView/hooks/useContentSearch/useContentSearch.ts
@@ -19,7 +19,7 @@ interface UseContentSearchParams {
 	limit?: number;
 }
 
-function toResult(match: {
+export function toSearchContentResult(match: {
 	absolutePath: string;
 	relativePath: string;
 	line: number;
@@ -183,7 +183,7 @@ export function useContentSearch({
 					// UI retries can cause overlaps in edge cases.
 					const id = `${event.match.absolutePath}:${event.match.line}:${event.match.column}`;
 					if (prev.some((r) => r.id === id)) return prev;
-					return [...prev, toResult(event.match)];
+					return [...prev, toSearchContentResult(event.match)];
 				});
 				// Refresh the idle timer on every event so long-running
 				// searches don't prematurely report "done" mid-stream.

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/SearchView/hooks/useWorkspaceContentSearch/index.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/SearchView/hooks/useWorkspaceContentSearch/index.ts
@@ -1,0 +1,1 @@
+export { useWorkspaceContentSearch } from "./useWorkspaceContentSearch";

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/SearchView/hooks/useWorkspaceContentSearch/useWorkspaceContentSearch.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/SearchView/hooks/useWorkspaceContentSearch/useWorkspaceContentSearch.ts
@@ -1,0 +1,102 @@
+import { workspaceTrpc } from "@superset/workspace-client";
+import { useCallback, useMemo, useState } from "react";
+import { useDebouncedValue } from "renderer/hooks/useDebouncedValue";
+import { getSearchValidationError } from "../../utils/searchPattern/searchPattern";
+import { toSearchContentResult } from "../useContentSearch/useContentSearch";
+
+const DEFAULT_SEARCH_LIMIT = 500;
+
+interface UseWorkspaceContentSearchParams {
+	workspaceId: string | undefined;
+	query: string;
+	includePattern: string;
+	excludePattern: string;
+	isRegex: boolean;
+	caseSensitive: boolean;
+	wholeWord?: boolean;
+	multiline?: boolean;
+	enabled?: boolean;
+	limit?: number;
+}
+
+export function useWorkspaceContentSearch({
+	workspaceId,
+	query,
+	includePattern,
+	excludePattern,
+	isRegex,
+	caseSensitive,
+	wholeWord = false,
+	multiline = false,
+	enabled = true,
+	limit = DEFAULT_SEARCH_LIMIT,
+}: UseWorkspaceContentSearchParams) {
+	const trimmedQuery = query.trim();
+	const validationError = useMemo(
+		() => getSearchValidationError(trimmedQuery, isRegex),
+		[trimmedQuery, isRegex],
+	);
+	const debouncedQuery = useDebouncedValue(trimmedQuery, 150);
+	const isDebouncing =
+		trimmedQuery.length > 0 && trimmedQuery !== debouncedQuery;
+	const [refreshEpoch, setRefreshEpoch] = useState(0);
+	const refresh = useCallback(() => {
+		setRefreshEpoch((current) => current + 1);
+	}, []);
+
+	const input = useMemo(
+		() => ({
+			workspaceId: workspaceId ?? "",
+			query: debouncedQuery,
+			includeHidden: false,
+			includePattern,
+			excludePattern,
+			limit,
+			isRegex,
+			caseSensitive,
+			wholeWord,
+			multiline,
+			scopeId: `search-tab:${refreshEpoch}`,
+		}),
+		[
+			workspaceId,
+			debouncedQuery,
+			includePattern,
+			excludePattern,
+			limit,
+			isRegex,
+			caseSensitive,
+			wholeWord,
+			multiline,
+			refreshEpoch,
+		],
+	);
+
+	const queryEnabled =
+		Boolean(workspaceId) &&
+		enabled &&
+		debouncedQuery.length > 0 &&
+		validationError === null;
+	const searchQuery = workspaceTrpc.filesystem.searchContent.useQuery(input, {
+		enabled: queryEnabled,
+		staleTime: 0,
+		refetchOnWindowFocus: false,
+	});
+
+	const searchResults = useMemo(
+		() =>
+			validationError === null
+				? (searchQuery.data?.matches.map(toSearchContentResult) ?? [])
+				: [],
+		[searchQuery.data?.matches, validationError],
+	);
+
+	return {
+		searchResults,
+		isFetching:
+			validationError === null && (searchQuery.isFetching || isDebouncing),
+		hasQuery: trimmedQuery.length > 0,
+		validationError,
+		refresh,
+	};
+}

--- a/bun.lock
+++ b/bun.lock
@@ -843,6 +843,7 @@
         "better-sqlite3": "12.6.2",
         "drizzle-orm": "0.45.2",
         "hono": "4.12.22",
+        "js-yaml": "4.1.1",
         "mastracode": "0.18.1",
         "mime-types": "3.0.2",
         "node-pty": "1.1.0",
@@ -855,6 +856,7 @@
       "devDependencies": {
         "@superset/typescript": "workspace:*",
         "@types/better-sqlite3": "7.6.13",
+        "@types/js-yaml": "4.0.9",
         "@types/mime-types": "3.0.1",
         "@types/node": "24.12.0",
         "@types/semver": "7.7.1",

--- a/packages/host-service/package.json
+++ b/packages/host-service/package.json
@@ -75,6 +75,7 @@
 		"better-sqlite3": "12.6.2",
 		"drizzle-orm": "0.45.2",
 		"hono": "4.12.22",
+		"js-yaml": "4.1.1",
 		"mastracode": "0.18.1",
 		"mime-types": "3.0.2",
 		"node-pty": "1.1.0",
@@ -87,6 +88,7 @@
 	"devDependencies": {
 		"@superset/typescript": "workspace:*",
 		"@types/better-sqlite3": "7.6.13",
+		"@types/js-yaml": "4.0.9",
 		"@types/mime-types": "3.0.1",
 		"@types/node": "24.12.0",
 		"@types/semver": "7.7.1",

--- a/packages/host-service/src/trpc/router/github/github.ts
+++ b/packages/host-service/src/trpc/router/github/github.ts
@@ -1,5 +1,380 @@
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { TRPCError } from "@trpc/server";
+import { eq } from "drizzle-orm";
+import yaml from "js-yaml";
 import { z } from "zod";
+import { projects, workspaces } from "../../../db/schema";
+import type { HostServiceContext } from "../../../types";
 import { protectedProcedure, router } from "../../index";
+import { getDefaultBranchName } from "../git/utils/git-helpers";
+import { resolveGithubRepo } from "../workspace-creation/shared/project-helpers";
+
+const ghRepositoryPullRequestSchema = z.object({
+	number: z.number(),
+	title: z.string(),
+	url: z.string(),
+	state: z.enum(["OPEN", "CLOSED", "MERGED"]),
+	isDraft: z.boolean().optional().default(false),
+	headRefName: z.string().optional(),
+	updatedAt: z.string().nullable().optional(),
+	author: z
+		.object({
+			login: z.string().optional(),
+		})
+		.nullable()
+		.optional(),
+});
+
+const ghRepositoryWorkflowSchema = z.object({
+	id: z.number(),
+	name: z.string(),
+	path: z.string().optional(),
+	state: z.string().optional(),
+});
+
+const ghRepositoryWorkflowsResponseSchema = z.object({
+	workflows: z.array(ghRepositoryWorkflowSchema).optional(),
+});
+
+const ghRepositoryWorkflowRunSchema = z.object({
+	id: z.number(),
+	name: z.string().nullable().optional(),
+	display_title: z.string().nullable().optional(),
+	html_url: z.string().optional(),
+	status: z.string().nullable().optional(),
+	conclusion: z.string().nullable().optional(),
+	event: z.string().nullable().optional(),
+	created_at: z.string().nullable().optional(),
+	updated_at: z.string().nullable().optional(),
+	run_started_at: z.string().nullable().optional(),
+	head_branch: z.string().nullable().optional(),
+	head_sha: z.string().nullable().optional(),
+	run_number: z.number().optional(),
+	workflow_id: z.number().optional(),
+});
+
+const ghRepositoryWorkflowRunsResponseSchema = z.object({
+	workflow_runs: z.array(ghRepositoryWorkflowRunSchema).optional(),
+});
+
+const ghRepositoryLabelSchema = z.object({
+	name: z.string(),
+	color: z.string().optional(),
+	description: z.string().nullable().optional(),
+});
+
+const ghRepositoryAssigneeSchema = z.object({
+	login: z.string(),
+	avatar_url: z.string().optional(),
+});
+
+interface WorkflowDispatchInput {
+	name: string;
+	description: string;
+	required: boolean;
+	default: string;
+	type: "string" | "choice" | "boolean" | "number" | "environment";
+	options: string[];
+}
+
+interface WorkflowDispatchInfo {
+	supportsDispatch: boolean;
+	inputs: WorkflowDispatchInput[];
+}
+
+function normalizeIdentityList(values: string[]): string[] {
+	return Array.from(
+		new Set(values.map((value) => value.trim()).filter(Boolean)),
+	);
+}
+
+async function loadRepositorySegment<T>({
+	label,
+	load,
+	fallback,
+	workspaceId,
+	repositoryNameWithOwner,
+}: {
+	label: string;
+	load: () => Promise<T>;
+	fallback: T;
+	workspaceId: string;
+	repositoryNameWithOwner: string;
+}): Promise<T> {
+	try {
+		return await load();
+	} catch (error) {
+		console.warn("[github/repository-overview] Falling back to empty segment", {
+			label,
+			workspaceId,
+			repositoryNameWithOwner,
+			error,
+		});
+		return fallback;
+	}
+}
+
+function sanitizeIssueAssetBasename(value: string): string {
+	return value
+		.toLowerCase()
+		.replace(/[^a-z0-9._-]+/g, "-")
+		.replace(/-+/g, "-")
+		.replace(/^-|-$/g, "")
+		.slice(0, 80);
+}
+
+function getIssueAssetExtension({
+	filename,
+	mimeType,
+}: {
+	filename?: string;
+	mimeType?: string;
+}): string {
+	const lower = filename?.toLowerCase() ?? "";
+	if (lower.endsWith(".png")) return "png";
+	if (lower.endsWith(".jpg") || lower.endsWith(".jpeg")) return "jpg";
+	if (lower.endsWith(".gif")) return "gif";
+	if (lower.endsWith(".webp")) return "webp";
+
+	if (mimeType === "image/jpeg") return "jpg";
+	if (mimeType === "image/gif") return "gif";
+	if (mimeType === "image/webp") return "webp";
+	return "png";
+}
+
+function parseWorkflowDispatchInfo({
+	repoPath,
+	workflowPath,
+}: {
+	repoPath: string;
+	workflowPath?: string;
+}): WorkflowDispatchInfo {
+	const noDispatch: WorkflowDispatchInfo = {
+		supportsDispatch: false,
+		inputs: [],
+	};
+
+	if (!workflowPath) {
+		return noDispatch;
+	}
+
+	const absolutePath = path.join(repoPath, workflowPath);
+	if (!existsSync(absolutePath)) {
+		return noDispatch;
+	}
+
+	let content: string;
+	try {
+		content = readFileSync(absolutePath, "utf8");
+	} catch {
+		return noDispatch;
+	}
+
+	const hasDispatch =
+		/^\s*workflow_dispatch\s*:/m.test(content) ||
+		/^\s*on\s*:\s*workflow_dispatch\s*$/m.test(content) ||
+		/^\s*on\s*:\s*\[[^\]]*\bworkflow_dispatch\b[^\]]*\]/m.test(content);
+
+	if (!hasDispatch) {
+		return noDispatch;
+	}
+
+	try {
+		const parsed = yaml.load(content) as Record<string, unknown> | null;
+		if (!parsed || typeof parsed !== "object") {
+			return { supportsDispatch: true, inputs: [] };
+		}
+
+		const onBlock = parsed.on ?? parsed.true;
+		if (!onBlock || typeof onBlock !== "object") {
+			return { supportsDispatch: true, inputs: [] };
+		}
+
+		const dispatchBlock = (onBlock as Record<string, unknown>)
+			.workflow_dispatch;
+		if (!dispatchBlock || typeof dispatchBlock !== "object") {
+			return { supportsDispatch: true, inputs: [] };
+		}
+
+		const rawInputs = (dispatchBlock as Record<string, unknown>).inputs;
+		if (!rawInputs || typeof rawInputs !== "object") {
+			return { supportsDispatch: true, inputs: [] };
+		}
+
+		const inputs: WorkflowDispatchInput[] = Object.entries(
+			rawInputs as Record<string, unknown>,
+		).map(([name, value]) => {
+			const input = (value ?? {}) as Record<string, unknown>;
+			const inputType = String(input.type ?? "string");
+			const options: string[] = Array.isArray(input.options)
+				? input.options.map(String)
+				: [];
+
+			return {
+				name,
+				description: String(input.description ?? ""),
+				required: Boolean(input.required ?? false),
+				default: String(input.default ?? ""),
+				type: (
+					["string", "choice", "boolean", "number", "environment"] as const
+				).includes(inputType as never)
+					? (inputType as WorkflowDispatchInput["type"])
+					: "string",
+				options,
+			};
+		});
+
+		return { supportsDispatch: true, inputs };
+	} catch {
+		return { supportsDispatch: true, inputs: [] };
+	}
+}
+
+async function resolveRepositoryTarget(
+	ctx: HostServiceContext,
+	workspaceId: string,
+) {
+	const workspace = ctx.db.query.workspaces
+		.findFirst({ where: eq(workspaces.id, workspaceId) })
+		.sync();
+	if (!workspace) {
+		throw new TRPCError({
+			code: "NOT_FOUND",
+			message: "Workspace not found",
+		});
+	}
+
+	const project = ctx.db.query.projects
+		.findFirst({ where: eq(projects.id, workspace.projectId) })
+		.sync();
+	if (!project) {
+		throw new TRPCError({
+			code: "NOT_FOUND",
+			message: "Project not found",
+		});
+	}
+
+	const repo = await resolveGithubRepo(ctx, workspace.projectId);
+	const repoPath = workspace.worktreePath || repo.repoPath;
+	const git = await ctx.git(repoPath);
+	const branchSummary = await git.branch();
+	const currentBranch = branchSummary.current || workspace.branch;
+	const defaultBranch = (await getDefaultBranchName(git)) ?? "main";
+	const repositoryNameWithOwner = `${repo.owner}/${repo.name}`;
+	const repositoryUrl = `https://github.com/${repositoryNameWithOwner}`;
+	const upstreamOwner =
+		workspace.upstreamOwner ?? project.repoOwner ?? repo.owner;
+	const upstreamRepo = workspace.upstreamRepo ?? project.repoName ?? repo.name;
+	const upstreamNameWithOwner = `${upstreamOwner}/${upstreamRepo}`;
+	const upstreamUrl = `https://github.com/${upstreamNameWithOwner}`;
+	let branchExistsOnRemote = false;
+	try {
+		await git.raw([
+			"ls-remote",
+			"--exit-code",
+			"--heads",
+			"origin",
+			currentBranch,
+		]);
+		branchExistsOnRemote = true;
+	} catch {
+		branchExistsOnRemote = false;
+	}
+
+	return {
+		workspace,
+		repoPath,
+		repositoryNameWithOwner,
+		repositoryUrl,
+		upstreamNameWithOwner,
+		upstreamUrl,
+		isFork: upstreamNameWithOwner !== repositoryNameWithOwner,
+		branchExistsOnRemote,
+		currentBranch,
+		defaultBranch,
+	};
+}
+
+async function ensureGitHubBranchExists({
+	ctx,
+	repoPath,
+	repositoryNameWithOwner,
+	branchName,
+	baseBranch,
+}: {
+	ctx: HostServiceContext;
+	repoPath: string;
+	repositoryNameWithOwner: string;
+	branchName: string;
+	baseBranch: string;
+}) {
+	try {
+		await ctx.execGh(
+			["api", `repos/${repositoryNameWithOwner}/git/ref/heads/${branchName}`],
+			{ cwd: repoPath, timeout: 30_000 },
+		);
+		return;
+	} catch (error) {
+		const errorText =
+			error instanceof Error ? error.message.toLowerCase() : String(error);
+		const isMissingRefError =
+			errorText.includes("404") ||
+			errorText.includes("not found") ||
+			errorText.includes("no ref found");
+		if (!isMissingRefError) {
+			throw error;
+		}
+	}
+
+	const raw = (await ctx.execGh(
+		["api", `repos/${repositoryNameWithOwner}/git/ref/heads/${baseBranch}`],
+		{ cwd: repoPath, timeout: 30_000 },
+	)) as { object?: { sha?: string } };
+	const sha = raw.object?.sha;
+	if (!sha) {
+		throw new TRPCError({
+			code: "INTERNAL_SERVER_ERROR",
+			message: "Could not determine the base branch SHA for issue assets.",
+		});
+	}
+
+	await ctx.execGh(
+		[
+			"api",
+			"--method",
+			"POST",
+			`repos/${repositoryNameWithOwner}/git/refs`,
+			"-f",
+			`ref=refs/heads/${branchName}`,
+			"-f",
+			`sha=${sha}`,
+		],
+		{ cwd: repoPath, timeout: 30_000 },
+	);
+}
+
+function mapJobStatus(
+	status: string,
+	conclusion: string | null,
+): "success" | "failure" | "pending" | "skipped" | "cancelled" {
+	if (status !== "completed") {
+		return "pending";
+	}
+	switch (conclusion) {
+		case "success":
+			return "success";
+		case "failure":
+		case "timed_out":
+			return "failure";
+		case "cancelled":
+			return "cancelled";
+		case "skipped":
+			return "skipped";
+		default:
+			return "pending";
+	}
+}
 
 export const githubRouter = router({
 	getPRStatus: protectedProcedure
@@ -130,6 +505,371 @@ export const githubRouter = router({
 		const { data } = await octokit.users.getAuthenticated();
 		return data;
 	}),
+
+	getRepositoryOverview: protectedProcedure
+		.input(z.object({ workspaceId: z.string() }))
+		.query(async ({ ctx, input }) => {
+			const {
+				repoPath,
+				repositoryNameWithOwner,
+				repositoryUrl,
+				upstreamUrl,
+				upstreamNameWithOwner,
+				isFork,
+				branchExistsOnRemote,
+				currentBranch,
+				defaultBranch,
+			} = await resolveRepositoryTarget(ctx, input.workspaceId);
+
+			const [pullRequests, workflows, labels, assignees] = await Promise.all([
+				loadRepositorySegment({
+					label: "pullRequests",
+					workspaceId: input.workspaceId,
+					repositoryNameWithOwner,
+					fallback: [] as Array<z.infer<typeof ghRepositoryPullRequestSchema>>,
+					load: async () => {
+						const result = await ctx.execGh(
+							[
+								"pr",
+								"list",
+								"--repo",
+								repositoryNameWithOwner,
+								"--state",
+								"open",
+								"--limit",
+								"8",
+								"--json",
+								"number,title,url,state,isDraft,headRefName,updatedAt,author",
+							],
+							{ cwd: repoPath, timeout: 30_000 },
+						);
+						return z.array(ghRepositoryPullRequestSchema).parse(result);
+					},
+				}),
+				loadRepositorySegment({
+					label: "workflows",
+					workspaceId: input.workspaceId,
+					repositoryNameWithOwner,
+					fallback: [] as Array<z.infer<typeof ghRepositoryWorkflowSchema>>,
+					load: async () => {
+						const result = await ctx.execGh(
+							[
+								"api",
+								`repos/${repositoryNameWithOwner}/actions/workflows?per_page=100`,
+							],
+							{ cwd: repoPath, timeout: 30_000 },
+						);
+						return (
+							ghRepositoryWorkflowsResponseSchema.parse(result).workflows ?? []
+						);
+					},
+				}),
+				loadRepositorySegment({
+					label: "labels",
+					workspaceId: input.workspaceId,
+					repositoryNameWithOwner,
+					fallback: [] as Array<z.infer<typeof ghRepositoryLabelSchema>>,
+					load: async () => {
+						const result = await ctx.execGh(
+							["api", `repos/${repositoryNameWithOwner}/labels?per_page=100`],
+							{ cwd: repoPath, timeout: 30_000 },
+						);
+						return z.array(ghRepositoryLabelSchema).parse(result);
+					},
+				}),
+				loadRepositorySegment({
+					label: "assignees",
+					workspaceId: input.workspaceId,
+					repositoryNameWithOwner,
+					fallback: [] as Array<z.infer<typeof ghRepositoryAssigneeSchema>>,
+					load: async () => {
+						const result = await ctx.execGh(
+							[
+								"api",
+								`repos/${repositoryNameWithOwner}/assignees?per_page=100`,
+							],
+							{ cwd: repoPath, timeout: 30_000 },
+						);
+						return z.array(ghRepositoryAssigneeSchema).parse(result);
+					},
+				}),
+			]);
+
+			return {
+				repositoryNameWithOwner,
+				repositoryUrl,
+				upstreamUrl,
+				upstreamNameWithOwner,
+				isFork,
+				branchExistsOnRemote,
+				currentBranch,
+				defaultBranch,
+				issueAssignees: assignees.map((assignee) => ({
+					login: assignee.login,
+					avatarUrl: assignee.avatar_url ?? null,
+				})),
+				issueLabels: labels.map((label) => ({
+					name: label.name,
+					color: label.color ?? "",
+					description: label.description ?? "",
+				})),
+				pullsUrl: `${repositoryUrl}/pulls`,
+				issuesUrl: `${repositoryUrl}/issues`,
+				actionsUrl: `${repositoryUrl}/actions`,
+				newIssueUrl: `${repositoryUrl}/issues/new`,
+				pullRequests: pullRequests.map((pullRequest) => ({
+					number: pullRequest.number,
+					title: pullRequest.title,
+					url: pullRequest.url,
+					state: pullRequest.isDraft
+						? "draft"
+						: pullRequest.state.toLowerCase(),
+					headRefName: pullRequest.headRefName ?? "",
+					updatedAt: pullRequest.updatedAt ?? null,
+					authorLogin: pullRequest.author?.login ?? null,
+				})),
+				workflows: workflows
+					.filter((workflow) => workflow.state !== "disabled_manually")
+					.map((workflow) => {
+						const dispatchInfo = parseWorkflowDispatchInfo({
+							repoPath,
+							workflowPath: workflow.path,
+						});
+						return {
+							id: workflow.id,
+							name: workflow.name,
+							path: workflow.path ?? "",
+							state: workflow.state ?? "unknown",
+							supportsDispatch: dispatchInfo.supportsDispatch,
+							inputs: dispatchInfo.inputs,
+						};
+					})
+					.filter((workflow) => workflow.supportsDispatch),
+			};
+		}),
+
+	createIssue: protectedProcedure
+		.input(
+			z.object({
+				workspaceId: z.string(),
+				title: z.string().trim().min(1),
+				body: z.string().optional(),
+				assignees: z.array(z.string()).optional(),
+				labels: z.array(z.string()).optional(),
+			}),
+		)
+		.mutation(async ({ ctx, input }) => {
+			const { repoPath, repositoryNameWithOwner } =
+				await resolveRepositoryTarget(ctx, input.workspaceId);
+			const args = [
+				"issue",
+				"create",
+				"--repo",
+				repositoryNameWithOwner,
+				"--title",
+				input.title.trim(),
+				"--body",
+				input.body?.trim() || "",
+			];
+			const assignees = normalizeIdentityList(input.assignees ?? []);
+			const labels = normalizeIdentityList(input.labels ?? []);
+			if (assignees.length > 0) {
+				args.push("--assignee", assignees.join(","));
+			}
+			if (labels.length > 0) {
+				args.push("--label", labels.join(","));
+			}
+
+			const result = await ctx.execGh(args, { cwd: repoPath, timeout: 30_000 });
+			return {
+				url: typeof result === "string" ? result.trim() : "",
+			};
+		}),
+
+	uploadIssueAsset: protectedProcedure
+		.input(
+			z.object({
+				workspaceId: z.string(),
+				filename: z.string().trim().min(1),
+				contentBase64: z.string().trim().min(1),
+				mimeType: z.string().optional(),
+			}),
+		)
+		.mutation(async ({ ctx, input }) => {
+			const { repoPath, repositoryNameWithOwner, defaultBranch } =
+				await resolveRepositoryTarget(ctx, input.workspaceId);
+			const assetBranch = "superset-issue-assets";
+			await ensureGitHubBranchExists({
+				ctx,
+				repoPath,
+				repositoryNameWithOwner,
+				branchName: assetBranch,
+				baseBranch: defaultBranch,
+			});
+
+			const now = new Date();
+			const extension = getIssueAssetExtension({
+				filename: input.filename,
+				mimeType: input.mimeType,
+			});
+			const basename =
+				sanitizeIssueAssetBasename(input.filename.replace(/\.[^.]+$/, "")) ||
+				"pasted-image";
+			const timestamp = now.toISOString().replace(/[:.]/g, "-");
+			const assetPath = [
+				".superset",
+				"issue-assets",
+				String(now.getUTCFullYear()),
+				String(now.getUTCMonth() + 1).padStart(2, "0"),
+				`${timestamp}-${basename}.${extension}`,
+			].join("/");
+
+			await ctx.execGh(
+				[
+					"api",
+					"--method",
+					"PUT",
+					`repos/${repositoryNameWithOwner}/contents/${assetPath}`,
+					"-f",
+					`message=Add issue asset ${assetPath}`,
+					"-f",
+					`content=${input.contentBase64}`,
+					"-f",
+					`branch=${assetBranch}`,
+				],
+				{ cwd: repoPath, timeout: 60_000 },
+			);
+
+			const assetUrl = `https://github.com/${repositoryNameWithOwner}/raw/${assetBranch}/${assetPath}`;
+			return {
+				name: `${basename}.${extension}`,
+				url: assetUrl,
+				markdown: `![${basename}](${assetUrl})`,
+			};
+		}),
+
+	dispatchWorkflow: protectedProcedure
+		.input(
+			z.object({
+				workspaceId: z.string(),
+				workflowId: z.number().int().positive(),
+				ref: z.string().optional(),
+				inputs: z.record(z.string(), z.string()).optional(),
+			}),
+		)
+		.mutation(async ({ ctx, input }) => {
+			const {
+				repoPath,
+				repositoryNameWithOwner,
+				currentBranch,
+				defaultBranch,
+				branchExistsOnRemote,
+			} = await resolveRepositoryTarget(ctx, input.workspaceId);
+			const requestedRef = input.ref?.trim() || currentBranch || defaultBranch;
+			const targetRef =
+				requestedRef === currentBranch && !branchExistsOnRemote
+					? defaultBranch
+					: requestedRef;
+			const args = [
+				"api",
+				"--method",
+				"POST",
+				`repos/${repositoryNameWithOwner}/actions/workflows/${input.workflowId}/dispatches`,
+				"-f",
+				`ref=${targetRef}`,
+			];
+
+			if (input.inputs) {
+				for (const [key, value] of Object.entries(input.inputs)) {
+					args.push("-f", `inputs[${key}]=${value}`);
+				}
+			}
+
+			await ctx.execGh(args, { cwd: repoPath, timeout: 30_000 });
+			return {
+				success: true as const,
+				ref: targetRef,
+				dispatchedAt: new Date().toISOString(),
+			};
+		}),
+
+	getWorkflowRuns: protectedProcedure
+		.input(
+			z.object({
+				workspaceId: z.string(),
+				workflowId: z.number().int().positive(),
+			}),
+		)
+		.query(async ({ ctx, input }) => {
+			const { repoPath, repositoryNameWithOwner } =
+				await resolveRepositoryTarget(ctx, input.workspaceId);
+			const result = await ctx.execGh(
+				[
+					"api",
+					`repos/${repositoryNameWithOwner}/actions/workflows/${input.workflowId}/runs?per_page=10&event=workflow_dispatch`,
+				],
+				{ cwd: repoPath, timeout: 30_000 },
+			);
+			const runs =
+				ghRepositoryWorkflowRunsResponseSchema.parse(result).workflow_runs ??
+				[];
+			return runs.map((run) => ({
+				id: run.id,
+				name: run.name ?? "",
+				displayTitle: run.display_title ?? "",
+				url: run.html_url ?? "",
+				status: run.status ?? "unknown",
+				conclusion: run.conclusion ?? null,
+				event: run.event ?? null,
+				createdAt: run.created_at ?? null,
+				updatedAt: run.updated_at ?? null,
+				runStartedAt: run.run_started_at ?? null,
+				headBranch: run.head_branch ?? null,
+				headSha: run.head_sha ?? null,
+				runNumber: run.run_number ?? null,
+				workflowId: run.workflow_id ?? input.workflowId,
+			}));
+		}),
+
+	getWorkflowRunJobs: protectedProcedure
+		.input(
+			z.object({
+				workspaceId: z.string(),
+				runId: z.number().int().positive(),
+			}),
+		)
+		.query(async ({ ctx, input }) => {
+			const { repoPath, repositoryNameWithOwner } =
+				await resolveRepositoryTarget(ctx, input.workspaceId);
+			const result = await ctx.execGh(
+				[
+					"api",
+					`repos/${repositoryNameWithOwner}/actions/runs/${input.runId}/jobs?per_page=100`,
+				],
+				{ cwd: repoPath, timeout: 30_000 },
+			);
+			const parsed = z
+				.object({
+					jobs: z
+						.array(
+							z.object({
+								id: z.number(),
+								name: z.string(),
+								status: z.string(),
+								conclusion: z.string().nullable(),
+								html_url: z.string().nullable().optional(),
+							}),
+						)
+						.optional(),
+				})
+				.parse(result);
+
+			return (parsed.jobs ?? []).map((job) => ({
+				detailsUrl: job.html_url ?? "",
+				name: job.name,
+				status: mapJobStatus(job.status, job.conclusion),
+			}));
+		}),
 
 	mergePR: protectedProcedure
 		.input(

--- a/packages/host-service/src/trpc/router/github/github.ts
+++ b/packages/host-service/src/trpc/router/github/github.ts
@@ -171,24 +171,29 @@ function parseWorkflowDispatchInfo({
 		return noDispatch;
 	}
 
-	const hasDispatch =
-		/^\s*workflow_dispatch\s*:/m.test(content) ||
-		/^\s*on\s*:\s*workflow_dispatch\s*$/m.test(content) ||
-		/^\s*on\s*:\s*\[[^\]]*\bworkflow_dispatch\b[^\]]*\]/m.test(content);
-
-	if (!hasDispatch) {
-		return noDispatch;
-	}
-
 	try {
 		const parsed = yaml.load(content) as Record<string, unknown> | null;
 		if (!parsed || typeof parsed !== "object") {
-			return { supportsDispatch: true, inputs: [] };
+			return noDispatch;
 		}
 
 		const onBlock = parsed.on ?? parsed.true;
-		if (!onBlock || typeof onBlock !== "object") {
+		if (onBlock === "workflow_dispatch") {
 			return { supportsDispatch: true, inputs: [] };
+		}
+
+		if (Array.isArray(onBlock)) {
+			return onBlock.map(String).includes("workflow_dispatch")
+				? { supportsDispatch: true, inputs: [] }
+				: noDispatch;
+		}
+
+		if (!onBlock || typeof onBlock !== "object") {
+			return noDispatch;
+		}
+
+		if (!Object.hasOwn(onBlock, "workflow_dispatch")) {
+			return noDispatch;
 		}
 
 		const dispatchBlock = (onBlock as Record<string, unknown>)
@@ -227,7 +232,7 @@ function parseWorkflowDispatchInfo({
 
 		return { supportsDispatch: true, inputs };
 	} catch {
-		return { supportsDispatch: true, inputs: [] };
+		return noDispatch;
 	}
 }
 

--- a/packages/panes/src/core/store/store.ts
+++ b/packages/panes/src/core/store/store.ts
@@ -17,6 +17,7 @@ import {
 	positionToDirection,
 	removePaneFromLayout,
 	replacePaneIdInLayout,
+	splitNodeInLayout,
 	splitPaneInLayout,
 	updateAtPath,
 } from "./utils";
@@ -54,6 +55,7 @@ function buildBalancedTree(
 function buildTab<TData>(args: {
 	id?: string;
 	titleOverride?: string;
+	color?: string | null;
 	panes: [Pane<TData>, ...Pane<TData>[]];
 	activePaneId?: string;
 }): Tab<TData> {
@@ -68,6 +70,7 @@ function buildTab<TData>(args: {
 	return {
 		id: args.id ?? generateId("tab"),
 		titleOverride: args.titleOverride,
+		color: args.color,
 		createdAt: Date.now(),
 		activePaneId: args.activePaneId ?? args.panes[0].id,
 		layout: buildBalancedTree(leaves),
@@ -103,6 +106,7 @@ export type CreatePaneInput<TData> = {
 export type CreateTabInput<TData> = {
 	id?: string;
 	titleOverride?: string;
+	color?: string | null;
 	panes: [CreatePaneInput<TData>, ...CreatePaneInput<TData>[]];
 	activePaneId?: string;
 };
@@ -115,6 +119,7 @@ export interface WorkspaceStore<TData> extends WorkspaceState<TData> {
 		tabId: string;
 		titleOverride?: string;
 	}) => void;
+	setTabColor: (args: { tabId: string; color: string | null }) => void;
 	getTab: (tabId: string) => Tab<TData> | null;
 	getActiveTab: () => Tab<TData> | null;
 
@@ -162,6 +167,11 @@ export interface WorkspaceStore<TData> extends WorkspaceState<TData> {
 
 	movePaneToSplit: (args: {
 		sourcePaneId: string;
+		targetPaneId: string;
+		position: SplitPosition;
+	}) => void;
+	moveTabToSplit: (args: {
+		sourceTabId: string;
 		targetPaneId: string;
 		position: SplitPosition;
 	}) => void;
@@ -227,6 +237,14 @@ export function createWorkspaceStore<TData>(
 			set((s) => ({
 				tabs: s.tabs.map((t) =>
 					t.id === args.tabId ? { ...t, titleOverride: args.titleOverride } : t,
+				),
+			}));
+		},
+
+		setTabColor: (args) => {
+			set((s) => ({
+				tabs: s.tabs.map((t) =>
+					t.id === args.tabId ? { ...t, color: args.color } : t,
 				),
 			}));
 		},
@@ -718,6 +736,43 @@ export function createWorkspaceStore<TData>(
 								layout: nextTargetLayout,
 								panes: { ...t.panes, [sourcePane.id]: sourcePane },
 								activePaneId: sourcePane.id,
+							};
+						}
+						return t;
+					})
+					.filter((t): t is Tab<TData> => t !== null);
+
+				return { tabs: nextTabs, activeTabId: targetTab.id };
+			});
+		},
+
+		moveTabToSplit: (args) => {
+			set((s) => {
+				const sourceTab = s.tabs.find((t) => t.id === args.sourceTabId);
+				const targetTab = s.tabs.find((t) => t.panes[args.targetPaneId]);
+				if (!sourceTab || !targetTab) return s;
+				if (sourceTab.id === targetTab.id) return s;
+				if (!sourceTab.layout || !targetTab.layout) return s;
+				if (!findPaneInLayout(targetTab.layout, args.targetPaneId)) return s;
+
+				const nextTargetLayout = splitNodeInLayout(
+					targetTab.layout,
+					args.targetPaneId,
+					sourceTab.layout,
+					args.position,
+				);
+				const activePaneId =
+					sourceTab.activePaneId ?? findFirstPaneId(sourceTab.layout);
+
+				const nextTabs = s.tabs
+					.map((t) => {
+						if (t.id === sourceTab.id) return null;
+						if (t.id === targetTab.id) {
+							return {
+								...t,
+								layout: nextTargetLayout,
+								panes: { ...t.panes, ...sourceTab.panes },
+								activePaneId,
 							};
 						}
 						return t;

--- a/packages/panes/src/core/store/store.ts
+++ b/packages/panes/src/core/store/store.ts
@@ -52,6 +52,25 @@ function buildBalancedTree(
 	};
 }
 
+function normalizeTabColor(color: string | null | undefined): string | null {
+	if (!color) return null;
+	const hex = color.trim().replace(/^#/, "").toLowerCase();
+	if (/^[0-9a-f]{3}$/.test(hex)) {
+		return `#${hex
+			.split("")
+			.map((char) => `${char}${char}`)
+			.join("")}`;
+	}
+	if (/^[0-9a-f]{6}$/.test(hex)) {
+		return `#${hex}`;
+	}
+	return null;
+}
+
+function normalizeTab<TData>(tab: Tab<TData>): Tab<TData> {
+	return { ...tab, color: normalizeTabColor(tab.color) };
+}
+
 function buildTab<TData>(args: {
 	id?: string;
 	titleOverride?: string;
@@ -70,7 +89,7 @@ function buildTab<TData>(args: {
 	return {
 		id: args.id ?? generateId("tab"),
 		titleOverride: args.titleOverride,
-		color: args.color,
+		color: normalizeTabColor(args.color),
 		createdAt: Date.now(),
 		activePaneId: args.activePaneId ?? args.panes[0].id,
 		layout: buildBalancedTree(leaves),
@@ -197,7 +216,7 @@ export function createWorkspaceStore<TData>(
 ): StoreApi<WorkspaceStore<TData>> {
 	return createStore<WorkspaceStore<TData>>((set, get) => ({
 		version: 1,
-		tabs: options?.initialState?.tabs ?? [],
+		tabs: (options?.initialState?.tabs ?? []).map(normalizeTab),
 		activeTabId: options?.initialState?.activeTabId ?? null,
 
 		addTab: (args) => {
@@ -244,7 +263,9 @@ export function createWorkspaceStore<TData>(
 		setTabColor: (args) => {
 			set((s) => ({
 				tabs: s.tabs.map((t) =>
-					t.id === args.tabId ? { ...t, color: args.color } : t,
+					t.id === args.tabId
+						? { ...t, color: normalizeTabColor(args.color) }
+						: t,
 				),
 			}));
 		},
@@ -763,6 +784,10 @@ export function createWorkspaceStore<TData>(
 				);
 				const activePaneId =
 					sourceTab.activePaneId ?? findFirstPaneId(sourceTab.layout);
+				const hasPaneIdCollision = Object.keys(sourceTab.panes).some(
+					(paneId) => paneId in targetTab.panes,
+				);
+				if (hasPaneIdCollision) return s;
 
 				const nextTabs = s.tabs
 					.map((t) => {
@@ -936,7 +961,7 @@ export function createWorkspaceStore<TData>(
 						: next;
 				return {
 					version: resolved.version,
-					tabs: resolved.tabs,
+					tabs: resolved.tabs.map(normalizeTab),
 					activeTabId: resolved.activeTabId,
 				};
 			});

--- a/packages/panes/src/core/store/utils/index.ts
+++ b/packages/panes/src/core/store/utils/index.ts
@@ -14,6 +14,7 @@ export {
 	positionToDirection,
 	removePaneFromLayout,
 	replacePaneIdInLayout,
+	splitNodeInLayout,
 	splitPaneInLayout,
 	updateAtPath,
 } from "./utils";

--- a/packages/panes/src/core/store/utils/utils.ts
+++ b/packages/panes/src/core/store/utils/utils.ts
@@ -92,25 +92,43 @@ export function splitPaneInLayout(
 	newPaneId: string,
 	position: SplitPosition,
 ): LayoutNode {
+	return splitNodeInLayout(
+		node,
+		targetPaneId,
+		{ type: "pane", paneId: newPaneId },
+		position,
+	);
+}
+
+export function splitNodeInLayout(
+	node: LayoutNode,
+	targetPaneId: string,
+	insertedNode: LayoutNode,
+	position: SplitPosition,
+): LayoutNode {
 	if (node.type === "pane") {
 		if (node.paneId !== targetPaneId) return node;
 
 		const direction = positionToDirection(position);
-		const newPaneNode: LayoutNode = { type: "pane", paneId: newPaneId };
 		const isFirst = position === "left" || position === "top";
 
 		return {
 			type: "split",
 			direction,
-			first: isFirst ? newPaneNode : node,
-			second: isFirst ? node : newPaneNode,
+			first: isFirst ? insertedNode : node,
+			second: isFirst ? node : insertedNode,
 		};
 	}
 
 	return {
 		...node,
-		first: splitPaneInLayout(node.first, targetPaneId, newPaneId, position),
-		second: splitPaneInLayout(node.second, targetPaneId, newPaneId, position),
+		first: splitNodeInLayout(node.first, targetPaneId, insertedNode, position),
+		second: splitNodeInLayout(
+			node.second,
+			targetPaneId,
+			insertedNode,
+			position,
+		),
 	};
 }
 

--- a/packages/panes/src/react/components/Workspace/Workspace.tsx
+++ b/packages/panes/src/react/components/Workspace/Workspace.tsx
@@ -17,6 +17,7 @@ export function Workspace<TData>({
 	renderAddTabMenu,
 	renderTabBarTrailing,
 	renderBelowTabBar,
+	renderTabContextMenuItems,
 	onBeforeCloseTab,
 	onAfterCloseTab,
 	onInteractionStateChange,
@@ -99,6 +100,7 @@ export function Workspace<TData>({
 				renderAddTabMenu={renderAddTabMenu}
 				renderTabBarTrailing={renderTabBarTrailing}
 				renderTabAccessory={renderTabAccessory}
+				renderTabContextMenuItems={renderTabContextMenuItems}
 			/>
 			{renderBelowTabBar?.()}
 			{activeTab ? (

--- a/packages/panes/src/react/components/Workspace/components/Tab/components/Pane/Pane.tsx
+++ b/packages/panes/src/react/components/Workspace/components/Tab/components/Pane/Pane.tsx
@@ -14,11 +14,18 @@ import type {
 	RendererContext,
 } from "../../../../../../types";
 import { PaneHeaderActions } from "../../../../../PaneHeaderActions";
-import { PANE_MIN_SIZE_CLASS_NAME } from "../../constants";
+import {
+	PANE_DRAG_TYPE,
+	PANE_MIN_SIZE_CLASS_NAME,
+	TAB_DRAG_TYPE,
+} from "../../constants";
 import { DropZoneOverlay } from "./components/DropZoneOverlay";
 import { PaneContent } from "./components/PaneContent";
 import { PaneContextMenu } from "./components/PaneContextMenu";
-import { PANE_DRAG_TYPE, PaneHeader } from "./components/PaneHeader";
+import { PaneHeader } from "./components/PaneHeader";
+
+type PaneDragItem = { paneId: string };
+type TabDragItem = { tabId: string };
 
 interface PaneComponentProps<TData> {
 	store: StoreApi<WorkspaceStore<TData>>;
@@ -166,8 +173,17 @@ export function Pane<TData>({
 
 	const [{ isOver, canDrop }, connectDrop] = useDrop(
 		() => ({
-			accept: PANE_DRAG_TYPE,
-			canDrop: (item: { paneId: string }) => item.paneId !== pane.id,
+			accept: [PANE_DRAG_TYPE, TAB_DRAG_TYPE],
+			canDrop: (item: PaneDragItem | TabDragItem, monitor) => {
+				if (monitor.getItemType() === PANE_DRAG_TYPE && "paneId" in item) {
+					return item.paneId !== pane.id;
+				}
+				if (monitor.getItemType() === TAB_DRAG_TYPE && "tabId" in item) {
+					const sourceTab = store.getState().getTab(item.tabId);
+					return !!sourceTab && !sourceTab.panes[pane.id];
+				}
+				return false;
+			},
 			hover: (_item, monitor) => {
 				const offset = monitor.getClientOffset();
 				const el = dropRef.current;
@@ -179,14 +195,24 @@ export function Pane<TData>({
 					setDropPosition(pos);
 				}
 			},
-			drop: (item: { paneId: string }) => {
+			drop: (item: PaneDragItem | TabDragItem, monitor) => {
 				const pos = dropPositionRef.current;
 				if (!pos) return;
-				store.getState().movePaneToSplit({
-					sourcePaneId: item.paneId,
-					targetPaneId: pane.id,
-					position: pos,
-				});
+				if (monitor.getItemType() === TAB_DRAG_TYPE && "tabId" in item) {
+					store.getState().moveTabToSplit({
+						sourceTabId: item.tabId,
+						targetPaneId: pane.id,
+						position: pos,
+					});
+					return;
+				}
+				if (monitor.getItemType() === PANE_DRAG_TYPE && "paneId" in item) {
+					store.getState().movePaneToSplit({
+						sourcePaneId: item.paneId,
+						targetPaneId: pane.id,
+						position: pos,
+					});
+				}
 			},
 			collect: (monitor) => ({
 				isOver: monitor.isOver(),

--- a/packages/panes/src/react/components/Workspace/components/Tab/components/Pane/components/PaneHeader/PaneHeader.tsx
+++ b/packages/panes/src/react/components/Workspace/components/Tab/components/Pane/components/PaneHeader/PaneHeader.tsx
@@ -1,6 +1,7 @@
 import { cn } from "@superset/ui/utils";
 import { type ReactNode, useCallback, useRef } from "react";
 import { useDrag } from "react-dnd";
+import { PANE_DRAG_TYPE } from "../../../../constants";
 import { DefaultHeaderContent } from "./components/DefaultHeaderContent";
 
 interface PaneHeaderProps {
@@ -15,8 +16,6 @@ interface PaneHeaderProps {
 	onClick?: () => void;
 	onMiddleClick?: () => void;
 }
-
-export const PANE_DRAG_TYPE = "pane";
 
 export function PaneHeader({
 	title,

--- a/packages/panes/src/react/components/Workspace/components/Tab/components/Pane/components/PaneHeader/index.ts
+++ b/packages/panes/src/react/components/Workspace/components/Tab/components/Pane/components/PaneHeader/index.ts
@@ -1,1 +1,2 @@
-export { PANE_DRAG_TYPE, PaneHeader } from "./PaneHeader";
+export { PANE_DRAG_TYPE } from "../../../../constants";
+export { PaneHeader } from "./PaneHeader";

--- a/packages/panes/src/react/components/Workspace/components/Tab/constants.ts
+++ b/packages/panes/src/react/components/Workspace/components/Tab/constants.ts
@@ -1,1 +1,3 @@
 export const PANE_MIN_SIZE_CLASS_NAME = "min-h-[160px] min-w-[260px]";
+export const PANE_DRAG_TYPE = "pane";
+export const TAB_DRAG_TYPE = "tab";

--- a/packages/panes/src/react/components/Workspace/components/TabBar/TabBar.tsx
+++ b/packages/panes/src/react/components/Workspace/components/TabBar/TabBar.tsx
@@ -16,8 +16,8 @@ import {
 import { useDrop } from "react-dnd";
 import type { Tab } from "../../../../../types";
 import type { PaneRegistry } from "../../../../types";
-import { PANE_DRAG_TYPE } from "../Tab/components/Pane/components/PaneHeader";
-import { TAB_DRAG_TYPE, TabItem } from "./components/TabItem";
+import { PANE_DRAG_TYPE, TAB_DRAG_TYPE } from "../Tab/constants";
+import { TabItem } from "./components/TabItem";
 import { computeInsertIndex, TAB_WIDTH } from "./utils";
 
 interface TabBarProps<TData> {
@@ -35,6 +35,7 @@ interface TabBarProps<TData> {
 	renderAddTabMenu?: () => ReactNode;
 	renderTabBarTrailing?: () => ReactNode;
 	renderTabAccessory?: (tab: Tab<TData>) => ReactNode;
+	renderTabContextMenuItems?: (tab: Tab<TData>) => ReactNode;
 }
 
 type TabDragItem = { tabId: string };
@@ -85,6 +86,7 @@ export function TabBar<TData>({
 	renderAddTabMenu,
 	renderTabBarTrailing,
 	renderTabAccessory,
+	renderTabContextMenuItems,
 }: TabBarProps<TData>) {
 	const tabsTrackRef = useRef<HTMLDivElement>(null);
 	const [hasHorizontalOverflow, setHasHorizontalOverflow] = useState(false);
@@ -214,6 +216,7 @@ export function TabBar<TData>({
 								onRename={(title) => onRenameTab(tab.id, title)}
 								icon={renderTabIcon?.(tab)}
 								accessory={renderTabAccessory?.(tab)}
+								renderContextMenuItems={renderTabContextMenuItems}
 							/>
 						</div>
 					))}

--- a/packages/panes/src/react/components/Workspace/components/TabBar/components/TabItem/TabItem.tsx
+++ b/packages/panes/src/react/components/Workspace/components/TabBar/components/TabItem/TabItem.tsx
@@ -15,10 +15,8 @@ import { useDrag, useDrop } from "react-dnd";
 import type { Tab } from "../../../../../../../types";
 import type { PaneRegistry } from "../../../../../../types";
 import { useTabTitle } from "../../../../utils/useTabTitle";
-import { PANE_DRAG_TYPE } from "../../../Tab/components/Pane/components/PaneHeader";
+import { PANE_DRAG_TYPE, TAB_DRAG_TYPE } from "../../../Tab/constants";
 import { TabRenameInput } from "./components/TabRenameInput";
-
-export const TAB_DRAG_TYPE = "tab";
 
 interface TabItemProps<TData> {
 	tab: Tab<TData>;
@@ -33,6 +31,7 @@ interface TabItemProps<TData> {
 	onRename: (title: string | undefined) => void;
 	icon?: ReactNode;
 	accessory?: ReactNode;
+	renderContextMenuItems?: (tab: Tab<TData>) => ReactNode;
 }
 
 export function TabItem<TData>({
@@ -48,10 +47,13 @@ export function TabItem<TData>({
 	onRename,
 	icon,
 	accessory,
+	renderContextMenuItems,
 }: TabItemProps<TData>) {
 	const [isEditing, setIsEditing] = useState(false);
 	const [editValue, setEditValue] = useState("");
 	const title = useTabTitle(tab, tabs, registry);
+	const hasTabColor = typeof tab.color === "string" && tab.color.length > 0;
+	const customContextMenuItems = renderContextMenuItems?.(tab);
 
 	const startEditing = () => {
 		setEditValue(title);
@@ -111,19 +113,24 @@ export function TabItem<TData>({
 	return (
 		<ContextMenu>
 			<ContextMenuTrigger asChild>
-				{/* biome-ignore lint/a11y/noStaticElementInteractions: mousedown selects tab immediately before drag threshold */}
 				<div
 					ref={setRef}
 					className={cn(
 						"group relative flex h-full w-full items-center border-r border-border transition-colors",
-						isActive
-							? "bg-border/30 text-foreground"
-							: "text-muted-foreground/70 hover:bg-tertiary/20 hover:text-muted-foreground",
+						hasTabColor
+							? "text-foreground"
+							: isActive
+								? "bg-border/30 text-foreground"
+								: "text-muted-foreground/70 hover:bg-tertiary/20 hover:text-muted-foreground",
 						isPaneOver && "bg-primary/5",
 						isDragging && "opacity-30",
 					)}
-					onMouseDown={(event) => {
-						if (event.button === 0) onSelect();
+					style={{
+						...(hasTabColor
+							? {
+									backgroundColor: `${tab.color}${isActive ? "30" : "18"}`,
+								}
+							: {}),
 					}}
 				>
 					{isEditing ? (
@@ -146,6 +153,7 @@ export function TabItem<TData>({
 								<TooltipTrigger asChild>
 									<button
 										className="flex h-full min-w-0 flex-1 items-center gap-1.5 pl-3 pr-1 text-left text-xs transition-colors"
+										onClick={onSelect}
 										onAuxClick={(event) => {
 											if (event.button === 1) {
 												event.preventDefault();
@@ -207,6 +215,8 @@ export function TabItem<TData>({
 					Rename
 				</ContextMenuItem>
 				<ContextMenuSeparator />
+				{customContextMenuItems}
+				{customContextMenuItems && <ContextMenuSeparator />}
 				<ContextMenuItem onSelect={onClose}>
 					<XIcon className="mr-2 size-4" />
 					Close

--- a/packages/panes/src/react/components/Workspace/components/TabBar/components/TabItem/index.ts
+++ b/packages/panes/src/react/components/Workspace/components/TabBar/components/TabItem/index.ts
@@ -1,1 +1,2 @@
-export { TAB_DRAG_TYPE, TabItem } from "./TabItem";
+export { TAB_DRAG_TYPE } from "../../../Tab/constants";
+export { TabItem } from "./TabItem";

--- a/packages/panes/src/react/types.ts
+++ b/packages/panes/src/react/types.ts
@@ -107,6 +107,7 @@ export interface WorkspaceProps<TData> {
 	renderAddTabMenu?: () => ReactNode;
 	renderTabBarTrailing?: () => ReactNode;
 	renderBelowTabBar?: () => ReactNode;
+	renderTabContextMenuItems?: (tab: Tab<TData>) => ReactNode;
 	onBeforeClosePane?: (
 		pane: Pane<TData>,
 		tab: Tab<TData>,

--- a/packages/panes/src/types.ts
+++ b/packages/panes/src/types.ts
@@ -27,6 +27,7 @@ export interface Pane<TData> {
 export interface Tab<TData> {
 	id: string;
 	titleOverride?: string;
+	color?: string | null;
 	createdAt: number;
 	activePaneId: string | null;
 	layout: LayoutNode;

--- a/packages/workspace-client/src/workspace-trpc.ts
+++ b/packages/workspace-client/src/workspace-trpc.ts
@@ -1,6 +1,10 @@
 import type { AppRouter } from "@superset/host-service/trpc";
 import { createTRPCReact } from "@trpc/react-query";
+import { createContext } from "react";
+
+const workspaceTrpcReactContext = createContext<unknown>(null);
 
 export const workspaceTrpc = createTRPCReact<AppRouter>({
 	abortOnUnmount: true,
+	context: workspaceTrpcReactContext,
 });


### PR DESCRIPTION
Summary:
- Fix the v2 top bar inset so macOS window controls no longer overlap.
- Bring v2 right sidebar closer to v1 with Git review panel, Docker, Files, Search, Problems, and Databases tabs while excluding Claude/Codex/Kimi.
- Restore v2 tab drag-to-split behavior and tab color controls.

Test Plan:
- [x] bun run lint
- [x] bun run typecheck

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 右サイドバーに Docker/Search/Problems/Databases/Review タブを追加・拡張。Databases/Git Graph ペインをワークスペース内で開閉・表示可能に。
  * タブに色設定を追加し、タブを別ペインへドラッグ移動できるように。タブのコンテキストメニューをカスタム提供可能に。
  * レビューパネルやサイドバーでPRステータス/コメント表示・外部ハンドラ連携を強化。

* **Bug Fixes / UX**
  * macOSでTopBarの余白を常時確保。エラー詳細のコピー動作を改善。

* **Tests**
  * v1プロジェクト取り込みロジックのテストを追加。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->