### PR TITLE
Restore fork settings entries

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/settings/behavior/components/BehaviorSettings/BehaviorSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/behavior/components/BehaviorSettings/BehaviorSettings.tsx
@@ -1,4 +1,4 @@
-import type { FileOpenMode } from "@superset/local-db";
+import type { FileDragBehavior, FileOpenMode } from "@superset/local-db";
 import { Input } from "@superset/ui/input";
 import { Label } from "@superset/ui/label";
 import {
@@ -22,6 +22,7 @@ import {
 	DEFAULT_RIGHT_SIDEBAR_OPEN_VIEW_WIDTH,
 	MAX_RIGHT_SIDEBAR_OPEN_VIEW_WIDTH,
 	MIN_RIGHT_SIDEBAR_OPEN_VIEW_WIDTH,
+	SUPPORTS_AGENT_SLEEP_PREVENTION,
 } from "shared/constants";
 import {
 	isItemVisible,
@@ -38,8 +39,15 @@ export function BehaviorSettings({ visibleItems }: BehaviorSettingsProps) {
 		SETTING_ITEM_ID.BEHAVIOR_CONFIRM_QUIT,
 		visibleItems,
 	);
+	const showPreventAgentSleep =
+		SUPPORTS_AGENT_SLEEP_PREVENTION &&
+		isItemVisible(SETTING_ITEM_ID.BEHAVIOR_PREVENT_AGENT_SLEEP, visibleItems);
 	const showFileOpenMode = isItemVisible(
 		SETTING_ITEM_ID.BEHAVIOR_FILE_OPEN_MODE,
+		visibleItems,
+	);
+	const showFileDragBehavior = isItemVisible(
+		SETTING_ITEM_ID.BEHAVIOR_FILE_DRAG_BEHAVIOR,
 		visibleItems,
 	);
 	const showRightSidebarOpenViewWidth = isItemVisible(
@@ -80,6 +88,29 @@ export function BehaviorSettings({ visibleItems }: BehaviorSettingsProps) {
 		setConfirmOnQuit.mutate({ enabled });
 	};
 
+	const { data: preventAgentSleep, isLoading: isPreventAgentSleepLoading } =
+		electronTrpc.settings.getPreventAgentSleep.useQuery();
+	const setPreventAgentSleep =
+		electronTrpc.settings.setPreventAgentSleep.useMutation({
+			onMutate: async ({ enabled }) => {
+				await utils.settings.getPreventAgentSleep.cancel();
+				const previous = utils.settings.getPreventAgentSleep.getData();
+				utils.settings.getPreventAgentSleep.setData(undefined, enabled);
+				return { previous };
+			},
+			onError: (_err, _vars, context) => {
+				if (context?.previous !== undefined) {
+					utils.settings.getPreventAgentSleep.setData(
+						undefined,
+						context.previous,
+					);
+				}
+			},
+			onSettled: () => {
+				utils.settings.getPreventAgentSleep.invalidate();
+			},
+		});
+
 	const { data: fileOpenMode, isLoading: isFileOpenModeLoading } =
 		electronTrpc.settings.getFileOpenMode.useQuery();
 	const setFileOpenMode = electronTrpc.settings.setFileOpenMode.useMutation({
@@ -98,6 +129,28 @@ export function BehaviorSettings({ visibleItems }: BehaviorSettingsProps) {
 			utils.settings.getFileOpenMode.invalidate();
 		},
 	});
+	const { data: fileDragBehavior, isLoading: isFileDragBehaviorLoading } =
+		electronTrpc.settings.getFileDragBehavior.useQuery();
+	const setFileDragBehavior =
+		electronTrpc.settings.setFileDragBehavior.useMutation({
+			onMutate: async ({ behavior }) => {
+				await utils.settings.getFileDragBehavior.cancel();
+				const previous = utils.settings.getFileDragBehavior.getData();
+				utils.settings.getFileDragBehavior.setData(undefined, behavior);
+				return { previous };
+			},
+			onError: (_err, _vars, context) => {
+				if (context?.previous !== undefined) {
+					utils.settings.getFileDragBehavior.setData(
+						undefined,
+						context.previous,
+					);
+				}
+			},
+			onSettled: () => {
+				utils.settings.getFileDragBehavior.invalidate();
+			},
+		});
 
 	const { data: resourceMonitorEnabled, isLoading: isResourceMonitorLoading } =
 		electronTrpc.settings.getShowResourceMonitor.useQuery();
@@ -229,6 +282,34 @@ export function BehaviorSettings({ visibleItems }: BehaviorSettingsProps) {
 					</div>
 				)}
 
+				{showPreventAgentSleep && (
+					<div className="flex items-center justify-between">
+						<div className="space-y-0.5">
+							<Label
+								htmlFor="prevent-agent-sleep"
+								className="text-sm font-medium"
+							>
+								Prevent system sleep during agent tasks
+							</Label>
+							<p className="text-xs text-muted-foreground">
+								Keep your computer awake while Claude, Codex, and other agents
+								are running in Superset terminals on supported macOS and Linux
+								systems
+							</p>
+						</div>
+						<Switch
+							id="prevent-agent-sleep"
+							checked={preventAgentSleep ?? false}
+							onCheckedChange={(enabled) =>
+								setPreventAgentSleep.mutate({ enabled })
+							}
+							disabled={
+								isPreventAgentSleepLoading || setPreventAgentSleep.isPending
+							}
+						/>
+					</div>
+				)}
+
 				{showFileOpenMode && (
 					<div className="flex items-center justify-between">
 						<div className="space-y-0.5">
@@ -250,6 +331,42 @@ export function BehaviorSettings({ visibleItems }: BehaviorSettingsProps) {
 							<SelectContent>
 								<SelectItem value="split-pane">Split pane</SelectItem>
 								<SelectItem value="new-tab">New tab</SelectItem>
+							</SelectContent>
+						</Select>
+					</div>
+				)}
+
+				{showFileDragBehavior && (
+					<div className="flex items-center justify-between">
+						<div className="space-y-0.5">
+							<Label className="text-sm font-medium">
+								Sidebar file drag behavior
+							</Label>
+							<p className="text-xs text-muted-foreground">
+								Choose whether dragging files from the Files or Changes sidebar
+								into the main area opens them in the file viewer or pastes their
+								path into terminals
+							</p>
+						</div>
+						<Select
+							value={fileDragBehavior ?? "open-file-viewer"}
+							onValueChange={(value) =>
+								setFileDragBehavior.mutate({
+									behavior: value as FileDragBehavior,
+								})
+							}
+							disabled={
+								isFileDragBehaviorLoading || setFileDragBehavior.isPending
+							}
+						>
+							<SelectTrigger className="w-[220px]">
+								<SelectValue />
+							</SelectTrigger>
+							<SelectContent>
+								<SelectItem value="open-file-viewer">
+									Open file viewer
+								</SelectItem>
+								<SelectItem value="paste-path">Paste file path</SelectItem>
 							</SelectContent>
 						</Select>
 					</div>

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/layout.tsx
@@ -130,6 +130,8 @@ function getPathFromSection(section: SettingsSection): string {
 			return "/settings/security";
 		case "permissions":
 			return "/settings/permissions";
+		case "project":
+			return "/settings/projects";
 		case "hosts":
 			return "/settings/hosts";
 		default:

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/layout.tsx
@@ -30,15 +30,22 @@ const SECTION_ORDER: SettingsSection[] = [
 	"ringtones",
 	"keyboard",
 	"behavior",
+	"diagnostics",
 	"git",
+	"agents",
 	"terminal",
 	"links",
 	"models",
+	"extensions",
+	"vscodeExtensions",
 	"organization",
 	"teams",
 	"integrations",
+	"serviceStatus",
 	"billing",
 	"apikeys",
+	"metrics",
+	"security",
 	"permissions",
 	"hosts",
 	"experimental",
@@ -52,15 +59,26 @@ function getSectionFromPath(pathname: string): SettingsSection | null {
 	if (pathname.includes("/settings/ringtones")) return "ringtones";
 	if (pathname.includes("/settings/keyboard")) return "keyboard";
 	if (pathname.includes("/settings/behavior")) return "behavior";
+	if (pathname.includes("/settings/diagnostics")) return "diagnostics";
 	if (pathname.includes("/settings/git")) return "git";
+	if (pathname.includes("/settings/agents")) return "agents";
 	if (pathname.includes("/settings/terminal")) return "terminal";
 	if (pathname.includes("/settings/links")) return "links";
 	if (pathname.includes("/settings/models")) return "models";
 	if (pathname.includes("/settings/experimental")) return "experimental";
 	if (pathname.includes("/settings/integrations")) return "integrations";
+	if (pathname.includes("/settings/vscode-extensions"))
+		return "vscodeExtensions";
+	if (pathname.includes("/settings/extensions")) return "extensions";
+	if (pathname.includes("/settings/service-status")) return "serviceStatus";
+	if (pathname.includes("/settings/security")) return "security";
+	if (pathname.includes("/settings/metrics")) return "metrics";
+	if (pathname.includes("/settings/billing")) return "billing";
+	if (pathname.includes("/settings/api-keys")) return "apikeys";
 	if (pathname.includes("/settings/permissions")) return "permissions";
 	if (pathname.includes("/settings/hosts")) return "hosts";
 	if (pathname.includes("/settings/project")) return "project";
+	if (pathname.includes("/settings/projects")) return "project";
 	return null;
 }
 
@@ -80,18 +98,36 @@ function getPathFromSection(section: SettingsSection): string {
 			return "/settings/keyboard";
 		case "behavior":
 			return "/settings/behavior";
+		case "diagnostics":
+			return "/settings/diagnostics";
 		case "git":
 			return "/settings/git";
+		case "agents":
+			return "/settings/agents";
 		case "terminal":
 			return "/settings/terminal";
 		case "links":
 			return "/settings/links";
 		case "models":
 			return "/settings/models";
+		case "extensions":
+			return "/settings/extensions";
+		case "vscodeExtensions":
+			return "/settings/vscode-extensions";
 		case "experimental":
 			return "/settings/experimental";
 		case "integrations":
 			return "/settings/integrations";
+		case "serviceStatus":
+			return "/settings/service-status";
+		case "billing":
+			return "/settings/billing";
+		case "apikeys":
+			return "/settings/api-keys";
+		case "metrics":
+			return "/settings/metrics";
+		case "security":
+			return "/settings/security";
 		case "permissions":
 			return "/settings/permissions";
 		case "hosts":

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/permissions/components/PermissionsSettings/PermissionsSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/permissions/components/PermissionsSettings/PermissionsSettings.tsx
@@ -81,6 +81,7 @@ export function PermissionsSettings({
 		electronTrpc.permissions.requestAccessibility.useMutation();
 	const requestMicrophone =
 		electronTrpc.permissions.requestMicrophone.useMutation();
+	const requestCamera = electronTrpc.permissions.requestCamera.useMutation();
 	const requestAppleEvents =
 		electronTrpc.permissions.requestAppleEvents.useMutation();
 	const requestLocalNetwork =
@@ -137,6 +138,18 @@ export function PermissionsSettings({
 								description="Use voice transcription and push-to-talk features."
 								granted={status?.microphone}
 								onRequest={() => requestMicrophone.mutate()}
+							/>
+						)}
+
+						{isItemVisible(
+							SETTING_ITEM_ID.PERMISSIONS_CAMERA,
+							visibleItems,
+						) && (
+							<PermissionRow
+								label="Camera"
+								description="Use video input in websites and tools running inside Superset."
+								granted={status?.camera}
+								onRequest={() => requestCamera.mutate()}
 							/>
 						)}
 

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/utils/settings-search/settings-search.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/utils/settings-search/settings-search.test.ts
@@ -76,4 +76,18 @@ describe("settings search - font settings", () => {
 		const ids = getIds(results);
 		expect(ids).toContain(SETTING_ITEM_ID.EXPERIMENTAL_RERUN_ONBOARDING);
 	});
+
+	it("empty search keeps fork-specific settings sections discoverable", () => {
+		const ids = getIds(searchSettings(""));
+		expect(ids).toContain(SETTING_ITEM_ID.METRICS_GITHUB_OVERVIEW);
+		expect(ids).toContain(SETTING_ITEM_ID.SERVICE_STATUS_PROVIDERS);
+		expect(ids).toContain(SETTING_ITEM_ID.EXTENSIONS_BROWSER);
+		expect(ids).toContain(SETTING_ITEM_ID.VSCODE_EXTENSIONS_MANAGE);
+		expect(ids).toContain(SETTING_ITEM_ID.RINGTONES_AIVIS);
+	});
+
+	it('searching "rate limit" returns GitHub metrics', () => {
+		const ids = getIds(searchSettings("rate limit"));
+		expect(ids).toContain(SETTING_ITEM_ID.METRICS_GITHUB_OVERVIEW);
+	});
 });

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/utils/settings-search/settings-search.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/utils/settings-search/settings-search.ts
@@ -1,4 +1,5 @@
 import type { SettingsSection } from "renderer/stores/settings-state";
+import { SUPPORTS_AGENT_SLEEP_PREVENTION } from "shared/constants";
 
 export const SETTING_ITEM_ID = {
 	ACCOUNT_PROFILE: "account-profile",
@@ -25,7 +26,9 @@ export const SETTING_ITEM_ID = {
 
 	KEYBOARD_SHORTCUTS: "keyboard-shortcuts",
 	BEHAVIOR_CONFIRM_QUIT: "behavior-confirm-quit",
+	BEHAVIOR_PREVENT_AGENT_SLEEP: "behavior-prevent-agent-sleep",
 	BEHAVIOR_FILE_OPEN_MODE: "behavior-file-open-mode",
+	BEHAVIOR_FILE_DRAG_BEHAVIOR: "behavior-file-drag-behavior",
 	BEHAVIOR_RESOURCE_MONITOR: "behavior-resource-monitor",
 	BEHAVIOR_OPEN_LINKS_IN_APP: "behavior-open-links-in-app",
 
@@ -72,9 +75,12 @@ export const SETTING_ITEM_ID = {
 	API_KEYS_LIST: "api-keys-list",
 	API_KEYS_GENERATE: "api-keys-generate",
 
+	EXTENSIONS_BROWSER: "extensions-browser",
+
 	PERMISSIONS_FULL_DISK_ACCESS: "permissions-full-disk-access",
 	PERMISSIONS_ACCESSIBILITY: "permissions-accessibility",
 	PERMISSIONS_MICROPHONE: "permissions-microphone",
+	PERMISSIONS_CAMERA: "permissions-camera",
 	PERMISSIONS_APPLE_EVENTS: "permissions-apple-events",
 	PERMISSIONS_LOCAL_NETWORK: "permissions-local-network",
 
@@ -102,6 +108,7 @@ export const SETTING_ITEM_ID = {
 	RINGTONES_AIVIS: "ringtones-aivis",
 	RINGTONES_AIVIS_DICTIONARY: "ringtones-aivis-dictionary",
 	RINGTONES_AIVIS_USAGE: "ringtones-aivis-usage",
+	SERVICE_STATUS_ADD: "service-status-add",
 	SERVICE_STATUS_PROVIDERS: "service-status-providers",
 	TERMINAL_SUGGESTIONS: "terminal-suggestions",
 	VSCODE_EXTENSIONS_MANAGE: "vscode-extensions-manage",
@@ -158,6 +165,8 @@ export const SETTING_ITEM_VARIANT: Record<SettingItemId, SettingVariant> = {
 
 	[SETTING_ITEM_ID.BEHAVIOR_CONFIRM_QUIT]: "shared",
 	[SETTING_ITEM_ID.BEHAVIOR_FILE_OPEN_MODE]: "v1",
+	[SETTING_ITEM_ID.BEHAVIOR_FILE_DRAG_BEHAVIOR]: "shared",
+	[SETTING_ITEM_ID.BEHAVIOR_PREVENT_AGENT_SLEEP]: "shared",
 	[SETTING_ITEM_ID.BEHAVIOR_RESOURCE_MONITOR]: "shared",
 	[SETTING_ITEM_ID.BEHAVIOR_OPEN_LINKS_IN_APP]: "v1",
 
@@ -204,9 +213,12 @@ export const SETTING_ITEM_VARIANT: Record<SettingItemId, SettingVariant> = {
 	[SETTING_ITEM_ID.API_KEYS_LIST]: "shared",
 	[SETTING_ITEM_ID.API_KEYS_GENERATE]: "shared",
 
+	[SETTING_ITEM_ID.EXTENSIONS_BROWSER]: "shared",
+
 	[SETTING_ITEM_ID.PERMISSIONS_FULL_DISK_ACCESS]: "shared",
 	[SETTING_ITEM_ID.PERMISSIONS_ACCESSIBILITY]: "shared",
 	[SETTING_ITEM_ID.PERMISSIONS_MICROPHONE]: "shared",
+	[SETTING_ITEM_ID.PERMISSIONS_CAMERA]: "shared",
 	[SETTING_ITEM_ID.PERMISSIONS_APPLE_EVENTS]: "shared",
 	[SETTING_ITEM_ID.PERMISSIONS_LOCAL_NETWORK]: "shared",
 
@@ -231,6 +243,7 @@ export const SETTING_ITEM_VARIANT: Record<SettingItemId, SettingVariant> = {
 	[SETTING_ITEM_ID.RINGTONES_AIVIS]: "shared",
 	[SETTING_ITEM_ID.RINGTONES_AIVIS_DICTIONARY]: "shared",
 	[SETTING_ITEM_ID.RINGTONES_AIVIS_USAGE]: "shared",
+	[SETTING_ITEM_ID.SERVICE_STATUS_ADD]: "shared",
 	[SETTING_ITEM_ID.SERVICE_STATUS_PROVIDERS]: "shared",
 	[SETTING_ITEM_ID.TERMINAL_SUGGESTIONS]: "shared",
 	[SETTING_ITEM_ID.VSCODE_EXTENSIONS_MANAGE]: "shared",
@@ -501,6 +514,26 @@ export const SETTINGS_ITEMS: SettingsItem[] = [
 		],
 	},
 	{
+		id: SETTING_ITEM_ID.APPEARANCE_VIBRANCY,
+		section: "appearance",
+		title: "Window Vibrancy",
+		description: "Make the window semi-transparent with a macOS vibrancy blur",
+		keywords: [
+			"appearance",
+			"vibrancy",
+			"transparent",
+			"transparency",
+			"blur",
+			"opacity",
+			"glass",
+			"warp",
+			"macos",
+			"ウィンドウ透過",
+			"不透明度",
+			"ブラー",
+		],
+	},
+	{
 		id: SETTING_ITEM_ID.RINGTONES_NOTIFICATION,
 		section: "ringtones",
 		title: "Notification Sound",
@@ -520,6 +553,53 @@ export const SETTINGS_ITEMS: SettingsItem[] = [
 			"chime",
 			"mute",
 			"volume",
+		],
+	},
+	{
+		id: SETTING_ITEM_ID.RINGTONES_AIVIS,
+		section: "ringtones",
+		title: "Aivis Voice Announcement",
+		description:
+			"Speak the workspace/branch via Aivis API after the notification sound",
+		keywords: [
+			"aivis",
+			"tts",
+			"voice",
+			"speech",
+			"announce",
+			"読み上げ",
+			"音声合成",
+			"アイビス",
+		],
+	},
+	{
+		id: SETTING_ITEM_ID.RINGTONES_AIVIS_DICTIONARY,
+		section: "ringtones",
+		title: "Aivis User Dictionary",
+		description:
+			"Register custom pronunciations for branch names, acronyms, and proper nouns",
+		keywords: [
+			"aivis",
+			"dictionary",
+			"pronunciation",
+			"辞書",
+			"読み方",
+			"カスタム読み",
+			"固有名詞",
+		],
+	},
+	{
+		id: SETTING_ITEM_ID.RINGTONES_AIVIS_USAGE,
+		section: "ringtones",
+		title: "Aivis Usage",
+		description: "Daily Aivis API request count, characters and credits",
+		keywords: [
+			"aivis",
+			"usage",
+			"credits",
+			"使用量",
+			"クレジット",
+			"リクエスト",
 		],
 	},
 	{
@@ -559,6 +639,29 @@ export const SETTINGS_ITEMS: SettingsItem[] = [
 			"unsaved",
 		],
 	},
+	...(SUPPORTS_AGENT_SLEEP_PREVENTION
+		? [
+				{
+					id: SETTING_ITEM_ID.BEHAVIOR_PREVENT_AGENT_SLEEP,
+					section: "behavior" as const,
+					title: "Prevent system sleep during agent tasks",
+					description:
+						"Keep your computer awake while agents are running in Superset terminals on supported macOS and Linux systems",
+					keywords: [
+						"features",
+						"sleep",
+						"prevent",
+						"awake",
+						"caffeinate",
+						"agent",
+						"terminal",
+						"task",
+						"macos",
+						"linux",
+					],
+				},
+			]
+		: []),
 	{
 		id: SETTING_ITEM_ID.GIT_DELETE_LOCAL_BRANCH,
 		section: "git",
@@ -595,6 +698,59 @@ export const SETTINGS_ITEMS: SettingsItem[] = [
 		],
 	},
 	{
+		id: SETTING_ITEM_ID.GIT_SMART_COMMIT,
+		section: "git",
+		title: "Smart Commit",
+		description:
+			"Commit all changes when there are no staged changes (VS Code style)",
+		keywords: [
+			"git",
+			"commit",
+			"smart",
+			"stage",
+			"staged",
+			"unstaged",
+			"tracked",
+			"auto",
+			"all",
+		],
+	},
+	{
+		id: SETTING_ITEM_ID.GIT_AUTO_STASH,
+		section: "git",
+		title: "Auto Stash",
+		description:
+			"Stash local changes before pull/sync and restore after (VS Code style)",
+		keywords: ["git", "stash", "pull", "sync", "auto", "restore", "pop"],
+	},
+	{
+		id: SETTING_ITEM_ID.GIT_BRANCH_SORT_ORDER,
+		section: "git",
+		title: "Branch Sort Order",
+		description:
+			"Order used in the base branch picker (committer date or alphabetical)",
+		keywords: [
+			"git",
+			"branch",
+			"sort",
+			"order",
+			"committer",
+			"date",
+			"alphabetical",
+			"picker",
+			"pin",
+			"default",
+		],
+	},
+	{
+		id: SETTING_ITEM_ID.GIT_POST_COMMIT_COMMAND,
+		section: "git",
+		title: "Post Commit Command",
+		description:
+			"Run push or sync automatically after a successful commit (VS Code style)",
+		keywords: ["git", "commit", "post", "push", "sync", "auto", "after"],
+	},
+	{
 		id: SETTING_ITEM_ID.BEHAVIOR_FILE_OPEN_MODE,
 		section: "behavior",
 		title: "File open mode",
@@ -609,6 +765,25 @@ export const SETTINGS_ITEMS: SettingsItem[] = [
 			"tab",
 			"new tab",
 			"split pane",
+			"viewer",
+			"behavior",
+		],
+	},
+	{
+		id: SETTING_ITEM_ID.BEHAVIOR_FILE_DRAG_BEHAVIOR,
+		section: "behavior",
+		title: "Sidebar file drag behavior",
+		description:
+			"Choose whether dragging files from the Files or Changes sidebar opens the file viewer or pastes file paths into terminals",
+		keywords: [
+			"file",
+			"drag",
+			"drop",
+			"sidebar",
+			"files",
+			"changes",
+			"terminal",
+			"path",
 			"viewer",
 			"behavior",
 		],
@@ -631,6 +806,28 @@ export const SETTINGS_ITEMS: SettingsItem[] = [
 			"initial",
 			"viewer",
 			"changes",
+		],
+	},
+	{
+		id: SETTING_ITEM_ID.BEHAVIOR_LANGUAGE_DIAGNOSTICS,
+		section: "diagnostics",
+		title: "Language diagnostics",
+		description:
+			"Choose which language services report errors and warnings in Problems",
+		keywords: [
+			"diagnostics",
+			"problems",
+			"errors",
+			"warnings",
+			"typescript",
+			"tsx",
+			"json",
+			"toml",
+			"dart",
+			"flutter",
+			"language server",
+			"lint",
+			"validation",
 		],
 	},
 	{
@@ -795,6 +992,22 @@ export const SETTINGS_ITEMS: SettingsItem[] = [
 			"stop",
 			"manage",
 			"pty",
+		],
+	},
+	{
+		id: SETTING_ITEM_ID.TERMINAL_SUGGESTIONS,
+		section: "terminal",
+		title: "Shell History Suggestions",
+		description: "Show command suggestions from shell history",
+		keywords: [
+			"terminal",
+			"suggest",
+			"suggestion",
+			"autocomplete",
+			"history",
+			"shell",
+			"command",
+			"dropdown",
 		],
 	},
 	{
@@ -1184,6 +1397,45 @@ export const SETTINGS_ITEMS: SettingsItem[] = [
 		],
 	},
 	{
+		id: SETTING_ITEM_ID.PROJECT_AUTO_IMPORT_WORKTREES,
+		section: "project",
+		title: "Auto-import detected worktrees",
+		description:
+			"Automatically import worktrees created outside Superset (e.g. by LLM agents)",
+		keywords: [
+			"project",
+			"auto",
+			"automatic",
+			"import",
+			"worktree",
+			"worktrees",
+			"detect",
+			"llm",
+			"claude",
+			"agent",
+		],
+	},
+	{
+		id: SETTING_ITEM_ID.PROJECT_AUTO_REMOVE_WORKTREES,
+		section: "project",
+		title: "Auto-remove missing worktrees",
+		description:
+			"Automatically remove worktrees from the sidebar when they are deleted from disk",
+		keywords: [
+			"project",
+			"auto",
+			"automatic",
+			"remove",
+			"delete",
+			"cleanup",
+			"missing",
+			"worktree",
+			"worktrees",
+			"orphan",
+			"sync",
+		],
+	},
+	{
 		id: SETTING_ITEM_ID.PROJECT_ENV_VARS,
 		section: "project",
 		title: "Environment Variables",
@@ -1229,6 +1481,178 @@ export const SETTINGS_ITEMS: SettingsItem[] = [
 			"mcp",
 			"claude desktop",
 			"claude code",
+		],
+	},
+	{
+		id: SETTING_ITEM_ID.EXTENSIONS_BROWSER,
+		section: "extensions",
+		title: "Browser Extensions",
+		description:
+			"Install and manage Chrome extensions from the Chrome Web Store",
+		keywords: [
+			"extensions",
+			"browser",
+			"chrome",
+			"web store",
+			"install",
+			"toolbar",
+			"extension",
+		],
+	},
+	{
+		id: SETTING_ITEM_ID.VSCODE_EXTENSIONS_MANAGE,
+		section: "vscodeExtensions",
+		title: "VS Code Extensions",
+		description:
+			"Manage VS Code extensions like Claude Code, ChatGPT, and Kimi Code running inside Superset",
+		keywords: [
+			"vscode",
+			"vs code",
+			"extension",
+			"claude",
+			"chatgpt",
+			"codex",
+			"kimi",
+			"ai",
+			"install",
+			"manage",
+		],
+	},
+	{
+		id: SETTING_ITEM_ID.VSCODE_EXTENSIONS_INDENT_RAINBOW,
+		section: "vscodeExtensions",
+		title: "Indent Rainbow",
+		description:
+			"Colorize indentation levels in the code editor with customizable rainbow colors",
+		keywords: [
+			"indent",
+			"rainbow",
+			"color",
+			"indentation",
+			"editor",
+			"highlight",
+		],
+	},
+	{
+		id: SETTING_ITEM_ID.VSCODE_EXTENSIONS_TRAILING_SPACES,
+		section: "vscodeExtensions",
+		title: "Trailing Spaces",
+		description:
+			"Highlight trailing whitespace at the end of lines in the code editor",
+		keywords: [
+			"trailing",
+			"spaces",
+			"whitespace",
+			"trim",
+			"editor",
+			"highlight",
+		],
+	},
+	{
+		id: SETTING_ITEM_ID.VSCODE_EXTENSIONS_REFERENCE_GRAPH,
+		section: "vscodeExtensions",
+		title: "Reference Graph",
+		description:
+			"Visualize code symbol references and call hierarchies as interactive graphs",
+		keywords: [
+			"reference",
+			"graph",
+			"call",
+			"hierarchy",
+			"symbol",
+			"visualization",
+			"editor",
+		],
+	},
+	{
+		id: SETTING_ITEM_ID.METRICS_GITHUB_OVERVIEW,
+		section: "metrics",
+		title: "GitHub Overview",
+		description:
+			"GitHub sync health, active workspaces, rate limits, and scheduler state",
+		keywords: [
+			"metrics",
+			"github",
+			"overview",
+			"health",
+			"rate limit",
+			"scheduler",
+			"debug",
+			"sync",
+			"status",
+		],
+	},
+	{
+		id: SETTING_ITEM_ID.METRICS_GITHUB_TRAFFIC,
+		section: "metrics",
+		title: "GitHub Traffic",
+		description:
+			"Operation volume, cache efficiency, and workspace-level GitHub activity",
+		keywords: [
+			"metrics",
+			"github",
+			"traffic",
+			"cache",
+			"efficiency",
+			"calls",
+			"api",
+			"preview",
+			"comments",
+		],
+	},
+	{
+		id: SETTING_ITEM_ID.METRICS_GITHUB_COPY,
+		section: "metrics",
+		title: "GitHub Debug Copy",
+		description:
+			"Copy summary, JSON bundle, and repro template for GitHub sync debugging",
+		keywords: [
+			"metrics",
+			"github",
+			"copy",
+			"debug bundle",
+			"repro",
+			"json",
+			"support",
+			"diagnostics",
+		],
+	},
+	{
+		id: SETTING_ITEM_ID.SERVICE_STATUS_PROVIDERS,
+		section: "serviceStatus",
+		title: "Service Status Providers",
+		description:
+			"Manage which external status pages appear in the header (Claude, Codex, GitHub, ...)",
+		keywords: [
+			"service status",
+			"status",
+			"providers",
+			"statuspage",
+			"external",
+			"header",
+			"indicator",
+			"health",
+			"uptime",
+			"incident",
+			"dashboard",
+		],
+	},
+	{
+		id: SETTING_ITEM_ID.SERVICE_STATUS_ADD,
+		section: "serviceStatus",
+		title: "Add Custom Status Provider",
+		description:
+			"Add a Statuspage.io-compatible provider with a custom label and icon",
+		keywords: [
+			"service status",
+			"status",
+			"add",
+			"custom",
+			"provider",
+			"statuspage",
+			"icon",
+			"url",
+			"manual",
 		],
 	},
 	{
@@ -1284,6 +1708,22 @@ export const SETTINGS_ITEMS: SettingsItem[] = [
 			"recording",
 			"push to talk",
 			"codex",
+			"privacy",
+		],
+	},
+	{
+		id: SETTING_ITEM_ID.PERMISSIONS_CAMERA,
+		section: "permissions",
+		title: "Camera",
+		description:
+			"Use video input in websites and tools running inside Superset",
+		keywords: [
+			"permissions",
+			"camera",
+			"video",
+			"webcam",
+			"browser",
+			"website",
 			"privacy",
 		],
 	},

--- a/apps/desktop/src/renderer/stores/settings-state.ts
+++ b/apps/desktop/src/renderer/stores/settings-state.ts
@@ -26,8 +26,7 @@ export type SettingsSection =
 	| "security"
 	| "serviceStatus"
 	| "vscodeExtensions"
-	| "hosts"
-	| "experimental";
+	| "hosts";
 
 interface SettingsState {
 	activeSection: SettingsSection;

--- a/packages/host-service/src/trpc/router/github/github.ts
+++ b/packages/host-service/src/trpc/router/github/github.ts
@@ -83,6 +83,40 @@ interface WorkflowDispatchInfo {
 	inputs: WorkflowDispatchInput[];
 }
 
+const GITHUB_REPOSITORY_QUERY_CACHE_TTL_MS = 30_000;
+
+const githubRepositoryQueryCache = new Map<
+	string,
+	{ expiresAt: number; promise: Promise<unknown> }
+>();
+
+function readCachedGitHubRepositoryQuery<T>(
+	key: string,
+	load: () => Promise<T>,
+): Promise<T> {
+	const now = Date.now();
+	const cached = githubRepositoryQueryCache.get(key);
+	if (cached && cached.expiresAt > now) {
+		return cached.promise as Promise<T>;
+	}
+
+	const promise = load();
+	promise.catch(() => {});
+	githubRepositoryQueryCache.set(key, {
+		expiresAt: now + GITHUB_REPOSITORY_QUERY_CACHE_TTL_MS,
+		promise: promise as Promise<unknown>,
+	});
+	return promise;
+}
+
+function invalidateGitHubRepositoryQueryCache(prefix: string): void {
+	for (const key of githubRepositoryQueryCache.keys()) {
+		if (key.startsWith(prefix)) {
+			githubRepositoryQueryCache.delete(key);
+		}
+	}
+}
+
 function normalizeIdentityList(values: string[]): string[] {
 	return Array.from(
 		new Set(values.map((value) => value.trim()).filter(Boolean)),
@@ -514,143 +548,159 @@ export const githubRouter = router({
 	getRepositoryOverview: protectedProcedure
 		.input(z.object({ workspaceId: z.string() }))
 		.query(async ({ ctx, input }) => {
-			const {
-				repoPath,
-				repositoryNameWithOwner,
-				repositoryUrl,
-				upstreamUrl,
-				upstreamNameWithOwner,
-				isFork,
-				branchExistsOnRemote,
-				currentBranch,
-				defaultBranch,
-			} = await resolveRepositoryTarget(ctx, input.workspaceId);
+			return readCachedGitHubRepositoryQuery(
+				`repository-overview:${input.workspaceId}`,
+				async () => {
+					const {
+						repoPath,
+						repositoryNameWithOwner,
+						repositoryUrl,
+						upstreamUrl,
+						upstreamNameWithOwner,
+						isFork,
+						branchExistsOnRemote,
+						currentBranch,
+						defaultBranch,
+					} = await resolveRepositoryTarget(ctx, input.workspaceId);
 
-			const [pullRequests, workflows, labels, assignees] = await Promise.all([
-				loadRepositorySegment({
-					label: "pullRequests",
-					workspaceId: input.workspaceId,
-					repositoryNameWithOwner,
-					fallback: [] as Array<z.infer<typeof ghRepositoryPullRequestSchema>>,
-					load: async () => {
-						const result = await ctx.execGh(
-							[
-								"pr",
-								"list",
-								"--repo",
+					const [pullRequests, workflows, labels, assignees] =
+						await Promise.all([
+							loadRepositorySegment({
+								label: "pullRequests",
+								workspaceId: input.workspaceId,
 								repositoryNameWithOwner,
-								"--state",
-								"open",
-								"--limit",
-								"8",
-								"--json",
-								"number,title,url,state,isDraft,headRefName,updatedAt,author",
-							],
-							{ cwd: repoPath, timeout: 30_000 },
-						);
-						return z.array(ghRepositoryPullRequestSchema).parse(result);
-					},
-				}),
-				loadRepositorySegment({
-					label: "workflows",
-					workspaceId: input.workspaceId,
-					repositoryNameWithOwner,
-					fallback: [] as Array<z.infer<typeof ghRepositoryWorkflowSchema>>,
-					load: async () => {
-						const result = await ctx.execGh(
-							[
-								"api",
-								`repos/${repositoryNameWithOwner}/actions/workflows?per_page=100`,
-							],
-							{ cwd: repoPath, timeout: 30_000 },
-						);
-						return (
-							ghRepositoryWorkflowsResponseSchema.parse(result).workflows ?? []
-						);
-					},
-				}),
-				loadRepositorySegment({
-					label: "labels",
-					workspaceId: input.workspaceId,
-					repositoryNameWithOwner,
-					fallback: [] as Array<z.infer<typeof ghRepositoryLabelSchema>>,
-					load: async () => {
-						const result = await ctx.execGh(
-							["api", `repos/${repositoryNameWithOwner}/labels?per_page=100`],
-							{ cwd: repoPath, timeout: 30_000 },
-						);
-						return z.array(ghRepositoryLabelSchema).parse(result);
-					},
-				}),
-				loadRepositorySegment({
-					label: "assignees",
-					workspaceId: input.workspaceId,
-					repositoryNameWithOwner,
-					fallback: [] as Array<z.infer<typeof ghRepositoryAssigneeSchema>>,
-					load: async () => {
-						const result = await ctx.execGh(
-							[
-								"api",
-								`repos/${repositoryNameWithOwner}/assignees?per_page=100`,
-							],
-							{ cwd: repoPath, timeout: 30_000 },
-						);
-						return z.array(ghRepositoryAssigneeSchema).parse(result);
-					},
-				}),
-			]);
+								fallback: [] as Array<
+									z.infer<typeof ghRepositoryPullRequestSchema>
+								>,
+								load: async () => {
+									const result = await ctx.execGh(
+										[
+											"pr",
+											"list",
+											"--repo",
+											repositoryNameWithOwner,
+											"--state",
+											"open",
+											"--limit",
+											"8",
+											"--json",
+											"number,title,url,state,isDraft,headRefName,updatedAt,author",
+										],
+										{ cwd: repoPath, timeout: 30_000 },
+									);
+									return z.array(ghRepositoryPullRequestSchema).parse(result);
+								},
+							}),
+							loadRepositorySegment({
+								label: "workflows",
+								workspaceId: input.workspaceId,
+								repositoryNameWithOwner,
+								fallback: [] as Array<
+									z.infer<typeof ghRepositoryWorkflowSchema>
+								>,
+								load: async () => {
+									const result = await ctx.execGh(
+										[
+											"api",
+											`repos/${repositoryNameWithOwner}/actions/workflows?per_page=100`,
+										],
+										{ cwd: repoPath, timeout: 30_000 },
+									);
+									return (
+										ghRepositoryWorkflowsResponseSchema.parse(result)
+											.workflows ?? []
+									);
+								},
+							}),
+							loadRepositorySegment({
+								label: "labels",
+								workspaceId: input.workspaceId,
+								repositoryNameWithOwner,
+								fallback: [] as Array<z.infer<typeof ghRepositoryLabelSchema>>,
+								load: async () => {
+									const result = await ctx.execGh(
+										[
+											"api",
+											`repos/${repositoryNameWithOwner}/labels?per_page=100`,
+										],
+										{ cwd: repoPath, timeout: 30_000 },
+									);
+									return z.array(ghRepositoryLabelSchema).parse(result);
+								},
+							}),
+							loadRepositorySegment({
+								label: "assignees",
+								workspaceId: input.workspaceId,
+								repositoryNameWithOwner,
+								fallback: [] as Array<
+									z.infer<typeof ghRepositoryAssigneeSchema>
+								>,
+								load: async () => {
+									const result = await ctx.execGh(
+										[
+											"api",
+											`repos/${repositoryNameWithOwner}/assignees?per_page=100`,
+										],
+										{ cwd: repoPath, timeout: 30_000 },
+									);
+									return z.array(ghRepositoryAssigneeSchema).parse(result);
+								},
+							}),
+						]);
 
-			return {
-				repositoryNameWithOwner,
-				repositoryUrl,
-				upstreamUrl,
-				upstreamNameWithOwner,
-				isFork,
-				branchExistsOnRemote,
-				currentBranch,
-				defaultBranch,
-				issueAssignees: assignees.map((assignee) => ({
-					login: assignee.login,
-					avatarUrl: assignee.avatar_url ?? null,
-				})),
-				issueLabels: labels.map((label) => ({
-					name: label.name,
-					color: label.color ?? "",
-					description: label.description ?? "",
-				})),
-				pullsUrl: `${repositoryUrl}/pulls`,
-				issuesUrl: `${repositoryUrl}/issues`,
-				actionsUrl: `${repositoryUrl}/actions`,
-				newIssueUrl: `${repositoryUrl}/issues/new`,
-				pullRequests: pullRequests.map((pullRequest) => ({
-					number: pullRequest.number,
-					title: pullRequest.title,
-					url: pullRequest.url,
-					state: pullRequest.isDraft
-						? "draft"
-						: pullRequest.state.toLowerCase(),
-					headRefName: pullRequest.headRefName ?? "",
-					updatedAt: pullRequest.updatedAt ?? null,
-					authorLogin: pullRequest.author?.login ?? null,
-				})),
-				workflows: workflows
-					.filter((workflow) => workflow.state !== "disabled_manually")
-					.map((workflow) => {
-						const dispatchInfo = parseWorkflowDispatchInfo({
-							repoPath,
-							workflowPath: workflow.path,
-						});
-						return {
-							id: workflow.id,
-							name: workflow.name,
-							path: workflow.path ?? "",
-							state: workflow.state ?? "unknown",
-							supportsDispatch: dispatchInfo.supportsDispatch,
-							inputs: dispatchInfo.inputs,
-						};
-					})
-					.filter((workflow) => workflow.supportsDispatch),
-			};
+					return {
+						repositoryNameWithOwner,
+						repositoryUrl,
+						upstreamUrl,
+						upstreamNameWithOwner,
+						isFork,
+						branchExistsOnRemote,
+						currentBranch,
+						defaultBranch,
+						issueAssignees: assignees.map((assignee) => ({
+							login: assignee.login,
+							avatarUrl: assignee.avatar_url ?? null,
+						})),
+						issueLabels: labels.map((label) => ({
+							name: label.name,
+							color: label.color ?? "",
+							description: label.description ?? "",
+						})),
+						pullsUrl: `${repositoryUrl}/pulls`,
+						issuesUrl: `${repositoryUrl}/issues`,
+						actionsUrl: `${repositoryUrl}/actions`,
+						newIssueUrl: `${repositoryUrl}/issues/new`,
+						pullRequests: pullRequests.map((pullRequest) => ({
+							number: pullRequest.number,
+							title: pullRequest.title,
+							url: pullRequest.url,
+							state: pullRequest.isDraft
+								? "draft"
+								: pullRequest.state.toLowerCase(),
+							headRefName: pullRequest.headRefName ?? "",
+							updatedAt: pullRequest.updatedAt ?? null,
+							authorLogin: pullRequest.author?.login ?? null,
+						})),
+						workflows: workflows
+							.filter((workflow) => workflow.state !== "disabled_manually")
+							.map((workflow) => {
+								const dispatchInfo = parseWorkflowDispatchInfo({
+									repoPath,
+									workflowPath: workflow.path,
+								});
+								return {
+									id: workflow.id,
+									name: workflow.name,
+									path: workflow.path ?? "",
+									state: workflow.state ?? "unknown",
+									supportsDispatch: dispatchInfo.supportsDispatch,
+									inputs: dispatchInfo.inputs,
+								};
+							})
+							.filter((workflow) => workflow.supportsDispatch),
+					};
+				},
+			);
 		}),
 
 	createIssue: protectedProcedure
@@ -791,6 +841,12 @@ export const githubRouter = router({
 			}
 
 			await ctx.execGh(args, { cwd: repoPath, timeout: 30_000 });
+			invalidateGitHubRepositoryQueryCache(
+				`workflow-runs:${input.workspaceId}:${input.workflowId}`,
+			);
+			invalidateGitHubRepositoryQueryCache(
+				`repository-overview:${input.workspaceId}`,
+			);
 			return {
 				success: true as const,
 				ref: targetRef,
@@ -806,34 +862,39 @@ export const githubRouter = router({
 			}),
 		)
 		.query(async ({ ctx, input }) => {
-			const { repoPath, repositoryNameWithOwner } =
-				await resolveRepositoryTarget(ctx, input.workspaceId);
-			const result = await ctx.execGh(
-				[
-					"api",
-					`repos/${repositoryNameWithOwner}/actions/workflows/${input.workflowId}/runs?per_page=10&event=workflow_dispatch`,
-				],
-				{ cwd: repoPath, timeout: 30_000 },
+			return readCachedGitHubRepositoryQuery(
+				`workflow-runs:${input.workspaceId}:${input.workflowId}`,
+				async () => {
+					const { repoPath, repositoryNameWithOwner } =
+						await resolveRepositoryTarget(ctx, input.workspaceId);
+					const result = await ctx.execGh(
+						[
+							"api",
+							`repos/${repositoryNameWithOwner}/actions/workflows/${input.workflowId}/runs?per_page=10&event=workflow_dispatch`,
+						],
+						{ cwd: repoPath, timeout: 30_000 },
+					);
+					const runs =
+						ghRepositoryWorkflowRunsResponseSchema.parse(result)
+							.workflow_runs ?? [];
+					return runs.map((run) => ({
+						id: run.id,
+						name: run.name ?? "",
+						displayTitle: run.display_title ?? "",
+						url: run.html_url ?? "",
+						status: run.status ?? "unknown",
+						conclusion: run.conclusion ?? null,
+						event: run.event ?? null,
+						createdAt: run.created_at ?? null,
+						updatedAt: run.updated_at ?? null,
+						runStartedAt: run.run_started_at ?? null,
+						headBranch: run.head_branch ?? null,
+						headSha: run.head_sha ?? null,
+						runNumber: run.run_number ?? null,
+						workflowId: run.workflow_id ?? input.workflowId,
+					}));
+				},
 			);
-			const runs =
-				ghRepositoryWorkflowRunsResponseSchema.parse(result).workflow_runs ??
-				[];
-			return runs.map((run) => ({
-				id: run.id,
-				name: run.name ?? "",
-				displayTitle: run.display_title ?? "",
-				url: run.html_url ?? "",
-				status: run.status ?? "unknown",
-				conclusion: run.conclusion ?? null,
-				event: run.event ?? null,
-				createdAt: run.created_at ?? null,
-				updatedAt: run.updated_at ?? null,
-				runStartedAt: run.run_started_at ?? null,
-				headBranch: run.head_branch ?? null,
-				headSha: run.head_sha ?? null,
-				runNumber: run.run_number ?? null,
-				workflowId: run.workflow_id ?? input.workflowId,
-			}));
 		}),
 
 	getWorkflowRunJobs: protectedProcedure
@@ -844,36 +905,41 @@ export const githubRouter = router({
 			}),
 		)
 		.query(async ({ ctx, input }) => {
-			const { repoPath, repositoryNameWithOwner } =
-				await resolveRepositoryTarget(ctx, input.workspaceId);
-			const result = await ctx.execGh(
-				[
-					"api",
-					`repos/${repositoryNameWithOwner}/actions/runs/${input.runId}/jobs?per_page=100`,
-				],
-				{ cwd: repoPath, timeout: 30_000 },
-			);
-			const parsed = z
-				.object({
-					jobs: z
-						.array(
-							z.object({
-								id: z.number(),
-								name: z.string(),
-								status: z.string(),
-								conclusion: z.string().nullable(),
-								html_url: z.string().nullable().optional(),
-							}),
-						)
-						.optional(),
-				})
-				.parse(result);
+			return readCachedGitHubRepositoryQuery(
+				`workflow-run-jobs:${input.workspaceId}:${input.runId}`,
+				async () => {
+					const { repoPath, repositoryNameWithOwner } =
+						await resolveRepositoryTarget(ctx, input.workspaceId);
+					const result = await ctx.execGh(
+						[
+							"api",
+							`repos/${repositoryNameWithOwner}/actions/runs/${input.runId}/jobs?per_page=100`,
+						],
+						{ cwd: repoPath, timeout: 30_000 },
+					);
+					const parsed = z
+						.object({
+							jobs: z
+								.array(
+									z.object({
+										id: z.number(),
+										name: z.string(),
+										status: z.string(),
+										conclusion: z.string().nullable(),
+										html_url: z.string().nullable().optional(),
+									}),
+								)
+								.optional(),
+						})
+						.parse(result);
 
-			return (parsed.jobs ?? []).map((job) => ({
-				detailsUrl: job.html_url ?? "",
-				name: job.name,
-				status: mapJobStatus(job.status, job.conclusion),
-			}));
+					return (parsed.jobs ?? []).map((job) => ({
+						detailsUrl: job.html_url ?? "",
+						name: job.name,
+						status: mapJobStatus(job.status, job.conclusion),
+					}));
+				},
+			);
 		}),
 
 	mergePR: protectedProcedure

--- a/packages/host-service/src/trpc/router/github/github.ts
+++ b/packages/host-service/src/trpc/router/github/github.ts
@@ -90,18 +90,33 @@ const githubRepositoryQueryCache = new Map<
 	{ expiresAt: number; promise: Promise<unknown> }
 >();
 
+function sweepExpiredGitHubRepositoryQueryCache(now = Date.now()): void {
+	for (const [key, entry] of githubRepositoryQueryCache) {
+		if (entry.expiresAt <= now) {
+			githubRepositoryQueryCache.delete(key);
+		}
+	}
+}
+
 function readCachedGitHubRepositoryQuery<T>(
 	key: string,
 	load: () => Promise<T>,
 ): Promise<T> {
 	const now = Date.now();
+	sweepExpiredGitHubRepositoryQueryCache(now);
 	const cached = githubRepositoryQueryCache.get(key);
 	if (cached && cached.expiresAt > now) {
 		return cached.promise as Promise<T>;
 	}
 
-	const promise = load();
-	promise.catch(() => {});
+	let promise: Promise<T>;
+	promise = load().catch((error) => {
+		const cachedAfterError = githubRepositoryQueryCache.get(key);
+		if (cachedAfterError?.promise === promise) {
+			githubRepositoryQueryCache.delete(key);
+		}
+		throw error;
+	});
 	githubRepositoryQueryCache.set(key, {
 		expiresAt: now + GITHUB_REPOSITORY_QUERY_CACHE_TTL_MS,
 		promise: promise as Promise<unknown>,
@@ -110,6 +125,7 @@ function readCachedGitHubRepositoryQuery<T>(
 }
 
 function invalidateGitHubRepositoryQueryCache(prefix: string): void {
+	sweepExpiredGitHubRepositoryQueryCache();
 	for (const key of githubRepositoryQueryCache.keys()) {
 		if (key.startsWith(prefix)) {
 			githubRepositoryQueryCache.delete(key);
@@ -842,9 +858,6 @@ export const githubRouter = router({
 
 			await ctx.execGh(args, { cwd: repoPath, timeout: 30_000 });
 			invalidateGitHubRepositoryQueryCache(
-				`workflow-runs:${input.workspaceId}:${input.workflowId}`,
-			);
-			invalidateGitHubRepositoryQueryCache(
 				`repository-overview:${input.workspaceId}`,
 			);
 			return {
@@ -862,39 +875,34 @@ export const githubRouter = router({
 			}),
 		)
 		.query(async ({ ctx, input }) => {
-			return readCachedGitHubRepositoryQuery(
-				`workflow-runs:${input.workspaceId}:${input.workflowId}`,
-				async () => {
-					const { repoPath, repositoryNameWithOwner } =
-						await resolveRepositoryTarget(ctx, input.workspaceId);
-					const result = await ctx.execGh(
-						[
-							"api",
-							`repos/${repositoryNameWithOwner}/actions/workflows/${input.workflowId}/runs?per_page=10&event=workflow_dispatch`,
-						],
-						{ cwd: repoPath, timeout: 30_000 },
-					);
-					const runs =
-						ghRepositoryWorkflowRunsResponseSchema.parse(result)
-							.workflow_runs ?? [];
-					return runs.map((run) => ({
-						id: run.id,
-						name: run.name ?? "",
-						displayTitle: run.display_title ?? "",
-						url: run.html_url ?? "",
-						status: run.status ?? "unknown",
-						conclusion: run.conclusion ?? null,
-						event: run.event ?? null,
-						createdAt: run.created_at ?? null,
-						updatedAt: run.updated_at ?? null,
-						runStartedAt: run.run_started_at ?? null,
-						headBranch: run.head_branch ?? null,
-						headSha: run.head_sha ?? null,
-						runNumber: run.run_number ?? null,
-						workflowId: run.workflow_id ?? input.workflowId,
-					}));
-				},
+			const { repoPath, repositoryNameWithOwner } =
+				await resolveRepositoryTarget(ctx, input.workspaceId);
+			const result = await ctx.execGh(
+				[
+					"api",
+					`repos/${repositoryNameWithOwner}/actions/workflows/${input.workflowId}/runs?per_page=10&event=workflow_dispatch`,
+				],
+				{ cwd: repoPath, timeout: 30_000 },
 			);
+			const runs =
+				ghRepositoryWorkflowRunsResponseSchema.parse(result).workflow_runs ??
+				[];
+			return runs.map((run) => ({
+				id: run.id,
+				name: run.name ?? "",
+				displayTitle: run.display_title ?? "",
+				url: run.html_url ?? "",
+				status: run.status ?? "unknown",
+				conclusion: run.conclusion ?? null,
+				event: run.event ?? null,
+				createdAt: run.created_at ?? null,
+				updatedAt: run.updated_at ?? null,
+				runStartedAt: run.run_started_at ?? null,
+				headBranch: run.head_branch ?? null,
+				headSha: run.head_sha ?? null,
+				runNumber: run.run_number ?? null,
+				workflowId: run.workflow_id ?? input.workflowId,
+			}));
 		}),
 
 	getWorkflowRunJobs: protectedProcedure


### PR DESCRIPTION
## Summary
- Restore fork-specific Settings registry entries so Metrics, Service Status, Extensions, VS Code Extensions, Aivis, Git, Behavior, and Camera permission settings are discoverable again.
- Restore Settings section routing for fork-specific pages.
- Add short-lived host-service GitHub repository query caching to reduce repeated gh calls from the v2 repository surface.

## Test Plan
- [x] rtk git diff --check
- [x] rtk bunx biome check apps/desktop/src/renderer/routes/_authenticated/settings/behavior/components/BehaviorSettings/BehaviorSettings.tsx apps/desktop/src/renderer/routes/_authenticated/settings/layout.tsx apps/desktop/src/renderer/routes/_authenticated/settings/permissions/components/PermissionsSettings/PermissionsSettings.tsx apps/desktop/src/renderer/routes/_authenticated/settings/utils/settings-search/settings-search.test.ts apps/desktop/src/renderer/routes/_authenticated/settings/utils/settings-search/settings-search.ts apps/desktop/src/renderer/stores/settings-state.ts packages/host-service/src/trpc/router/github/github.ts
- [x] rtk bun run typecheck

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * エージェント実行中のスリープ無効化設定を追加
  * サイドバーからのファイルドラッグ動作設定を追加（開く／パス貼り付けなど）
  * カメラ権限のリクエスト機能を追加
  * 設定ページのセクション並び・遷移先を拡張（診断、拡張、エージェント等を追加）

* **テスト**
  * 設定検索の振る舞いを検証する新規テストを追加

* **パフォーマンス改善**
  * GitHub関連クエリにキャッシュを導入し読み込みを改善
<!-- end of auto-generated comment: release notes by coderabbit.ai -->